### PR TITLE
Assorted bug fixes for Postgres connection handling.

### DIFF
--- a/Dockerfile.debian-qa
+++ b/Dockerfile.debian-qa
@@ -1,5 +1,11 @@
 FROM debian:sid
 
+ENV TAR v0.4.tar.gz
+ENV ORIG pgcopydb_0.4.orig.tar.gz
+ENV WORKDIR /usr/src/pgcopydb-0.4
+ENV ARCHIVE https://github.com/dimitri/pgcopydb/archive/refs/tags/
+ENV RELEASE ${ARCHIVE}${TAR}
+
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
         build-essential \
@@ -25,21 +31,15 @@ RUN apt-get update \
         curl \
   && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /usr/src/pgcopydb
-
-COPY ./Makefile ./
-COPY ./README.md ./
-COPY ./CHANGELOG.md ./
-COPY ./LICENSE ./
-COPY ./src ./src/
-COPY ./docs ./docs/
-
 WORKDIR /usr/src
-RUN tar czf pgcopydb_0.4.orig.tar.gz pgcopydb
 
-WORKDIR /usr/src/pgcopydb
+RUN curl -L -o ${TAR} ${RELEASE}
+RUN tar xf ${TAR}
+RUN mv ${TAR} ${ORIG}
 
+WORKDIR ${WORKDIR}
 COPY ./debian/ ./debian/
+
 RUN dpkg-buildpackage --no-sign
 
 WORKDIR /usr/src

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,15 @@ test: build
 
 tests: test ;
 
+tests/pagila: build
+	$(MAKE) -C tests/pagila
+
+tests/pagila-multi-steps: build
+	$(MAKE) -C tests/pagila-multi-steps
+
+tests/blobs: build
+	$(MAKE) -C tests/blobs
+
 install: bin
 	$(MAKE) -C src/bin/ install
 
@@ -28,13 +37,21 @@ indent:
 build:
 	docker build -t pgcopydb .
 
+# debian packages built from the current sources
 deb:
 	docker build -f Dockerfile.debian -t pgcopydb_debian .
 
 debsh: deb
 	docker run --rm -it pgcopydb_debian bash
 
+# debian packages built from latest tag, manually maintained in the Dockerfile
+deb-qa:
+	docker build -f Dockerfile.debian-qa -t pgcopydb_debian_qa .
+
+debsh-qa: deb-qa
+	docker run --rm -it pgcopydb_debian_qa bash
+
 .PHONY: all
 .PHONY: bin clean install docs
-.PHONY: test tests
-.PHONY: deb
+.PHONY: test tests tests/pagila
+.PHONY: deb debsh deb-qa debsh-qa

--- a/Makefile
+++ b/Makefile
@@ -53,5 +53,5 @@ debsh-qa: deb-qa
 
 .PHONY: all
 .PHONY: bin clean install docs
-.PHONY: test tests tests/pagila
+.PHONY: test tests tests/pagila tests/pagila-multi-steps tests/blobs
 .PHONY: deb debsh deb-qa debsh-qa

--- a/src/bin/pgcopydb/cli_copy.c
+++ b/src/bin/pgcopydb/cli_copy.c
@@ -792,7 +792,7 @@ cli_copy_blobs(int argc, char **argv)
 {
 	CopyDataSpec copySpecs = { 0 };
 
-	(void) cli_copy_prepare_specs(&copySpecs, DATA_SECTION_CONSTRAINTS);
+	(void) cli_copy_prepare_specs(&copySpecs, DATA_SECTION_BLOBS);
 
 	Summary summary = { 0 };
 	TopLevelTimings *timings = &(summary.timings);
@@ -801,29 +801,10 @@ cli_copy_blobs(int argc, char **argv)
 
 	log_info("Copy large objects");
 
-	/*
-	 * First, we need to open a snapshot that we're going to re-use in all our
-	 * connections to the source database. When the --snapshot option has been
-	 * used, instead of exporting a new snapshot, we can just re-use it.
-	 */
-	if (!copydb_prepare_snapshot(&copySpecs))
-	{
-		/* errors have already been logged */
-		exit(EXIT_CODE_INTERNAL_ERROR);
-	}
-
 	if (!copydb_copy_blobs(&copySpecs))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);
-	}
-
-	if (!copydb_close_snapshot(&(copySpecs.sourceSnapshot)))
-	{
-		log_fatal("Failed to close snapshot \"%s\" on \"%s\"",
-				  copySpecs.sourceSnapshot.snapshot,
-				  copySpecs.sourceSnapshot.pguri);
-		exit(EXIT_CODE_SOURCE);
 	}
 
 	(void) summary_set_current_time(timings, TIMING_STEP_END);

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -122,6 +122,7 @@ typedef enum
 	DATA_SECTION_SET_SEQUENCES,
 	DATA_SECTION_INDEXES,
 	DATA_SECTION_CONSTRAINTS,
+	DATA_SECTION_BLOBS,
 	DATA_SECTION_VACUUM,
 	DATA_SECTION_ALL
 } CopyDataSection;
