### PR TITLE
Skip long-running transactions when --not-consistent is used.

### DIFF
--- a/src/bin/pgcopydb/cli_dump.c
+++ b/src/bin/pgcopydb/cli_dump.c
@@ -321,7 +321,8 @@ cli_dump_schema_section(CopyDBOptions *dumpDBoptions,
 						   restoreOptions,
 						   false, /* skipLargeObjects */
 						   dumpDBoptions->restart,
-						   dumpDBoptions->resume))
+						   dumpDBoptions->resume,
+						   !dumpDBoptions->notConsistent))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);
@@ -358,7 +359,7 @@ cli_dump_schema_section(CopyDBOptions *dumpDBoptions,
 		exit(EXIT_CODE_INTERNAL_ERROR);
 	}
 
-	if (!copydb_close_snapshot(&(copySpecs.sourceSnapshot)))
+	if (!copydb_close_snapshot(&copySpecs))
 	{
 		log_fatal("Failed to close snapshot \"%s\" on \"%s\"",
 				  copySpecs.sourceSnapshot.snapshot,

--- a/src/bin/pgcopydb/cli_restore.c
+++ b/src/bin/pgcopydb/cli_restore.c
@@ -415,17 +415,15 @@ cli_restore_schema_parse_list(int argc, char **argv)
 			exit(EXIT_CODE_INTERNAL_ERROR);
 		}
 
-		TransactionSnapshot *sourceSnapshot = &(copySpecs.sourceSnapshot);
-
 		/* fetch schema information from source catalogs, including filtering */
 		if (!copydb_fetch_schema_and_prepare_specs(&copySpecs))
 		{
 			/* errors have already been logged */
-			(void) copydb_close_snapshot(sourceSnapshot);
+			(void) copydb_close_snapshot(&copySpecs);
 			exit(EXIT_CODE_TARGET);
 		}
 
-		(void) copydb_close_snapshot(sourceSnapshot);
+		(void) copydb_close_snapshot(&copySpecs);
 	}
 
 	log_info("Preparing the pg_restore --use-list for the pre-data "
@@ -504,7 +502,8 @@ cli_restore_prepare_specs(CopyDataSpec *copySpecs)
 						   restoreDBoptions.restoreOptions,
 						   false, /* skipLargeObjects */
 						   restoreDBoptions.restart,
-						   restoreDBoptions.resume))
+						   restoreDBoptions.resume,
+						   !restoreDBoptions.notConsistent))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);

--- a/src/bin/pgcopydb/pgcmd.c
+++ b/src/bin/pgcopydb/pgcmd.c
@@ -372,7 +372,7 @@ pg_dump_db(PostgresPaths *pgPaths,
 	args[argsIndex++] = (char *) pgPaths->pg_dump;
 	args[argsIndex++] = "-Fc";
 
-	if (snapshot != NULL)
+	if (!IS_EMPTY_STRING_BUFFER(snapshot))
 	{
 		args[argsIndex++] = "--snapshot";
 		args[argsIndex++] = (char *) snapshot;

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -1056,7 +1056,10 @@ pgsql_execute_with_params(PGSQL *pgsql, const char *sql, int paramCount,
 		return false;
 	}
 
-	log_debug("%s;", sql);
+	char *endpoint =
+		pgsql->connectionType == PGSQL_CONN_SOURCE ? "SOURCE" : "TARGET";
+
+	log_debug("[%s] %s;", endpoint, sql);
 
 	if (paramCount > 0)
 	{
@@ -1110,16 +1113,13 @@ pgsql_execute_with_params(PGSQL *pgsql, const char *sql, int paramCount,
 		int lineCount = splitLines(message, errorLines, BUFSIZE);
 		int lineNumber = 0;
 
-		char *prefix =
-			pgsql->connectionType == PGSQL_CONN_SOURCE ? "[SOURCE]" : "[TARGET]";
-
 		/*
 		 * PostgreSQL Error message might contain several lines. Log each of
 		 * them as a separate ERROR line here.
 		 */
 		for (lineNumber = 0; lineNumber < lineCount; lineNumber++)
 		{
-			log_error("%s %s", prefix, errorLines[lineNumber]);
+			log_error("[%s] %s", endpoint, errorLines[lineNumber]);
 		}
 
 		log_error("SQL query: %s", sql);
@@ -1609,7 +1609,10 @@ pg_copy_from_stdin(PGSQL *pgsql, const char *qname)
 
 	sformat(sql, sizeof(sql), "COPY %s FROM stdin", qname);
 
-	log_debug("%s;", sql);
+	char *endpoint =
+		pgsql->connectionType == PGSQL_CONN_SOURCE ? "SOURCE" : "TARGET";
+
+	log_debug("[%s] %s;", endpoint, sql);
 
 	PGresult *res = PQexec(pgsql->connection, sql);
 

--- a/tests/pagila-multi-steps/copydb.sh
+++ b/tests/pagila-multi-steps/copydb.sh
@@ -45,7 +45,7 @@ echo snapshot ${PGCOPYDB_SNAPSHOT}
 pgcopydb dump schema --snapshot "${sn}"
 pgcopydb restore pre-data --resume
 
-pgcopydb copy table-data --resume
+pgcopydb copy table-data --resume -vv
 pgcopydb copy sequences --resume
 pgcopydb copy blobs --resume
 pgcopydb copy indexes --resume

--- a/tests/pagila-multi-steps/copydb.sh
+++ b/tests/pagila-multi-steps/copydb.sh
@@ -45,7 +45,7 @@ echo snapshot ${PGCOPYDB_SNAPSHOT}
 pgcopydb dump schema --snapshot "${sn}"
 pgcopydb restore pre-data --resume
 
-pgcopydb copy table-data --resume -vv
+pgcopydb copy table-data --resume
 pgcopydb copy sequences --resume
 pgcopydb copy blobs --resume
 pgcopydb copy indexes --resume


### PR DESCRIPTION
To prevent limitations around lock management when running pgcopydb on a
source database with lots of objects, we now benefit from --not-consistent
as an opportunity to reduce long-running transactions.

It was already the case that --not-consistent wouldn't require exporting or
setting a snapshot, but the opportunity was not yet implemented fully.