### PR TITLE
Implement setting GUC values to our src/dst Postgres connections.

### DIFF
--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -201,6 +201,9 @@ typedef enum
 } PostgresDumpSection;
 
 
+extern GUC srcSettings[];
+extern GUC dstSettings[];
+
 bool copydb_init_workdir(CopyDataSpec *copySpecs,
 						 char *dir,
 						 bool restart,

--- a/src/bin/pgcopydb/indexes.c
+++ b/src/bin/pgcopydb/indexes.c
@@ -375,6 +375,14 @@ copydb_create_index(const char *pguri,
 		return false;
 	}
 
+	/* also set our GUC values for the target connection */
+	if (!pgsql_set_gucs(&dst, dstSettings))
+	{
+		log_fatal("Failed to set our GUC settings on the target connection, "
+				  "see above for details");
+		return false;
+	}
+
 	if (!pgsql_execute(&dst, summary.command))
 	{
 		/* errors have already been logged */

--- a/src/bin/pgcopydb/pgsql.h
+++ b/src/bin/pgcopydb/pgsql.h
@@ -199,6 +199,14 @@ typedef struct SingleValueResultContext
 } SingleValueResultContext;
 
 
+/* PostgreSQL ("Grand Unified Configuration") setting */
+typedef struct GUC
+{
+	char *name;
+	char *value;
+} GUC;
+
+
 bool pgsql_init(PGSQL *pgsql, char *url, ConnectionType connectionType);
 
 void pgsql_set_retry_policy(ConnectionRetryPolicy *retryPolicy,
@@ -241,5 +249,7 @@ bool pg_copy(PGSQL *src, PGSQL *dst,
 bool pgsql_get_sequence(PGSQL *pgsql, const char *nspname, const char *relname,
 						int64_t *lastValue,
 						bool *isCalled);
+
+bool pgsql_set_gucs(PGSQL *pgsql, GUC *settings);
 
 #endif /* PGSQL_H */

--- a/src/bin/pgcopydb/table-data.c
+++ b/src/bin/pgcopydb/table-data.c
@@ -868,6 +868,14 @@ copydb_create_constraints(CopyTableDataSpec *tableSpecs)
 		return false;
 	}
 
+	/* also set our GUC values for the target connection */
+	if (!pgsql_set_gucs(&dst, dstSettings))
+	{
+		log_fatal("Failed to set our GUC settings on the target connection, "
+				  "see above for details");
+		return false;
+	}
+
 	/*
 	 * Postgres doesn't implement ALTER TABLE ... ADD CONSTRAINT ... IF NOT
 	 * EXISTS, which we would be using here in some cases otherwise.


### PR DESCRIPTION
At the minimum we want to use the same client_encoding on both connections,
so that we know that we are dealing with the same data without having to
actually look into it.

Then, for bulk-loading and index creation, some settings are easy to set on
the target connection to get a better perf profile (e.g.
maintenance_work_mem).