### PR TITLE
Implement --restart, --resume --not-consistent.

### DIFF
--- a/src/bin/pgcopydb/cli_copy.c
+++ b/src/bin/pgcopydb/cli_copy.c
@@ -47,7 +47,10 @@ CommandLine copy__db_command =
 		"  --index-jobs          Number of concurrent CREATE INDEX jobs to run\n"
 		"  --drop-if-exists      On the target database, clean-up from a previous run first\n"
 		"  --no-owner            Do not set ownership of objects to match the original database\n"
-		"  --skip-large-objects  Skip copying large objects (blobs)\n",
+		"  --skip-large-objects  Skip copying large objects (blobs)\n"
+		"  --restart             Allow restarting when temp files exist already\n"
+		"  --resume              Allow resuming operations after a failure\n"
+		"  --not-consistent      Allow taking a new snapshot on the source database\n",
 		cli_copy_db_getopts,
 		cli_copy_db);
 
@@ -98,9 +101,9 @@ static CommandLine copy_table_data_command =
 		"  --source          Postgres URI to the source database\n"
 		"  --target          Postgres URI to the target database\n"
 		"  --table-jobs      Number of concurrent COPY jobs to run\n"
-		"  --restart             Allow restarting when temp files exist already\n"
-		"  --resume              Allow resuming operations after a failure\n"
-		"  --not-consistent      Allow taking a new snapshot on the source database\n",
+		"  --restart         Allow restarting when temp files exist already\n"
+		"  --resume          Allow resuming operations after a failure\n"
+		"  --not-consistent  Allow taking a new snapshot on the source database\n",
 		cli_copy_db_getopts,
 		cli_copy_table_data);
 
@@ -111,10 +114,9 @@ static CommandLine copy_sequence_command =
 		" --source ... --target ... [ --table-jobs ... --index-jobs ... ] ",
 		"  --source          Postgres URI to the source database\n"
 		"  --target          Postgres URI to the target database\n"
-		"  --table-jobs      Number of concurrent COPY jobs to run\n"
-		"  --restart             Allow restarting when temp files exist already\n"
-		"  --resume              Allow resuming operations after a failure\n"
-		"  --not-consistent      Allow taking a new snapshot on the source database\n",
+		"  --restart         Allow restarting when temp files exist already\n"
+		"  --resume          Allow resuming operations after a failure\n"
+		"  --not-consistent  Allow taking a new snapshot on the source database\n",
 		cli_copy_db_getopts,
 		cli_copy_sequences);
 
@@ -125,10 +127,10 @@ static CommandLine copy_indexes_command =
 		" --source ... --target ... [ --table-jobs ... --index-jobs ... ] ",
 		"  --source          Postgres URI to the source database\n"
 		"  --target          Postgres URI to the target database\n"
-		"  --table-jobs      Number of concurrent COPY jobs to run\n"
-		"  --restart             Allow restarting when temp files exist already\n"
-		"  --resume              Allow resuming operations after a failure\n"
-		"  --not-consistent      Allow taking a new snapshot on the source database\n",
+		"  --index-jobs      Number of concurrent CREATE INDEX jobs to run\n"
+		"  --restart         Allow restarting when temp files exist already\n"
+		"  --resume          Allow resuming operations after a failure\n"
+		"  --not-consistent  Allow taking a new snapshot on the source database\n",
 		cli_copy_db_getopts,
 		cli_copy_indexes);
 
@@ -139,10 +141,9 @@ static CommandLine copy_constraints_command =
 		" --source ... --target ... [ --table-jobs ... --index-jobs ... ] ",
 		"  --source          Postgres URI to the source database\n"
 		"  --target          Postgres URI to the target database\n"
-		"  --table-jobs      Number of concurrent COPY jobs to run\n"
-		"  --restart             Allow restarting when temp files exist already\n"
-		"  --resume              Allow resuming operations after a failure\n"
-		"  --not-consistent      Allow taking a new snapshot on the source database\n",
+		"  --restart         Allow restarting when temp files exist already\n"
+		"  --resume          Allow resuming operations after a failure\n"
+		"  --not-consistent  Allow taking a new snapshot on the source database\n",
 		cli_copy_db_getopts,
 		cli_copy_constraints);
 

--- a/src/bin/pgcopydb/cli_copy.h
+++ b/src/bin/pgcopydb/cli_copy.h
@@ -24,6 +24,9 @@ typedef struct CopyDBOptions
 	bool dropIfExists;
 	bool noOwner;
 	bool skipLargeObjects;
+	bool restart;
+	bool resume;
+	bool notConsistent;
 } CopyDBOptions;
 
 

--- a/src/bin/pgcopydb/cli_dump.h
+++ b/src/bin/pgcopydb/cli_dump.h
@@ -19,6 +19,9 @@ typedef struct DumpDBOptions
 {
 	char source_pguri[MAXCONNINFO];
 	char target_dir[MAXPGPATH];
+	bool restart;
+	bool resume;
+	bool notConsistent;
 } DumpDBOptions;
 
 

--- a/src/bin/pgcopydb/cli_restore.h
+++ b/src/bin/pgcopydb/cli_restore.h
@@ -21,6 +21,9 @@ typedef struct RestoreDBOptions
 	char target_pguri[MAXCONNINFO];
 	bool dropIfExists;
 	bool noOwner;
+	bool restart;
+	bool resume;
+	bool notConsistent;
 } RestoreDBOptions;
 
 

--- a/src/bin/pgcopydb/copydb.c
+++ b/src/bin/pgcopydb/copydb.c
@@ -28,41 +28,23 @@
  * store temporary information while the pgcopydb process is running.
  */
 bool
-copydb_init_workdir(CopyFilePaths *cfPaths, char *dir, bool removeDir)
+copydb_init_workdir(CopyDataSpec *copySpecs,
+					char *dir,
+					bool restart,
+					bool resume)
 {
+	CopyFilePaths *cfPaths = &(copySpecs->cfPaths);
+	DirectoryState *dirState = &(copySpecs->dirState);
+
 	pid_t pid = getpid();
 
-	if (dir != NULL && !IS_EMPTY_STRING_BUFFER(dir))
+	if (!copydb_prepare_filepaths(cfPaths, dir))
 	{
-		strlcpy(cfPaths->topdir, dir, sizeof(cfPaths->topdir));
-	}
-	else
-	{
-		char tmpdir[MAXPGPATH] = { 0 };
-
-		if (!get_env_copy_with_fallback("XDG_RUNTIME_DIR",
-										tmpdir,
-										sizeof(tmpdir),
-										"/tmp"))
-		{
-			/* errors have already been logged */
-			return false;
-		}
-
-		sformat(cfPaths->topdir, MAXPGPATH, "%s/pgcopydb", tmpdir);
+		/* errors have already been logged */
+		return false;
 	}
 
-	/* now that we have our topdir, prepare all the others from there */
-	sformat(cfPaths->pidfile, MAXPGPATH, "%s/pgcopydb.pid", cfPaths->topdir);
-	sformat(cfPaths->schemadir, MAXPGPATH, "%s/schema", cfPaths->topdir);
-	sformat(cfPaths->rundir, MAXPGPATH, "%s/run", cfPaths->topdir);
-	sformat(cfPaths->tbldir, MAXPGPATH, "%s/run/tables", cfPaths->topdir);
-	sformat(cfPaths->idxdir, MAXPGPATH, "%s/run/indexes", cfPaths->topdir);
-
-	sformat(cfPaths->idxfilepath, MAXPGPATH,
-			"%s/run/indexes.json", cfPaths->topdir);
-
-	/* now create the target directories that we depend on. */
+	/* check to see if there is already another pgcopydb running */
 	if (directory_exists(cfPaths->topdir))
 	{
 		pid_t onFilePid = 0;
@@ -84,58 +66,68 @@ copydb_init_workdir(CopyFilePaths *cfPaths, char *dir, bool removeDir)
 				return false;
 			}
 		}
-
-		/* warn about trashing data from a previous run */
-		if (removeDir)
-		{
-			log_warn("Directory \"%s\" already exists: removing it entirely",
-					 cfPaths->topdir);
-		}
 	}
 
-	/*
-	 * dir is the --target provided in file-based commands such as `pgcopydb
-	 * dump db`, and we might have to create the whole directory hierarchy that
-	 * we expect when given a --target /tmp/demo or something.
-	 *
-	 * When using a command such as `pgcopydb copy db` then the target is a
-	 * Postgres URI and we use internal directories such as /tmp/pgcopydb/ and
-	 * we want to avoid deleting files from a previous run, so we bypass
-	 * creating empty directories with ensure_empty_dir in that case.
-	 *
-	 * dir is NULL when the command uses its own internal directories
-	 * dir is NOT NULL when the command uses --source dir or --target dir
-	 */
-	bool shouldCreateDirectories =
-		dir == NULL || !directory_exists(cfPaths->topdir);
+	bool removeDir = false;
 
-	/*
-	 * And that's why we should cache our decision making: right after this
-	 * point, the target directory exists, and we might still have to make the
-	 * decision again to create sub-directories. We should ensure consistent
-	 * decision making, so we can't call directory_exists(cfPaths->topdir)
-	 * anymore.
-	 */
-	if (shouldCreateDirectories)
+	if (!copydb_inspect_workdir(cfPaths, dirState))
 	{
-		log_debug("mkdir -p \"%s\"", cfPaths->topdir);
+		/* errors have already been logged */
+		return false;
+	}
 
-		if (removeDir)
+	if (dirState->directoryExists)
+	{
+		if (restart)
 		{
-			if (!ensure_empty_dir(cfPaths->topdir, 0700))
-			{
-				/* errors have already been logged. */
-				return false;
-			}
+			removeDir = true;
 		}
-		else
+		else if (dirState->allDone)
 		{
-			if (pg_mkdir_p((char *) cfPaths->topdir, 0700) == -1)
-			{
-				log_fatal("Failed to create directory \"%s\"", cfPaths->topdir);
-				return false;
-			}
+			log_fatal("Please use --restart to allow for removing files "
+					  "that belong to a completed previous run.");
+			return false;
 		}
+
+		/* if we did nothing yet, just act as if --resume was used */
+		else if (!dirState->schemaDumpIsDone)
+		{
+			log_debug("schema dump is done, just continue");
+		}
+
+		/* if --resume --not-consistent has been used, we just continue */
+		else if (!resume)
+		{
+			log_fatal("Please use --resume --not-consistent to allow "
+					  "for resuming from the previous run, "
+					  "which failed before completion.");
+			return false;
+		}
+
+		/*
+		 * Here we should have restart true or resume true or we didn't even do
+		 * the schema dump on the previous run.
+		 */
+	}
+
+	/* warn about trashing data from a previous run */
+	if (removeDir && !restart)
+	{
+		log_info("Inspection of \"%s\" shows that it is safe "
+				 "to remove it and continue",
+				 cfPaths->topdir);
+	}
+
+	if (removeDir)
+	{
+		log_info("Removing directory \"%s\"", cfPaths->topdir);
+	}
+
+	/* make sure the directory exists, possibly making it empty */
+	if (!copydb_rmdir_or_mkdir(cfPaths->topdir, removeDir))
+	{
+		/* errors have already been logged */
+		return false;
 	}
 
 	/* now populate our pidfile */
@@ -153,27 +145,238 @@ copydb_init_workdir(CopyFilePaths *cfPaths, char *dir, bool removeDir)
 		NULL
 	};
 
-	if (shouldCreateDirectories)
+	for (int i = 0; dirs[i] != NULL; i++)
 	{
-		for (int i = 0; dirs[i] != NULL; i++)
+		if (!copydb_rmdir_or_mkdir(dirs[i], removeDir))
 		{
-			log_debug("mkdir -p \"%s\"", dirs[i]);
+			/* errors have already been logged */
+			return false;
+		}
+	}
 
