### PR TITLE
Implement pgcopydb stream catchup.

### DIFF
--- a/docs/ref/pgcopydb_stream.rst
+++ b/docs/ref/pgcopydb_stream.rst
@@ -12,6 +12,7 @@ This command prefixes the following sub-commands:
   pgcopydb stream
     setup      Setup source and target systems for logical decoding
     prefetch   Stream JSON changes from the source database and transform them to SQL
+    catchup    Apply prefetched changes from SQL files to the target database
     receive    Stream changes from the source database
     transform  Transform changes from the source database into SQL commands
     apply      Apply changes from the source database into the target database
@@ -27,6 +28,18 @@ step.
    clone --follow`` is strongly advised.
 
    This mode of operations has been designed for unit testing.
+
+.. note::
+
+   The sub-commands ``stream setup`` then ``stream prefetch`` and ``stream
+   catchup`` are higher level commands, that use internal information to
+   know which files to process. Those commands also keep track of their
+   progress.
+
+   The sub-commands ``stream receive``, ``stream transform``, and ``stream
+   apply`` are lower level interface that work on given files. Those
+   commands still keep track of their progress, but have to be given more
+   information to work.
 
 This is still a work in progress. Stay tuned.
 
@@ -92,6 +105,33 @@ SQL file.
      --not-consistent Allow taking a new snapshot on the source database
      --slot-name      Stream changes recorded by this slot
      --endpos         LSN position where to stop receiving changes
+
+.. _pgcopydb_stream_catchup:
+
+pgcopydb stream catchup
+-----------------------
+
+pgcopydb stream catchup - Apply prefetched changes from SQL files to the target database
+
+The command ``pgcopydb stream catchup`` connects to the target database and
+applies changes from the SQL files that have been prepared with the
+``pgcopydb stream prefetch`` command.
+
+
+::
+
+   pgcopydb stream catchup: Apply prefetched changes from SQL files to the target database
+   usage: pgcopydb stream catchup  --source ... --target ...
+
+     --source         Postgres URI to the source database
+     --target         Postgres URI to the target database
+     --dir            Work directory to use
+     --restart        Allow restarting when temp files exist already
+     --resume         Allow resuming operations after a failure
+     --not-consistent Allow taking a new snapshot on the source database
+     --slot-name      Stream changes recorded by this slot
+     --endpos         LSN position where to stop receiving changes  --origin         Name of the Postgres replication origin
+
 
 .. _pgcopydb_stream_receive:
 

--- a/src/bin/pgcopydb/cli_common.c
+++ b/src/bin/pgcopydb/cli_common.c
@@ -403,14 +403,14 @@ cli_copydb_is_consistent(CopyDBOptions *options)
 	 * If the origin file does not exists, then we don't have to check about
 	 * re-using the same origin node name as in the previous run.
 	 */
-	if (!file_exists(cfPaths.originfile))
+	if (!file_exists(cfPaths.cdc.originfile))
 	{
 		return true;
 	}
 
 	char *previous_origin = NULL;
 
-	if (!read_file(cfPaths.originfile, &previous_origin, &size))
+	if (!read_file(cfPaths.cdc.originfile, &previous_origin, &size))
 	{
 		/* errors have already been logged */
 		return false;

--- a/src/bin/pgcopydb/cli_stream.c
+++ b/src/bin/pgcopydb/cli_stream.c
@@ -8,6 +8,10 @@
 #include <getopt.h>
 #include <inttypes.h>
 
+#include "postgres.h"
+#include "access/xlog_internal.h"
+#include "access/xlogdefs.h"
+
 #include "cli_common.h"
 #include "cli_root.h"
 #include "commandline.h"
@@ -30,6 +34,7 @@ static void cli_stream_apply(int argc, char **argv);
 
 static void cli_stream_setup(int argc, char **argv);
 static void cli_stream_prefetch(int argc, char **argv);
+static void cli_stream_catchup(int argc, char **argv);
 
 static void stream_start_in_mode(LogicalStreamMode mode);
 
@@ -64,6 +69,23 @@ static CommandLine stream_prefetch_command =
 		"  --endpos         LSN position where to stop receiving changes",
 		cli_stream_getopts,
 		cli_stream_prefetch);
