### PR TITLE
Implement pgcopydb stream prefetch.

### DIFF
--- a/docs/ref/pgcopydb_create.rst
+++ b/docs/ref/pgcopydb_create.rst
@@ -14,12 +14,14 @@ pgcopydb create
   pgcopydb create
     snapshot  Create and exports a snapshot on the source database
     slot      Create a replication slot in the source database
+    origin    Create a replication origin in the target database
 
 
 ::
 
   pgcopydb drop
     slot  Drop a replication slot in the source database
+    origin  Drop a replication origin in the target database
 
 .. _pgcopydb_create_snapshot:
 
@@ -62,6 +64,27 @@ executes a SQL query to create a logical replication slot using the plugin
      --snapshot       Use snapshot obtained with pg_export_snapshot
      --slot-name      Use this Postgres replication slot name
 
+.. _pgcopydb_create_origin:
+
+pgcopydb create origin
+----------------------
+
+pgcopydb create origin - Create a replication origin in the target database
+
+The command ``pgcopydb create origin`` connects to the target database and
+executes a SQL query to create a logical replication origin. The starting
+LSN position ``--startpos`` is required.
+
+::
+
+   pgcopydb create origin: Create a replication origin in the target database
+   usage: pgcopydb create origin  --target ...
+
+     --target         Postgres URI to the target database
+     --dir            Work directory to use
+     --origin         Use this Postgres origin name
+     --start-pos      LSN position from where to start applying changes
+
 .. _pgcopydb_drop_slot:
 
 pgcopydb drop slot
@@ -82,11 +105,31 @@ name (that defaults to ``pgcopydb``).
      --dir            Work directory to use
      --slot-name      Use this Postgres replication slot name
 
+.. _pgcopydb_drop_origin:
+
+pgcopydb drop origin
+--------------------
+
+pgcopydb drop origin - Drop a replication origin in the target database
+
+The command ``pgcopydb drop origin`` connects to the target database and
+executes a SQL query to drop the logical replication origin with the given
+name (that defaults to ``pgcopydb``).
+
+::
+
+   usage: pgcopydb drop origin  --target ...
+
+     --target         Postgres URI to the target database
+     --dir            Work directory to use
+     --origin         Use this Postgres origin name
+
 
 Options
 -------
 
-The following options are available to ``pgcopydb create`` subcommands:
+The following options are available to ``pgcopydb create`` and ``pgcopydb
+drop`` subcommands:
 
 --source
 
@@ -121,6 +164,28 @@ The following options are available to ``pgcopydb create`` subcommands:
   format-version 2.
 
   __ https://github.com/eulerto/wal2json/
+
+--origin
+
+  Logical replication target system needs to track the transactions that
+  have been applied already, so that in case we get disconnected or need to
+  resume operations we can skip already replayed transaction.
+
+  Postgres uses a notion of an origin node name as documented in
+  `Replication Progress Tracking`__. This option allows to pick your own
+  node name and defaults to "pgcopydb". Picking a different name is useful
+  in some advanced scenarios like migrating several sources in the same
+  target, where each source should have their own unique origin node name.
+
+  __ https://www.postgresql.org/docs/current/replication-origins.html
+
+--startpos
+
+  Logical replication target system registers progress by assigning a
+  current LSN to the ``--origin`` node name. When creating an origin on the
+  target database system, it is required to provide the current LSN from the
+  source database system, in order to properly bootstrap pgcopydb logical
+  decoding.
 
 Environment
 -----------

--- a/docs/ref/pgcopydb_stream.rst
+++ b/docs/ref/pgcopydb_stream.rst
@@ -41,13 +41,13 @@ The command ``pgcopydb stream prefetch`` connects to the source database
 using the logical replication protocl and the given replication slot, that
 should be created with the logical decoding plugin `wal2json`__.
 