-			if (removeDir)
-			{
-				if (!ensure_empty_dir(dirs[i], 0700))
-				{
-					return false;
-				}
-			}
-			else
-			{
-				if (pg_mkdir_p((char *) dirs[i], 0700) == -1)
-				{
-					log_fatal("Failed to create directory \"%s\"", dir);
-					return false;
-				}
-			}
+	return true;
+}
+
+
+/*
+ * copydb_inspect_workdir inspects the given target directory to see what work
+ * has been tracked in there. From the doneFile(s) and the lockFile(s) that we
+ * can list in the directory, we can have a good idea of why the command is
+ * attempted to be run again.
+ */
+bool
+copydb_inspect_workdir(CopyFilePaths *cfPaths, DirectoryState *dirState)
+{
+	dirState->directoryExists = directory_exists(cfPaths->topdir);
+
+	if (!dirState->directoryExists)
+	{
+		return true;
+	}
+
+	/* the directory exists, checks if our expected components are there */
+	bool foundAllComponents = true;
+
+	const char *dirs[] = {
+		cfPaths->schemadir,
+		cfPaths->rundir,
+		cfPaths->tbldir,
+		cfPaths->idxdir,
+		NULL
+	};
+
+	for (int i = 0; dirs[i] != NULL; i++)
+	{
+		foundAllComponents = foundAllComponents && directory_exists(dirs[i]);
+	}
+
+	if (!foundAllComponents)
+	{
+		log_debug("copydb_inspect_workdir: not all components found");
+		dirState->directoryIsReady = false;
+		return true;
+	}
+
+	dirState->schemaDumpIsDone =
+		file_exists(cfPaths->done.preDataDump) &&
+		file_exists(cfPaths->done.postDataDump);
+
+	dirState->schemaPreDataHasBeenRestored =
+		file_exists(cfPaths->done.preDataRestore);
+
+	dirState->schemaPostDataHasBeenRestored =
+		file_exists(cfPaths->done.postDataRestore);
+
+	dirState->tableCopyIsDone = file_exists(cfPaths->done.tables);
+	dirState->indexCopyIsDone = file_exists(cfPaths->done.indexes);
+	dirState->sequenceCopyIsDone = file_exists(cfPaths->done.sequences);
+	dirState->blobsCopyIsDone = false;
+
+	dirState->allDone =
+		dirState->schemaDumpIsDone &&
+		dirState->schemaPreDataHasBeenRestored &&
+		dirState->schemaPostDataHasBeenRestored &&
+		dirState->tableCopyIsDone &&
+		dirState->indexCopyIsDone &&
+		dirState->sequenceCopyIsDone;
+
+	/* let's be verbose about our inspection results */
+	log_info("Work directory \"%s\" already exists", cfPaths->topdir);
+
+	if (dirState->allDone)
+	{
+		log_info("A previous run has run through completion");
+		return true;
+	}
+
+	if (dirState->schemaDumpIsDone)
+	{
+		log_info("Schema dump for pre-data and post-data section have been done");
+	}
+
+	if (dirState->schemaPreDataHasBeenRestored)
+	{
+		log_info("Pre-data schema has been restored on the target instance");
+	}
+
+	if (dirState->tableCopyIsDone)
+	{
+		log_info("All the table data has been copied to the target instance");
+	}
+
+	if (dirState->indexCopyIsDone)
+	{
+		log_info("All the indexes and constraints "
+				 "have been copied to the target instance");
+	}
+
+	if (dirState->sequenceCopyIsDone)
+	{
+		log_info("All the sequences have been copied to the target instance");
+	}
+
+	if (dirState->schemaPostDataHasBeenRestored)
+	{
+		log_info("Post-data schema has been restored on the target instance");
+	}
+
+	return true;
+}
+
+
+/*
+ * copydb_prepare_filepaths computes all the path components that are needed
+ * for top-level operations.
+ */
+bool
+copydb_prepare_filepaths(CopyFilePaths *cfPaths, const char *dir)
+{
+	char topdir[MAXPGPATH] = { 0 };
+
+	if (dir != NULL && !IS_EMPTY_STRING_BUFFER(dir))
+	{
+		strlcpy(topdir, dir, sizeof(topdir));
+	}
+	else
+	{
+		char tmpdir[MAXPGPATH] = { 0 };
+
+		if (!get_env_copy_with_fallback("XDG_RUNTIME_DIR",
+										tmpdir,
+										sizeof(tmpdir),
+										"/tmp"))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+
+		sformat(topdir, sizeof(topdir), "%s/pgcopydb", tmpdir);
+	}
+
+	/* first copy the top directory */
+	strlcpy(cfPaths->topdir, topdir, sizeof(cfPaths->topdir));
+
+	/* now that we have our topdir, prepare all the others from there */
+	sformat(cfPaths->pidfile, MAXPGPATH, "%s/pgcopydb.pid", cfPaths->topdir);
+	sformat(cfPaths->schemadir, MAXPGPATH, "%s/schema", cfPaths->topdir);
+	sformat(cfPaths->rundir, MAXPGPATH, "%s/run", cfPaths->topdir);
+	sformat(cfPaths->tbldir, MAXPGPATH, "%s/run/tables", cfPaths->topdir);
+	sformat(cfPaths->idxdir, MAXPGPATH, "%s/run/indexes", cfPaths->topdir);
+
+	/* now prepare the done files */
+	struct pair
+	{
+		char *dst;
+		char *fmt;
+	};
+
+	struct pair donePaths[] = {
+		{ (char *) &(cfPaths->done.preDataDump), "%s/run/dump-pre.done" },
+		{ (char *) &(cfPaths->done.postDataDump), "%s/run/dump-post.done" },
+		{ (char *) &(cfPaths->done.preDataRestore), "%s/run/restore-pre.done" },
+		{ (char *) &(cfPaths->done.postDataRestore), "%s/run/restore-post.done" },
+
+		{ (char *) &(cfPaths->done.tables), "%s/run/tables.done" },
+		{ (char *) &(cfPaths->done.indexes), "%s/run/indexes.done" },
+		{ (char *) &(cfPaths->done.sequences), "%s/run/sequences.done" },
+		{ (char *) &(cfPaths->done.blobs), "%s/run/blobs.done" },
+		{ NULL, NULL }
+	};
+
+	for (int i = 0; donePaths[i].dst != NULL; i++)
+	{
+		sformat(donePaths[i].dst, MAXPGPATH, donePaths[i].fmt, cfPaths->topdir);
+	}
+
+	return true;
+}
+
+
+/*
+ * copydb_prepare_dump_paths computes the paths for the pg_dump and pg_restore
+ * activities.
+ */
+bool
+copydb_prepare_dump_paths(CopyFilePaths *cfPaths, DumpPaths *dumpPaths)
+{
+	sformat(dumpPaths->preFilename, MAXPGPATH, "%s/%s",
+			cfPaths->schemadir, "pre.dump");
+
+	sformat(dumpPaths->postFilename, MAXPGPATH, "%s/%s",
+			cfPaths->schemadir, "post.dump");
+
+	sformat(dumpPaths->listFilename, MAXPGPATH, "%s/%s",
+			cfPaths->schemadir, "post.list");
+
+	return true;
+}
+
+
+/*
+ * copydb_rmdir_or_mkdir ensure that given directory is empty. For that it
+ * either uses rm -rf on an existing directory or just mkdir -p on a possibly
+ * existing directory, depending on the removeDir argument.
+ */
+bool
+copydb_rmdir_or_mkdir(const char *dir, bool removeDir)
+{
+	if (removeDir)
+	{
+		log_debug("rm -rf \"%s\" && mkdir -p \"%s\"", dir, dir);
+
+		if (!ensure_empty_dir(dir, 0700))
+		{
+			return false;
+		}
+	}
+	else
+	{
+		log_debug("mkdir -p \"%s\"", dir);
+
+		if (pg_mkdir_p((char *) dir, 0700) == -1)
+		{
+			log_fatal("Failed to create directory \"%s\"", dir);
+			return false;
 		}
 	}
 
@@ -196,7 +399,9 @@ copydb_init_specs(CopyDataSpec *specs,
 				  CopyDataSection section,
 				  bool dropIfExists,
 				  bool noOwner,
-				  bool skipLargeObjects)
+				  bool skipLargeObjects,
+				  bool restart,
+				  bool resume)
 {
 	/* fill-in a structure with the help of the C compiler */
 	CopyDataSpec tmpCopySpecs = {
@@ -217,6 +422,9 @@ copydb_init_specs(CopyDataSpec *specs,
 		.dropIfExists = dropIfExists,
 		.noOwner = noOwner,
 		.skipLargeObjects = skipLargeObjects,
+
+		.restart = restart,
+		.resume = resume,
 
 		.tableJobs = tableJobs,
 		.indexJobs = indexJobs,
@@ -239,14 +447,11 @@ copydb_init_specs(CopyDataSpec *specs,
 	*specs = tmpCopySpecs;
 
 	/* now compute some global paths that are needed for pgcopydb */
-	sformat(specs->dumpPaths.preFilename, MAXPGPATH, "%s/%s",
-			specs->cfPaths.schemadir, "pre.dump");
-
-	sformat(specs->dumpPaths.postFilename, MAXPGPATH, "%s/%s",
-			specs->cfPaths.schemadir, "post.dump");
-
-	sformat(specs->dumpPaths.listFilename, MAXPGPATH, "%s/%s",
-			specs->cfPaths.schemadir, "post.list");
+	if (!copydb_prepare_dump_paths(&(specs->cfPaths), &(specs->dumpPaths)))
+	{
+		/* errors have already been logged */
+		return false;
+	}
 
 	/* create the table semaphore (critical section, one at a time please) */
 	specs->tableSemaphore.initValue = 1;
@@ -299,8 +504,9 @@ copydb_init_table_specs(CopyTableDataSpec *tableSpecs,
 		},
 
 		.section = specs->section,
+		.resume = specs->resume,
 
-		.sourceTable = source,
+		.sourceTable = { 0 },
 		.indexArray = NULL,
 		.summary = NULL,
 
@@ -322,14 +528,17 @@ copydb_init_table_specs(CopyTableDataSpec *tableSpecs,
 			specs->sourceSnapshot.snapshot,
 			sizeof(tmpTableSpecs.sourceSnapshot.snapshot));
 
+	/* copy the SourceTable into our memory area */
+	tmpTableSpecs.sourceTable = *source;
+
 	/* copy the structure as a whole memory area to the target place */
 	*tableSpecs = tmpTableSpecs;
 
 	/* compute the table fully qualified name */
 	sformat(tableSpecs->qname, sizeof(tableSpecs->qname),
 			"\"%s\".\"%s\"",
-			tableSpecs->sourceTable->nspname,
-			tableSpecs->sourceTable->relname);
+			tableSpecs->sourceTable.nspname,
+			tableSpecs->sourceTable.relname);
 
 
 	/* now compute the table-specific paths we are using in copydb */
@@ -344,249 +553,6 @@ copydb_init_table_specs(CopyTableDataSpec *tableSpecs,
 	sformat(tableSpecs->tablePaths.idxListFile, MAXPGPATH, "%s/%u.idx",
 			tableSpecs->cfPaths->tbldir,
 			source->oid);
-
-	return true;
-}
-
-
-/*
- * copydb_init_index_file_paths prepares a given index (and constraint) file
- * paths to help orchestrate the concurrent operations.
- */
-bool
-copydb_init_indexes_paths(CopyTableDataSpec *tableSpecs)
-{
-	SourceIndexArray *indexArray = tableSpecs->indexArray;
-	IndexFilePathsArray *indexPathsArray = &(tableSpecs->indexPathsArray);
-
-	indexPathsArray->count = indexArray->count;
-	indexPathsArray->array =
-		(IndexFilePaths *) malloc(indexArray->count * sizeof(IndexFilePaths));
-
-	for (int i = 0; i < indexArray->count; i++)
-	{
-		SourceIndex *index = &(indexArray->array[i]);
-		IndexFilePaths *indexPaths = &(indexPathsArray->array[i]);
-
-		sformat(indexPaths->lockFile, sizeof(indexPaths->lockFile),
-				"%s/%u",
-				tableSpecs->cfPaths->rundir,
-				index->indexOid);
-
-		sformat(indexPaths->doneFile, sizeof(indexPaths->doneFile),
-				"%s/%u.done",
-				tableSpecs->cfPaths->idxdir,
-				index->indexOid);
-
-		sformat(indexPaths->constraintDoneFile,
-				sizeof(indexPaths->constraintDoneFile),
-				"%s/%u.done",
-				tableSpecs->cfPaths->idxdir,
-				index->constraintOid);
-	}
-
-	return true;
-}
-
-
-/*
- * copydb_objectid_has_been_processed_already returns true when a doneFile
- * could be found on-disk for the given target object OID.
- */
-bool
-copydb_objectid_has_been_processed_already(CopyDataSpec *specs, uint32_t oid)
-{
-	char doneFile[MAXPGPATH] = { 0 };
-
-	/* build the doneFile for the target index or constraint */
-	sformat(doneFile, sizeof(doneFile), "%s/%u.done",
-			specs->cfPaths.idxdir,
-			oid);
-
-	if (file_exists(doneFile))
-	{
-		char *sql = NULL;
-		long size = 0L;
-
-		if (!read_file(doneFile, &sql, &size))
-		{
-			/* no worries, just skip then */
-		}
-
-		/* we're interested in the last line of the file */
-		char *lines[BUFSIZE] = { 0 };
-		int lineCount = splitLines(sql, lines, BUFSIZE);
-
-		log_debug("Skipping dumpId %d (%s)", oid, lines[lineCount - 1]);
-
-		/* read_file allocates memory */
-		free(sql);
-
-		return true;
-	}
-
-	return false;
-}
-
-
-/*
- * copydb_dump_source_schema uses pg_dump -Fc --schema --section=pre-data or
- * --section=post-data to dump the source database schema to files.
- */
-bool
-copydb_dump_source_schema(CopyDataSpec *specs, PostgresDumpSection section)
-{
-	if (section == PG_DUMP_SECTION_SCHEMA ||
-		section == PG_DUMP_SECTION_PRE_DATA ||
-		section == PG_DUMP_SECTION_ALL)
-	{
-		if (!pg_dump_db(&(specs->pgPaths),
-						specs->source_pguri,
-						"pre-data",
-						specs->dumpPaths.preFilename))
-		{
-			/* errors have already been logged */
-			return false;
-		}
-	}
-
-	if (section == PG_DUMP_SECTION_SCHEMA ||
-		section == PG_DUMP_SECTION_POST_DATA ||
-		section == PG_DUMP_SECTION_ALL)
-	{
-		if (!pg_dump_db(&(specs->pgPaths),
-						specs->source_pguri,
-						"post-data",
-						specs->dumpPaths.postFilename))
-		{
-			/* errors have already been logged */
-			return false;
-		}
-	}
-
-	return true;
-}
-
-
-/*
- * copydb_target_prepare_schema restores the pre.dump file into the target
- * database.
- */
-bool
-copydb_target_prepare_schema(CopyDataSpec *specs)
-{
-	if (!file_exists(specs->dumpPaths.preFilename))
-	{
-		log_fatal("File \"%s\" does not exists", specs->dumpPaths.preFilename);
-		return false;
-	}
-
-	if (!pg_restore_db(&(specs->pgPaths),
-					   specs->target_pguri,
-					   specs->dumpPaths.preFilename,
-					   NULL,
-					   specs->dropIfExists,
-					   specs->noOwner))
-	{
-		/* errors have already been logged */
-		return false;
-	}
-
-	return true;
-}
-
-
-/*
- * copydb_target_finalize_schema finalizes the schema after all the data has
- * been copied over, and after indexes and their constraints have been created
- * too.
- */
-bool
-copydb_target_finalize_schema(CopyDataSpec *specs)
-{
-	if (!file_exists(specs->dumpPaths.postFilename))
-	{
-		log_fatal("File \"%s\" does not exists", specs->dumpPaths.postFilename);
-		return false;
-	}
-
-	/*
-	 * The post.dump archive file contains all the objects to create once the
-	 * table data has been copied over. It contains in particular the
-	 * constraints and indexes that we have already built concurrently in the
-	 * previous step, so we want to filter those out.
-	 *
-	 * Here's how to filter out some objects with pg_restore:
-	 *
-	 *   1. pg_restore -f- --list post.dump > post.list
-	 *   2. edit post.list to comment out lines
-	 *   3. pg_restore --use-list post.list post.dump
-	 */
-	ArchiveContentArray contents = { 0 };
-
-	if (!pg_restore_list(&(specs->pgPaths),
-						 specs->dumpPaths.postFilename,
-						 &contents))
-	{
-		/* errors have already been logged */
-		return false;
-	}
-
-	/* edit our post.list file now */
-	PQExpBuffer listContents = createPQExpBuffer();
-
-	if (listContents == NULL)
-	{
-		log_error(ALLOCATION_FAILED_ERROR);
-		free(listContents);
-		return false;
-	}
-
-	/* for each object in the list, comment when we already processed it */
-	for (int i = 0; i < contents.count; i++)
-	{
-		uint32_t oid = contents.array[i].objectOid;
-
-		/* commenting is done by prepending ";" as prefix to the line */
-		char *prefix =
-			copydb_objectid_has_been_processed_already(specs, oid) ? ";" : "";
-
-		appendPQExpBuffer(listContents, "%s%d; %u %u\n",
-						  prefix,
-						  contents.array[i].dumpId,
-						  contents.array[i].catalogOid,
-						  contents.array[i].objectOid);
-	}
-
-	/* memory allocation could have failed while building string */
-	if (PQExpBufferBroken(listContents))
-	{
-		log_error("Failed to create pg_restore list file: out of memory");
-		destroyPQExpBuffer(listContents);
-		return false;
-	}
-
-	if (!write_file(listContents->data,
-					listContents->len,
-					specs->dumpPaths.listFilename))
-	{
-		/* errors have already been logged */
-		destroyPQExpBuffer(listContents);
-		return false;
-	}
-
-	destroyPQExpBuffer(listContents);
-
-	if (!pg_restore_db(&(specs->pgPaths),
-					   specs->target_pguri,
-					   specs->dumpPaths.postFilename,
-					   specs->dumpPaths.listFilename,
-					   specs->dropIfExists,
-					   specs->noOwner))
-	{
-		/* errors have already been logged */
-		return false;
-	}
 
 	return true;
 }
@@ -701,947 +667,15 @@ copydb_close_snapshot(TransactionSnapshot *snapshot)
 
 	if (!pgsql_commit(pgsql))
 	{
-		/* errors have already been logged */
+		log_fatal("Failed to close snapshot \"%s\" on \"%s\"",
+				  snapshot->snapshot,
+				  snapshot->pguri);
 		return false;
 	}
 
 	(void) pgsql_finish(pgsql);
 
 	return true;
-}
-
-
-/*
- * copydb_table_data fetches the list of tables from the source database and
- * then run a pg_dump --data-only --schema ... --table ... | pg_restore on each
- * of them, using up to tblJobs sub-processes for that.
- *
- * Each subprocess also fetches a list of indexes for each given table, and
- * creates those indexes in parallel using up to idxJobs sub-processes for
- * that.
- */
-bool
-copydb_copy_all_table_data(CopyDataSpec *specs)
-{
-	SourceTableArray tableArray = { 0, NULL };
-	CopyTableDataSpecsArray *tableSpecsArray = &(specs->tableSpecsArray);
-
-	/*
-	 * First, we need to open a snapshot that we're going to re-use in all our
-	 * connections to the source database.
-	 */
-	TransactionSnapshot *sourceSnapshot = &(specs->sourceSnapshot);
-
-	if (!copydb_export_snapshot(sourceSnapshot))
-	{
-		log_fatal("Failed to export a snapshot on \"%s\"", sourceSnapshot->pguri);
-		return false;
-	}
-
-	/*
-	 * Check if we have large objects to take into account, because that's not
-	 * supported at the moment.
-	 */
-	if (!specs->skipLargeObjects)
-	{
-		int64_t largeObjectCount = 0;
-
-		if (!schema_count_large_objects(&(specs->sourceSnapshot.pgsql),
-										&largeObjectCount))
-		{
-			/* errors have already been logged */
-			return false;
-		}
-
-		if (largeObjectCount > 0)
-		{
-			log_fatal("pgcopydb version %s has no support for large objects, "
-					  "and we found %lld rows in pg_largeobject_metadata",
-					  PGCOPYDB_VERSION,
-					  (long long) largeObjectCount);
-			log_fatal("Consider using --skip-large-objects");
-			return false;
-		}
-	}
-
-	log_info("Listing ordinary tables in \"%s\"", specs->source_pguri);
-
-	/*
-	 * Now get the list of the tables we want to COPY over.
-	 */
-	if (!schema_list_ordinary_tables(&(specs->sourceSnapshot.pgsql),
-									 &tableArray))
-	{
-		/* errors have already been logged */
-		return false;
-	}
-
-	int count = tableArray.count;
-	int errors = 0;
-
-	/* only use as many processes as required */
-	if (count < specs->tableJobs)
-	{
-		specs->tableJobs = count;
-	}
-
-	log_info("Fetched information for %d tables, now starting %d processes",
-			 tableArray.count,
-			 specs->tableJobs);
-
-	specs->tableSpecsArray.count = count;
-	specs->tableSpecsArray.array =
-		(CopyTableDataSpec *) malloc(count * sizeof(CopyTableDataSpec));
-
-	/*
-	 * Prepare the copy specs for each table we have.
-	 */
-	for (int tableIndex = 0; tableIndex < tableArray.count; tableIndex++)
-	{
-		/* initialize our TableDataProcess entry now */
-		SourceTable *source = &(tableArray.array[tableIndex]);
-
-		/* okay now start the subprocess for this table */
-		CopyTableDataSpec *tableSpecs = &(tableSpecsArray->array[tableIndex]);
-
-		if (!copydb_init_table_specs(tableSpecs, specs, source))
-		{
-			/* errors have already been logged */
-			goto terminate;
-		}
-	}
-
-	/*
-	 * Now we have tableArray.count tables to migrate and we want to use
-	 * specs->tableJobs sub-processes to work on those migrations. Start the
-	 * processes, each sub-process walks through the array and pick the first
-	 * table that's not being processed already, until all has been done.
-	 */
-	if (!copydb_start_table_processes(specs))
-	{
-		log_fatal("Failed to start a sub-process to COPY the data");
-		(void) copydb_fatal_exit();
-	}
-
-	/*
-	 * Now is a good time to reset sequences: we're waiting for the TABLE DATA
-	 * sections and the CREATE INDEX, CONSTRAINTS and VACUUM ANALYZE to be done
-	 * with. Sequences can be reset to their expected values while the COPY are
-	 * still running, as COPY won't drain identifiers from the sequences
-	 * anyway.
-	 */
-	log_info("Reset the sequences values on the target database");
-
-	if (!copydb_copy_all_sequences(specs))
-	{
-		/* errors have already been logged */
-		++errors;
-	}
-
-terminate:
-
-	/* close the source transaction snapshot now */
-	if (!copydb_close_snapshot(sourceSnapshot))
-	{
-		log_fatal("Failed to close snapshot \"%s\" on \"%s\"",
-				  sourceSnapshot->snapshot,
-				  sourceSnapshot->pguri);
-		++errors;
-	}
-
-	/* now we have a unknown count of subprocesses still running */
-	if (!copydb_wait_for_subprocesses())
-	{
-		/* errors have already been logged */
-		++errors;
-	}
-
-	/*
-	 * Now that all the sub-processes are done, we can also unlink the index
-	 * concurrency semaphore.
-	 */
-	if (!semaphore_finish(&(specs->tableSemaphore)))
-	{
-		log_warn("Failed to remove table concurrency semaphore %d, "
-				 "see above for details",
-				 specs->tableSemaphore.semId);
-	}
-
-	if (!semaphore_finish(&(specs->indexSemaphore)))
-	{
-		log_warn("Failed to remove index concurrency semaphore %d, "
-				 "see above for details",
-				 specs->indexSemaphore.semId);
-	}
-
-	return errors == 0;
-}
-
-
-/*
- * copydb_copy_all_sequences fetches the list of sequences from the source
- * database and then for each of them runs a SELECT last_value, is_called FROM
- * the sequence on the source database and then calls SELECT setval(); on the
- * target database with the same values.
- */
-bool
-copydb_copy_all_sequences(CopyDataSpec *specs)
-{
-	/* re-use the main snapshot and transaction to list sequences */
-	PGSQL *src = &(specs->sourceSnapshot.pgsql);
-	PGSQL dst = { 0 };
-
-	if (!pgsql_init(&dst, specs->target_pguri, PGSQL_CONN_TARGET))
-	{
-		/* errors have already been logged */
-		return false;
-	}
-
-	SourceSequenceArray sequenceArray = { 0, NULL };
-
-	log_info("Listing sequences in \"%s\"", specs->source_pguri);
-
-	if (!schema_list_sequences(src, &sequenceArray))
-	{
-		/* errors have already been logged */
-		return false;
-	}
-
-	log_info("Fetched information for %d sequences", sequenceArray.count);
-
-	if (!pgsql_begin(&dst))
-	{
-		/* errors have already been logged */
-		return false;
-	}
-
-	int errors = 0;
-
-	for (int seqIndex = 0; seqIndex < sequenceArray.count; seqIndex++)
-	{
-		SourceSequence *seq = &(sequenceArray.array[seqIndex]);
-
-		char qname[BUFSIZE] = { 0 };
-
-		sformat(qname, sizeof(qname), "\"%s\".\"%s\"",
-				seq->nspname,
-				seq->relname);
-
-		if (!schema_get_sequence_value(src, seq))
-		{
-			/* just skip this one */
-			log_warn("Failed to get sequence values for %s", qname);
-			++errors;
-			continue;
-		}
-
-		if (!schema_set_sequence_value(&dst, seq))
-		{
-			/* just skip this one */
-			log_warn("Failed to set sequence values for %s", qname);
-			++errors;
-			continue;
-		}
-	}
-
-	if (!pgsql_commit(&dst))
-	{
-		/* errors have already been logged */
-		++errors;
-	}
-
-	return errors == 0;
-}
-
-
-/*
- * copydb_start_table_processes forks() as many as specs->tableJobs processes
- * that will all concurrently process TABLE DATA and then CREATE INDEX and then
- * also VACUUM ANALYZE each table.
- */
-bool
-copydb_start_table_processes(CopyDataSpec *specs)
-{
-	for (int i = 0; i < specs->tableJobs; i++)
-	{
-		/*
-		 * Flush stdio channels just before fork, to avoid double-output
-		 * problems.
-		 */
-		fflush(stdout);
-		fflush(stderr);
-
-		int fpid = fork();
-
-		switch (fpid)
-		{
-			case -1:
-			{
-				log_error("Failed to fork a worker process");
-				return false;
-			}
-
-			case 0:
-			{
-				/* child process runs the command */
-				if (!copydb_start_table_process(specs))
-				{
-					/* errors have already been logged */
-					exit(EXIT_CODE_INTERNAL_ERROR);
-				}
-
-				exit(EXIT_CODE_QUIT);
-			}
-
-			default:
-			{
-				/* fork succeeded, in parent */
-				break;
-			}
-		}
-	}
-
-	return copydb_wait_for_subprocesses();
-}
-
-
-/*
- * copydb_start_table_process stats a sub-process that walks through the array
- * of tables to COPY over from the source database to the target database.
- *
- * Each process walks through the entire array, and for each entry:
- *
- *  - acquires a semaphore to enter the critical section, alone
- *    - check if the current entry is already done, or being processed
- *    - if not, create the lock file
- *  - exit the critical section
- *  - if we created a lock file, process the selected table
- */
-bool
-copydb_start_table_process(CopyDataSpec *specs)
-{
-	int errors = 0;
-
-	CopyTableDataSpecsArray *tableSpecsArray = &(specs->tableSpecsArray);
-
-	/* connect once to the source database for the whole process */
-	if (!copydb_set_snapshot(&(specs->sourceSnapshot)))
-	{
-		/* errors have already been logged */
-		return false;
-	}
-
-	for (int tableIndex = 0; tableIndex < tableSpecsArray->count; tableIndex++)
-	{
-		/* initialize our TableDataProcess entry now */
-		CopyTableDataSpec *tableSpecs = &(tableSpecsArray->array[tableIndex]);
-
-		bool isBeingProcessed = false;
-
-		if (!copydb_table_is_being_processed(specs,
-											 tableSpecs,
-											 &isBeingProcessed))
-		{
-			/* errors have already been logged */
-			return false;
-		}
-
-		log_trace("%s isBeingProcessed: %s",
-				  tableSpecs->qname,
-				  isBeingProcessed ? "yes" : "no");
-
-		/* if the table is being processed, we should skip it now */
-		if (isBeingProcessed)
-		{
-			log_debug("Skipping table %s, already done or being processed",
-					  tableSpecs->qname);
-			continue;
-		}
-
-		/*
-		 * 1. Now COPY the TABLE DATA from the source to the destination.
-		 */
-		tableSpecs->sourceSnapshot = specs->sourceSnapshot;
-
-		if (!copydb_copy_table(tableSpecs))
-		{
-			/* errors have already been logged */
-			return false;
-		}
-
-		/* enter the critical section to communicate that we're done */
-		if (!copydb_mark_table_as_done(specs, tableSpecs))
-		{
-			/* errors have already been logged */
-			return false;
-		}
-
-		/*
-		 * 2. Fetch the list of indexes and constraints attached to this table.
-		 */
-		SourceIndexArray indexArray = { 0 };
-
-		tableSpecs->indexArray = &indexArray;
-
-		if (tableSpecs->section == DATA_SECTION_INDEXES ||
-			tableSpecs->section == DATA_SECTION_CONSTRAINTS ||
-			tableSpecs->section == DATA_SECTION_ALL)
-		{
-			if (!schema_list_table_indexes(&(tableSpecs->sourceSnapshot.pgsql),
-										   tableSpecs->sourceTable->nspname,
-										   tableSpecs->sourceTable->relname,
-										   tableSpecs->indexArray))
-			{
-				/* errors have already been logged */
-				++errors;
-			}
-
-			/* build the index file paths we need for the upcoming operations */
-			if (!copydb_init_indexes_paths(tableSpecs))
-			{
-				/* errors have already been logged */
-				++errors;
-			}
-		}
-
-		/*
-		 * 3. Now start the CREATE INDEX sub-processes for this table.
-		 *
-		 *    This starts a main sub-process that launches as many worker
-		 *    processes as indexes to be built concurrently, and waits until
-		 *    these CREATE INDEX commands are all done.
-		 *
-		 *    When the indexes are done being built, then the constraints are
-		 *    created in the main sub-process.
-		 */
-		if (!copydb_copy_table_indexes(tableSpecs))
-		{
-			log_warn("Failed to create all the indexes for %s, "
-					 "see above for details",
-					 tableSpecs->qname);
-			log_warn("Consider `pgcopydb copy indexes` to try again");
-			++errors;
-		}
-
-		/*
-		 * 4. Now start the VACUUM ANALYZE parts of the processing, in a
-		 *    concurrent sub-process. The sub-process is running in parallel to
-		 *    the CREATE INDEX and constraints processes.
-		 */
-		if (!copydb_start_vacuum_table(tableSpecs))
-		{
-			log_warn("Failed to VACUUM ANALYZE %s", tableSpecs->qname);
-			++errors;
-		}
-
-		/*
-		 * 4. Opportunistically see if some CREATE INDEX processed have
-		 *    finished already.
-		 */
-		if (!copydb_collect_finished_subprocesses())
-		{
-			/* errors have already been logged */
-			++errors;
-		}
-	}
-
-	/* terminate our connection to the source database now */
-	(void) pgsql_finish(&(specs->sourceSnapshot.pgsql));
-
-	/*
-	 * When this process has finished looping over all the tables in the table
-	 * array, then it waits until all the sub-processes are done. That's the
-	 * CREATE INDEX workers and the VACUUM workers.
-	 */
-	if (!copydb_wait_for_subprocesses())
-	{
-		/* errors have already been logged */
-		++errors;
-	}
-
-	return errors == 0;
-}
-
-
-/*
- * copydb_table_is_being_processed checks lock and done files to see if a given
- * table is already being processed, or has already been processed entirely by
- * another process. In which case the table is to be skipped by the current
- * process.
- */
-bool
-copydb_table_is_being_processed(CopyDataSpec *specs,
-								CopyTableDataSpec *tableSpecs,
-								bool *isBeingProcessed)
-{
-	/* enter the critical section */
-	(void) semaphore_lock(&(specs->tableSemaphore));
-
-	/*
-	 * If the doneFile exists, then the table has been processed already,
-	 * skip it.
-	 *
-	 * If the lockFile exists, then the table is currently being processed
-	 * by another worker process, skip it.
-	 */
-	if (file_exists(tableSpecs->tablePaths.doneFile) ||
-		file_exists(tableSpecs->tablePaths.lockFile))
-	{
-		*isBeingProcessed = true;
-		(void) semaphore_unlock(&(specs->tableSemaphore));
-		return true;
-	}
-
-	/*
-	 * Otherwise, the table is not being processed yet.
-	 */
-	*isBeingProcessed = false;
-
-	/*
-	 * First, write the lockFile, with a summary of what's going-on.
-	 */
-	CopyTableSummary emptySummary = { 0 };
-	CopyTableSummary *summary =
-		(CopyTableSummary *) malloc(sizeof(CopyTableSummary));
-
-	*summary = emptySummary;
-
-	summary->pid = getpid();
-	summary->table = tableSpecs->sourceTable;
-
-	sformat(summary->command, sizeof(summary->command),
-			"COPY %s;",
-			tableSpecs->qname);
-
-	if (!open_table_summary(summary, tableSpecs->tablePaths.lockFile))
-	{
-		log_info("Failed to create the lock file at \"%s\"",
-				 tableSpecs->tablePaths.lockFile);
-
-		/* end of the critical section */
-		(void) semaphore_unlock(&(specs->tableSemaphore));
-
-		return false;
-	}
-
-	/* attach the new summary to the tableSpecs, where it was NULL before */
-	tableSpecs->summary = summary;
-
-	/* end of the critical section */
-	(void) semaphore_unlock(&(specs->tableSemaphore));
-
-	return true;
-}
-
-
-/*
- * copydb_mark_table_as_done creates the table doneFile with the expected
- * summary content. To create a doneFile we must acquire the synchronisation
- * semaphore first. The lockFile is also removed here.
- */
-bool
-copydb_mark_table_as_done(CopyDataSpec *specs,
-						  CopyTableDataSpec *tableSpecs)
-{
-	/* enter the critical section to communicate that we're done */
-	(void) semaphore_lock(&(specs->tableSemaphore));
-
-	if (!unlink_file(tableSpecs->tablePaths.lockFile))
-	{
-		log_error("Failed to remove the lockFile \"%s\"",
-				  tableSpecs->tablePaths.lockFile);
-		(void) semaphore_unlock(&(specs->tableSemaphore));
-		return false;
-	}
-
-	/* write the doneFile with the summary and timings now */
-	if (!finish_table_summary(tableSpecs->summary,
-							  tableSpecs->tablePaths.doneFile))
-	{
-		log_info("Failed to create the summary file at \"%s\"",
-				 tableSpecs->tablePaths.doneFile);
-		(void) semaphore_unlock(&(specs->tableSemaphore));
-		return false;
-	}
-
-	/* end of the critical section */
-	(void) semaphore_unlock(&(specs->tableSemaphore));
-
-	return true;
-}
-
-
-/*
- * copydb_copy_table implements the sub-process activity to pg_dump |
- * pg_restore the table's data and then create the indexes and the constraints
- * in parallel.
- */
-bool
-copydb_copy_table(CopyTableDataSpec *tableSpecs)
-{
-	/* we want to set transaction snapshot to the main one on the source */
-	PGSQL *src = &(tableSpecs->sourceSnapshot.pgsql);
-	PGSQL dst = { 0 };
-
-	CopyTableSummary *summary = tableSpecs->summary;
-
-	/* initialize our connection to the target database */
-	if (!pgsql_init(&dst, tableSpecs->target_pguri, PGSQL_CONN_TARGET))
-	{
-		/* errors have already been logged */
-		return false;
-	}
-
-	/* COPY the data from the source table to the target table */
-	if (tableSpecs->section == DATA_SECTION_TABLE_DATA ||
-		tableSpecs->section == DATA_SECTION_ALL)
-	{
-		/* Now copy the data from source to target */
-		log_info("%s", summary->command);
-
-		if (!pg_copy(src, &dst, tableSpecs->qname, tableSpecs->qname))
-		{
-			/* errors have already been logged */
-			return false;
-		}
-	}
-
-	return true;
-}
-
-
-/*
- * copydb_copy_table_indexes fetches the index definitions attached to the
- * given source table, and starts as many processes as we have definitions to
- * create all indexes in parallel to each other.
- */
-bool
-copydb_copy_table_indexes(CopyTableDataSpec *tableSpecs)
-{
-	if (tableSpecs->section != DATA_SECTION_INDEXES &&
-		tableSpecs->section != DATA_SECTION_ALL)
-	{
-		return true;
-	}
-
-	/*
-	 * Indexes are created all-at-once in parallel, a sub-process is
-	 * forked per index definition to send each SQL/DDL command to the
-	 * Postgres server.
-	 */
-	if (tableSpecs->indexArray->count >= 1)
-	{
-		log_info("Creating %d index%s for table %s",
-				 tableSpecs->indexArray->count,
-				 tableSpecs->indexArray->count > 1 ? "es" : "",
-				 tableSpecs->qname);
-	}
-	else
-	{
-		log_debug("Table %s has no index attached", tableSpecs->qname);
-		return true;
-	}
-
-	/*
-	 * Flush stdio channels just before fork, to avoid double-output problems.
-	 */
-	fflush(stdout);
-	fflush(stderr);
-
-	int fpid = fork();
-
-	switch (fpid)
-	{
-		case -1:
-		{
-			log_error("Failed to fork a worker process");
-			return false;
-		}
-
-		case 0:
-		{
-			/* child process runs the command */
-			if (!copydb_start_create_indexes(tableSpecs))
-			{
-				log_error("Failed to create indexes, see above for details");
-				exit(EXIT_CODE_INTERNAL_ERROR);
-			}
-
-			/*
-			 * When done as part of the full copy, we also create each index's
-			 * constraint as soon as the parallel index built is done.
-			 */
-			if (tableSpecs->section == DATA_SECTION_ALL)
-			{
-				if (!copydb_create_constraints(tableSpecs))
-				{
-					log_error("Failed to create constraints, "
-							  "see above for details");
-					exit(EXIT_CODE_INTERNAL_ERROR);
-				}
-			}
-
-			/*
-			 * Create an index list file for the table, so that we can easily
-			 * find relevant indexing information from the table itself.
-			 */
-			if (!create_table_index_file(tableSpecs->summary,
-										 tableSpecs->indexArray,
-										 tableSpecs->tablePaths.idxListFile))
-			{
-				/* this only means summary is missing some indexing information */
-				log_warn("Failed to create table %s index list file \"%s\"",
-						 tableSpecs->qname,
-						 tableSpecs->tablePaths.idxListFile);
-			}
-
-			exit(EXIT_CODE_QUIT);
-		}
-
-		default:
-		{
-			/* fork succeeded, in parent */
-			break;
-		}
-	}
-
-	/* now we're done, and we want async behavior, do not wait */
-	return true;
-}
-
-
-/*
- * copydb_start_create_indexes creates all the indexes for a given table in
- * parallel, using a sub-process to send each index command.
- */
-bool
-copydb_start_create_indexes(CopyTableDataSpec *tableSpecs)
-{
-	SourceTable *sourceTable = tableSpecs->sourceTable;
-	SourceIndexArray *indexArray = tableSpecs->indexArray;
-
-	for (int i = 0; i < indexArray->count; i++)
-	{
-		/*
-		 * Fork a sub-process for each index, so that they're created in
-		 * parallel. Flush stdio channels just before fork, to avoid
-		 * double-output problems.
-		 */
-		fflush(stdout);
-		fflush(stderr);
-
-		/* time to create the node_active sub-process */
-		int fpid = fork();
-
-		switch (fpid)
-		{
-			case -1:
-			{
-				log_error("Failed to fork a process for creating index for "
-						  "table \"%s\".\"%s\"",
-						  sourceTable->nspname,
-						  sourceTable->relname);
-				return -1;
-			}
-
-			case 0:
-			{
-				/* child process runs the command */
-				if (!copydb_create_index(tableSpecs, i))
-				{
-					/* errors have already been logged */
-					exit(EXIT_CODE_INTERNAL_ERROR);
-				}
-
-				exit(EXIT_CODE_QUIT);
-			}
-
-			default:
-			{
-				/* fork succeeded, in parent */
-				break;
-			}
-		}
-	}
-
-	/*
-	 * Here we need to be sync, so that the caller can continue with creating
-	 * the constraints from the indexes right when all the indexes have been
-	 * built.
-	 */
-	return copydb_wait_for_subprocesses();
-}
-
-
-/*
- * copydb_create_indexes creates all the indexes for a given table in
- * parallel, using a sub-process to send each index command.
- */
-bool
-copydb_create_index(CopyTableDataSpec *tableSpecs, int idx)
-{
-	IndexFilePaths *indexPaths = &(tableSpecs->indexPathsArray.array[idx]);
-	SourceIndexArray *indexArray = tableSpecs->indexArray;
-	SourceIndex *index = &(indexArray->array[idx]);
-
-	const char *pguri = tableSpecs->target_pguri;
-	PGSQL dst = { 0 };
-
-	/* First, write the lockFile, with a summary of what's going-on */
-	CopyIndexSummary summary = {
-		.pid = getpid(),
-		.index = index,
-		.command = { 0 }
-	};
-
-	/* prepare the CREATE INDEX command, adding IF NOT EXISTS */
-	if (tableSpecs->section == DATA_SECTION_INDEXES)
-	{
-		int ci_len = strlen("CREATE INDEX ");
-		int cu_len = strlen("CREATE UNIQUE INDEX ");
-
-		if (strncmp(index->indexDef, "CREATE INDEX ", ci_len) == 0)
-		{
-			sformat(summary.command, sizeof(summary.command),
-					"CREATE INDEX IF NOT EXISTS %s;",
-					index->indexDef + ci_len);
-		}
-		else if (strncmp(index->indexDef, "CREATE UNIQUE INDEX ", cu_len) == 0)
-		{
-			sformat(summary.command, sizeof(summary.command),
-					"CREATE UNIQUE INDEX IF NOT EXISTS %s;",
-					index->indexDef + cu_len);
-		}
-		else
-		{
-			log_error("Failed to parse \"%s\"", index->indexDef);
-			return false;
-		}
-	}
-	else
-	{
-		/*
-		 * Just use the pg_get_indexdef() command, with an added semi-colon for
-		 * logging clarity.
-		 */
-		sformat(summary.command, sizeof(summary.command),
-				"%s;",
-				index->indexDef);
-	}
-
-	if (!open_index_summary(&summary, indexPaths->lockFile))
-	{
-		log_info("Failed to create the lock file at \"%s\"",
-				 indexPaths->lockFile);
-		return false;
-	}
-
-	/* now grab an index semaphore lock */
-	(void) semaphore_lock(tableSpecs->indexSemaphore);
-
-	if (!pgsql_init(&dst, (char *) pguri, PGSQL_CONN_TARGET))
-	{
-		/* errors have already been logged */
-		exit(EXIT_CODE_TARGET);
-	}
-
-	log_info("%s", summary.command);
-
-	if (!pgsql_execute(&dst, summary.command))
-	{
-		/* errors have already been logged */
-		(void) semaphore_unlock(tableSpecs->indexSemaphore);
-		exit(EXIT_CODE_TARGET);
-	}
-
-	/* the CREATE INDEX command is done, release our lock */
-	(void) semaphore_unlock(tableSpecs->indexSemaphore);
-
-	/* create the doneFile for the index */
-	if (!finish_index_summary(&summary, indexPaths->doneFile))
-	{
-		log_info("Failed to create the summary file at \"%s\"",
-				 indexPaths->doneFile);
-		return false;
-	}
-
-	/* also remove the lockFile, we don't need it anymore */
-	if (!unlink_file(indexPaths->lockFile))
-	{
-		/* just continue, this is not a show-stopper */
-		log_warn("Failed to remove the lockFile \"%s\"", indexPaths->lockFile);
-	}
-
-	return true;
-}
-
-
-/*
- * copydb_create_constraints loops over the index definitions for a given table
- * and creates all the associated constraints, one after the other.
- */
-bool
-copydb_create_constraints(CopyTableDataSpec *tableSpecs)
-{
-	int errors = 0;
-	SourceIndexArray *indexArray = tableSpecs->indexArray;
-
-	const char *pguri = tableSpecs->target_pguri;
-	PGSQL dst = { 0 };
-
-	if (!pgsql_init(&dst, (char *) pguri, PGSQL_CONN_TARGET))
-	{
-		/* errors have already been logged */
-		return false;
-	}
-
-	for (int i = 0; i < indexArray->count; i++)
-	{
-		SourceIndex *index = &(indexArray->array[i]);
-		IndexFilePaths *indexPaths = &(tableSpecs->indexPathsArray.array[i]);
-
-		if (index->constraintOid > 0 &&
-			!IS_EMPTY_STRING_BUFFER(index->constraintName))
-		{
-			char sql[BUFSIZE] = { 0 };
-
-			sformat(sql, sizeof(sql),
-					"ALTER TABLE \"%s\".\"%s\" "
-					"ADD CONSTRAINT \"%s\" %s "
-					"USING INDEX \"%s\"",
-					index->tableNamespace,
-					index->tableRelname,
-					index->constraintName,
-					index->isPrimary
-					? "PRIMARY KEY"
-					: (index->isUnique ? "UNIQUE" : ""),
-					index->indexRelname);
-
-			log_info("%s;", sql);
-
-			if (!pgsql_execute(&dst, sql))
-			{
-				/* errors have already been logged */
-				return false;
-			}
-
-			/* create the doneFile for the constraint */
-			char contents[BUFSIZE] = { 0 };
-
-			sformat(contents, sizeof(contents), "%s;\n", sql);
-
-			if (!write_file(contents,
-							strlen(contents),
-							indexPaths->constraintDoneFile))
-			{
-				log_warn("Failed to create the constraint done file");
-				log_warn("Restoring the --post-data part of the schema "
-						 "might fail because of already existing objects");
-			}
-		}
-	}
-
-	return errors == 0;
 }
 
 

--- a/src/bin/pgcopydb/dump_restore.c
+++ b/src/bin/pgcopydb/dump_restore.c
@@ -1,0 +1,284 @@
+/*
+ * src/bin/pgcopydb/dump_restore.c
+ *     Implementation of a CLI to copy a database between two Postgres instances
+ */
+
+#include <errno.h>
+#include <getopt.h>
+#include <inttypes.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "cli_common.h"
+#include "cli_copy.h"
+#include "cli_root.h"
+#include "copydb.h"
+#include "env_utils.h"
+#include "lock_utils.h"
+#include "log.h"
+#include "pidfile.h"
+#include "schema.h"
+#include "signals.h"
+#include "string_utils.h"
+#include "summary.h"
+
+
+/*
+ * copydb_objectid_has_been_processed_already returns true when a doneFile
+ * could be found on-disk for the given target object OID.
+ */
+bool
+copydb_objectid_has_been_processed_already(CopyDataSpec *specs, uint32_t oid)
+{
+	char doneFile[MAXPGPATH] = { 0 };
+
+	/* build the doneFile for the target index or constraint */
+	sformat(doneFile, sizeof(doneFile), "%s/%u.done",
+			specs->cfPaths.idxdir,
+			oid);
+
+	if (file_exists(doneFile))
+	{
+		char *sql = NULL;
+		long size = 0L;
+
+		if (!read_file(doneFile, &sql, &size))
+		{
+			/* no worries, just skip then */
+		}
+
+		/* we're interested in the last line of the file */
+		char *lines[BUFSIZE] = { 0 };
+		int lineCount = splitLines(sql, lines, BUFSIZE);
+
+		log_debug("Skipping dumpId %d (%s)", oid, lines[lineCount - 1]);
+
+		/* read_file allocates memory */
+		free(sql);
+
+		return true;
+	}
+
+	return false;
+}
+
+
+/*
+ * copydb_dump_source_schema uses pg_dump -Fc --schema --section=pre-data or
+ * --section=post-data to dump the source database schema to files.
+ */
+bool
+copydb_dump_source_schema(CopyDataSpec *specs, PostgresDumpSection section)
+{
+	if (section == PG_DUMP_SECTION_SCHEMA ||
+		section == PG_DUMP_SECTION_PRE_DATA ||
+		section == PG_DUMP_SECTION_ALL)
+	{
+		if (file_exists(specs->cfPaths.done.preDataDump))
+		{
+			log_info("Skipping pg_dump --section=pre-data, "
+					 "as \"%s\" already exists",
+					 specs->cfPaths.done.preDataDump);
+		}
+		else if (!pg_dump_db(&(specs->pgPaths),
+							 specs->source_pguri,
+							 "pre-data",
+							 specs->dumpPaths.preFilename))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+
+		/* now write the doneFile to keep track */
+		if (!write_file("", 0, specs->cfPaths.done.preDataDump))
+		{
+			log_error("Failed to write the tracking file \%s\"",
+					  specs->cfPaths.done.preDataDump);
+			return false;
+		}
+	}
+
+	if (section == PG_DUMP_SECTION_SCHEMA ||
+		section == PG_DUMP_SECTION_POST_DATA ||
+		section == PG_DUMP_SECTION_ALL)
+	{
+		if (file_exists(specs->cfPaths.done.postDataDump))
+		{
+			log_info("Skipping pg_dump --section=post-data, "
+					 "as \"%s\" already exists",
+					 specs->cfPaths.done.postDataDump);
+		}
+		else if (!pg_dump_db(&(specs->pgPaths),
+							 specs->source_pguri,
+							 "post-data",
+							 specs->dumpPaths.postFilename))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+
+		/* now write the doneFile to keep track */
+		if (!write_file("", 0, specs->cfPaths.done.postDataDump))
+		{
+			log_error("Failed to write the tracking file \%s\"",
+					  specs->cfPaths.done.postDataDump);
+			return false;
+		}
+	}
+
+	return true;
+}
+
+
+/*
+ * copydb_target_prepare_schema restores the pre.dump file into the target
+ * database.
+ */
+bool
+copydb_target_prepare_schema(CopyDataSpec *specs)
+{
+	if (!file_exists(specs->dumpPaths.preFilename))
+	{
+		log_fatal("File \"%s\" does not exists", specs->dumpPaths.preFilename);
+		return false;
+	}
+
+	if (file_exists(specs->cfPaths.done.preDataRestore))
+	{
+		log_info("Skipping pg_restore of pre-data section, "
+				 "done on a previous run");
+		return true;
+	}
+
+	if (!pg_restore_db(&(specs->pgPaths),
+					   specs->target_pguri,
+					   specs->dumpPaths.preFilename,
+					   NULL,
+					   specs->dropIfExists,
+					   specs->noOwner))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now write the doneFile to keep track */
+	if (!write_file("", 0, specs->cfPaths.done.preDataRestore))
+	{
+		log_error("Failed to write the tracking file \%s\"",
+				  specs->cfPaths.done.preDataRestore);
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * copydb_target_finalize_schema finalizes the schema after all the data has
+ * been copied over, and after indexes and their constraints have been created
+ * too.
+ */
+bool
+copydb_target_finalize_schema(CopyDataSpec *specs)
+{
+	if (!file_exists(specs->dumpPaths.postFilename))
+	{
+		log_fatal("File \"%s\" does not exists", specs->dumpPaths.postFilename);
+		return false;
+	}
+
+	if (file_exists(specs->cfPaths.done.postDataRestore))
+	{
+		log_info("Skipping pg_restore --section=pre-data, "
+				 "done on a previous run");
+		return true;
+	}
+
+	/*
+	 * The post.dump archive file contains all the objects to create once the
+	 * table data has been copied over. It contains in particular the
+	 * constraints and indexes that we have already built concurrently in the
+	 * previous step, so we want to filter those out.
+	 *
+	 * Here's how to filter out some objects with pg_restore:
+	 *
+	 *   1. pg_restore -f- --list post.dump > post.list
+	 *   2. edit post.list to comment out lines
+	 *   3. pg_restore --use-list post.list post.dump
+	 */
+	ArchiveContentArray contents = { 0 };
+
+	if (!pg_restore_list(&(specs->pgPaths),
+						 specs->dumpPaths.postFilename,
+						 &contents))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* edit our post.list file now */
+	PQExpBuffer listContents = createPQExpBuffer();
+
+	if (listContents == NULL)
+	{
+		log_error(ALLOCATION_FAILED_ERROR);
+		free(listContents);
+		return false;
+	}
+
+	/* for each object in the list, comment when we already processed it */
+	for (int i = 0; i < contents.count; i++)
+	{
+		uint32_t oid = contents.array[i].objectOid;
+
+		/* commenting is done by prepending ";" as prefix to the line */
+		char *prefix =
+			copydb_objectid_has_been_processed_already(specs, oid) ? ";" : "";
+
+		appendPQExpBuffer(listContents, "%s%d; %u %u\n",
+						  prefix,
+						  contents.array[i].dumpId,
+						  contents.array[i].catalogOid,
+						  contents.array[i].objectOid);
+	}
+
+	/* memory allocation could have failed while building string */
+	if (PQExpBufferBroken(listContents))
+	{
+		log_error("Failed to create pg_restore list file: out of memory");
+		destroyPQExpBuffer(listContents);
+		return false;
+	}
+
+	if (!write_file(listContents->data,
+					listContents->len,
+					specs->dumpPaths.listFilename))
+	{
+		/* errors have already been logged */
+		destroyPQExpBuffer(listContents);
+		return false;
+	}
+
+	destroyPQExpBuffer(listContents);
+
+	if (!pg_restore_db(&(specs->pgPaths),
+					   specs->target_pguri,
+					   specs->dumpPaths.postFilename,
+					   specs->dumpPaths.listFilename,
+					   specs->dropIfExists,
+					   specs->noOwner))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now write the doneFile to keep track */
+	if (!write_file("", 0, specs->cfPaths.done.postDataRestore))
+	{
+		log_error("Failed to write the tracking file \%s\"",
+				  specs->cfPaths.done.postDataRestore);
+		return false;
+	}
+
+	return true;
+}

--- a/src/bin/pgcopydb/indexes.c
+++ b/src/bin/pgcopydb/indexes.c
@@ -1,0 +1,561 @@
+/*
+ * src/bin/pgcopydb/indexes.c
+ *     Implementation of a CLI to copy a database between two Postgres instances
+ */
+
+#include <errno.h>
+#include <getopt.h>
+#include <inttypes.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "cli_common.h"
+#include "cli_copy.h"
+#include "cli_root.h"
+#include "copydb.h"
+#include "env_utils.h"
+#include "lock_utils.h"
+#include "log.h"
+#include "pidfile.h"
+#include "schema.h"
+#include "signals.h"
+#include "string_utils.h"
+#include "summary.h"
+
+
+/*
+ * copydb_init_index_file_paths prepares a given index (and constraint) file
+ * paths to help orchestrate the concurrent operations.
+ */
+bool
+copydb_init_indexes_paths(CopyFilePaths *cfPaths,
+						  SourceIndexArray *indexArray,
+						  IndexFilePathsArray *indexPathsArray)
+{
+	indexPathsArray->count = indexArray->count;
+	indexPathsArray->array =
+		(IndexFilePaths *) malloc(indexArray->count * sizeof(IndexFilePaths));
+
+	for (int i = 0; i < indexArray->count; i++)
+	{
+		SourceIndex *index = &(indexArray->array[i]);
+		IndexFilePaths *indexPaths = &(indexPathsArray->array[i]);
+
+		sformat(indexPaths->lockFile, sizeof(indexPaths->lockFile),
+				"%s/%u",
+				cfPaths->rundir,
+				index->indexOid);
+
+		sformat(indexPaths->doneFile, sizeof(indexPaths->doneFile),
+				"%s/%u.done",
+				cfPaths->idxdir,
+				index->indexOid);
+
+		sformat(indexPaths->constraintDoneFile,
+				sizeof(indexPaths->constraintDoneFile),
+				"%s/%u.done",
+				cfPaths->idxdir,
+				index->constraintOid);
+	}
+
+	return true;
+}
+
+
+/*
+ * copydb_copy_all_indexes fetches the list of indexes from the source database
+ * and then create all the same indexes on the target database, which is
+ * expected to have the same tables created already.
+ */
+bool
+copydb_copy_all_indexes(CopyDataSpec *specs)
+{
+	if (specs->dirState.indexCopyIsDone)
+	{
+		log_info("Skipping indexes, already done on a previous run");
+		return true;
+	}
+
+	if (specs->section != DATA_SECTION_INDEXES &&
+		specs->section != DATA_SECTION_CONSTRAINTS &&
+		specs->section != DATA_SECTION_ALL)
+	{
+		log_debug("Skipping indexes in section %d", specs->section);
+		return true;
+	}
+
+	PGSQL src = { 0 };
+	SourceIndexArray indexArray = { 0, NULL };
+	IndexFilePathsArray indexPathsArray = { 0, NULL };
+
+	log_info("Listing indexes in \"%s\"", specs->source_pguri);
+
+	if (!pgsql_init(&src, specs->source_pguri, PGSQL_CONN_SOURCE))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	if (!schema_list_all_indexes(&src, &indexArray))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* build the index file paths we need for the upcoming operations */
+	if (!copydb_init_indexes_paths(&(specs->cfPaths),
+								   &indexArray,
+								   &indexPathsArray))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	log_info("Creating %d indexes in the target database using %d processed",
+			 indexArray.count,
+			 specs->indexJobs);
+
+	if (!copydb_start_index_processes(specs, &indexArray, &indexPathsArray))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* free malloc'ed memory area */
+	free(indexArray.array);
+	free(indexPathsArray.array);
+
+	return false;
+}
+
+
+/*
+ * copydb_start_index_processes forks() as many as specs->indexJobs processes
+ * that will all concurrently run the CREATE INDEX needed to copy the indexes
+ * from the source database to the target database.
+ */
+bool
+copydb_start_index_processes(CopyDataSpec *specs,
+							 SourceIndexArray *indexArray,
+							 IndexFilePathsArray *indexPathsArray)
+{
+	Semaphore lockFileSemaphore = { 0 };
+
+	lockFileSemaphore.initValue = 1;
+
+	if (!semaphore_create(&lockFileSemaphore))
+	{
+		log_error("Failed to create the same-index concurrency semaphore "
+				  "to orchestrate %d CREATE INDEX jobs",
+				  specs->indexJobs);
+		return false;
+	}
+
+	for (int i = 0; i < specs->indexJobs; i++)
+	{
+		/*
+		 * Flush stdio channels just before fork, to avoid double-output
+		 * problems.
+		 */
+		fflush(stdout);
+		fflush(stderr);
+
+		int fpid = fork();
+
+		switch (fpid)
+		{
+			case -1:
+			{
+				log_error("Failed to fork a worker process");
+				return false;
+			}
+
+			case 0:
+			{
+				/* child process runs the command */
+				if (!copydb_start_index_process(specs,
+												indexArray,
+												indexPathsArray,
+												&lockFileSemaphore))
+				{
+					/* errors have already been logged */
+					exit(EXIT_CODE_INTERNAL_ERROR);
+				}
+
+				exit(EXIT_CODE_QUIT);
+			}
+
+			default:
+			{
+				/* fork succeeded, in parent */
+				break;
+			}
+		}
+	}
+
+	bool success = copydb_wait_for_subprocesses();
+
+	/* and write that we successfully finished copying all tables */
+	if (!write_file("", 0, specs->cfPaths.done.indexes))
+	{
+		log_warn("Failed to write the tracking file \%s\"",
+				 specs->cfPaths.done.indexes);
+	}
+
+	if (!semaphore_finish(&lockFileSemaphore))
+	{
+		log_warn("Failed to remove same-index concurrency semaphore %d, "
+				 "see above for details",
+				 lockFileSemaphore.semId);
+	}
+
+	return success;
+}
+
+
+/*
+ * copydb_start_index_process stats a sub-process that walks through the array
+ * of indexes to copy over from the source database to the target database.
+ *
+ * Each process walks through the entire array, and for each entry:
+ *
+ *  - acquires a semaphore to enter the critical section, alone
+ *    - check if the current entry is already done, or being processed
+ *    - if not, create the lock file
+ *  - exit the critical section
+ *  - if we created a lock file, process the selected table
+ */
+bool
+copydb_start_index_process(CopyDataSpec *specs,
+						   SourceIndexArray *indexArray,
+						   IndexFilePathsArray *indexPathsArray,
+						   Semaphore *lockFileSemaphore)
+{
+	int errors = 0;
+
+	for (int i = 0; i < indexArray->count; i++)
+	{
+		SourceIndex *index = &(indexArray->array[i]);
+		IndexFilePaths *indexPaths = &(indexPathsArray->array[i]);
+
+		bool ifNotExists = true;
+
+		if (!copydb_create_index(specs->target_pguri,
+								 index,
+								 indexPaths,
+								 lockFileSemaphore,
+								 &(specs->indexSemaphore),
+								 ifNotExists))
+		{
+			/* errors have already been logged */
+			++errors;
+			continue;
+		}
+	}
+
+	if (!copydb_wait_for_subprocesses())
+	{
+		/* errors have already been logged */
+		++errors;
+	}
+
+	return errors == 0;
+}
+
+
+/*
+ * copydb_create_indexes creates all the indexes for a given table in
+ * parallel, using a sub-process to send each index command.
+ *
+ * This function uses two distinct semaphores:
+ *
+ * - the lockFileSemaphore allows multiple worker process to lock around the
+ *   choice of the next index to process, guaranteeing that any single index is
+ *   processed by only one worker: same-index concurrency.
+ *
+ * - the createIndexSemaphore should be initialized with indexJobs as its
+ *   initValue to enable creating up to that number of indexes at the same time
+ *   on the target system.
+ */
+bool
+copydb_create_index(const char *pguri,
+					SourceIndex *index,
+					IndexFilePaths *indexPaths,
+					Semaphore *lockFileSemaphore,
+					Semaphore *createIndexSemaphore,
+					bool ifNotExists)
+{
+	PGSQL dst = { 0 };
+
+	/* First, write the lockFile, with a summary of what's going-on */
+	CopyIndexSummary summary = {
+		.pid = getpid(),
+		.index = index,
+		.command = { 0 }
+	};
+
+	bool isDone = false;
+	bool isBeingProcessed = false;
+
+	/* deal with same-index concurrency if we have to */
+	if (!copydb_index_is_being_processed(index,
+										 indexPaths,
+										 lockFileSemaphore,
+										 &summary,
+										 &isDone,
+										 &isBeingProcessed))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	if (isDone || isBeingProcessed)
+	{
+		log_debug("Skipping index %s which is being created by another process",
+				  index->indexRelname);
+		return true;
+	}
+
+	/* now grab an index semaphore lock to deal if we have one */
+	(void) semaphore_lock(createIndexSemaphore);
+
+	/* prepare the create index command, maybe adding IF NOT EXISTS */
+	if (!copydb_prepare_create_index_command(index,
+											 ifNotExists,
+											 summary.command,
+											 sizeof(summary.command)))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	log_info("%s", summary.command);
+
+	if (!pgsql_init(&dst, (char *) pguri, PGSQL_CONN_TARGET))
+	{
+		/* errors have already been logged */
+		(void) semaphore_unlock(createIndexSemaphore);
+		return false;
+	}
+
+	if (!pgsql_execute(&dst, summary.command))
+	{
+		/* errors have already been logged */
+		(void) semaphore_unlock(createIndexSemaphore);
+		return false;
+	}
+
+	/* the CREATE INDEX command is done, release our lock */
+	(void) semaphore_unlock(createIndexSemaphore);
+
+	if (!copydb_mark_index_as_done(index,
+								   indexPaths,
+								   lockFileSemaphore,
+								   &summary))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * copydb_index_is_being_processed checks lock and done files to see if a given
+ * index is already being processed, or has been processed entirely by another
+ * process. In which case the index is to be skipped by the current process.
+ */
+bool
+copydb_index_is_being_processed(SourceIndex *index,
+								IndexFilePaths *indexPaths,
+								Semaphore *lockFileSemaphore,
+								CopyIndexSummary *summary,
+								bool *isDone,
+								bool *isBeingProcessed)
+{
+	/* some callers have no same-index concurrency, just create the lockFile */
+	if (lockFileSemaphore == NULL)
+	{
+		if (!open_index_summary(summary, indexPaths->lockFile))
+		{
+			log_info("Failed to create the lock file at \"%s\"",
+					 indexPaths->lockFile);
+			(void) semaphore_unlock(lockFileSemaphore);
+			return false;
+		}
+
+		*isDone = false;
+		*isBeingProcessed = false;
+
+		return true;
+	}
+
+	/* enter the critical section */
+	(void) semaphore_lock(lockFileSemaphore);
+
+	if (file_exists(indexPaths->doneFile))
+	{
+		*isDone = true;
+		*isBeingProcessed = false;
+		(void) semaphore_unlock(lockFileSemaphore);
+
+		return true;
+	}
+
+	/* okay so it's not done yet */
+	*isDone = false;
+
+	/* check if the lockFile has already been claimed for this index */
+	if (file_exists(indexPaths->lockFile))
+	{
+		CopyIndexSummary indexSummary = { .index = index };
+
+		if (!read_index_summary(&indexSummary, indexPaths->lockFile))
+		{
+			/* errors have already been logged */
+			(void) semaphore_unlock(lockFileSemaphore);
+			return false;
+		}
+
+		/* if we can signal the pid, it is still running */
+		if (kill(indexSummary.pid, 0) == 0)
+		{
+			*isBeingProcessed = true;
+			(void) semaphore_unlock(lockFileSemaphore);
+
+			log_debug("Skipping index %s processed by concurrent worker %d",
+					  index->indexRelname, indexSummary.pid);
+
+			return true;
+		}
+		else
+		{
+			log_warn("Found stale pid %d in file \"%s\", removing it "
+					 "and creating index %s",
+					 indexSummary.pid,
+					 indexPaths->lockFile,
+					 index->indexRelname);
+
+			/* stale pid, remove the old lockFile now, then process index */
+			if (!unlink_file(indexPaths->lockFile))
+			{
+				log_error("Failed to remove the lockFile \"%s\"",
+						  indexPaths->lockFile);
+				(void) semaphore_unlock(lockFileSemaphore);
+				return false;
+			}
+		}
+	}
+
+	/*
+	 * Otherwise, the index is not being processed yet.
+	 */
+	*isBeingProcessed = false;
+
+	if (!open_index_summary(summary, indexPaths->lockFile))
+	{
+		log_info("Failed to create the lock file at \"%s\"",
+				 indexPaths->lockFile);
+		(void) semaphore_unlock(lockFileSemaphore);
+		return false;
+	}
+
+	/* end of the critical section */
+	(void) semaphore_unlock(lockFileSemaphore);
+
+	return true;
+}
+
+
+/*
+ * copydb_mark_index_as_done creates the table doneFile with the expected
+ * summary content. To create a doneFile we must acquire the synchronisation
+ * semaphore first. The lockFile is also removed here.
+ */
+bool
+copydb_mark_index_as_done(SourceIndex *index,
+						  IndexFilePaths *indexPaths,
+						  Semaphore *lockFileSemaphore,
+						  CopyIndexSummary *summary)
+{
+	if (lockFileSemaphore != NULL)
+	{
+		(void) semaphore_lock(lockFileSemaphore);
+	}
+
+	/* create the doneFile for the index */
+	if (!finish_index_summary(summary, indexPaths->doneFile))
+	{
+		log_info("Failed to create the summary file at \"%s\"",
+				 indexPaths->doneFile);
+
+		if (lockFileSemaphore != NULL)
+		{
+			(void) semaphore_unlock(lockFileSemaphore);
+		}
+		return false;
+	}
+
+	/* also remove the lockFile, we don't need it anymore */
+	if (!unlink_file(indexPaths->lockFile))
+	{
+		log_error("Failed to remove the lockFile \"%s\"", indexPaths->lockFile);
+		if (lockFileSemaphore != NULL)
+		{
+			(void) semaphore_unlock(lockFileSemaphore);
+		}
+		return false;
+	}
+
+	if (lockFileSemaphore != NULL)
+	{
+		(void) semaphore_unlock(lockFileSemaphore);
+	}
+
+	return true;
+}
+
+
+/*
+ * copydb_prepare_create_index_command prepares the
+ */
+bool
+copydb_prepare_create_index_command(SourceIndex *index,
+									bool ifNotExists,
+									char *command,
+									size_t size)
+{
+	/* prepare the create index command, maybe adding IF NOT EXISTS */
+	if (ifNotExists)
+	{
+		int ci_len = strlen("CREATE INDEX ");
+		int cu_len = strlen("CREATE UNIQUE INDEX ");
+
+		if (strncmp(index->indexDef, "CREATE INDEX ", ci_len) == 0)
+		{
+			sformat(command, size, "CREATE INDEX IF NOT EXISTS %s;",
+					index->indexDef + ci_len);
+		}
+		else if (strncmp(index->indexDef, "CREATE UNIQUE INDEX ", cu_len) == 0)
+		{
+			sformat(command, size, "CREATE UNIQUE INDEX IF NOT EXISTS %s;",
+					index->indexDef + cu_len);
+		}
+		else
+		{
+			log_error("Failed to parse \"%s\"", index->indexDef);
+			return false;
+		}
+	}
+	else
+	{
+		/*
+		 * Just use the pg_get_indexdef() command, with an added semi-colon for
+		 * logging clarity.
+		 */
+		sformat(command, size, "%s;", index->indexDef);
+	}
+
+	return true;
+}

--- a/src/bin/pgcopydb/pgsql.h
+++ b/src/bin/pgcopydb/pgsql.h
@@ -233,8 +233,10 @@ bool hostname_from_uri(const char *pguri,
 					   char *hostname, int maxHostLength, int *port);
 bool validate_connection_string(const char *connectionString);
 
+bool pgsql_truncate(PGSQL *pgsql, const char *qname);
+
 bool pg_copy(PGSQL *src, PGSQL *dst,
-			 const char *srcQname, const char *dstQname);
+			 const char *srcQname, const char *dstQname, bool truncate);
 
 bool pgsql_get_sequence(PGSQL *pgsql, const char *nspname, const char *relname,
 						int64_t *lastValue,

--- a/src/bin/pgcopydb/schema.c
+++ b/src/bin/pgcopydb/schema.c
@@ -235,13 +235,13 @@ schema_list_all_indexes(PGSQL *pgsql, SourceIndexArray *indexArray)
 	if (!pgsql_execute_with_params(pgsql, sql, 0, NULL, NULL,
 								   &context, &getIndexArray))
 	{
-		log_error("Failed to retrieve current state from the monitor");
+		log_error("Failed to list all indexes");
 		return false;
 	}
 
 	if (!context.parsedOk)
 	{
-		log_error("Failed to parse current state from the monitor");
+		log_error("Failed to list all indexes");
 		return false;
 	}
 
@@ -302,13 +302,15 @@ schema_list_table_indexes(PGSQL *pgsql,
 								   paramCount, paramTypes, paramValues,
 								   &context, &getIndexArray))
 	{
-		log_error("Failed to retrieve current state from the monitor");
+		log_error("Failed to list all indexes for table \"%s\".\"%s\"",
+				  schemaName, tableName);
 		return false;
 	}
 
 	if (!context.parsedOk)
 	{
-		log_error("Failed to parse current state from the monitor");
+		log_error("Failed to list all indexes for table \"%s\".\"%s\"",
+				  schemaName, tableName);
 		return false;
 	}
 

--- a/src/bin/pgcopydb/sequences.c
+++ b/src/bin/pgcopydb/sequences.c
@@ -1,0 +1,124 @@
+/*
+ * src/bin/pgcopydb/sequences.c
+ *     Implementation of a CLI to copy a database between two Postgres instances
+ */
+
+#include <errno.h>
+#include <getopt.h>
+#include <inttypes.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "cli_common.h"
+#include "cli_copy.h"
+#include "cli_root.h"
+#include "copydb.h"
+#include "env_utils.h"
+#include "lock_utils.h"
+#include "log.h"
+#include "pidfile.h"
+#include "schema.h"
+#include "signals.h"
+#include "string_utils.h"
+#include "summary.h"
+
+
+/*
+ * copydb_copy_all_sequences fetches the list of sequences from the source
+ * database and then for each of them runs a SELECT last_value, is_called FROM
+ * the sequence on the source database and then calls SELECT setval(); on the
+ * target database with the same values.
+ */
+bool
+copydb_copy_all_sequences(CopyDataSpec *specs)
+{
+	if (specs->dirState.sequenceCopyIsDone)
+	{
+		log_info("Skipping sequences, already done on a previous run");
+		return true;
+	}
+
+	if (specs->section != DATA_SECTION_SET_SEQUENCES &&
+		specs->section != DATA_SECTION_ALL)
+	{
+		log_debug("Skipping sequences in section %d", specs->section);
+		return true;
+	}
+
+	log_info("Reset sequences values on the target database");
+
+	/* re-use the main snapshot and transaction to list sequences */
+	PGSQL *src = &(specs->sourceSnapshot.pgsql);
+	PGSQL dst = { 0 };
+
+	if (!pgsql_init(&dst, specs->target_pguri, PGSQL_CONN_TARGET))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	SourceSequenceArray sequenceArray = { 0, NULL };
+
+	log_info("Listing sequences in \"%s\"", specs->source_pguri);
+
+	if (!schema_list_sequences(src, &sequenceArray))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	log_info("Fetched information for %d sequences", sequenceArray.count);
+
+	if (!pgsql_begin(&dst))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	int errors = 0;
+
+	for (int seqIndex = 0; seqIndex < sequenceArray.count; seqIndex++)
+	{
+		SourceSequence *seq = &(sequenceArray.array[seqIndex]);
+
+		char qname[BUFSIZE] = { 0 };
+
+		sformat(qname, sizeof(qname), "\"%s\".\"%s\"",
+				seq->nspname,
+				seq->relname);
+
+		if (!schema_get_sequence_value(src, seq))
+		{
+			/* just skip this one */
+			log_warn("Failed to get sequence values for %s", qname);
+			++errors;
+			continue;
+		}
+
+		if (!schema_set_sequence_value(&dst, seq))
+		{
+			/* just skip this one */
+			log_warn("Failed to set sequence values for %s", qname);
+			++errors;
+			continue;
+		}
+	}
+
+	if (!pgsql_commit(&dst))
+	{
+		/* errors have already been logged */
+		++errors;
+	}
+
+	/* and write that we successfully finished copying all tables */
+	if (!write_file("", 0, specs->cfPaths.done.sequences))
+	{
+		log_warn("Failed to write the tracking file \%s\"",
+				 specs->cfPaths.done.sequences);
+	}
+
+	/* free our temporary memory that's been malloc'ed */
+	free(sequenceArray.array);
+
+	return errors == 0;
+}

--- a/src/bin/pgcopydb/summary.c
+++ b/src/bin/pgcopydb/summary.c
@@ -820,7 +820,7 @@ prepare_summary_table(Summary *summary, CopyDataSpec *specs)
 	for (int tableIndex = 0; tableIndex < tableSpecsArray->count; tableIndex++)
 	{
 		CopyTableDataSpec *tableSpecs = &(tableSpecsArray->array[tableIndex]);
-		SourceTable *table = tableSpecs->sourceTable;
+		SourceTable *table = &(tableSpecs->sourceTable);
 
 		SummaryTableEntry *entry = &(summaryTable->array[tableIndex]);
 

--- a/src/bin/pgcopydb/table-data.c
+++ b/src/bin/pgcopydb/table-data.c
@@ -1,0 +1,967 @@
+/*
+ * src/bin/pgcopydb/table-data.c
+ *     Implementation of a CLI to copy a database between two Postgres instances
+ */
+
+#include <errno.h>
+#include <getopt.h>
+#include <inttypes.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "cli_common.h"
+#include "cli_copy.h"
+#include "cli_root.h"
+#include "copydb.h"
+#include "env_utils.h"
+#include "lock_utils.h"
+#include "log.h"
+#include "pidfile.h"
+#include "schema.h"
+#include "signals.h"
+#include "string_utils.h"
+#include "summary.h"
+
+
+/*
+ * copydb_table_data fetches the list of tables from the source database and
+ * then run a pg_dump --data-only --schema ... --table ... | pg_restore on each
+ * of them, using up to tblJobs sub-processes for that.
+ *
+ * Each subprocess also fetches a list of indexes for each given table, and
+ * creates those indexes in parallel using up to idxJobs sub-processes for
+ * that.
+ */
+bool
+copydb_copy_all_table_data(CopyDataSpec *specs)
+{
+	int errors = 0;
+
+	if (specs->dirState.tableCopyIsDone &&
+		specs->dirState.indexCopyIsDone &&
+		specs->dirState.sequenceCopyIsDone)
+	{
+		log_info("Skipping tables, indexes, and sequences, "
+				 "already done on a previous run");
+		return true;
+	}
+
+	/*
+	 * First, we need to open a snapshot that we're going to re-use in all our
+	 * connections to the source database.
+	 */
+	TransactionSnapshot *sourceSnapshot = &(specs->sourceSnapshot);
+
+	if (!copydb_export_snapshot(sourceSnapshot))
+	{
+		log_fatal("Failed to export a snapshot on \"%s\"", sourceSnapshot->pguri);
+		return false;
+	}
+
+	/* now fetch the list of tables from the source database */
+	if (!copydb_prepare_table_specs(specs))
+	{
+		/* errors have already been logged */
+		(void) copydb_close_snapshot(sourceSnapshot);
+		return false;
+	}
+
+	/*
+	 * Now we have tableArray.count tables to migrate and we want to use
+	 * specs->tableJobs sub-processes to work on those migrations. Start the
+	 * processes, each sub-process walks through the array and pick the first
+	 * table that's not being processed already, until all has been done.
+	 */
+	if (!copydb_start_table_processes(specs))
+	{
+		log_fatal("Failed to start a sub-process to COPY the data");
+		(void) copydb_close_snapshot(sourceSnapshot);
+		(void) copydb_fatal_exit();
+	}
+
+	/*
+	 * Now is a good time to reset sequences: we're waiting for the TABLE DATA
+	 * sections and the CREATE INDEX, CONSTRAINTS and VACUUM ANALYZE to be done
+	 * with. Sequences can be reset to their expected values while the COPY are
+	 * still running, as COPY won't drain identifiers from the sequences
+	 * anyway.
+	 */
+	if (!copydb_copy_all_sequences(specs))
+	{
+		/* errors have already been logged */
+		++errors;
+	}
+
+	/* now we have a unknown count of subprocesses still running */
+	if (!copydb_wait_for_subprocesses())
+	{
+		/* errors have already been logged */
+		++errors;
+	}
+
+	/* we don't need the snapshot anymore */
+	(void) copydb_close_snapshot(sourceSnapshot);
+
+	/*
+	 * Now that all the sub-processes are done, we can also unlink the index
+	 * concurrency semaphore.
+	 */
+	if (!semaphore_finish(&(specs->tableSemaphore)))
+	{
+		log_warn("Failed to remove table concurrency semaphore %d, "
+				 "see above for details",
+				 specs->tableSemaphore.semId);
+	}
+
+	if (!semaphore_finish(&(specs->indexSemaphore)))
+	{
+		log_warn("Failed to remove index concurrency semaphore %d, "
+				 "see above for details",
+				 specs->indexSemaphore.semId);
+	}
+
+	/* and write that we successfully finished copying all indexes */
+	if (!write_file("", 0, specs->cfPaths.done.indexes))
+	{
+		log_warn("Failed to write the tracking file \%s\"",
+				 specs->cfPaths.done.indexes);
+	}
+
+	return errors == 0;
+}
+
+
+/*
+ * copydb_prepare_table_data fetches the list of tables to COPY data from the
+ * source and into the target, and initialises our internal
+ * CopyTableDataSpecsArray to drive the operations.
+ */
+bool
+copydb_prepare_table_specs(CopyDataSpec *specs)
+{
+	SourceTableArray tableArray = { 0, NULL };
+	CopyTableDataSpecsArray *tableSpecsArray = &(specs->tableSpecsArray);
+
+	/*
+	 * Check if we have large objects to take into account, because that's not
+	 * supported at the moment.
+	 */
+	if (!specs->skipLargeObjects)
+	{
+		int64_t largeObjectCount = 0;
+
+		if (!schema_count_large_objects(&(specs->sourceSnapshot.pgsql),
+										&largeObjectCount))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+
+		if (largeObjectCount > 0)
+		{
+			log_fatal("pgcopydb version %s has no support for large objects, "
+					  "and we found %lld rows in pg_largeobject_metadata",
+					  PGCOPYDB_VERSION,
+					  (long long) largeObjectCount);
+			log_fatal("Consider using --skip-large-objects");
+			return false;
+		}
+	}
+
+	log_info("Listing ordinary tables in \"%s\"", specs->source_pguri);
+
+	/*
+	 * Now get the list of the tables we want to COPY over.
+	 */
+	if (!schema_list_ordinary_tables(&(specs->sourceSnapshot.pgsql),
+									 &tableArray))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	int count = tableArray.count;
+
+	/* only use as many processes as required */
+	if (count < specs->tableJobs)
+	{
+		specs->tableJobs = count;
+	}
+
+	log_info("Fetched information for %d tables, now starting %d processes",
+			 tableArray.count,
+			 specs->tableJobs);
+
+	specs->tableSpecsArray.count = count;
+	specs->tableSpecsArray.array =
+		(CopyTableDataSpec *) malloc(count * sizeof(CopyTableDataSpec));
+
+	/*
+	 * Prepare the copy specs for each table we have.
+	 */
+	for (int tableIndex = 0; tableIndex < tableArray.count; tableIndex++)
+	{
+		/* initialize our TableDataProcess entry now */
+		SourceTable *source = &(tableArray.array[tableIndex]);
+		CopyTableDataSpec *tableSpecs = &(tableSpecsArray->array[tableIndex]);
+
+		/*
+		 * The CopyTableDataSpec structure has its own memory area for the
+		 * SourceTable entry, which is copied by the following function. This
+		 * means that 'SourceTableArray tableArray' is actually local memory.
+		 */
+		if (!copydb_init_table_specs(tableSpecs, specs, source))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+	}
+
+	/* free our temporary memory that's been malloc'ed */
+	free(tableArray.array);
+
+	return true;
+}
+
+
+/*
+ * copydb_start_table_processes forks() as many as specs->tableJobs processes
+ * that will all concurrently process TABLE DATA and then CREATE INDEX and then
+ * also VACUUM ANALYZE each table.
+ */
+bool
+copydb_start_table_processes(CopyDataSpec *specs)
+{
+	for (int i = 0; i < specs->tableJobs; i++)
+	{
+		/*
+		 * Flush stdio channels just before fork, to avoid double-output
+		 * problems.
+		 */
+		fflush(stdout);
+		fflush(stderr);
+
+		int fpid = fork();
+
+		switch (fpid)
+		{
+			case -1:
+			{
+				log_error("Failed to fork a worker process");
+				return false;
+			}
+
+			case 0:
+			{
+				/* child process runs the command */
+				if (!copydb_start_table_process(specs))
+				{
+					/* errors have already been logged */
+					exit(EXIT_CODE_INTERNAL_ERROR);
+				}
+
+				exit(EXIT_CODE_QUIT);
+			}
+
+			default:
+			{
+				/* fork succeeded, in parent */
+				break;
+			}
+		}
+	}
+
+	bool success = copydb_wait_for_subprocesses();
+
+	/* and write that we successfully finished copying all tables */
+	if (!write_file("", 0, specs->cfPaths.done.tables))
+	{
+		log_warn("Failed to write the tracking file \%s\"",
+				 specs->cfPaths.done.tables);
+	}
+
+	return success;
+}
+
+
+/*
+ * copydb_start_table_process stats a sub-process that walks through the array
+ * of tables to COPY over from the source database to the target database.
+ *
+ * Each process walks through the entire array, and for each entry:
+ *
+ *  - acquires a semaphore to enter the critical section, alone
+ *    - check if the current entry is already done, or being processed
+ *    - if not, create the lock file
+ *  - exit the critical section
+ *  - if we created a lock file, process the selected table
+ */
+bool
+copydb_start_table_process(CopyDataSpec *specs)
+{
+	int errors = 0;
+
+	CopyTableDataSpecsArray *tableSpecsArray = &(specs->tableSpecsArray);
+
+	/* connect once to the source database for the whole process */
+	if (!copydb_set_snapshot(&(specs->sourceSnapshot)))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	for (int tableIndex = 0; tableIndex < tableSpecsArray->count; tableIndex++)
+	{
+		/* initialize our TableDataProcess entry now */
+		CopyTableDataSpec *tableSpecs = &(tableSpecsArray->array[tableIndex]);
+
+		/* reuse the same connection to the source database */
+		tableSpecs->sourceSnapshot = specs->sourceSnapshot;
+
+		bool isDone = false;
+		bool isBeingProcessed = false;
+
+		if (!copydb_table_is_being_processed(specs,
+											 tableSpecs,
+											 &isDone,
+											 &isBeingProcessed))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+
+		/*
+		 * 1. Now COPY the TABLE DATA from the source to the destination.
+		 */
+		if (!isDone && !isBeingProcessed)
+		{
+			if (!copydb_copy_table(tableSpecs))
+			{
+				/* errors have already been logged */
+				return false;
+			}
+
+			/* enter the critical section to communicate that we're done */
+			if (!copydb_mark_table_as_done(specs, tableSpecs))
+			{
+				/* errors have already been logged */
+				return false;
+			}
+		}
+
+		/*
+		 * 2. Fetch the list of indexes and constraints attached to this table
+		 *    and create them in a background process.
+		 */
+		if (specs->dirState.indexCopyIsDone)
+		{
+			log_info("Skipping indexes, already done on a previous run");
+		}
+		else if ((!isDone && !isBeingProcessed))
+		{
+			if (!copydb_copy_table_indexes(tableSpecs))
+			{
+				log_warn("Failed to create all the indexes for %s, "
+						 "see above for details",
+						 tableSpecs->qname);
+				log_warn("Consider `pgcopydb copy indexes` to try again");
+				++errors;
+			}
+		}
+
+		/*
+		 * 3. Now start the VACUUM ANALYZE parts of the processing, in a
+		 *    concurrent sub-process. The sub-process is running in parallel to
+		 *    the CREATE INDEX and constraints processes.
+		 */
+		if (!isDone && !isBeingProcessed)
+		{
+			if (!copydb_start_vacuum_table(tableSpecs))
+			{
+				log_warn("Failed to VACUUM ANALYZE %s", tableSpecs->qname);
+				++errors;
+			}
+		}
+
+		/*
+		 * 4. Opportunistically see if some CREATE INDEX processed have
+		 *    finished already.
+		 */
+		if (!copydb_collect_finished_subprocesses())
+		{
+			/* errors have already been logged */
+			++errors;
+		}
+	}
+
+	/* terminate our connection to the source database now */
+	(void) pgsql_finish(&(specs->sourceSnapshot.pgsql));
+
+	/*
+	 * When this process has finished looping over all the tables in the table
+	 * array, then it waits until all the sub-processes are done. That's the
+	 * CREATE INDEX workers and the VACUUM workers.
+	 */
+	if (!copydb_wait_for_subprocesses())
+	{
+		/* errors have already been logged */
+		++errors;
+	}
+
+	return errors == 0;
+}
+
+
+/*
+ * copydb_table_is_being_processed checks lock and done files to see if a given
+ * table is already being processed, or has already been processed entirely by
+ * another process. In which case the table is to be skipped by the current
+ * process.
+ */
+bool
+copydb_table_is_being_processed(CopyDataSpec *specs,
+								CopyTableDataSpec *tableSpecs,
+								bool *isDone,
+								bool *isBeingProcessed)
+{
+	if (specs->dirState.tableCopyIsDone)
+	{
+		log_info("Skipping table %s, already done on a previous run",
+				 tableSpecs->qname);
+
+		*isDone = true;
+		*isBeingProcessed = false;
+		return true;
+	}
+
+	/* enter the critical section */
+	(void) semaphore_lock(&(specs->tableSemaphore));
+
+	/*
+	 * If the doneFile exists, then the table has been processed already,
+	 * skip it.
+	 *
+	 * If the lockFile exists, then the table is currently being processed
+	 * by another worker process, skip it.
+	 */
+	if (file_exists(tableSpecs->tablePaths.doneFile))
+	{
+		*isDone = true;
+		*isBeingProcessed = false;
+		(void) semaphore_unlock(&(specs->tableSemaphore));
+
+		return true;
+	}
+
+	/* okay so it's not done yet */
+	*isDone = false;
+
+	if (file_exists(tableSpecs->tablePaths.lockFile))
+	{
+		/*
+		 * Now it could be that the lockFile still exists and has been created
+		 * on a previous run, in which case the pid in there would be a stale
+		 * pid.
+		 *
+		 * So check for that situation before returning with the happy path.
+		 */
+		CopyTableSummary tableSummary = { .table = &(tableSpecs->sourceTable) };
+
+		if (!read_table_summary(&tableSummary, tableSpecs->tablePaths.lockFile))
+		{
+			/* errors have already been logged */
+			(void) semaphore_unlock(&(specs->tableSemaphore));
+
+			return false;
+		}
+
+		/* if we can signal the pid, it is still running */
+		if (kill(tableSummary.pid, 0) == 0)
+		{
+			*isBeingProcessed = true;
+			(void) semaphore_unlock(&(specs->tableSemaphore));
+
+			log_debug("Skipping table %s processed by concurrent worker %d",
+					  tableSpecs->qname, tableSummary.pid);
+
+			return true;
+		}
+		else
+		{
+			log_warn("Found stale pid %d in file \"%s\", removing it "
+					 "and processing table %s",
+					 tableSummary.pid,
+					 tableSpecs->tablePaths.lockFile,
+					 tableSpecs->qname);
+
+			/* stale pid, remove the old lockFile now, then process the table */
+			if (!unlink_file(tableSpecs->tablePaths.lockFile))
+			{
+				log_error("Failed to remove the lockFile \"%s\"",
+						  tableSpecs->tablePaths.lockFile);
+				(void) semaphore_unlock(&(specs->tableSemaphore));
+				return false;
+			}
+
+			/* pass through to the rest of this function */
+		}
+	}
+
+	/*
+	 * Otherwise, the table is not being processed yet.
+	 */
+	*isBeingProcessed = false;
+
+	/*
+	 * First, write the lockFile, with a summary of what's going-on.
+	 */
+	CopyTableSummary emptySummary = { 0 };
+	CopyTableSummary *summary =
+		(CopyTableSummary *) malloc(sizeof(CopyTableSummary));
+
+	*summary = emptySummary;
+
+	summary->pid = getpid();
+	summary->table = &(tableSpecs->sourceTable);
+
+	sformat(summary->command, sizeof(summary->command),
+			"COPY %s;",
+			tableSpecs->qname);
+
+	if (!open_table_summary(summary, tableSpecs->tablePaths.lockFile))
+	{
+		log_info("Failed to create the lock file at \"%s\"",
+				 tableSpecs->tablePaths.lockFile);
+
+		/* end of the critical section */
+		(void) semaphore_unlock(&(specs->tableSemaphore));
+
+		return false;
+	}
+
+	/* attach the new summary to the tableSpecs, where it was NULL before */
+	tableSpecs->summary = summary;
+
+	/* end of the critical section */
+	(void) semaphore_unlock(&(specs->tableSemaphore));
+
+	return true;
+}
+
+
+/*
+ * copydb_mark_table_as_done creates the table doneFile with the expected
+ * summary content. To create a doneFile we must acquire the synchronisation
+ * semaphore first. The lockFile is also removed here.
+ */
+bool
+copydb_mark_table_as_done(CopyDataSpec *specs,
+						  CopyTableDataSpec *tableSpecs)
+{
+	/* enter the critical section to communicate that we're done */
+	(void) semaphore_lock(&(specs->tableSemaphore));
+
+	if (!unlink_file(tableSpecs->tablePaths.lockFile))
+	{
+		log_error("Failed to remove the lockFile \"%s\"",
+				  tableSpecs->tablePaths.lockFile);
+		(void) semaphore_unlock(&(specs->tableSemaphore));
+		return false;
+	}
+
+	/* write the doneFile with the summary and timings now */
+	if (!finish_table_summary(tableSpecs->summary,
+							  tableSpecs->tablePaths.doneFile))
+	{
+		log_info("Failed to create the summary file at \"%s\"",
+				 tableSpecs->tablePaths.doneFile);
+		(void) semaphore_unlock(&(specs->tableSemaphore));
+		return false;
+	}
+
+	/* end of the critical section */
+	(void) semaphore_unlock(&(specs->tableSemaphore));
+
+	return true;
+}
+
+
+/*
+ * copydb_copy_table implements the sub-process activity to pg_dump |
+ * pg_restore the table's data and then create the indexes and the constraints
+ * in parallel.
+ */
+bool
+copydb_copy_table(CopyTableDataSpec *tableSpecs)
+{
+	/* COPY the data from the source table to the target table */
+	if (tableSpecs->section != DATA_SECTION_TABLE_DATA &&
+		tableSpecs->section != DATA_SECTION_ALL)
+	{
+		log_debug("Skipping table data in section %d", tableSpecs->section);
+		return true;
+	}
+
+	/* we want to set transaction snapshot to the main one on the source */
+	PGSQL *src = &(tableSpecs->sourceSnapshot.pgsql);
+	PGSQL dst = { 0 };
+
+	CopyTableSummary *summary = tableSpecs->summary;
+
+	/* initialize our connection to the target database */
+	if (!pgsql_init(&dst, tableSpecs->target_pguri, PGSQL_CONN_TARGET))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* Now copy the data from source to target */
+	log_info("%s", summary->command);
+
+	/* when using `pgcopydb copy table-data`, we don't truncate */
+	bool truncate = tableSpecs->section != DATA_SECTION_TABLE_DATA;
+
+	if (!pg_copy(src, &dst, tableSpecs->qname, tableSpecs->qname, truncate))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * copydb_copy_table_indexes fetches the index definitions attached to the
+ * given source table, and starts as many processes as we have definitions to
+ * create all indexes in parallel to each other.
+ */
+bool
+copydb_copy_table_indexes(CopyTableDataSpec *tableSpecs)
+{
+	if (tableSpecs->section != DATA_SECTION_INDEXES &&
+		tableSpecs->section != DATA_SECTION_CONSTRAINTS &&
+		tableSpecs->section != DATA_SECTION_ALL)
+	{
+		log_debug("Skipping index creation in section %d", tableSpecs->section);
+		return true;
+	}
+
+	SourceIndexArray indexArray = { 0 };
+
+	tableSpecs->indexArray = &indexArray;
+
+	if (!schema_list_table_indexes(&(tableSpecs->sourceSnapshot.pgsql),
+								   tableSpecs->sourceTable.nspname,
+								   tableSpecs->sourceTable.relname,
+								   tableSpecs->indexArray))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* build the index file paths we need for the upcoming operations */
+	if (!copydb_init_indexes_paths(tableSpecs->cfPaths,
+								   tableSpecs->indexArray,
+								   &(tableSpecs->indexPathsArray)))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/*
+	 * Indexes are created all-at-once in parallel, a sub-process is
+	 * forked per index definition to send each SQL/DDL command to the
+	 * Postgres server.
+	 */
+	if (tableSpecs->indexArray->count >= 1)
+	{
+		log_info("Creating %d index%s for table %s",
+				 tableSpecs->indexArray->count,
+				 tableSpecs->indexArray->count > 1 ? "es" : "",
+				 tableSpecs->qname);
+	}
+	else
+	{
+		log_debug("Table %s has no index attached", tableSpecs->qname);
+		return true;
+	}
+
+	/*
+	 * Flush stdio channels just before fork, to avoid double-output problems.
+	 */
+	fflush(stdout);
+	fflush(stderr);
+
+	int fpid = fork();
+
+	switch (fpid)
+	{
+		case -1:
+		{
+			log_error("Failed to fork a worker process");
+			return false;
+		}
+
+		case 0:
+		{
+			/* child process runs the command */
+			if (!copydb_start_create_table_indexes(tableSpecs))
+			{
+				log_error("Failed to create indexes, see above for details");
+				exit(EXIT_CODE_INTERNAL_ERROR);
+			}
+
+			/*
+			 * When done as part of the full copy, we also create each index's
+			 * constraint as soon as the parallel index built is done.
+			 */
+			if (tableSpecs->section == DATA_SECTION_ALL ||
+				tableSpecs->section == DATA_SECTION_CONSTRAINTS)
+			{
+				if (!copydb_create_constraints(tableSpecs))
+				{
+					log_error("Failed to create constraints, "
+							  "see above for details");
+					exit(EXIT_CODE_INTERNAL_ERROR);
+				}
+			}
+
+			/*
+			 * Create an index list file for the table, so that we can easily
+			 * find relevant indexing information from the table itself.
+			 */
+			if (!create_table_index_file(tableSpecs->summary,
+										 tableSpecs->indexArray,
+										 tableSpecs->tablePaths.idxListFile))
+			{
+				/* this only means summary is missing some indexing information */
+				log_warn("Failed to create table %s index list file \"%s\"",
+						 tableSpecs->qname,
+						 tableSpecs->tablePaths.idxListFile);
+			}
+
+			exit(EXIT_CODE_QUIT);
+		}
+
+		default:
+		{
+			/* fork succeeded, in parent */
+			break;
+		}
+	}
+
+	/* now we're done, and we want async behavior, do not wait */
+	return true;
+}
+
+
+/*
+ * copydb_start_create_indexes creates all the indexes for a given table in
+ * parallel, using a sub-process to send each index command.
+ */
+bool
+copydb_start_create_table_indexes(CopyTableDataSpec *tableSpecs)
+{
+	SourceTable *sourceTable = &(tableSpecs->sourceTable);
+	SourceIndexArray *indexArray = tableSpecs->indexArray;
+	IndexFilePathsArray *indexPathsArray = &(tableSpecs->indexPathsArray);
+
+	for (int i = 0; i < indexArray->count; i++)
+	{
+		/*
+		 * Fork a sub-process for each index, so that they're created in
+		 * parallel. Flush stdio channels just before fork, to avoid
+		 * double-output problems.
+		 */
+		fflush(stdout);
+		fflush(stderr);
+
+		/* time to create the node_active sub-process */
+		int fpid = fork();
+
+		switch (fpid)
+		{
+			case -1:
+			{
+				log_error("Failed to fork a process for creating index for "
+						  "table \"%s\".\"%s\"",
+						  sourceTable->nspname,
+						  sourceTable->relname);
+				return -1;
+			}
+
+			case 0:
+			{
+				SourceIndex *index = &(indexArray->array[i]);
+				IndexFilePaths *indexPaths = &(indexPathsArray->array[i]);
+
+				/*
+				 * Add IF NOT EXISTS clause when the --resume option has been
+				 * used, or when the command is `pgcopydb copy indexes`, in
+				 * which cases we don't know what to expect on the target
+				 * database.
+				 */
+				bool ifNotExists =
+					tableSpecs->resume ||
+					tableSpecs->section == DATA_SECTION_INDEXES;
+
+				/* by design, we don't have same-index concurrency */
+				Semaphore *lockFileSemaphore = NULL;
+
+				/* child process runs the command */
+				if (!copydb_create_index(tableSpecs->target_pguri,
+										 index,
+										 indexPaths,
+										 lockFileSemaphore,
+										 tableSpecs->indexSemaphore,
+										 ifNotExists))
+				{
+					/* errors have already been logged */
+					exit(EXIT_CODE_INTERNAL_ERROR);
+				}
+
+				exit(EXIT_CODE_QUIT);
+			}
+
+			default:
+			{
+				/* fork succeeded, in parent */
+				break;
+			}
+		}
+	}
+
+	/*
+	 * Here we need to be sync, so that the caller can continue with creating
+	 * the constraints from the indexes right when all the indexes have been
+	 * built.
+	 */
+	return copydb_wait_for_subprocesses();
+}
+
+
+/*
+ * copydb_create_constraints loops over the index definitions for a given table
+ * and creates all the associated constraints, one after the other.
+ */
+bool
+copydb_create_constraints(CopyTableDataSpec *tableSpecs)
+{
+	int errors = 0;
+	SourceIndexArray *indexArray = tableSpecs->indexArray;
+
+	const char *pguri = tableSpecs->target_pguri;
+	PGSQL dst = { 0 };
+
+	if (!pgsql_init(&dst, (char *) pguri, PGSQL_CONN_TARGET))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/*
+	 * Postgres doesn't implement ALTER TABLE ... ADD CONSTRAINT ... IF NOT
+	 * EXISTS, which we would be using here in some cases otherwise.
+	 *
+	 * When --resume is used, for instance, the previous run could have been
+	 * interrupted after a constraint creation on the target database, but
+	 * before the creation of its constraintDoneFile.
+	 */
+	SourceIndexArray dstIndexArray = { 0, NULL };
+
+	if (!schema_list_table_indexes(&dst,
+								   tableSpecs->sourceTable.nspname,
+								   tableSpecs->sourceTable.relname,
+								   &dstIndexArray))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	if (dstIndexArray.count > 0)
+	{
+		log_info("Found %d/%d indexes on target database for table %s",
+				 dstIndexArray.count,
+				 indexArray->count,
+				 tableSpecs->qname);
+	}
+
+	for (int i = 0; i < indexArray->count; i++)
+	{
+		SourceIndex *index = &(indexArray->array[i]);
+		IndexFilePaths *indexPaths = &(tableSpecs->indexPathsArray.array[i]);
+
+		/* some indexes are not attached to a constraint at all */
+		if (index->constraintOid <= 0 ||
+			IS_EMPTY_STRING_BUFFER(index->constraintName))
+		{
+			continue;
+		}
+
+		/* skip constraints that already exist on the target database */
+		bool foundConstraintOnTarget = false;
+
+		for (int dstI = 0; dstI < dstIndexArray.count; dstI++)
+		{
+			SourceIndex *dstIndex = &(dstIndexArray.array[dstI]);
+
+			if (strcmp(index->constraintName, dstIndex->constraintName) == 0)
+			{
+				foundConstraintOnTarget = true;
+				log_info("Found constraint \"%s\" on target, skipping",
+						 index->constraintName);
+				break;
+			}
+		}
+
+		char sql[BUFSIZE] = { 0 };
+
+		sformat(sql, sizeof(sql),
+				"ALTER TABLE \"%s\".\"%s\" "
+				"ADD CONSTRAINT \"%s\" %s "
+				"USING INDEX \"%s\"",
+				index->tableNamespace,
+				index->tableRelname,
+				index->constraintName,
+				index->isPrimary
+				? "PRIMARY KEY"
+				: (index->isUnique ? "UNIQUE" : ""),
+				index->indexRelname);
+
+		if (!foundConstraintOnTarget)
+		{
+			log_info("%s;", sql);
+
+			if (!pgsql_execute(&dst, sql))
+			{
+				/* errors have already been logged */
+				return false;
+			}
+		}
+
+		/*
+		 * Create the doneFile for the constraint when we know it exists on the
+		 * target database, the main use of this doneFile is to filter out
+		 * already existing objects from the pg_restore --section post-data
+		 * later.
+		 */
+		char contents[BUFSIZE] = { 0 };
+
+		sformat(contents, sizeof(contents), "%s;\n", sql);
+
+		if (!write_file(contents,
+						strlen(contents),
+						indexPaths->constraintDoneFile))
+		{
+			log_warn("Failed to create the constraint done file");
+			log_warn("Restoring the --post-data part of the schema "
+					 "might fail because of already existing objects");
+		}
+	}
+
+	/* free malloc'ed memory area */
+	free(dstIndexArray.array);
+
+	return errors == 0;
+}


### PR DESCRIPTION
This allows to resume from a previous run that would have been interrupted,
or would have failed halfway through. To be able to continue from a previous
run, the user needs to accept a non-consistent operation, where another
snapshot is used the second time.

Internally, the work that has been done already is tracked via lock files
and done files in the working directory.