### PR TITLE
WIP: Implement support for copying roles.

### DIFF
--- a/docs/ref/pgcopydb_dump.rst
+++ b/docs/ref/pgcopydb_dump.rst
@@ -13,6 +13,7 @@ This command prefixes the following sub-commands:
      schema     Dump source database schema as custom files in target directory
      pre-data   Dump source database pre-data schema as custom files in target directory
      post-data  Dump source database post-data schema as custom files in target directory
+     roles      Dump source database roles as custome file in work directory
 
 
 .. _pgcopydb_dump_schema:
@@ -71,6 +72,26 @@ The command ``pgcopydb dump post-data`` uses pg_dump to export SQL schema
      --source          Postgres URI to the source database
      --target          Directory where to save the dump files
      --snapshot            Use snapshot obtained with pg_export_snapshot
+
+
+.. _pgcopydb_dump_roles:
+
+pgcopydb dump roles
+-------------------
+
+pgcopydb dump roles - Dump source database roles as custome file in work directory
+
+The command ``pgcopydb dump roles`` uses pg_dumpall --roles-only to export
+SQL definitions of the roles found on the source Postgres instance.
+
+::
+
+   pgcopydb dump roles: Dump source database roles as custome file in work directory
+   usage: pgcopydb dump roles  --source <URI>
+
+     --source          Postgres URI to the source database
+     --target          Directory where to save the dump files
+     --dir             Work directory to use
 
 
 Description

--- a/docs/ref/pgcopydb_restore.rst
+++ b/docs/ref/pgcopydb_restore.rst
@@ -13,6 +13,7 @@ This command prefixes the following sub-commands:
     schema      Restore a database schema from custom files to target database
     pre-data    Restore a database pre-data schema from custom file to target database
     post-data   Restore a database post-data schema from custom file to target database
+    roles       Restore database roles from SQL file to target database
     parse-list  Parse pg_restore --list output from custom file
 
 
@@ -102,6 +103,26 @@ be fed with the directory output from the ``pgcopydb dump ...`` commands.
      --restart            Allow restarting when temp files exist already
      --resume             Allow resuming operations after a failure
      --not-consistent     Allow taking a new snapshot on the source database
+
+
+.. _pgcopydb_restore_roles:
+
+pgcopydb restore roles
+----------------------
+
+pgcopydb restore roles - Restore database roles from SQL file to target database
+
+The command ``pgcopydb restore roles`` uses psql to create the SQL script
+obtained from the command ``pgcopydb dump roles``.
+
+::
+
+   pgcopydb restore roles: Restore database roles from SQL file to target database
+   usage: pgcopydb restore roles  --dir <dir> [ --source <URI> ] --target <URI>
+
+     --source             Postgres URI to the source database
+     --target             Postgres URI to the target database
+     --dir                Work directory to use
 
 
 .. _pgcopydb_restore_parse_list:

--- a/src/bin/pgcopydb/cli_dump.c
+++ b/src/bin/pgcopydb/cli_dump.c
@@ -25,6 +25,7 @@ static int cli_dump_schema_getopts(int argc, char **argv);
 static void cli_dump_schema(int argc, char **argv);
 static void cli_dump_schema_pre_data(int argc, char **argv);
 static void cli_dump_schema_post_data(int argc, char **argv);
+static void cli_dump_roles(int argc, char **argv);
 
 static void cli_dump_schema_section(CopyDBOptions *dumpDBoptions,
 									PostgresDumpSection section);
