### PR TITLE
Increase the default timeout from 2s to 10s.

### DIFF
--- a/src/bin/pgcopydb/main.c
+++ b/src/bin/pgcopydb/main.c
@@ -24,7 +24,7 @@
 
 char pgcopydb_argv0[MAXPGPATH];
 char pgcopydb_program[MAXPGPATH];
-int pgconnect_timeout = 2;      /* see also POSTGRES_CONNECT_TIMEOUT */
+int pgconnect_timeout = 10;     /* see also POSTGRES_CONNECT_TIMEOUT */
 
 char *ps_buffer;                /* will point to argv area */
 size_t ps_buffer_size;          /* space determined at run time */


### PR DESCRIPTION
In our context we need to connect through unknown network layers, the
default of 2s is better suited for a known local connection. 10s seems a
good trade-off for pgcopydb.