### PR TITLE
Fix support for exclusion constraints.

### DIFF
--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -315,7 +315,7 @@ bool copydb_start_table_process(CopyDataSpec *specs);
 bool copydb_copy_table(CopyTableDataSpec *tableSpecs);
 
 bool copydb_copy_table_indexes(CopyTableDataSpec *tableSpecs);
-bool copydb_start_create_table_indexes(CopyTableDataSpec *tableSpecs);
+bool copydb_create_table_indexes(CopyTableDataSpec *tableSpecs);
 
 bool copydb_create_constraints(CopyTableDataSpec *tableSpecs);
 

--- a/src/bin/pgcopydb/indexes.c
+++ b/src/bin/pgcopydb/indexes.c
@@ -452,7 +452,7 @@ copydb_index_is_being_processed(SourceIndex *index,
 	/* some callers have no same-index concurrency, just create the lockFile */
 	if (lockFileSemaphore == NULL)
 	{
-		if (!open_index_summary(summary, lockFile))
+		if (!open_index_summary(summary, lockFile, constraint))
 		{
 			log_info("Failed to create the lock file at \"%s\"", lockFile);
 			(void) semaphore_unlock(lockFileSemaphore);
@@ -526,7 +526,7 @@ copydb_index_is_being_processed(SourceIndex *index,
 	 */
 	*isBeingProcessed = false;
 
-	if (!open_index_summary(summary, lockFile))
+	if (!open_index_summary(summary, lockFile, constraint))
 	{
 		log_info("Failed to create the lock file at \"%s\"", lockFile);
 		(void) semaphore_unlock(lockFileSemaphore);
@@ -564,7 +564,7 @@ copydb_mark_index_as_done(SourceIndex *index,
 	}
 
 	/* create the doneFile for the index */
-	if (!finish_index_summary(summary, doneFile))
+	if (!finish_index_summary(summary, doneFile, constraint))
 	{
 		log_info("Failed to create the summary file at \"%s\"", doneFile);
 

--- a/src/bin/pgcopydb/indexes.c
+++ b/src/bin/pgcopydb/indexes.c
@@ -309,6 +309,8 @@ copydb_create_index(const char *pguri,
 	bool isDone = false;
 	bool isBeingProcessed = false;
 
+	bool isConstraintIndex = index->constraintOid != 0;
+
 	/*
 	 * When asked to create the constraint and there is no constraint attached
 	 * to this index, skip the operation entirely.
@@ -330,12 +332,12 @@ copydb_create_index(const char *pguri,
 	 * then create it during the constraint phase, as part of the "plain" ALTER
 	 * TABLE ... ADD CONSTRAINT ... command.
 	 */
-	else if (!constraint && !index->isPrimary && !index->isUnique)
+	else if (isConstraintIndex && !index->isPrimary && !index->isUnique)
 	{
-		log_warn("Skipping concurrent build of index for constraint "
-				 "\"%s\" %s on \"%s\".\"%s\", "
+		log_warn("Skipping concurrent build of index "
+				 "\"%s\" for constraint %s on \"%s\".\"%s\", "
 				 "it is not a UNIQUE or a PRIMARY constraint",
-				 index->constraintName,
+				 index->indexRelname,
 				 index->constraintDef,
 				 index->tableNamespace,
 				 index->tableRelname);

--- a/src/bin/pgcopydb/summary.c
+++ b/src/bin/pgcopydb/summary.c
@@ -685,7 +685,7 @@ print_toplevel_summary(Summary *summary, int tableJobs, int indexJobs)
 			tableJobs);
 
 	fformat(stdout, " %45s   %10s  %10s  %12d\n",
-			"Large Objects", "both",
+			"Large Objects (cumulative)", "both",
 			summary->timings.blobsMs,
 			1);
 

--- a/src/bin/pgcopydb/summary.c
+++ b/src/bin/pgcopydb/summary.c
@@ -213,6 +213,7 @@ create_table_index_file(CopyTableSummary *summary,
 		SourceIndex *index = &(indexArray->array[i]);
 
 		appendPQExpBuffer(content, "%d\n", index->indexOid);
+		appendPQExpBuffer(content, "%d\n", index->constraintOid);
 	}
 
 	/* memory allocation could have failed while building string */
@@ -281,19 +282,31 @@ read_table_index_file(SourceIndexArray *indexArray, char *filename)
 
 
 /*
- * write_index_summary writes the current Index Summary to given filename.
+ * write_index_summary writes the current Index Summary to given filename. The
+ * constraint bool allows to write the constraint definition instead of the
+ * index definition.
  */
 bool
-write_index_summary(CopyIndexSummary *summary, char *filename)
+write_index_summary(CopyIndexSummary *summary, char *filename, bool constraint)
 {
 	char contents[BUFSIZE] = { 0 };
+
+	uint32_t oid =
+		constraint
+		? summary->index->constraintOid
+		: summary->index->indexOid;
+
+	char *name =
+		constraint
+		? summary->index->constraintName
+		: summary->index->indexRelname;
 
 	sformat(contents, BUFSIZE,
 			"%d\n%u\n%s\n%s\n%lld\n%lld\n%lld\n%s\n",
 			summary->pid,
-			summary->index->indexOid,
+			oid,
 			summary->index->indexNamespace,
-			summary->index->indexRelname,
+			name,
 			(long long) summary->startTime,
 			(long long) summary->doneTime,
 			(long long) summary->durationMs,
@@ -397,7 +410,7 @@ read_index_summary(CopyIndexSummary *summary, const char *filename)
  * writes the summary in the given filename. Typically, the lockFile.
  */
 bool
-open_index_summary(CopyIndexSummary *summary, char *filename)
+open_index_summary(CopyIndexSummary *summary, char *filename, bool constraint)
 {
 	summary->startTime = time(NULL);
 	summary->doneTime = 0;
@@ -411,7 +424,7 @@ open_index_summary(CopyIndexSummary *summary, char *filename)
 
 	INSTR_TIME_SET_CURRENT(summary->startTimeInstr);
 
-	return write_index_summary(summary, filename);
+	return write_index_summary(summary, filename, constraint);
 }
 
 
@@ -420,7 +433,7 @@ open_index_summary(CopyIndexSummary *summary, char *filename)
  * summary in the given filename. Typically, the doneFile.
  */
 bool
-finish_index_summary(CopyIndexSummary *summary, char *filename)
+finish_index_summary(CopyIndexSummary *summary, char *filename, bool constraint)
 {
 	summary->doneTime = time(NULL);
 
@@ -429,7 +442,7 @@ finish_index_summary(CopyIndexSummary *summary, char *filename)
 
 	summary->durationMs = INSTR_TIME_GET_MILLISEC(summary->durationInstr);
 
-	return write_index_summary(summary, filename);
+	return write_index_summary(summary, filename, constraint);
 }
 
 
@@ -677,7 +690,7 @@ print_toplevel_summary(Summary *summary, int tableJobs, int indexJobs)
 			1);
 
 	fformat(stdout, " %45s   %10s  %10s  %12d\n",
-			"CREATE INDEX (cumulative)", "target",
+			"CREATE INDEX, CONSTRAINTS (cumulative)", "target",
 			summary->timings.totalIndexMs,
 			indexJobs);
 

--- a/src/bin/pgcopydb/summary.h
+++ b/src/bin/pgcopydb/summary.h
@@ -169,10 +169,13 @@ bool read_blobs_summary(CopyBlobsSummary *summary, char *filename);
 void summary_set_current_time(TopLevelTimings *timings, TimingStep step);
 
 
-bool write_index_summary(CopyIndexSummary *summary, char *filename);
+bool write_index_summary(CopyIndexSummary *summary, char *filename,
+						 bool constraint);
 bool read_index_summary(CopyIndexSummary *summary, const char *filename);
-bool open_index_summary(CopyIndexSummary *summary, char *filename);
-bool finish_index_summary(CopyIndexSummary *summary, char *filename);
+bool open_index_summary(CopyIndexSummary *summary, char *filename,
+						bool constraint);
+bool finish_index_summary(CopyIndexSummary *summary, char *filename,
+						  bool constraint);
 
 void summary_prepare_toplevel_durations(Summary *summary);
 void print_toplevel_summary(Summary *summary, int tableJobs, int indexJobs);

--- a/src/bin/pgcopydb/table-data.c
+++ b/src/bin/pgcopydb/table-data.c
@@ -699,7 +699,7 @@ copydb_copy_table_indexes(CopyTableDataSpec *tableSpecs)
 		case 0:
 		{
 			/* child process runs the command */
-			if (!copydb_start_create_table_indexes(tableSpecs))
+			if (!copydb_create_table_indexes(tableSpecs))
 			{
 				log_error("Failed to create indexes, see above for details");
 				exit(EXIT_CODE_INTERNAL_ERROR);
@@ -750,11 +750,11 @@ copydb_copy_table_indexes(CopyTableDataSpec *tableSpecs)
 
 
 /*
- * copydb_start_create_indexes creates all the indexes for a given table in
- * parallel, using a sub-process to send each index command.
+ * copydb_create_indexes creates all the indexes for a given table in parallel,
+ * using a sub-process to send each index command.
  */
 bool
-copydb_start_create_table_indexes(CopyTableDataSpec *tableSpecs)
+copydb_create_table_indexes(CopyTableDataSpec *tableSpecs)
 {
 	SourceTable *sourceTable = &(tableSpecs->sourceTable);
 	SourceIndexArray *indexArray = tableSpecs->indexArray;


### PR DESCRIPTION
This is a work-in-progress PR to fix support for constraints for indexes that we can't build concurrently. The ALTER TABLE ... ADD CONSTRAINT ... USING INDEX ... only works for UNIQUE and PRIMARY KEY constraints.

Fixes #22 ; see #23.