@@ -32,8 +33,8 @@ static void cli_dump_schema_section(CopyDBOptions *dumpDBoptions,
 static CommandLine dump_schema_command =
 	make_command(
 		"schema",
-		"Dump source database schema as custom files in target directory",
-		" --source <URI> --target <dir> ",
+		"Dump source database schema as custom files in work directory",
+		" --source <URI> ",
 		"  --source          Postgres URI to the source database\n"
 		"  --target          Directory where to save the dump files\n"
 		"  --dir             Work directory to use\n"
@@ -44,8 +45,8 @@ static CommandLine dump_schema_command =
 static CommandLine dump_schema_pre_data_command =
 	make_command(
 		"pre-data",
-		"Dump source database pre-data schema as custom files in target directory",
-		" --source <URI> --target <dir> ",
+		"Dump source database pre-data schema as custom files in work directory",
+		" --source <URI> ",
 		"  --source          Postgres URI to the source database\n"
 		"  --target          Directory where to save the dump files\n"
 		"  --dir             Work directory to use\n"
@@ -56,8 +57,8 @@ static CommandLine dump_schema_pre_data_command =
 static CommandLine dump_schema_post_data_command =
 	make_command(
 		"post-data",
-		"Dump source database post-data schema as custom files in target directory",
-		" --source <URI> --target <dir>",
+		"Dump source database post-data schema as custom files in work directory",
+		" --source <URI>",
 		"  --source          Postgres URI to the source database\n"
 		"  --target          Directory where to save the dump files\n"
 		"  --dir             Work directory to use\n"
@@ -65,10 +66,22 @@ static CommandLine dump_schema_post_data_command =
 		cli_dump_schema_getopts,
 		cli_dump_schema_post_data);
 
+static CommandLine dump_roles_command =
+	make_command(
+		"roles",
+		"Dump source database roles as custome file in work directory",
+		" --source <URI>",
+		"  --source          Postgres URI to the source database\n"
+		"  --target          Directory where to save the dump files\n"
+		"  --dir             Work directory to use\n",
+		cli_dump_schema_getopts,
+		cli_dump_roles);
+
 static CommandLine *dump_subcommands[] = {
 	&dump_schema_command,
 	&dump_schema_pre_data_command,
 	&dump_schema_post_data_command,
+	&dump_roles_command,
 	NULL
 };
 
@@ -281,6 +294,16 @@ cli_dump_schema_post_data(int argc, char **argv)
 
 
 /*
+ * cli_dump_roles implements the command: pgcopydb dump roles
+ */
+static void
+cli_dump_roles(int argc, char **argv)
+{
+	(void) cli_dump_schema_section(&dumpDBoptions, PG_DUMP_SECTION_ROLES);
+}
+
+
+/*
  * cli_dump_schema_section implements the actual work for the commands in this
  * file.
  */
@@ -337,9 +360,18 @@ cli_dump_schema_section(CopyDBOptions *dumpDBoptions,
 	log_info("Dumping database from \"%s\"", scrubbedSourceURI);
 	log_info("Dumping database into directory \"%s\"", cfPaths->topdir);
 
-	log_info("Using pg_dump for Postgres \"%s\" at \"%s\"",
-			 pgPaths->pg_version,
-			 pgPaths->pg_dump);
+	if (section == PG_DUMP_SECTION_ROLES)
+	{
+		log_info("Using pg_dumpall for Postgres \"%s\" at \"%s\"",
+				 pgPaths->pg_version,
+				 pgPaths->pg_dump);
+	}
+	else
+	{
+		log_info("Using pg_dump for Postgres \"%s\" at \"%s\"",
+				 pgPaths->pg_version,
+				 pgPaths->pg_dumpall);
+	}
 
 	/*
 	 * First, we need to open a snapshot that we're going to re-use in all our
@@ -352,12 +384,25 @@ cli_dump_schema_section(CopyDBOptions *dumpDBoptions,
 		exit(EXIT_CODE_INTERNAL_ERROR);
 	}
 
-	if (!copydb_dump_source_schema(&copySpecs,
-								   copySpecs.sourceSnapshot.snapshot,
-								   section))
+	if (section == PG_DUMP_SECTION_ROLES)
 	{
-		/* errors have already been logged */
-		exit(EXIT_CODE_INTERNAL_ERROR);
+		if (!pg_dumpall_roles(&(copySpecs.pgPaths),
+							  copySpecs.source_pguri,
+							  copySpecs.dumpPaths.rolesFilename))
+		{
+			/* errors have already been logged */
+			exit(EXIT_CODE_INTERNAL_ERROR);
+		}
+	}
+	else
+	{
+		if (!copydb_dump_source_schema(&copySpecs,
+									   copySpecs.sourceSnapshot.snapshot,
+									   section))
+		{
+			/* errors have already been logged */
+			exit(EXIT_CODE_INTERNAL_ERROR);
+		}
 	}
 
 	if (!copydb_close_snapshot(&copySpecs))

--- a/src/bin/pgcopydb/copydb.c
+++ b/src/bin/pgcopydb/copydb.c
@@ -431,6 +431,9 @@ copydb_prepare_filepaths(CopyFilePaths *cfPaths, const char *dir, bool auxilliar
 bool
 copydb_prepare_dump_paths(CopyFilePaths *cfPaths, DumpPaths *dumpPaths)
 {
+	sformat(dumpPaths->rolesFilename, MAXPGPATH, "%s/%s",
+			cfPaths->schemadir, "roles.sql");
+
 	sformat(dumpPaths->preFilename, MAXPGPATH, "%s/%s",
 			cfPaths->schemadir, "pre.dump");
 

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -70,6 +70,8 @@ typedef struct CopyFilePaths
 /* the main pg_dump and pg_restore process are driven from split files */
 typedef struct DumpPaths
 {
+	char rolesFilename[MAXPGPATH];   /* pg_dumpall --roles-only */
+
 	char preFilename[MAXPGPATH];     /* pg_dump --section=pre-data */
 	char preListFilename[MAXPGPATH]; /* pg_restore --list */
 
@@ -260,7 +262,8 @@ typedef enum
 	PG_DUMP_SECTION_SCHEMA,
 	PG_DUMP_SECTION_PRE_DATA,
 	PG_DUMP_SECTION_POST_DATA,
-	PG_DUMP_SECTION_DATA
+	PG_DUMP_SECTION_DATA,
+	PG_DUMP_SECTION_ROLES       /* pg_dumpall --roles-only */
 } PostgresDumpSection;
 
 

--- a/src/bin/pgcopydb/pgcmd.c
+++ b/src/bin/pgcopydb/pgcmd.c
@@ -110,6 +110,7 @@ void
 set_postgres_commands(PostgresPaths *pgPaths)
 {
 	path_in_same_directory(pgPaths->psql, "pg_dump", pgPaths->pg_dump);
+	path_in_same_directory(pgPaths->psql, "pg_dumpall", pgPaths->pg_dumpall);
 	path_in_same_directory(pgPaths->psql, "pg_restore", pgPaths->pg_restore);
 }
 
@@ -418,6 +419,186 @@ pg_dump_db(PostgresPaths *pgPaths,
 	if (program.returnCode != 0)
 	{
 		log_error("Failed to run pg_dump: exit code %d", program.returnCode);
+		free_program(&program);
+
+		return false;
+	}
+
+	free_program(&program);
+	return true;
+}
+
+
+/*
+ * Call pg_dump and get the given section of the dump into the target file.
+ */
+bool
+pg_dumpall_roles(PostgresPaths *pgPaths,
+				 const char *pguri,
+				 const char *filename)
+{
+	char *args[16];
+	int argsIndex = 0;
+
+	char command[BUFSIZE] = { 0 };
+
+	SafeURI safeURI = { 0 };
+	bool pgpassword_found_in_env = env_exists("PGPASSWORD");
+	char PGPASSWORD[MAXCONNINFO] = { 0 };
+
+	if (!extract_connection_string_password(pguri, &safeURI))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	setenv("PGCONNECT_TIMEOUT", POSTGRES_CONNECT_TIMEOUT, 1);
+
+	/* override PGPASSWORD environment variable if the pguri contains one */
+	if (!IS_EMPTY_STRING_BUFFER(safeURI.password))
+	{
+		if (pgpassword_found_in_env &&
+			!get_env_copy("PGPASSWORD", PGPASSWORD, MAXCONNINFO))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+		setenv("PGPASSWORD", safeURI.password, 1);
+	}
+
+	args[argsIndex++] = (char *) pgPaths->pg_dumpall;
+	args[argsIndex++] = "--roles-only";
+
+	args[argsIndex++] = "--file";
+	args[argsIndex++] = (char *) filename;
+
+	args[argsIndex++] = "--dbname";
+	args[argsIndex++] = (char *) safeURI.pguri;
+
+	args[argsIndex] = NULL;
+
+	/*
+	 * We do not want to call setsid() when running pg_dump.
+	 */
+	Program program = { 0 };
+
+	(void) initialize_program(&program, args, false);
+	program.processBuffer = &processBufferCallback;
+
+	/* log the exact command line we're using */
+	int commandSize = snprintf_program_command_line(&program, command, BUFSIZE);
+
+	if (commandSize >= BUFSIZE)
+	{
+		/* we only display the first BUFSIZE bytes of the real command */
+		log_info("%s...", command);
+	}
+	else
+	{
+		log_info("%s", command);
+	}
+
+	(void) execute_subprogram(&program);
+
+	/* make sure to reset the environment PGPASSWORD if we edited it */
+	if (pgpassword_found_in_env && !IS_EMPTY_STRING_BUFFER(safeURI.password))
+	{
+		setenv("PGPASSWORD", PGPASSWORD, 1);
+	}
+
+	if (program.returnCode != 0)
+	{
+		log_error("Failed to run pg_dump: exit code %d", program.returnCode);
+		free_program(&program);
+
+		return false;
+	}
+
+	free_program(&program);
+	return true;
+}
+
+
+/*
+ * pg_restore_roles calls psql on the roles SQL file obtained with pg_dumpall
+ * or the function pg_dumpall_roles.
+ */
+bool
+pg_restore_roles(PostgresPaths *pgPaths,
+				 const char *pguri,
+				 const char *filename)
+{
+	char *args[16];
+	int argsIndex = 0;
+
+	char command[BUFSIZE] = { 0 };
+
+	SafeURI safeURI = { 0 };
+	bool pgpassword_found_in_env = env_exists("PGPASSWORD");
+	char PGPASSWORD[MAXCONNINFO] = { 0 };
+
+	if (!extract_connection_string_password(pguri, &safeURI))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	setenv("PGCONNECT_TIMEOUT", POSTGRES_CONNECT_TIMEOUT, 1);
+
+	/* override PGPASSWORD environment variable if the pguri contains one */
+	if (!IS_EMPTY_STRING_BUFFER(safeURI.password))
+	{
+		if (pgpassword_found_in_env &&
+			!get_env_copy("PGPASSWORD", PGPASSWORD, MAXCONNINFO))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+		setenv("PGPASSWORD", safeURI.password, 1);
+	}
+
+	args[argsIndex++] = (char *) pgPaths->psql;
+	args[argsIndex++] = "--dbname";
+	args[argsIndex++] = (char *) safeURI.pguri;
+	args[argsIndex++] = "--no-psqlrc";
+	args[argsIndex++] = "--single-transaction";
+	args[argsIndex++] = "--file";
+	args[argsIndex++] = (char *) filename;
+
+	args[argsIndex] = NULL;
+
+	/*
+	 * We do not want to call setsid() when running pg_dump.
+	 */
+	Program program = { 0 };
+
+	(void) initialize_program(&program, args, false);
+	program.processBuffer = &processBufferCallback;
+
+	/* log the exact command line we're using */
+	int commandSize = snprintf_program_command_line(&program, command, BUFSIZE);
+
+	if (commandSize >= BUFSIZE)
+	{
+		/* we only display the first BUFSIZE bytes of the real command */
+		log_info("%s...", command);
+	}
+	else
+	{
+		log_info("%s", command);
+	}
+
+	(void) execute_subprogram(&program);
+
+	/* make sure to reset the environment PGPASSWORD if we edited it */
+	if (pgpassword_found_in_env && !IS_EMPTY_STRING_BUFFER(safeURI.password))
+	{
+		setenv("PGPASSWORD", PGPASSWORD, 1);
+	}
+
+	if (program.returnCode != 0)
+	{
+		log_error("Failed to run pg_restore: exit code %d", program.returnCode);
 		free_program(&program);
 
 		return false;

--- a/src/bin/pgcopydb/pgcmd.h
+++ b/src/bin/pgcopydb/pgcmd.h
@@ -24,6 +24,7 @@ typedef struct PostgresPaths
 	char psql[MAXPGPATH];
 	char pg_config[MAXPGPATH];
 	char pg_dump[MAXPGPATH];
+	char pg_dumpall[MAXPGPATH];
 	char pg_restore[MAXPGPATH];
 	char pg_version[PG_VERSION_STRING_MAX];
 } PostgresPaths;
@@ -84,6 +85,14 @@ bool pg_dump_db(PostgresPaths *pgPaths,
 				const char *snapshot,
 				const char *section,
 				const char *filename);
+
+bool pg_dumpall_roles(PostgresPaths *pgPaths,
+					  const char *pguri,
+					  const char *filename);
+
+bool pg_restore_roles(PostgresPaths *pgPaths,
+					  const char *pguri,
+					  const char *filename);
 
 bool pg_restore_db(PostgresPaths *pgPaths,
 				   const char *pguri,


### PR DESCRIPTION
Postgres roles are global objects, which means they do not belong to any
specific database in an instance. To be able to dump and restore the roles,
we need to use pg_dumpall --roles-only.

Fixed #49.