### PR TITLE
debian/tests/copydb: Remove directory before starting pgcopydb

### DIFF
--- a/debian/tests/copydb
+++ b/debian/tests/copydb
@@ -9,6 +9,7 @@ pg_virtualenv << EOF
   createdb src
   createdb dst
   psql -c 'create table foo as select 123+456' src
+  rm -rf $WORKDIR
   HOME=$WORKDIR pgcopydb copy-db --source "dbname=src" --target "dbname=dst" --dir $WORKDIR
   pg_dump -t foo dst
   pg_dump -t foo dst | grep 579


### PR DESCRIPTION
The autopkgtest would barf at the existing files left around from the
build-time test.