### PR TITLE
Fix version string handling in some cases.

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,9 @@
 #!/usr/bin/make -f
 
+VERSION = $(shell dpkg-parsechangelog --show-field version)
+
 override_dh_auto_build:
+	$(MAKE) -C src/bin/pgcopydb GIT_VERSION=$(VERSION) git-version.h
 	$(MAKE) -C src/bin/pgcopydb
 	$(MAKE) -C docs man
 

--- a/src/bin/pgcopydb/Makefile
+++ b/src/bin/pgcopydb/Makefile
@@ -80,7 +80,7 @@ include $(Po_files)
 endif
 
 
-$(PGCOPYDB): $(OBJS) $(INCLUDES) VERSION-FILE
+$(PGCOPYDB): VERSION-FILE $(OBJS) $(INCLUDES)
 	$(CC) $(CFLAGS) $(OBJS) $(LDFLAGS) $(LIBS) -o $@
 
 lib-snprintf.o: $(PG_SNPRINTF)
@@ -104,6 +104,7 @@ git-version.h:
 	echo "#define GIT_VERSION \""$(GIT_VERSION)"\"" > $@
 
 clean:
+	rm -f git-version.h
 	rm -f $(OBJS) $(PGCOPYDB)
 	rm -rf $(DEPDIR)
 

--- a/src/bin/pgcopydb/defaults.h
+++ b/src/bin/pgcopydb/defaults.h
@@ -6,9 +6,7 @@
 #ifndef DEFAULTS_H
 #define DEFAULTS_H
 
-#if __has_include("git-version.h")
 #include "git-version.h"
-#endif
 
 /* additional version information for printing version on CLI */
 #define PGCOPYDB_VERSION "0.5"


### PR DESCRIPTION
In particular fix the debian package build, and use dpkg-parsechangelog in
that environment so that we report the debian/changelog version string.