### PR TITLE
Review pgcopydb stream catchup command to implement a loop.

### DIFF
--- a/src/bin/pgcopydb/defaults.h
+++ b/src/bin/pgcopydb/defaults.h
@@ -50,6 +50,8 @@
 #define REPLICATION_PLUGIN "wal2json"
 #define REPLICATION_SLOT_NAME "pgcopydb"
 
+#define CATCHINGUP_SLEEP_MS 10 * 1000 /* 10s */
+
 /* internal default for allocating strings  */
 #define BUFSIZE 1024
 

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -3613,11 +3613,6 @@ pgsql_replication_origin_progress(PGSQL *pgsql,
 		return false;
 	}
 
-	log_debug("pgsql_replication_origin_progress: %p: %s %s",
-			  context.strVal,
-			  context.strVal,
-			  context.isNull ? "isNull" : "is not null");
-
 	if (context.isNull)
 	{
 		/* when we get a NULL, return 0/0 instead */

--- a/src/bin/pgcopydb/stream.c
+++ b/src/bin/pgcopydb/stream.c
@@ -46,6 +46,7 @@ stream_init_specs(StreamSpecs *specs,
 				  char *source_pguri,
 				  char *target_pguri,
 				  char *slotName,
+				  char *origin,
 				  uint64_t endpos,
 				  LogicalStreamMode mode)
 {
@@ -57,6 +58,7 @@ stream_init_specs(StreamSpecs *specs,
 	strlcpy(specs->source_pguri, source_pguri, MAXCONNINFO);
 	strlcpy(specs->target_pguri, target_pguri, MAXCONNINFO);
 	strlcpy(specs->slotName, slotName, sizeof(specs->slotName));
+	strlcpy(specs->origin, origin, sizeof(specs->origin));
 
 	if (!buildReplicationURI(specs->source_pguri, specs->logrep_pguri))
 	{

--- a/tests/cdc/copydb.sh
+++ b/tests/cdc/copydb.sh
@@ -74,10 +74,10 @@ DIFFOPTS='-I BEGIN -I COMMIT'
 diff ${DIFFOPTS} /usr/src/pgcopydb/${SQLFILE} ${SHAREDIR}/${SQLFILENAME}
 
 # now apply the SQL file to the target database
-pgcopydb stream catchup -vv
+pgcopydb stream catchup --endpos "${lsn}" -vv
 
 # now apply AGAIN the SQL file to the target database, skipping transactions
-pgcopydb stream catchup -vv
+pgcopydb stream catchup --endpos "${lsn}" -vv
 
 # cleanup
 pgcopydb drop origin


### PR DESCRIPTION
Unless when using the --endpos option, the `pgcopydb stream catchup` command
should keep looping and reading the same file again when it's not complete,
allowing concurrent activity with other processes such as `pgcopydb stream
prefetch`.