@@ -231,6 +232,8 @@ bool copydb_init_table_specs(CopyTableDataSpec *tableSpecs,
 							 CopyDataSpec *specs,
 							 SourceTable *source);
 
+bool copydb_copy_snapshot(CopyDataSpec *specs, TransactionSnapshot *snapshot);
+
 bool copydb_prepare_snapshot(CopyDataSpec *copySpecs);
 bool copydb_export_snapshot(TransactionSnapshot *snapshot);
 bool copydb_set_snapshot(TransactionSnapshot *snapshot);
@@ -309,8 +312,8 @@ bool copydb_copy_all_sequences(CopyDataSpec *specs);
 /* table-data.c */
 bool copydb_copy_all_table_data(CopyDataSpec *specs);
 
-bool copydb_start_table_processes(CopyDataSpec *specs);
-bool copydb_start_table_process(CopyDataSpec *specs);
+bool copydb_process_table_data(CopyDataSpec *specs);
+bool copydb_process_table_data_worker(CopyDataSpec *specs);
 
 bool copydb_copy_table(CopyTableDataSpec *tableSpecs);
 

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -245,7 +245,7 @@ bool copydb_start_vacuum_table(CopyTableDataSpec *tableSpecs);
 
 bool copydb_fatal_exit(void);
 bool copydb_wait_for_subprocesses(void);
-bool copydb_collect_finished_subprocesses(void);
+bool copydb_collect_finished_subprocesses(bool *allDone);
 
 
 /* indexes.c */

--- a/src/bin/pgcopydb/indexes.c
+++ b/src/bin/pgcopydb/indexes.c
@@ -93,19 +93,14 @@ copydb_copy_all_indexes(CopyDataSpec *specs)
 		return true;
 	}
 
-	PGSQL src = { 0 };
+	PGSQL *src = &(specs->sourceSnapshot.pgsql);
+
 	SourceIndexArray indexArray = { 0, NULL };
 	IndexFilePathsArray indexPathsArray = { 0, NULL };
 
 	log_info("Listing indexes in \"%s\"", specs->source_pguri);
 
-	if (!pgsql_init(&src, specs->source_pguri, PGSQL_CONN_SOURCE))
-	{
-		/* errors have already been logged */
-		return false;
-	}
-
-	if (!schema_list_all_indexes(&src, &indexArray))
+	if (!schema_list_all_indexes(src, &indexArray))
 	{
 		/* errors have already been logged */
 		return false;
@@ -120,7 +115,7 @@ copydb_copy_all_indexes(CopyDataSpec *specs)
 		return false;
 	}
 
-	log_info("Creating %d indexes in the target database using %d processed",
+	log_info("Creating %d indexes in the target database using %d processes",
 			 indexArray.count,
 			 specs->indexJobs);
 

--- a/src/bin/pgcopydb/indexes.c
+++ b/src/bin/pgcopydb/indexes.c
@@ -414,6 +414,8 @@ copydb_create_index(const char *pguri,
 		return false;
 	}
 
+	(void) pgsql_finish(&dst);
+
 	/* the CREATE INDEX command is done, release our lock */
 	(void) semaphore_unlock(createIndexSemaphore);
 

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -1584,6 +1584,9 @@ pg_copy(PGSQL *src, PGSQL *dst, const char *srcQname, const char *dstQname,
 		}
 	}
 
+	/* always close the target connection, that we opened in this function */
+	(void) pgsql_finish(dst);
+
 	return !failedOnSrc && !failedOnDst;
 }
 

--- a/tests/pagila/docker-compose.yml
+++ b/tests/pagila/docker-compose.yml
@@ -8,6 +8,10 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: h4ckm3
       POSTGRES_HOST_AUTH_METHOD: trust
+    command: >
+      -c ssl=on
+      -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
+      -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
   target:
     image: postgres:13-bullseye
     expose:
@@ -16,9 +20,14 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: h4ckm3
       POSTGRES_HOST_AUTH_METHOD: trust
+    command: >
+      -c ssl=on
+      -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
+      -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
   pgcopydb:
     build: .
     environment:
+      PGSSLMODE: "require"
       PGCOPYDB_SOURCE_PGURI: postgres://postgres:h4ckm3@source/postgres
       PGCOPYDB_TARGET_PGURI: postgres://postgres:h4ckm3@target/postgres
       PGCOPYDB_TARGET_TABLE_JOBS: 4


### PR DESCRIPTION
The auxiliary process for large objects would somehow piggyback on the main
snapshot connection instance, so make sure it's using its own private
connection.

Since re-using the same connection throughout a COPY process we switched to
multi statements connections, and those need to be closed explicitely. We
missed that in the previous coding.

Using SSL as in debian by default shows more errors, so make sure to run at
least one of our docker compose based testing in SSL too.

Move the copy of sequences data to a proper place that matches the comment
and refactor some function names to distinguish between async behavior (use
_start_ in the name then) and sync behavior. Recent changes made that
distinction hard to follow.