+
+static CommandLine stream_catchup_command =
+	make_command(
+		"catchup",
+		"Apply prefetched changes from SQL files to the target database",
+		" --source ... --target ...",
+		"  --source         Postgres URI to the source database\n"
+		"  --target         Postgres URI to the target database\n"
+		"  --dir            Work directory to use\n"
+		"  --restart        Allow restarting when temp files exist already\n"
+		"  --resume         Allow resuming operations after a failure\n"
+		"  --not-consistent Allow taking a new snapshot on the source database\n"
+		"  --slot-name      Stream changes recorded by this slot\n"
+		"  --endpos         LSN position where to stop receiving changes"
+		"  --origin         Name of the Postgres replication origin\n",
+		cli_stream_getopts,
+		cli_stream_catchup);
 
 static CommandLine stream_receive_command =
 	make_command(
@@ -111,6 +133,7 @@ static CommandLine stream_apply_command =
 static CommandLine *stream_subcommands[] = {
 	&stream_setup_command,
 	&stream_prefetch_command,
+	&stream_catchup_command,
 	&stream_receive_command,
 	&stream_transform_command,
 	&stream_apply_command,
@@ -377,6 +400,17 @@ cli_stream_receive(int argc, char **argv)
 
 
 /*
+ * cli_stream_prefetch implements receiving the JSON content and also
+ * transforming it to SQL on the fly, as soon as a JSON file is closed.
+ */
+static void
+cli_stream_prefetch(int argc, char **argv)
+{
+	(void) stream_start_in_mode(STREAM_MODE_PREFETCH);
+}
+
+
+/*
  * cli_stream_setup setups logical decoding on both the source and the target
  * database systems.
  *
@@ -442,13 +476,123 @@ cli_stream_setup(int argc, char **argv)
 
 
 /*
- * cli_stream_prefetch implements receiving the JSON content and also
- * transforming it to SQL on the fly, as soon as a JSON file is closed.
+ * cli_stream_catchup replays the SQL files that already exist, keeping track
+ * and updating the replication origin.
  */
 static void
-cli_stream_prefetch(int argc, char **argv)
+cli_stream_catchup(int argc, char **argv)
 {
-	(void) stream_start_in_mode(STREAM_MODE_PREFETCH);
+	CopyDataSpec copySpecs = { 0 };
+
+	(void) find_pg_commands(&(copySpecs.pgPaths));
+
+	bool auxilliary = false;
+
+	if (!copydb_init_workdir(&copySpecs,
+							 NULL,
+							 streamDBoptions.restart,
+							 streamDBoptions.resume,
+							 auxilliary))
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+
+	RestoreOptions restoreOptions = { 0 };
+
+	if (!copydb_init_specs(&copySpecs,
+						   streamDBoptions.source_pguri,
+						   streamDBoptions.target_pguri,
+						   1,   /* tableJobs */
+						   1,   /* indexJobs */
+						   DATA_SECTION_ALL,
+						   streamDBoptions.snapshot,
+						   restoreOptions,
+						   false, /* roles */
+						   false, /* skipLargeObjects */
+						   streamDBoptions.restart,
+						   streamDBoptions.resume,
+						   !streamDBoptions.notConsistent))
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+
+	StreamSpecs specs = { 0 };
+
+	if (!stream_init_specs(&specs,
+						   &(copySpecs.cfPaths.cdc),
+						   copySpecs.source_pguri,
+						   copySpecs.target_pguri,
+						   streamDBoptions.slotName,
+						   streamDBoptions.endpos,
+						   STREAM_MODE_APPLY))
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+
+	/*
+	 * First, we need to know enough about the source database system to be
+	 * able to generate WAL file names. That's means the current timeline and
+	 * the wal_segment_size.
+	 */
+	StreamApplyContext context = { 0 };
+
+	if (!stream_read_context(&specs, &(context.system), &(context.WalSegSz)))
+	{
+		log_error("Failed to read the streaming context information "
+				  "from the source database, see above for details");
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+
+	log_debug("Source database wal_segment_size is %u", context.WalSegSz);
+	log_debug("Source database timeline is %d", context.system.timeline);
+
+	if (!setupReplicationOrigin(&context,
+								&(specs.paths),
+								copySpecs.target_pguri,
+								streamDBoptions.origin))
+	{
+		log_error("Failed to setup replication origin on the target database");
+		exit(EXIT_CODE_TARGET);
+	}
+
+	log_info("Catching up from LSN %X/%X in \"%s\"",
+			 LSN_FORMAT_ARGS(context.previousLSN),
+			 context.sqlFileName);
+
+	/*
+	 * Our main loop reads the current SQL file, applying all the queries from
+	 * there and tracking progress, and then goes on to the next file, until no
+	 * such file exists.
+	 */
+	for (;;)
+	{
+		char *currentSQLFileName = context.sqlFileName;
+
+		if (!stream_apply_file(&context, context.sqlFileName))
+		{
+			/* errors have already been logged */
+			exit(EXIT_CODE_TARGET);
+		}
+
+		if (!computeSQLFileName(&context))
+		{
+			/* errors have already been logged */
+			exit(EXIT_CODE_TARGET);
+		}
+
+		if (strcmp(context.sqlFileName, currentSQLFileName) == 0)
+		{
+			log_debug("Reached end of file \"%s\", "
+					  "and nextlsn %X/%X still belongs to the same file: "
+					  "catching-up is done",
+					  currentSQLFileName,
+					  LSN_FORMAT_ARGS(context.nextlsn));
+			break;
+		}
+	}
 }
 
 
@@ -532,6 +676,7 @@ cli_stream_apply(int argc, char **argv)
 	StreamApplyContext context = { 0 };
 
 	if (!setupReplicationOrigin(&context,
+								&(copySpecs.cfPaths.cdc),
 								streamDBoptions.target_pguri,
 								streamDBoptions.origin))
 	{
@@ -596,7 +741,7 @@ stream_start_in_mode(LogicalStreamMode mode)
 	StreamSpecs specs = { 0 };
 
 	if (!stream_init_specs(&specs,
-						   copySpecs.cfPaths.cdcdir,
+						   &(copySpecs.cfPaths.cdc),
 						   copySpecs.source_pguri,
 						   copySpecs.target_pguri,
 						   streamDBoptions.slotName,

--- a/src/bin/pgcopydb/copydb.c
+++ b/src/bin/pgcopydb/copydb.c
@@ -173,7 +173,7 @@ copydb_init_workdir(CopyDataSpec *copySpecs,
 		cfPaths->rundir,
 		cfPaths->tbldir,
 		cfPaths->idxdir,
-		cfPaths->cdcdir,
+		cfPaths->cdc.dir,
 		NULL
 	};
 
@@ -387,7 +387,7 @@ copydb_prepare_filepaths(CopyFilePaths *cfPaths, const char *dir, bool auxilliar
 	 */
 	if (dir != NULL && !IS_EMPTY_STRING_BUFFER(dir))
 	{
-		sformat(cfPaths->cdcdir, MAXPGPATH, "%s/cdc", cfPaths->topdir);
+		sformat(cfPaths->cdc.dir, MAXPGPATH, "%s/cdc", cfPaths->topdir);
 	}
 	else
 	{
@@ -412,13 +412,28 @@ copydb_prepare_filepaths(CopyFilePaths *cfPaths, const char *dir, bool auxilliar
 			return false;
 		}
 
-		sformat(cfPaths->cdcdir, MAXPGPATH, "%s/pgcopydb", datadir);
+		sformat(cfPaths->cdc.dir, MAXPGPATH, "%s/pgcopydb", datadir);
 	}
 
-	log_debug("Change Data Capture data is managed at \"%s\"", cfPaths->cdcdir);
+	log_debug("Change Data Capture data is managed at \"%s\"",
+			  cfPaths->cdc.dir);
 
-	/* now prepare the originfile path */
-	sformat(cfPaths->originfile, MAXPGPATH, "%s/origin", cfPaths->cdcdir);
+	/* now prepare the originfile and timelinehistfile path */
+	sformat(cfPaths->cdc.originfile, MAXPGPATH,
+			"%s/origin",
+			cfPaths->cdc.dir);
+
+	sformat(cfPaths->cdc.tlihistfile, MAXPGPATH,
+			"%s/tli.history",
+			cfPaths->cdc.dir);
+
+	sformat(cfPaths->cdc.tlifile, MAXPGPATH,
+			"%s/tli",
+			cfPaths->cdc.dir);
+
+	sformat(cfPaths->cdc.walsegsizefile, MAXPGPATH,
+			"%s/wal_segment_size",
+			cfPaths->cdc.dir);
 
 	return true;
 }

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -48,6 +48,15 @@ typedef struct CopyDoneFilePaths
 	char blobs[MAXPGPATH];      /* /tmp/pgcopydb/run/blobs.done */
 } CopyDoneFilePaths;
 
+/* Change Data Capture (logical decoding) paths */
+typedef struct CDCPaths
+{
+	char dir[MAXPGPATH];              /* /tmp/pgcopydb/cdc */
+	char originfile[MAXPGPATH];       /* /tmp/pgcopydb/cdc/origin */
+	char walsegsizefile[MAXPGPATH];   /* /tmp/pgcopydb/cdc/wal_segment_size */
+	char tlifile[MAXPGPATH];          /* /tmp/pgcopydb/cdc/tli */
+	char tlihistfile[MAXPGPATH];      /* /tmp/pgcopydb/cdc/tli.history */
+} CDCPaths;
 
 /* maintain all the internal paths we need in one place */
 typedef struct CopyFilePaths
@@ -60,9 +69,7 @@ typedef struct CopyFilePaths
 	char tbldir[MAXPGPATH];           /* /tmp/pgcopydb/run/tables */
 	char idxdir[MAXPGPATH];           /* /tmp/pgcopydb/run/indexes */
 
-	char cdcdir[MAXPGPATH];           /* /tmp/pgcopydb/cdc */
-	char originfile[MAXPGPATH];       /* /tmp/pgcopydb/cdc/origin */
-
+	CDCPaths cdc;
 	CopyDoneFilePaths done;
 } CopyFilePaths;
 

--- a/tests/cdc/000000010000000000000002.sql
+++ b/tests/cdc/000000010000000000000002.sql
@@ -1,8 +1,8 @@
-BEGIN; -- {"xid":489,"lsn":"0/236F5A8"}
+BEGIN; -- {"xid":489,"lsn":"0/236F5A8","nextlsn":"0/236F5D8","timestamp":"2022-06-27 13:24:31.460822+00"}
 INSERT INTO "public"."rental" (rental_id, rental_date, inventory_id, customer_id, return_date, staff_id, last_update) VALUES (16050, '2022-06-01 00:00:00+00', 371, 291, NULL, 1, '2022-06-01 00:00:00+00');
 INSERT INTO "public"."payment_p2020_06" (payment_id, customer_id, staff_id, rental_id, amount, payment_date) VALUES (32099, 291, 1, 16050, 5.99, '2020-06-01 00:00:00+00');
-COMMIT; -- {"xid": 489,"lsn":"0/236F5A8"}
-BEGIN; -- {"xid":490,"lsn":"0/2370540"}
+COMMIT; -- {"xid": 489,"lsn":"0/236F5A8","nextlsn":"0/236F5D8","timestamp":"2022-06-27 13:24:31.460822+00"}
+BEGIN; -- {"xid":490,"lsn":"0/2370540","nextlsn":"0/2370570","timestamp":"2022-06-27 13:24:31.465929+00"}
 UPDATE "public"."payment_p2020_01" SET "payment_id" = 17055, "customer_id" = 196, "staff_id" = 2, "rental_id" = 106, "amount" = 11.95, "payment_date" = '2020-01-25 16:46:45.996577+00' WHERE "payment_id" = 17055 and "customer_id" = 196 and "staff_id" = 2 and "rental_id" = 106 and "amount" = 11.99 and "payment_date" = '2020-01-25 16:46:45.996577+00';
 UPDATE "public"."payment_p2020_02" SET "payment_id" = 17354, "customer_id" = 305, "staff_id" = 1, "rental_id" = 2166, "amount" = 11.95, "payment_date" = '2020-02-17 22:19:47.996577+00' WHERE "payment_id" = 17354 and "customer_id" = 305 and "staff_id" = 1 and "rental_id" = 2166 and "amount" = 11.99 and "payment_date" = '2020-02-17 22:19:47.996577+00';
 UPDATE "public"."payment_p2020_03" SET "payment_id" = 20403, "customer_id" = 362, "staff_id" = 1, "rental_id" = 14759, "amount" = 11.95, "payment_date" = '2020-03-21 21:57:24.996577+00' WHERE "payment_id" = 20403 and "customer_id" = 362 and "staff_id" = 1 and "rental_id" = 14759 and "amount" = 11.99 and "payment_date" = '2020-03-21 21:57:24.996577+00';
@@ -13,12 +13,12 @@ UPDATE "public"."payment_p2020_03" SET "payment_id" = 24866, "customer_id" = 237
 UPDATE "public"."payment_p2020_04" SET "payment_id" = 28799, "customer_id" = 591, "staff_id" = 2, "rental_id" = 4383, "amount" = 11.95, "payment_date" = '2020-04-07 18:14:17.996577+00' WHERE "payment_id" = 28799 and "customer_id" = 591 and "staff_id" = 2 and "rental_id" = 4383 and "amount" = 11.99 and "payment_date" = '2020-04-07 18:14:17.996577+00';
 UPDATE "public"."payment_p2020_04" SET "payment_id" = 28814, "customer_id" = 592, "staff_id" = 1, "rental_id" = 3973, "amount" = 11.95, "payment_date" = '2020-04-06 20:26:57.996577+00' WHERE "payment_id" = 28814 and "customer_id" = 592 and "staff_id" = 1 and "rental_id" = 3973 and "amount" = 11.99 and "payment_date" = '2020-04-06 20:26:57.996577+00';
 UPDATE "public"."payment_p2020_04" SET "payment_id" = 29136, "customer_id" = 13, "staff_id" = 2, "rental_id" = 8831, "amount" = 11.95, "payment_date" = '2020-04-29 20:06:07.996577+00' WHERE "payment_id" = 29136 and "customer_id" = 13 and "staff_id" = 2 and "rental_id" = 8831 and "amount" = 11.99 and "payment_date" = '2020-04-29 20:06:07.996577+00';
-COMMIT; -- {"xid": 490,"lsn":"0/2370540"}
-BEGIN; -- {"xid":491,"lsn":"0/2370810"}
+COMMIT; -- {"xid": 490,"lsn":"0/2370540","nextlsn":"0/2370570","timestamp":"2022-06-27 13:24:31.465929+00"}
+BEGIN; -- {"xid":491,"lsn":"0/2370810","nextlsn":"0/2370840","timestamp":"2022-06-27 13:24:31.483417+00"}
 DELETE FROM "public"."payment_p2020_06" WHERE "payment_id" = 32099 and "customer_id" = 291 and "staff_id" = 1 and "rental_id" = 16050 and "amount" = 5.99 and "payment_date" = '2020-06-01 00:00:00+00';
 DELETE FROM "public"."rental" WHERE "rental_id" = 16050;
-COMMIT; -- {"xid": 491,"lsn":"0/2370810"}
-BEGIN; -- {"xid":492,"lsn":"0/2370D90"}
+COMMIT; -- {"xid": 491,"lsn":"0/2370810","nextlsn":"0/2370840","timestamp":"2022-06-27 13:24:31.483417+00"}
+BEGIN; -- {"xid":492,"lsn":"0/2370D90","nextlsn":"0/2370DC0","timestamp":"2022-06-27 13:24:31.487749+00"}
 UPDATE "public"."payment_p2020_01" SET "payment_id" = 17055, "customer_id" = 196, "staff_id" = 2, "rental_id" = 106, "amount" = 11.99, "payment_date" = '2020-01-25 16:46:45.996577+00' WHERE "payment_id" = 17055 and "customer_id" = 196 and "staff_id" = 2 and "rental_id" = 106 and "amount" = 11.95 and "payment_date" = '2020-01-25 16:46:45.996577+00';
 UPDATE "public"."payment_p2020_02" SET "payment_id" = 17354, "customer_id" = 305, "staff_id" = 1, "rental_id" = 2166, "amount" = 11.99, "payment_date" = '2020-02-17 22:19:47.996577+00' WHERE "payment_id" = 17354 and "customer_id" = 305 and "staff_id" = 1 and "rental_id" = 2166 and "amount" = 11.95 and "payment_date" = '2020-02-17 22:19:47.996577+00';
 UPDATE "public"."payment_p2020_03" SET "payment_id" = 20403, "customer_id" = 362, "staff_id" = 1, "rental_id" = 14759, "amount" = 11.99, "payment_date" = '2020-03-21 21:57:24.996577+00' WHERE "payment_id" = 20403 and "customer_id" = 362 and "staff_id" = 1 and "rental_id" = 14759 and "amount" = 11.95 and "payment_date" = '2020-03-21 21:57:24.996577+00';
@@ -29,4 +29,4 @@ UPDATE "public"."payment_p2020_03" SET "payment_id" = 24866, "customer_id" = 237
 UPDATE "public"."payment_p2020_04" SET "payment_id" = 28799, "customer_id" = 591, "staff_id" = 2, "rental_id" = 4383, "amount" = 11.99, "payment_date" = '2020-04-07 18:14:17.996577+00' WHERE "payment_id" = 28799 and "customer_id" = 591 and "staff_id" = 2 and "rental_id" = 4383 and "amount" = 11.95 and "payment_date" = '2020-04-07 18:14:17.996577+00';
 UPDATE "public"."payment_p2020_04" SET "payment_id" = 28814, "customer_id" = 592, "staff_id" = 1, "rental_id" = 3973, "amount" = 11.99, "payment_date" = '2020-04-06 20:26:57.996577+00' WHERE "payment_id" = 28814 and "customer_id" = 592 and "staff_id" = 1 and "rental_id" = 3973 and "amount" = 11.95 and "payment_date" = '2020-04-06 20:26:57.996577+00';
 UPDATE "public"."payment_p2020_04" SET "payment_id" = 29136, "customer_id" = 13, "staff_id" = 2, "rental_id" = 8831, "amount" = 11.99, "payment_date" = '2020-04-29 20:06:07.996577+00' WHERE "payment_id" = 29136 and "customer_id" = 13 and "staff_id" = 2 and "rental_id" = 8831 and "amount" = 11.95 and "payment_date" = '2020-04-29 20:06:07.996577+00';
-COMMIT; -- {"xid": 492,"lsn":"0/2370D90"}
+COMMIT; -- {"xid": 492,"lsn":"0/2370D90","nextlsn":"0/2370DC0","timestamp":"2022-06-27 13:24:31.487749+00"}

--- a/tests/cdc/copydb.sh
+++ b/tests/cdc/copydb.sh
@@ -74,10 +74,10 @@ DIFFOPTS='-I BEGIN -I COMMIT'
 diff ${DIFFOPTS} /usr/src/pgcopydb/${SQLFILE} ${SHAREDIR}/${SQLFILENAME}
 
 # now apply the SQL file to the target database
-pgcopydb stream apply -vv ${SHAREDIR}/${SQLFILE}
+pgcopydb stream catchup -vv
 
 # now apply AGAIN the SQL file to the target database, skipping transactions
-pgcopydb stream apply -vv ${SHAREDIR}/${SQLFILE}
+pgcopydb stream catchup -vv
 
 # cleanup
 pgcopydb drop origin


### PR DESCRIPTION
This command knows how to catch-up from the current tracked position found
at the target database. This position should be created from the LSN
returned by the creation of the logical replication slot, which the other
command `pgcopydb stream setup` already does.