### PR TITLE
Fix GIT-VERSION-GEN default version to 0.8.

### DIFF
--- a/GIT-VERSION-GEN
+++ b/GIT-VERSION-GEN
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 GVF=GIT-VERSION-FILE
-DEF_VER=0.7
+DEF_VER=0.8
 
 LF='
 '


### PR DESCRIPTION
This script works very well with development versions but I couldn't yet
figure out how to properly manage released (tagged) version numbers when
building in a docker container. Oops.