+__ https://github.com/eulerto/wal2json/
+
 The prefetch command receives the changes from the source database in a
 streaming fashion, and writes them in a series of JSON files named the same
 as their origin WAL filename (with the ``.json`` extension). Each time a
 JSON file is closed, a subprocess is started to transform the JSON into an
 SQL file.
-
-__ https://github.com/eulerto/wal2json/
 
 
 ::
@@ -74,6 +74,8 @@ pgcopydb stream receive - Stream changes from the source database
 The command ``pgcopydb stream receive`` connects to the source database
 using the logical replication protocl and the given replication slot, that
 should be created with the logical decoding plugin `wal2json`__.
+
+__ https://github.com/eulerto/wal2json/
 
 The receive command receives the changes from the source database in a
 streaming fashion, and writes them in a series of JSON files named the same

--- a/docs/ref/pgcopydb_stream.rst
+++ b/docs/ref/pgcopydb_stream.rst
@@ -10,6 +10,7 @@ This command prefixes the following sub-commands:
 ::
 
   pgcopydb stream
+    setup      Setup source and target systems for logical decoding
     prefetch   Stream JSON changes from the source database and transform them to SQL
     receive    Stream changes from the source database
     transform  Transform changes from the source database into SQL commands
@@ -25,10 +26,39 @@ step.
    Using the ``pgcopydb follow`` command or the command ``pgcopydb
    clone --follow`` is strongly advised.
 
-   This mode of operations is useful for debugging and advanced use cases
-   only.
+   This mode of operations has been designed for unit testing.
 
 This is still a work in progress. Stay tuned.
+
+.. _pgcopydb_stream_setup:
+
+pgcopydb stream setup
+---------------------
+
+pgcopydb stream setup - Setup source and target systems for logical decoding
+
+The command ``pgcopydb stream setup`` connects to the source database and
+create a replication slot using the logical decoding plugin `wal2json`__,
+then connects to the target database and creates a replication origin
+positioned at the LSN position of the just created replication slot.
+
+__ https://github.com/eulerto/wal2json/
+
+
+::
+
+   pgcopydb stream setup: Setup source and target systems for logical decoding
+   usage: pgcopydb stream setup  --source ... --target ... --dir ...
+
+     --source         Postgres URI to the source database
+     --target         Postgres URI to the target database
+     --dir            Work directory to use
+     --restart        Allow restarting when temp files exist already
+     --resume         Allow resuming operations after a failure
+     --not-consistent Allow taking a new snapshot on the source database
+     --snapshot       Use snapshot obtained with pg_export_snapshot
+     --slot-name      Stream changes recorded by this slot
+     --origin         Name of the Postgres replication origin
 
 .. _pgcopydb_stream_prefetch:
 
@@ -62,7 +92,6 @@ SQL file.
      --not-consistent Allow taking a new snapshot on the source database
      --slot-name      Stream changes recorded by this slot
      --endpos         LSN position where to stop receiving changes
-
 
 .. _pgcopydb_stream_receive:
 

--- a/src/bin/pgcopydb/cli_common.h
+++ b/src/bin/pgcopydb/cli_common.h
@@ -43,6 +43,7 @@ typedef struct CopyDBOptions
 	bool follow;
 	bool createSlot;
 	uint64_t endpos;
+	uint64_t startpos;
 
 	char filterFileName[MAXPGPATH];
 	char slotName[MAXPGPATH];

--- a/src/bin/pgcopydb/ld_transform.c
+++ b/src/bin/pgcopydb/ld_transform.c
@@ -104,7 +104,7 @@ stream_transform_file(char *jsonfilename, char *sqlfilename)
 		char *message = content.lines[i];
 		LogicalMessageMetadata *metadata = &(content.messages[i]);
 
-		log_debug("stream_transform_file[%d]: %s", i, message);
+		log_trace("stream_transform_file[%d]: %s", i, message);
 
 		JSON_Value *json = json_parse_string(message);
 

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -3262,6 +3262,8 @@ pgsql_replication_origin_drop(PGSQL *pgsql, char *nodeName)
 	Oid paramTypes[1] = { TEXTOID };
 	const char *paramValues[1] = { nodeName };
 
