### PR TITLE
Add versioning information to the logs output.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+docs/_build
+
+src/bin/pgcopydb/pgcopydb
+src/bin/pgcopydb/*.o
+src/bin/pgcopydb/*.bc
+src/bin/pgcopydb/*.so
+src/bin/pgcopydb/*.so.[0-9]
+src/bin/pgcopydb/*.so.[0-9].[0-9]
+src/bin/pgcopydb/.deps/
+
+# ignore the git version number in release builds
+src/bin/pgcopydb/git-version.h

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ lib*.pc
 /src/Makefile.custom
 /tests/__pycache__/
 /env/
+/GIT-VERSION-FILE

--- a/GIT-VERSION-GEN
+++ b/GIT-VERSION-GEN
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+GVF=GIT-VERSION-FILE
+DEF_VER=0.5
+
+LF='
+'
+
+# First see if there is a version file (included in release tarballs),
+# then try git-describe, then default.
+if test -f version
+then
+	VN=$(cat version) || VN="$DEF_VER"
+elif test -d ${GIT_DIR:-.git} -o -f .git &&
+	VN=$(git describe --match "v[0-9]*" HEAD 2>/dev/null) &&
+	case "$VN" in
+	*$LF*) (exit 1) ;;
+	v[0-9]*)
+		git update-index -q --refresh
+		test -z "$(git diff-index --name-only HEAD --)" ||
+		VN="$VN-dirty" ;;
+	esac
+then
+	VN=$(echo "$VN" | sed -e 's/-/./g');
+else
+	VN="$DEF_VER"
+fi
+
+VN=$(expr "$VN" : v*'\(.*\)')
+
+if test -r $GVF
+then
+	VC=$(sed -e 's/^GIT_VERSION = //' <$GVF)
+else
+	VC=unset
+fi
+test "$VN" = "$VC" || {
+	echo >&2 "GIT_VERSION = $VN"
+	echo "GIT_VERSION = $VN" >$GVF
+}

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,16 @@ TOP := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
 all: bin ;
 
-bin:
+GIT-VERSION-FILE:
+	@$(SHELL_PATH) ./GIT-VERSION-GEN
+
+-include GIT-VERSION-FILE
+
+bin: GIT-VERSION-FILE
 	$(MAKE) -C src/bin/ all
 
 clean:
+	rm -f GIT-VERSION-FILE
 	$(MAKE) -C src/bin/ clean
 
 docs:
@@ -49,3 +55,4 @@ debsh-qa: deb-qa
 .PHONY: bin clean install docs
 .PHONY: test tests tests/*
 .PHONY: deb debsh deb-qa debsh-qa
+.PHONY: GIT-VERSION-FILE

--- a/src/bin/pgcopydb/.gitignore
+++ b/src/bin/pgcopydb/.gitignore
@@ -1,1 +1,2 @@
 pgcopydb
+git-version.h

--- a/src/bin/pgcopydb/Makefile
+++ b/src/bin/pgcopydb/Makefile
@@ -5,6 +5,8 @@ PGCOPYDB = ./pgcopydb
 
 SRC_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
+-include $(SRC_DIR)../../../GIT-VERSION-FILE
+
 DEPDIR = $(SRC_DIR)/.deps
 
 INCLUDES  = $(patsubst ${SRC_DIR}%.h,%.h,$(wildcard ${SRC_DIR}*.h))
@@ -78,7 +80,7 @@ include $(Po_files)
 endif
 
 
-$(PGCOPYDB): $(OBJS) $(INCLUDES)
+$(PGCOPYDB): $(OBJS) $(INCLUDES) VERSION-FILE
 	$(CC) $(CFLAGS) $(OBJS) $(LDFLAGS) $(LIBS) -o $@
 
 lib-snprintf.o: $(PG_SNPRINTF)
@@ -96,6 +98,11 @@ lib-commandline.o: $(COMMANDLINE_SRC)
 lib-parson.o: $(PARSON_SRC)
 	$(CC) $(CFLAGS) -c -MMD -MP -MF$(DEPDIR)/$(*F).Po -MT$@ -o $@ ${SRC_DIR}../lib/parson/parson.c
 
+VERSION-FILE: git-version.h ;
+
+git-version.h:
+	echo "#define GIT_VERSION \""$(GIT_VERSION)"\"" > $@
+
 clean:
 	rm -f $(OBJS) $(PGCOPYDB)
 	rm -rf $(DEPDIR)
@@ -107,3 +114,4 @@ install: $(PGCOPYDB)
 
 
 .PHONY: all monitor clean
+.PHONY: VERSION-FILE

--- a/src/bin/pgcopydb/cli_common.c
+++ b/src/bin/pgcopydb/cli_common.c
@@ -114,14 +114,12 @@ cli_print_version_getopts(int argc, char **argv)
 void
 cli_print_version(int argc, char **argv)
 {
-	const char *version = PGCOPYDB_VERSION;
-
 	if (outputJSON)
 	{
 		JSON_Value *js = json_value_init_object();
 		JSON_Object *root = json_value_get_object(js);
 
-		json_object_set_string(root, "pgcopydb", version);
+		json_object_set_string(root, "pgcopydb", VERSION_STRING);
 		json_object_set_string(root, "pg_major", PG_MAJORVERSION);
 		json_object_set_string(root, "pg_version", PG_VERSION);
 		json_object_set_string(root, "pg_version_str", PG_VERSION_STR);
@@ -131,7 +129,7 @@ cli_print_version(int argc, char **argv)
 	}
 	else
 	{
-		fformat(stdout, "pgcopydb version %s\n", version);
+		fformat(stdout, "pgcopydb version %s\n", VERSION_STRING);
 		fformat(stdout, "compiled with %s\n", PG_VERSION_STR);
 		fformat(stdout, "compatible with Postgres 10, 11, 12, 13, and 14\n");
 	}

--- a/src/bin/pgcopydb/defaults.h
+++ b/src/bin/pgcopydb/defaults.h
@@ -6,8 +6,18 @@
 #ifndef DEFAULTS_H
 #define DEFAULTS_H
 
+#if __has_include("git-version.h")
+#include "git-version.h"
+#endif
+
 /* additional version information for printing version on CLI */
 #define PGCOPYDB_VERSION "0.5"
+
+#ifdef GIT_VERSION
+#define VERSION_STRING GIT_VERSION
+#else
+#define VERSION_STRING PGCOPYDB_VERSION
+#endif
 
 /* environment variable to use to make DEBUG facilities available */
 #define PGCOPYDB_DEBUG "PGCOPYDB_DEBUG"

--- a/src/bin/pgcopydb/main.c
+++ b/src/bin/pgcopydb/main.c
@@ -148,6 +148,10 @@ main(int argc, char **argv)
 	bool exitOnQuit = true;
 	(void) set_signal_handlers(exitOnQuit);
 
+	log_info("Running pgcopydb version %s from \"%s\"",
+			 VERSION_STRING,
+			 pgcopydb_program);
+
 	if (!commandline_run(&command, argc, argv))
 	{
 		exit(EXIT_CODE_BAD_ARGS);


### PR DESCRIPTION
For that to be useful, we also integrate with the git scripts from git
itself to compute a trustworthy version string such as 0.5.5.gaea0ff0.dirty
when we have local changes are are building from a git checkout.