+	log_info("Dropping replication origin \"%s\"", nodeName);
+
 	if (!pgsql_execute_with_params(pgsql, sql,
 								   paramCount, paramTypes, paramValues,
 								   NULL, NULL))

--- a/src/bin/pgcopydb/stream.c
+++ b/src/bin/pgcopydb/stream.c
@@ -46,7 +46,8 @@ stream_init_specs(StreamSpecs *specs,
 				  char *source_pguri,
 				  char *target_pguri,
 				  char *slotName,
-				  uint64_t endpos)
+				  uint64_t endpos,
+				  LogicalStreamMode mode)
 {
 	/* just copy into StreamSpecs what's been initialized in copySpecs */
 	strlcpy(specs->cdcdir, cdcdir, MAXCONNINFO);
@@ -55,6 +56,8 @@ stream_init_specs(StreamSpecs *specs,
 	strlcpy(specs->slotName, slotName, sizeof(specs->slotName));
 
 	specs->endpos = endpos;
+
+	specs->mode = mode;
 
 	if (!buildReplicationURI(specs->source_pguri, specs->logrep_pguri))
 	{
@@ -103,6 +106,7 @@ startLogicalStreaming(StreamSpecs *specs)
 	StreamContext privateContext = { 0 };
 	LogicalStreamContext context = { 0 };
 
+	privateContext.mode = specs->mode;
 	privateContext.cdcdir = specs->cdcdir;
 	privateContext.startLSN = specs->startLSN;
 
@@ -203,66 +207,11 @@ streamWrite(LogicalStreamContext *context)
 {
 	StreamContext *privateContext = (StreamContext *) context->private;
 
-	/* get the segment number from the current_record_lsn */
-	XLogSegNo segno;
-	char wal[MAXPGPATH] = { 0 };
-	char walFileName[MAXPGPATH] = { 0 };
-
-	/* compute the WAL filename that would host the current LSN */
-	XLByteToSeg(context->cur_record_lsn, segno, context->WalSegSz);
-	XLogFileName(wal, context->timeline, segno, context->WalSegSz);
-
-	sformat(walFileName, sizeof(walFileName), "%s/%s.json",
-			privateContext->cdcdir,
-			wal);
-
-	if (strcmp(privateContext->walFileName, walFileName) != 0)
+	/* we might have to rotate to the next on-disk file */
+	if (!streamRotateFile(context))
 	{
-		/* if we had a WAL file opened, close it now */
-		if (!IS_EMPTY_STRING_BUFFER(privateContext->walFileName) &&
-			privateContext->jsonFile != NULL)
-		{
-			log_debug("closing %s", privateContext->walFileName);
-
-			if (fclose(privateContext->jsonFile) != 0)
-			{
-				/* errors have already been logged */
-				return false;
-			}
-		}
-
-		log_info("Now streaming changes to \"%s\"", walFileName);
-		strlcpy(privateContext->walFileName, walFileName, MAXPGPATH);
-
-		/*
-		 * When the target file already exists, open it in append mode.
-		 */
-		int flags = file_exists(walFileName) ? FOPEN_FLAGS_A : FOPEN_FLAGS_W;
-
-		privateContext->jsonFile =
-			fopen_with_umask(walFileName, "ab", flags, 0644);
-
-		if (privateContext->jsonFile == NULL)
-		{
-			/* errors have already been logged */
-			log_error("Failed to open file \"%s\": %m",
-					  privateContext->walFileName);
-			return false;
-		}
-
-		/*
-		 * Also maintain the "latest" symbolic link to the latest file where
-		 * we've been streaming changes in.
-		 */
-		char latest[MAXPGPATH] = { 0 };
-
-		sformat(latest, sizeof(latest), "%s/latest", privateContext->cdcdir);
-
-		if (!create_symbolic_link(privateContext->walFileName, latest))
-		{
-			/* errors have already been logged */
-			return false;
-		}
+		/* errors have already been logged */
+		return false;
 	}
 
 	LogicalMessageMetadata metadata = { 0 };
@@ -349,6 +298,171 @@ streamWrite(LogicalStreamContext *context)
 
 
 /*
+ * streamRotate decides if the received message should be appended to the
+ * already opened file or to a new file, and then opens that file and takes
+ * care of preparing the new file descriptor.
+ *
+ * A "latest" symbolic link is also maintained.
+ */
+bool
+streamRotateFile(LogicalStreamContext *context)
+{
+	StreamContext *privateContext = (StreamContext *) context->private;
+
+	/* get the segment number from the current_record_lsn */
+	XLogSegNo segno;
+	char wal[MAXPGPATH] = { 0 };
+	char walFileName[MAXPGPATH] = { 0 };
+
+	/* compute the WAL filename that would host the current LSN */
+	XLByteToSeg(context->cur_record_lsn, segno, context->WalSegSz);
+	XLogFileName(wal, context->timeline, segno, context->WalSegSz);
+
+	sformat(walFileName, sizeof(walFileName), "%s/%s.json",
+			privateContext->cdcdir,
+			wal);
+
+	/* in most cases, the file name is still the same */
+	if (strcmp(privateContext->walFileName, walFileName) == 0)
+	{
+		return true;
+	}
+
+	/* if we had a WAL file opened, close it now */
+	if (!IS_EMPTY_STRING_BUFFER(privateContext->walFileName) &&
+		privateContext->jsonFile != NULL)
+	{
+		bool time_to_abort = false;
+
+		if (!streamCloseFile(context, time_to_abort))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+	}
+
+	log_info("Now streaming changes to \"%s\"", walFileName);
+	strlcpy(privateContext->walFileName, walFileName, MAXPGPATH);
+
+	/* when dealing with a new JSON name, also prepare the SQL name */
+	sformat(privateContext->sqlFileName, sizeof(privateContext->sqlFileName),
+			"%s/%s.sql",
+			privateContext->cdcdir,
+			wal);
+
+	/*
+	 * When the target file already exists, open it in append mode.
+	 */
+	int flags = file_exists(walFileName) ? FOPEN_FLAGS_A : FOPEN_FLAGS_W;
+
+	privateContext->jsonFile =
+		fopen_with_umask(walFileName, "ab", flags, 0644);
+
+	if (privateContext->jsonFile == NULL)
+	{
+		/* errors have already been logged */
+		log_error("Failed to open file \"%s\": %m",
+				  privateContext->walFileName);
+		return false;
+	}
+
+	/*
+	 * Also maintain the "latest" symbolic link to the latest file where
+	 * we've been streaming changes in.
+	 */
+	char latest[MAXPGPATH] = { 0 };
+
+	sformat(latest, sizeof(latest), "%s/latest", privateContext->cdcdir);
+
+	if (!create_symbolic_link(privateContext->walFileName, latest))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * streamCloseFile closes the current file where the stream messages are
+ * written to. It's called from either streamWrite or streamClose logical
+ * stream client callback functions.
+ */
+bool
+streamCloseFile(LogicalStreamContext *context, bool time_to_abort)
+{
+	StreamContext *privateContext = (StreamContext *) context->private;
+
+	if (privateContext->jsonFile == NULL)
+	{
+		return true;
+	}
+
+	log_debug("Closing file \"%s\"", privateContext->walFileName);
+
+	if (fclose(privateContext->jsonFile) != 0)
+	{
+		log_error("Failed to close file \"%s\": %m",
+				  privateContext->walFileName);
+		return false;
+	}
+
+	/* in prefetch mode, kick-in a transform process */
+	switch (privateContext->mode)
+	{
+		case STREAM_MODE_RECEIVE:
+		{
+			/* nothing else to do in that streaming mode */
+			break;
+		}
+
+		case STREAM_MODE_PREFETCH:
+		{
+			/*
+			 * Now is the time to transform the JSON file into SQL.
+			 *
+			 * The transformation of the file uses enough CPU that we'd prefer
+			 * to start it in a subprocess.
+			 */
+			if (!streamTransformFileInSubprocess(context))
+			{
+				/* errors have already been logged */
+				return false;
+			}
+
+			/*
+			 * While streaming logical decoding JSON messages, the transforming
+			 * of the previous JSON file happens in parallel to the receiving
+			 * of the current one.
+			 *
+			 * When it's time_to_abort, we need to make sure the current file
+			 * has been transformed before exiting.
+			 */
+			if (time_to_abort)
+			{
+				if (!streamWaitForSubprocess(context))
+				{
+					/* errors have already been logged */
+					return false;
+				}
+			}
+
+			break;
+		}
+
+		default:
+		{
+			log_error("BUG: unknown LogicalStreamMode %d", privateContext->mode);
+			return false;
+		}
+	}
+
+	return true;
+}
+
+
+/*
  * streamFlush is a callback function for our LogicalStreamClient.
  *
  * This function is called when it's time to flush the data that's currently
@@ -398,26 +512,18 @@ streamFlush(LogicalStreamContext *context)
 bool
 streamClose(LogicalStreamContext *context)
 {
-	StreamContext *privateContext = (StreamContext *) context->private;
-
-	/* when there is currently no file opened, just skip the close operation */
-	if (privateContext->jsonFile == NULL)
-	{
-		return true;
-	}
-
 	if (!streamFlush(context))
 	{
 		/* errors have already been logged */
 		return false;
 	}
 
-	log_debug("streamClose: closing file \"%s\"", privateContext->walFileName);
+	bool time_to_abort = true;
 
-	if (fclose(privateContext->jsonFile) != 0)
+	if (!streamCloseFile(context, time_to_abort))
 	{
-		log_error("Failed to close file \"%s\": %m",
-				  privateContext->walFileName);
+		/* errors have already been logged */
+		return false;
 	}
 
 	return true;
@@ -754,4 +860,106 @@ StreamActionFromChar(char action)
 
 	/* keep compiler happy */
 	return STREAM_ACTION_UNKNOWN;
+}
+
+
+/*
+ * streamTransformFileInSubprocess creates an auxiliary process to run the
+ * stream_transform_file() function on the just closed JSON file.
+ */
+bool
+streamTransformFileInSubprocess(LogicalStreamContext *context)
+{
+	StreamContext *privateContext = (StreamContext *) context->private;
+
+	/*
+	 * First, wait any already started subprocess.
+	 *
+	 * The assumption here is that by the time we have received another WAL
+	 * size content of JSON messages, the transform subprocess should be
+	 * finished already.
+	 */
+	if (!streamWaitForSubprocess(context))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now we can fork a sub-process to transform the current file */
+	pid_t fpid = fork();
+
+	switch (fpid)
+	{
+		case -1:
+		{
+			log_error("Failed to fork a subprocess to transform "
+					  "JSON file \"%s\" into SQL",
+					  privateContext->walFileName);
+			return -1;
+		}
+
+		case 0:
+		{
+			/* child process runs the command */
+			if (!stream_transform_file(privateContext->walFileName,
+									   privateContext->sqlFileName))
+			{
+				/* errors have already been logged */
+				return false;
+			}
+
+			/* and we're done */
+			exit(EXIT_CODE_QUIT);
+		}
+
+		default:
+		{
+			privateContext->subprocess = fpid;
+			log_info("Starting subprocess %d to prepare \"%s\"",
+					 fpid,
+					 privateContext->sqlFileName);
+			break;
+		}
+	}
+
+	return true;
+}
+
+
+/*
+ * streamWaitForSubprocess calls waitpid() and blocks until the current
+ * subprocess is reported terminated by the Operating System.
+ */
+bool
+streamWaitForSubprocess(LogicalStreamContext *context)
+{
+	StreamContext *privateContext = (StreamContext *) context->private;
+
+	/* if a subprocess had been started before, wait until it's done. */
+	if (privateContext->subprocess > 0)
+	{
+		int status = 0;
+
+		if (waitpid(privateContext->subprocess, &status, 0) == -1)
+		{
+			log_error("Failed to wait for pid %d: %m",
+					  privateContext->subprocess);
+			return false;
+		}
+
+		if (WEXITSTATUS(status) != 0)
+		{
+			log_error("Failed to transform previous JSON file into SQL, "
+					  "see above for details");
+			return false;
+		}
+
+		log_debug("Transform subprocess %d exited successfully [%d]",
+				  privateContext->subprocess,
+				  status);
+
+		privateContext->subprocess = 0;
+	}
+
+	return true;
 }

--- a/src/bin/pgcopydb/stream.h
+++ b/src/bin/pgcopydb/stream.h
@@ -254,6 +254,12 @@ bool stream_read_latest(StreamSpecs *specs, StreamContent *content);
 
 bool buildReplicationURI(const char *pguri, char *repl_pguri);
 
+bool stream_create_repl_slot(CopyDataSpec *copySpecs,
+							 char *slotName, uint64_t *lsn);
+
+bool stream_create_origin(CopyDataSpec *copySpecs,
+						  char *nodeName, uint64_t startpos);
+
 StreamAction StreamActionFromChar(char action);
 
 /* ld_transform.c */

--- a/src/bin/pgcopydb/stream.h
+++ b/src/bin/pgcopydb/stream.h
@@ -36,13 +36,33 @@ typedef struct StreamCounters
 	uint64_t truncate;
 } StreamCounters;
 
+
+/*
+ * The detailed behavior of the LogicalStreamClient is implemented in the
+ * callback functions writeFunction, flushFunction, and closeFunction.
+ *
+ */
+typedef enum
+{
+	STREAM_MODE_UNKNOW = 0,
+	STREAM_MODE_RECEIVE,        /* pgcopydb receive */
+	STREAM_MODE_PREFETCH,       /* pgcopydb fetch */
+	STREAM_MODE_APPLY           /* pgcopydb replay */
+} LogicalStreamMode;
+
+
 typedef struct StreamContext
 {
 	char *cdcdir;
 
+	LogicalStreamMode mode;
+
 	uint64_t startLSN;
 	char walFileName[MAXPGPATH];
+	char sqlFileName[MAXPGPATH];
 	FILE *jsonFile;
+
+	pid_t subprocess;
 
 	StreamCounters counters;
 } StreamContext;
@@ -187,6 +207,8 @@ typedef struct StreamSpecs
 	uint64_t startLSN;
 	uint64_t endpos;
 
+	LogicalStreamMode mode;
+
 	bool restart;
 	bool resume;
 } StreamSpecs;
@@ -207,13 +229,20 @@ bool stream_init_specs(StreamSpecs *specs,
 					   char *source_pguri,
 					   char *target_pguri,
 					   char *slotName,
-					   uint64_t endpos);
+					   uint64_t endpos,
+					   LogicalStreamMode mode);
 
 bool startLogicalStreaming(StreamSpecs *specs);
 
 bool streamWrite(LogicalStreamContext *context);
 bool streamFlush(LogicalStreamContext *context);
 bool streamClose(LogicalStreamContext *context);
+
+bool streamRotateFile(LogicalStreamContext *context);
+bool streamCloseFile(LogicalStreamContext *context, bool time_to_abort);
+
+bool streamTransformFileInSubprocess(LogicalStreamContext *context);
+bool streamWaitForSubprocess(LogicalStreamContext *context);
 
 bool parseMessageMetadata(LogicalMessageMetadata *metadata,
 						  const char *buffer,


### PR DESCRIPTION
The prefetch command setup the logical decoding operations in a way that
allows transforming each JSON file received into an SQL file. It's a kind of
integration of the `stream receive` and `stream transform` commands,
where the transform process is started in the background as soon as needed.