### PR TITLE
Store the schema elements to a schema.json file.

### DIFF
--- a/docs/ref/pgcopydb_list.rst
+++ b/docs/ref/pgcopydb_list.rst
@@ -15,6 +15,7 @@ This command prefixes the following sub-commands:
     sequences    List all the source sequences to copy data from
     indexes      List all the indexes to create again after copying the data
     depends      List all the dependencies to filter-out
+    schema       List the schema to migrate, formatted in JSON
 
 
 .. _pgcopydb_list_tables:
@@ -123,6 +124,27 @@ objects that depend on excluded objects from the filtering rules.
      --table-name        Name of the target table
      --filter <filename> Use the filters defined in <filename>
      --list-skipped      List only tables that are setup to be skipped
+
+
+.. _pgcopydb_list_schema:
+
+pgcopydb list schema
+--------------------
+
+pgcopydb list schema - List the schema to migrate, formatted in JSON
+
+The command ``pgcopydb list schema`` connects to the source database and
+executes a SQL queries using the Postgres catalogs to get a list of the
+tables, indexes, and sequences to migrate. The command then outputs a JSON
+formatted string that contains detailed information about all those objects.
+
+::
+
+   pgcopydb list schema: List the schema to migrate, formatted in JSON
+   usage: pgcopydb list schema  --source ...
+
+     --source            Postgres URI to the source database
+     --filter <filename> Use the filters defined in <filename>
 
 
 Options
@@ -281,3 +303,1247 @@ Listing the indexes:
       17288 |     public |      track_full_pkey | track_full_pkey |     PRIMARY KEY (trackid) | CREATE UNIQUE INDEX track_full_pkey ON public.track_full USING btree (trackid)
       17452 |     public |             udc_pkey |        udc_pkey |           PRIMARY KEY (b) | CREATE UNIQUE INDEX udc_pkey ON public.udc USING btree (b)
       17469 |     public |           xzero_pkey |      xzero_pkey |           PRIMARY KEY (a) | CREATE UNIQUE INDEX xzero_pkey ON public.xzero USING btree (a)
+
+
+Listing the schema in JSON:
+
+::
+
+   $ pgcopydb list schema --split-at 200kB
+
+This gives the following JSON output:
+
+.. code-block:: json
+   :linenos:
+
+   {
+       "setup": {
+           "snapshot": "00000003-00051AAE-1",
+           "source_pguri": "postgres:\/\/@:\/pagila?",
+           "target_pguri": "postgres:\/\/@:\/plop?",
+           "table-jobs": 4,
+           "index-jobs": 4,
+           "split-tables-larger-than": 204800
+       },
+       "tables": [
+           {
+               "oid": 317934,
+               "schema": "public",
+               "name": "rental",
+               "reltuples": 16044,
+               "bytes": 1253376,
+               "bytes-pretty": "1224 kB",
+               "exclude-data": false,
+               "restore-list-name": "public rental postgres",
+               "part-key": "rental_id",
+               "parts": [
+                   {
+                       "number": 1,
+                       "total": 7,
+                       "min": 1,
+                       "max": 2294,
+                       "count": 2294
+                   },
+                   {
+                       "number": 2,
+                       "total": 7,
+                       "min": 2295,
+                       "max": 4588,
+                       "count": 2294
+                   },
+                   {
+                       "number": 3,
+                       "total": 7,
+                       "min": 4589,
+                       "max": 6882,
+                       "count": 2294
+                   },
+                   {
+                       "number": 4,
+                       "total": 7,
+                       "min": 6883,
+                       "max": 9176,
+                       "count": 2294
+                   },
+                   {
+                       "number": 5,
+                       "total": 7,
+                       "min": 9177,
+                       "max": 11470,
+                       "count": 2294
+                   },
+                   {
+                       "number": 6,
+                       "total": 7,
+                       "min": 11471,
+                       "max": 13764,
+                       "count": 2294
+                   },
+                   {
+                       "number": 7,
+                       "total": 7,
+                       "min": 13765,
+                       "max": 16049,
+                       "count": 2285
+                   }
+               ]
+           },
+           {
+               "oid": 317818,
+               "schema": "public",
+               "name": "film",
+               "reltuples": 1000,
+               "bytes": 483328,
+               "bytes-pretty": "472 kB",
+               "exclude-data": false,
+               "restore-list-name": "public film postgres",
+               "part-key": "film_id",
+               "parts": [
+                   {
+                       "number": 1,
+                       "total": 3,
+                       "min": 1,
+                       "max": 334,
+                       "count": 334
+                   },
+                   {
+                       "number": 2,
+                       "total": 3,
+                       "min": 335,
+                       "max": 668,
+                       "count": 334
+                   },
+                   {
+                       "number": 3,
+                       "total": 3,
+                       "min": 669,
+                       "max": 1000,
+                       "count": 332
+                   }
+               ]
+           },
+           {
+               "oid": 317920,
+               "schema": "public",
+               "name": "payment_p2020_04",
+               "reltuples": 6754,
+               "bytes": 434176,
+               "bytes-pretty": "424 kB",
+               "exclude-data": false,
+               "restore-list-name": "public payment_p2020_04 postgres",
+               "part-key": ""
+           },
+           {
+               "oid": 317916,
+               "schema": "public",
+               "name": "payment_p2020_03",
+               "reltuples": 5644,
+               "bytes": 368640,
+               "bytes-pretty": "360 kB",
+               "exclude-data": false,
+               "restore-list-name": "public payment_p2020_03 postgres",
+               "part-key": ""
+           },
+           {
+               "oid": 317830,
+               "schema": "public",
+               "name": "film_actor",
+               "reltuples": 5462,
+               "bytes": 270336,
+               "bytes-pretty": "264 kB",
+               "exclude-data": false,
+               "restore-list-name": "public film_actor postgres",
+               "part-key": ""
+           },
+           {
+               "oid": 317885,
+               "schema": "public",
+               "name": "inventory",
+               "reltuples": 4581,
+               "bytes": 270336,
+               "bytes-pretty": "264 kB",
+               "exclude-data": false,
+               "restore-list-name": "public inventory postgres",
+               "part-key": "inventory_id",
+               "parts": [
+                   {
+                       "number": 1,
+                       "total": 2,
+                       "min": 1,
+                       "max": 2291,
+                       "count": 2291
+                   },
+                   {
+                       "number": 2,
+                       "total": 2,
+                       "min": 2292,
+                       "max": 4581,
+                       "count": 2290
+                   }
+               ]
+           },
+           {
+               "oid": 317912,
+               "schema": "public",
+               "name": "payment_p2020_02",
+               "reltuples": 2312,
+               "bytes": 163840,
+               "bytes-pretty": "160 kB",
+               "exclude-data": false,
+               "restore-list-name": "public payment_p2020_02 postgres",
+               "part-key": ""
+           },
+           {
+               "oid": 317784,
+               "schema": "public",
+               "name": "customer",
+               "reltuples": 599,
+               "bytes": 106496,
+               "bytes-pretty": "104 kB",
+               "exclude-data": false,
+               "restore-list-name": "public customer postgres",
+               "part-key": "customer_id"
+           },
+           {
+               "oid": 317845,
+               "schema": "public",
+               "name": "address",
+               "reltuples": 603,
+               "bytes": 98304,
+               "bytes-pretty": "96 kB",
+               "exclude-data": false,
+               "restore-list-name": "public address postgres",
+               "part-key": "address_id"
+           },
+           {
+               "oid": 317908,
+               "schema": "public",
+               "name": "payment_p2020_01",
+               "reltuples": 1157,
+               "bytes": 98304,
+               "bytes-pretty": "96 kB",
+               "exclude-data": false,
+               "restore-list-name": "public payment_p2020_01 postgres",
+               "part-key": ""
+           },
+           {
+               "oid": 317855,
+               "schema": "public",
+               "name": "city",
+               "reltuples": 600,
+               "bytes": 73728,
+               "bytes-pretty": "72 kB",
+               "exclude-data": false,
+               "restore-list-name": "public city postgres",
+               "part-key": "city_id"
+           },
+           {
+               "oid": 317834,
+               "schema": "public",
+               "name": "film_category",
+               "reltuples": 1000,
+               "bytes": 73728,
+               "bytes-pretty": "72 kB",
+               "exclude-data": false,
+               "restore-list-name": "public film_category postgres",
+               "part-key": ""
+           },
+           {
+               "oid": 317798,
+               "schema": "public",
+               "name": "actor",
+               "reltuples": 200,
+               "bytes": 49152,
+               "bytes-pretty": "48 kB",
+               "exclude-data": false,
+               "restore-list-name": "public actor postgres",
+               "part-key": "actor_id"
+           },
+           {
+               "oid": 317924,
+               "schema": "public",
+               "name": "payment_p2020_05",
+               "reltuples": 182,
+               "bytes": 40960,
+               "bytes-pretty": "40 kB",
+               "exclude-data": false,
+               "restore-list-name": "public payment_p2020_05 postgres",
+               "part-key": ""
+           },
+           {
+               "oid": 317808,
+               "schema": "public",
+               "name": "category",
+               "reltuples": 0,
+               "bytes": 16384,
+               "bytes-pretty": "16 kB",
+               "exclude-data": false,
+               "restore-list-name": "public category postgres",
+               "part-key": "category_id"
+           },
+           {
+               "oid": 317865,
+               "schema": "public",
+               "name": "country",
+               "reltuples": 109,
+               "bytes": 16384,
+               "bytes-pretty": "16 kB",
+               "exclude-data": false,
+               "restore-list-name": "public country postgres",
+               "part-key": "country_id"
+           },
+           {
+               "oid": 317946,
+               "schema": "public",
+               "name": "staff",
+               "reltuples": 0,
+               "bytes": 16384,
+               "bytes-pretty": "16 kB",
+               "exclude-data": false,
+               "restore-list-name": "public staff postgres",
+               "part-key": "staff_id"
+           },
+           {
+               "oid": 378280,
+               "schema": "pgcopydb",
+               "name": "sentinel",
+               "reltuples": 1,
+               "bytes": 8192,
+               "bytes-pretty": "8192 bytes",
+               "exclude-data": false,
+               "restore-list-name": "pgcopydb sentinel dim",
+               "part-key": ""
+           },
+           {
+               "oid": 317892,
+               "schema": "public",
+               "name": "language",
+               "reltuples": 0,
+               "bytes": 8192,
+               "bytes-pretty": "8192 bytes",
+               "exclude-data": false,
+               "restore-list-name": "public language postgres",
+               "part-key": "language_id"
+           },
+           {
+               "oid": 317928,
+               "schema": "public",
+               "name": "payment_p2020_06",
+               "reltuples": 0,
+               "bytes": 8192,
+               "bytes-pretty": "8192 bytes",
+               "exclude-data": false,
+               "restore-list-name": "public payment_p2020_06 postgres",
+               "part-key": ""
+           },
+           {
+               "oid": 317957,
+               "schema": "public",
+               "name": "store",
+               "reltuples": 0,
+               "bytes": 8192,
+               "bytes-pretty": "8192 bytes",
+               "exclude-data": false,
+               "restore-list-name": "public store postgres",
+               "part-key": "store_id"
+           }
+       ],
+       "indexes": [
+           {
+               "oid": 378283,
+               "schema": "pgcopydb",
+               "name": "sentinel_expr_idx",
+               "isPrimary": false,
+               "isUnique": true,
+               "columns": "",
+               "sql": "CREATE UNIQUE INDEX sentinel_expr_idx ON pgcopydb.sentinel USING btree ((1))",
+               "restore-list-name": "pgcopydb sentinel_expr_idx dim",
+               "table": {
+                   "oid": 378280,
+                   "schema": "pgcopydb",
+                   "name": "sentinel"
+               }
+           },
+           {
+               "oid": 318001,
+               "schema": "public",
+               "name": "idx_actor_last_name",
+               "isPrimary": false,
+               "isUnique": false,
+               "columns": "last_name",
+               "sql": "CREATE INDEX idx_actor_last_name ON public.actor USING btree (last_name)",
+               "restore-list-name": "public idx_actor_last_name postgres",
+               "table": {
+                   "oid": 317798,
+                   "schema": "public",
+                   "name": "actor"
+               }
+           },
+           {
+               "oid": 317972,
+               "schema": "public",
+               "name": "actor_pkey",
+               "isPrimary": true,
+               "isUnique": true,
+               "columns": "actor_id",
+               "sql": "CREATE UNIQUE INDEX actor_pkey ON public.actor USING btree (actor_id)",
+               "restore-list-name": "",
+               "table": {
+                   "oid": 317798,
+                   "schema": "public",
+                   "name": "actor"
+               },
+               "constraint": {
+                   "oid": 317973,
+                   "name": "actor_pkey",
+                   "sql": "PRIMARY KEY (actor_id)"
+               }
+           },
+           {
+               "oid": 317974,
+               "schema": "public",
+               "name": "address_pkey",
+               "isPrimary": true,
+               "isUnique": true,
+               "columns": "address_id",
+               "sql": "CREATE UNIQUE INDEX address_pkey ON public.address USING btree (address_id)",
+               "restore-list-name": "",
+               "table": {
+                   "oid": 317845,
+                   "schema": "public",
+                   "name": "address"
+               },
+               "constraint": {
+                   "oid": 317975,
+                   "name": "address_pkey",
+                   "sql": "PRIMARY KEY (address_id)"
+               }
+           },
+           {
+               "oid": 318003,
+               "schema": "public",
+               "name": "idx_fk_city_id",
+               "isPrimary": false,
+               "isUnique": false,
+               "columns": "city_id",
+               "sql": "CREATE INDEX idx_fk_city_id ON public.address USING btree (city_id)",
+               "restore-list-name": "public idx_fk_city_id postgres",
+               "table": {
+                   "oid": 317845,
+                   "schema": "public",
+                   "name": "address"
+               }
+           },
+           {
+               "oid": 317976,
+               "schema": "public",
+               "name": "category_pkey",
+               "isPrimary": true,
+               "isUnique": true,
+               "columns": "category_id",
+               "sql": "CREATE UNIQUE INDEX category_pkey ON public.category USING btree (category_id)",
+               "restore-list-name": "",
+               "table": {
+                   "oid": 317808,
+                   "schema": "public",
+                   "name": "category"
+               },
+               "constraint": {
+                   "oid": 317977,
+                   "name": "category_pkey",
+                   "sql": "PRIMARY KEY (category_id)"
+               }
+           },
+           {
+               "oid": 317978,
+               "schema": "public",
+               "name": "city_pkey",
+               "isPrimary": true,
+               "isUnique": true,
+               "columns": "city_id",
+               "sql": "CREATE UNIQUE INDEX city_pkey ON public.city USING btree (city_id)",
+               "restore-list-name": "",
+               "table": {
+                   "oid": 317855,
+                   "schema": "public",
+                   "name": "city"
+               },
+               "constraint": {
+                   "oid": 317979,
+                   "name": "city_pkey",
+                   "sql": "PRIMARY KEY (city_id)"
+               }
+           },
+           {
+               "oid": 318004,
+               "schema": "public",
+               "name": "idx_fk_country_id",
+               "isPrimary": false,
+               "isUnique": false,
+               "columns": "country_id",
+               "sql": "CREATE INDEX idx_fk_country_id ON public.city USING btree (country_id)",
+               "restore-list-name": "public idx_fk_country_id postgres",
+               "table": {
+                   "oid": 317855,
+                   "schema": "public",
+                   "name": "city"
+               }
+           },
+           {
+               "oid": 317980,
+               "schema": "public",
+               "name": "country_pkey",
+               "isPrimary": true,
+               "isUnique": true,
+               "columns": "country_id",
+               "sql": "CREATE UNIQUE INDEX country_pkey ON public.country USING btree (country_id)",
+               "restore-list-name": "",
+               "table": {
+                   "oid": 317865,
+                   "schema": "public",
+                   "name": "country"
+               },
+               "constraint": {
+                   "oid": 317981,
+                   "name": "country_pkey",
+                   "sql": "PRIMARY KEY (country_id)"
+               }
+           },
+           {
+               "oid": 318024,
+               "schema": "public",
+               "name": "idx_last_name",
+               "isPrimary": false,
+               "isUnique": false,
+               "columns": "last_name",
+               "sql": "CREATE INDEX idx_last_name ON public.customer USING btree (last_name)",
+               "restore-list-name": "public idx_last_name postgres",
+               "table": {
+                   "oid": 317784,
+                   "schema": "public",
+                   "name": "customer"
+               }
+           },
+           {
+               "oid": 318002,
+               "schema": "public",
+               "name": "idx_fk_address_id",
+               "isPrimary": false,
+               "isUnique": false,
+               "columns": "address_id",
+               "sql": "CREATE INDEX idx_fk_address_id ON public.customer USING btree (address_id)",
+               "restore-list-name": "public idx_fk_address_id postgres",
+               "table": {
+                   "oid": 317784,
+                   "schema": "public",
+                   "name": "customer"
+               }
+           },
+           {
+               "oid": 317982,
+               "schema": "public",
+               "name": "customer_pkey",
+               "isPrimary": true,
+               "isUnique": true,
+               "columns": "customer_id",
+               "sql": "CREATE UNIQUE INDEX customer_pkey ON public.customer USING btree (customer_id)",
+               "restore-list-name": "",
+               "table": {
+                   "oid": 317784,
+                   "schema": "public",
+                   "name": "customer"
+               },
+               "constraint": {
+                   "oid": 317983,
+                   "name": "customer_pkey",
+                   "sql": "PRIMARY KEY (customer_id)"
+               }
+           },
+           {
+               "oid": 318023,
+               "schema": "public",
+               "name": "idx_fk_store_id",
+               "isPrimary": false,
+               "isUnique": false,
+               "columns": "store_id",
+               "sql": "CREATE INDEX idx_fk_store_id ON public.customer USING btree (store_id)",
+               "restore-list-name": "public idx_fk_store_id postgres",
+               "table": {
+                   "oid": 317784,
+                   "schema": "public",
+                   "name": "customer"
+               }
+           },
+           {
+               "oid": 318009,
+               "schema": "public",
+               "name": "idx_fk_original_language_id",
+               "isPrimary": false,
+               "isUnique": false,
+               "columns": "original_language_id",
+               "sql": "CREATE INDEX idx_fk_original_language_id ON public.film USING btree (original_language_id)",
+               "restore-list-name": "public idx_fk_original_language_id postgres",
+               "table": {
+                   "oid": 317818,
+                   "schema": "public",
+                   "name": "film"
+               }
+           },
+           {
+               "oid": 318026,
+               "schema": "public",
+               "name": "idx_title",
+               "isPrimary": false,
+               "isUnique": false,
+               "columns": "title",
+               "sql": "CREATE INDEX idx_title ON public.film USING btree (title)",
+               "restore-list-name": "public idx_title postgres",
+               "table": {
+                   "oid": 317818,
+                   "schema": "public",
+                   "name": "film"
+               }
+           },
+           {
+               "oid": 318000,
+               "schema": "public",
+               "name": "film_fulltext_idx",
+               "isPrimary": false,
+               "isUnique": false,
+               "columns": "fulltext",
+               "sql": "CREATE INDEX film_fulltext_idx ON public.film USING gist (fulltext)",
+               "restore-list-name": "public film_fulltext_idx postgres",
+               "table": {
+                   "oid": 317818,
+                   "schema": "public",
+                   "name": "film"
+               }
+           },
+           {
+               "oid": 317988,
+               "schema": "public",
+               "name": "film_pkey",
+               "isPrimary": true,
+               "isUnique": true,
+               "columns": "film_id",
+               "sql": "CREATE UNIQUE INDEX film_pkey ON public.film USING btree (film_id)",
+               "restore-list-name": "",
+               "table": {
+                   "oid": 317818,
+                   "schema": "public",
+                   "name": "film"
+               },
+               "constraint": {
+                   "oid": 317989,
+                   "name": "film_pkey",
+                   "sql": "PRIMARY KEY (film_id)"
+               }
+           },
+           {
+               "oid": 318008,
+               "schema": "public",
+               "name": "idx_fk_language_id",
+               "isPrimary": false,
+               "isUnique": false,
+               "columns": "language_id",
+               "sql": "CREATE INDEX idx_fk_language_id ON public.film USING btree (language_id)",
+               "restore-list-name": "public idx_fk_language_id postgres",
+               "table": {
+                   "oid": 317818,
+                   "schema": "public",
+                   "name": "film"
+               }
+           },
+           {
+               "oid": 317984,
+               "schema": "public",
+               "name": "film_actor_pkey",
+               "isPrimary": true,
+               "isUnique": true,
+               "columns": "actor_id,film_id",
+               "sql": "CREATE UNIQUE INDEX film_actor_pkey ON public.film_actor USING btree (actor_id, film_id)",
+               "restore-list-name": "",
+               "table": {
+                   "oid": 317830,
+                   "schema": "public",
+                   "name": "film_actor"
+               },
+               "constraint": {
+                   "oid": 317985,
+                   "name": "film_actor_pkey",
+                   "sql": "PRIMARY KEY (actor_id, film_id)"
+               }
+           },
+           {
+               "oid": 318006,
+               "schema": "public",
+               "name": "idx_fk_film_id",
+               "isPrimary": false,
+               "isUnique": false,
+               "columns": "film_id",
+               "sql": "CREATE INDEX idx_fk_film_id ON public.film_actor USING btree (film_id)",
+               "restore-list-name": "public idx_fk_film_id postgres",
+               "table": {
+                   "oid": 317830,
+                   "schema": "public",
+                   "name": "film_actor"
+               }
+           },
+           {
+               "oid": 317986,
+               "schema": "public",
+               "name": "film_category_pkey",
+               "isPrimary": true,
+               "isUnique": true,
+               "columns": "film_id,category_id",
+               "sql": "CREATE UNIQUE INDEX film_category_pkey ON public.film_category USING btree (film_id, category_id)",
+               "restore-list-name": "",
+               "table": {
+                   "oid": 317834,
+                   "schema": "public",
+                   "name": "film_category"
+               },
+               "constraint": {
+                   "oid": 317987,
+                   "name": "film_category_pkey",
+                   "sql": "PRIMARY KEY (film_id, category_id)"
+               }
+           },
+           {
+               "oid": 318025,
+               "schema": "public",
+               "name": "idx_store_id_film_id",
+               "isPrimary": false,
+               "isUnique": false,
+               "columns": "film_id,store_id",
+               "sql": "CREATE INDEX idx_store_id_film_id ON public.inventory USING btree (store_id, film_id)",
+               "restore-list-name": "public idx_store_id_film_id postgres",
+               "table": {
+                   "oid": 317885,
+                   "schema": "public",
+                   "name": "inventory"
+               }
+           },
+           {
+               "oid": 317990,
+               "schema": "public",
+               "name": "inventory_pkey",
+               "isPrimary": true,
+               "isUnique": true,
+               "columns": "inventory_id",
+               "sql": "CREATE UNIQUE INDEX inventory_pkey ON public.inventory USING btree (inventory_id)",
+               "restore-list-name": "",
+               "table": {
+                   "oid": 317885,
+                   "schema": "public",
+                   "name": "inventory"
+               },
+               "constraint": {
+                   "oid": 317991,
+                   "name": "inventory_pkey",
+                   "sql": "PRIMARY KEY (inventory_id)"
+               }
+           },
+           {
+               "oid": 317992,
+               "schema": "public",
+               "name": "language_pkey",
+               "isPrimary": true,
+               "isUnique": true,
+               "columns": "language_id",
+               "sql": "CREATE UNIQUE INDEX language_pkey ON public.language USING btree (language_id)",
+               "restore-list-name": "",
+               "table": {
+                   "oid": 317892,
+                   "schema": "public",
+                   "name": "language"
+               },
+               "constraint": {
+                   "oid": 317993,
+                   "name": "language_pkey",
+                   "sql": "PRIMARY KEY (language_id)"
+               }
+           },
+           {
+               "oid": 318010,
+               "schema": "public",
+               "name": "idx_fk_payment_p2020_01_customer_id",
+               "isPrimary": false,
+               "isUnique": false,
+               "columns": "customer_id",
+               "sql": "CREATE INDEX idx_fk_payment_p2020_01_customer_id ON public.payment_p2020_01 USING btree (customer_id)",
+               "restore-list-name": "public idx_fk_payment_p2020_01_customer_id postgres",
+               "table": {
+                   "oid": 317908,
+                   "schema": "public",
+                   "name": "payment_p2020_01"
+               }
+           },
+           {
+               "oid": 318029,
+               "schema": "public",
+               "name": "payment_p2020_01_customer_id_idx",
+               "isPrimary": false,
+               "isUnique": false,
+               "columns": "customer_id",
+               "sql": "CREATE INDEX payment_p2020_01_customer_id_idx ON public.payment_p2020_01 USING btree (customer_id)",
+               "restore-list-name": "public payment_p2020_01_customer_id_idx postgres",
+               "table": {
+                   "oid": 317908,
+                   "schema": "public",
+                   "name": "payment_p2020_01"
+               }
+           },
+           {
+               "oid": 318012,
+               "schema": "public",
+               "name": "idx_fk_payment_p2020_01_staff_id",
+               "isPrimary": false,
+               "isUnique": false,
+               "columns": "staff_id",
+               "sql": "CREATE INDEX idx_fk_payment_p2020_01_staff_id ON public.payment_p2020_01 USING btree (staff_id)",
+               "restore-list-name": "public idx_fk_payment_p2020_01_staff_id postgres",
+               "table": {
+                   "oid": 317908,
+                   "schema": "public",
+                   "name": "payment_p2020_01"
+               }
+           },
+           {
+               "oid": 318013,
+               "schema": "public",
+               "name": "idx_fk_payment_p2020_02_customer_id",
+               "isPrimary": false,
+               "isUnique": false,
+               "columns": "customer_id",
+               "sql": "CREATE INDEX idx_fk_payment_p2020_02_customer_id ON public.payment_p2020_02 USING btree (customer_id)",
+               "restore-list-name": "public idx_fk_payment_p2020_02_customer_id postgres",
+               "table": {
+                   "oid": 317912,
+                   "schema": "public",
+                   "name": "payment_p2020_02"
+               }
+           },
+           {
+               "oid": 318014,
+               "schema": "public",
+               "name": "idx_fk_payment_p2020_02_staff_id",
+               "isPrimary": false,
+               "isUnique": false,
+               "columns": "staff_id",
+               "sql": "CREATE INDEX idx_fk_payment_p2020_02_staff_id ON public.payment_p2020_02 USING btree (staff_id)",
+               "restore-list-name": "public idx_fk_payment_p2020_02_staff_id postgres",
+               "table": {
+                   "oid": 317912,
+                   "schema": "public",
+                   "name": "payment_p2020_02"
+               }
+           },
+           {
+               "oid": 318030,
+               "schema": "public",
+               "name": "payment_p2020_02_customer_id_idx",
+               "isPrimary": false,
+               "isUnique": false,
+               "columns": "customer_id",
+               "sql": "CREATE INDEX payment_p2020_02_customer_id_idx ON public.payment_p2020_02 USING btree (customer_id)",
+               "restore-list-name": "public payment_p2020_02_customer_id_idx postgres",
+               "table": {
+                   "oid": 317912,
+                   "schema": "public",
+                   "name": "payment_p2020_02"
+               }
+           },
+           {
+               "oid": 318016,
+               "schema": "public",
+               "name": "idx_fk_payment_p2020_03_staff_id",
+               "isPrimary": false,
+               "isUnique": false,
+               "columns": "staff_id",
+               "sql": "CREATE INDEX idx_fk_payment_p2020_03_staff_id ON public.payment_p2020_03 USING btree (staff_id)",
+               "restore-list-name": "public idx_fk_payment_p2020_03_staff_id postgres",
+               "table": {
+                   "oid": 317916,
+                   "schema": "public",
+                   "name": "payment_p2020_03"
+               }
+           },
+           {
+               "oid": 318031,
+               "schema": "public",
+               "name": "payment_p2020_03_customer_id_idx",
+               "isPrimary": false,
+               "isUnique": false,
+               "columns": "customer_id",
+               "sql": "CREATE INDEX payment_p2020_03_customer_id_idx ON public.payment_p2020_03 USING btree (customer_id)",
+               "restore-list-name": "public payment_p2020_03_customer_id_idx postgres",
+               "table": {
+                   "oid": 317916,
+                   "schema": "public",
+                   "name": "payment_p2020_03"
+               }
+           },
+           {
+               "oid": 318015,
+               "schema": "public",
+               "name": "idx_fk_payment_p2020_03_customer_id",
+               "isPrimary": false,
+               "isUnique": false,
+               "columns": "customer_id",
+               "sql": "CREATE INDEX idx_fk_payment_p2020_03_customer_id ON public.payment_p2020_03 USING btree (customer_id)",
+               "restore-list-name": "public idx_fk_payment_p2020_03_customer_id postgres",
+               "table": {
+                   "oid": 317916,
+                   "schema": "public",
+                   "name": "payment_p2020_03"
+               }
+           },
+           {
+               "oid": 318032,
+               "schema": "public",
+               "name": "payment_p2020_04_customer_id_idx",
+               "isPrimary": false,
+               "isUnique": false,
+               "columns": "customer_id",
+               "sql": "CREATE INDEX payment_p2020_04_customer_id_idx ON public.payment_p2020_04 USING btree (customer_id)",
+               "restore-list-name": "public payment_p2020_04_customer_id_idx postgres",
+               "table": {
+                   "oid": 317920,
+                   "schema": "public",
+                   "name": "payment_p2020_04"
+               }
+           },
+           {
+               "oid": 318018,
+               "schema": "public",
+               "name": "idx_fk_payment_p2020_04_staff_id",
+               "isPrimary": false,
+               "isUnique": false,
+               "columns": "staff_id",
+               "sql": "CREATE INDEX idx_fk_payment_p2020_04_staff_id ON public.payment_p2020_04 USING btree (staff_id)",
+               "restore-list-name": "public idx_fk_payment_p2020_04_staff_id postgres",
+               "table": {
+                   "oid": 317920,
+                   "schema": "public",
+                   "name": "payment_p2020_04"
+               }
+           },
+           {
+               "oid": 318017,
+               "schema": "public",
+               "name": "idx_fk_payment_p2020_04_customer_id",
+               "isPrimary": false,
+               "isUnique": false,
+               "columns": "customer_id",
+               "sql": "CREATE INDEX idx_fk_payment_p2020_04_customer_id ON public.payment_p2020_04 USING btree (customer_id)",
+               "restore-list-name": "public idx_fk_payment_p2020_04_customer_id postgres",
+               "table": {
+                   "oid": 317920,
+                   "schema": "public",
+                   "name": "payment_p2020_04"
+               }
+           },
+           {
+               "oid": 318019,
+               "schema": "public",
+               "name": "idx_fk_payment_p2020_05_customer_id",
+               "isPrimary": false,
+               "isUnique": false,
+               "columns": "customer_id",
+               "sql": "CREATE INDEX idx_fk_payment_p2020_05_customer_id ON public.payment_p2020_05 USING btree (customer_id)",
+               "restore-list-name": "public idx_fk_payment_p2020_05_customer_id postgres",
+               "table": {
+                   "oid": 317924,
+                   "schema": "public",
+                   "name": "payment_p2020_05"
+               }
+           },
+           {
+               "oid": 318020,
+               "schema": "public",
+               "name": "idx_fk_payment_p2020_05_staff_id",
+               "isPrimary": false,
+               "isUnique": false,
+               "columns": "staff_id",
+               "sql": "CREATE INDEX idx_fk_payment_p2020_05_staff_id ON public.payment_p2020_05 USING btree (staff_id)",
+               "restore-list-name": "public idx_fk_payment_p2020_05_staff_id postgres",
+               "table": {
+                   "oid": 317924,
+                   "schema": "public",
+                   "name": "payment_p2020_05"
+               }
+           },
+           {
+               "oid": 318033,
+               "schema": "public",
+               "name": "payment_p2020_05_customer_id_idx",
+               "isPrimary": false,
+               "isUnique": false,
+               "columns": "customer_id",
+               "sql": "CREATE INDEX payment_p2020_05_customer_id_idx ON public.payment_p2020_05 USING btree (customer_id)",
+               "restore-list-name": "public payment_p2020_05_customer_id_idx postgres",
+               "table": {
+                   "oid": 317924,
+                   "schema": "public",
+                   "name": "payment_p2020_05"
+               }
+           },
+           {
+               "oid": 318022,
+               "schema": "public",
+               "name": "idx_fk_payment_p2020_06_staff_id",
+               "isPrimary": false,
+               "isUnique": false,
+               "columns": "staff_id",
+               "sql": "CREATE INDEX idx_fk_payment_p2020_06_staff_id ON public.payment_p2020_06 USING btree (staff_id)",
+               "restore-list-name": "public idx_fk_payment_p2020_06_staff_id postgres",
+               "table": {
+                   "oid": 317928,
+                   "schema": "public",
+                   "name": "payment_p2020_06"
+               }
+           },
+           {
+               "oid": 318034,
+               "schema": "public",
+               "name": "payment_p2020_06_customer_id_idx",
+               "isPrimary": false,
+               "isUnique": false,
+               "columns": "customer_id",
+               "sql": "CREATE INDEX payment_p2020_06_customer_id_idx ON public.payment_p2020_06 USING btree (customer_id)",
+               "restore-list-name": "public payment_p2020_06_customer_id_idx postgres",
+               "table": {
+                   "oid": 317928,
+                   "schema": "public",
+                   "name": "payment_p2020_06"
+               }
+           },
+           {
+               "oid": 318021,
+               "schema": "public",
+               "name": "idx_fk_payment_p2020_06_customer_id",
+               "isPrimary": false,
+               "isUnique": false,
+               "columns": "customer_id",
+               "sql": "CREATE INDEX idx_fk_payment_p2020_06_customer_id ON public.payment_p2020_06 USING btree (customer_id)",
+               "restore-list-name": "public idx_fk_payment_p2020_06_customer_id postgres",
+               "table": {
+                   "oid": 317928,
+                   "schema": "public",
+                   "name": "payment_p2020_06"
+               }
+           },
+           {
+               "oid": 318028,
+               "schema": "public",
+               "name": "idx_unq_rental_rental_date_inventory_id_customer_id",
+               "isPrimary": false,
+               "isUnique": true,
+               "columns": "rental_date,inventory_id,customer_id",
+               "sql": "CREATE UNIQUE INDEX idx_unq_rental_rental_date_inventory_id_customer_id ON public.rental USING btree (rental_date, inventory_id, customer_id)",
+               "restore-list-name": "public idx_unq_rental_rental_date_inventory_id_customer_id postgres",
+               "table": {
+                   "oid": 317934,
+                   "schema": "public",
+                   "name": "rental"
+               }
+           },
+           {
+               "oid": 317994,
+               "schema": "public",
+               "name": "rental_pkey",
+               "isPrimary": true,
+               "isUnique": true,
+               "columns": "rental_id",
+               "sql": "CREATE UNIQUE INDEX rental_pkey ON public.rental USING btree (rental_id)",
+               "restore-list-name": "",
+               "table": {
+                   "oid": 317934,
+                   "schema": "public",
+                   "name": "rental"
+               },
+               "constraint": {
+                   "oid": 317995,
+                   "name": "rental_pkey",
+                   "sql": "PRIMARY KEY (rental_id)"
+               }
+           },
+           {
+               "oid": 318007,
+               "schema": "public",
+               "name": "idx_fk_inventory_id",
+               "isPrimary": false,
+               "isUnique": false,
+               "columns": "inventory_id",
+               "sql": "CREATE INDEX idx_fk_inventory_id ON public.rental USING btree (inventory_id)",
+               "restore-list-name": "public idx_fk_inventory_id postgres",
+               "table": {
+                   "oid": 317934,
+                   "schema": "public",
+                   "name": "rental"
+               }
+           },
+           {
+               "oid": 317996,
+               "schema": "public",
+               "name": "staff_pkey",
+               "isPrimary": true,
+               "isUnique": true,
+               "columns": "staff_id",
+               "sql": "CREATE UNIQUE INDEX staff_pkey ON public.staff USING btree (staff_id)",
+               "restore-list-name": "",
+               "table": {
+                   "oid": 317946,
+                   "schema": "public",
+                   "name": "staff"
+               },
+               "constraint": {
+                   "oid": 317997,
+                   "name": "staff_pkey",
+                   "sql": "PRIMARY KEY (staff_id)"
+               }
+           },
+           {
+               "oid": 318027,
+               "schema": "public",
+               "name": "idx_unq_manager_staff_id",
+               "isPrimary": false,
+               "isUnique": true,
+               "columns": "manager_staff_id",
+               "sql": "CREATE UNIQUE INDEX idx_unq_manager_staff_id ON public.store USING btree (manager_staff_id)",
+               "restore-list-name": "public idx_unq_manager_staff_id postgres",
+               "table": {
+                   "oid": 317957,
+                   "schema": "public",
+                   "name": "store"
+               }
+           },
+           {
+               "oid": 317998,
+               "schema": "public",
+               "name": "store_pkey",
+               "isPrimary": true,
+               "isUnique": true,
+               "columns": "store_id",
+               "sql": "CREATE UNIQUE INDEX store_pkey ON public.store USING btree (store_id)",
+               "restore-list-name": "",
+               "table": {
+                   "oid": 317957,
+                   "schema": "public",
+                   "name": "store"
+               },
+               "constraint": {
+                   "oid": 317999,
+                   "name": "store_pkey",
+                   "sql": "PRIMARY KEY (store_id)"
+               }
+           }
+       ],
+       "sequences": [
+           {
+               "oid": 317796,
+               "schema": "public",
+               "name": "actor_actor_id_seq",
+               "last-value": 200,
+               "is-called": true,
+               "restore-list-name": "public actor_actor_id_seq postgres"
+           },
+           {
+               "oid": 317843,
+               "schema": "public",
+               "name": "address_address_id_seq",
+               "last-value": 605,
+               "is-called": true,
+               "restore-list-name": "public address_address_id_seq postgres"
+           },
+           {
+               "oid": 317806,
+               "schema": "public",
+               "name": "category_category_id_seq",
+               "last-value": 16,
+               "is-called": true,
+               "restore-list-name": "public category_category_id_seq postgres"
+           },
+           {
+               "oid": 317853,
+               "schema": "public",
+               "name": "city_city_id_seq",
+               "last-value": 600,
+               "is-called": true,
+               "restore-list-name": "public city_city_id_seq postgres"
+           },
+           {
+               "oid": 317863,
+               "schema": "public",
+               "name": "country_country_id_seq",
+               "last-value": 109,
+               "is-called": true,
+               "restore-list-name": "public country_country_id_seq postgres"
+           },
+           {
+               "oid": 317782,
+               "schema": "public",
+               "name": "customer_customer_id_seq",
+               "last-value": 599,
+               "is-called": true,
+               "restore-list-name": "public customer_customer_id_seq postgres"
+           },
+           {
+               "oid": 317816,
+               "schema": "public",
+               "name": "film_film_id_seq",
+               "last-value": 1000,
+               "is-called": true,
+               "restore-list-name": "public film_film_id_seq postgres"
+           },
+           {
+               "oid": 317883,
+               "schema": "public",
+               "name": "inventory_inventory_id_seq",
+               "last-value": 4581,
+               "is-called": true,
+               "restore-list-name": "public inventory_inventory_id_seq postgres"
+           },
+           {
+               "oid": 317890,
+               "schema": "public",
+               "name": "language_language_id_seq",
+               "last-value": 6,
+               "is-called": true,
+               "restore-list-name": "public language_language_id_seq postgres"
+           },
+           {
+               "oid": 317902,
+               "schema": "public",
+               "name": "payment_payment_id_seq",
+               "last-value": 32099,
+               "is-called": true,
+               "restore-list-name": "public payment_payment_id_seq postgres"
+           },
+           {
+               "oid": 317932,
+               "schema": "public",
+               "name": "rental_rental_id_seq",
+               "last-value": 16050,
+               "is-called": true,
+               "restore-list-name": "public rental_rental_id_seq postgres"
+           },
+           {
+               "oid": 317944,
+               "schema": "public",
+               "name": "staff_staff_id_seq",
+               "last-value": 2,
+               "is-called": true,
+               "restore-list-name": "public staff_staff_id_seq postgres"
+           },
+           {
+               "oid": 317955,
+               "schema": "public",
+               "name": "store_store_id_seq",
+               "last-value": 2,
+               "is-called": true,
+               "restore-list-name": "public store_store_id_seq postgres"
+           }
+       ]
+   }

--- a/src/bin/pgcopydb/cli_clone_follow.c
+++ b/src/bin/pgcopydb/cli_clone_follow.c
@@ -366,7 +366,8 @@ start_clone_process(CopyDataSpec *copySpecs, pid_t *pid)
 
 			if (!cloneDB(copySpecs))
 			{
-				/* errors have already been logged */
+				log_error("Failed to start the clone sub-process, "
+						  "see above for details");
 				exit(EXIT_CODE_SOURCE);
 			}
 
@@ -447,6 +448,13 @@ cloneDB(CopyDataSpec *copySpecs)
 
 	/* fetch schema information from source catalogs, including filtering */
 	if (!copydb_fetch_schema_and_prepare_specs(copySpecs))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* prepare the schema JSON file with all the migration details */
+	if (!copydb_prepare_schema_json_file(copySpecs))
 	{
 		/* errors have already been logged */
 		return false;

--- a/src/bin/pgcopydb/copydb.c
+++ b/src/bin/pgcopydb/copydb.c
@@ -1615,6 +1615,9 @@ copydb_prepare_schema_json_file(CopyDataSpec *copySpecs)
 	char *serialized_string = json_serialize_to_string_pretty(js);
 	size_t len = strlen(serialized_string);
 
+	log_debug("Storing migration schema in JSON file \"%s\"",
+			  copySpecs->cfPaths.schemafile);
+
 	if (!write_file(serialized_string, len, copySpecs->cfPaths.schemafile))
 	{
 		log_error("Failed to write schema JSON file, see above for details");

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -65,6 +65,7 @@ typedef struct CopyFilePaths
 	char pidfile[MAXPGPATH];          /* /tmp/pgcopydb/pgcopydb.pid */
 	char snfile[MAXPGPATH];           /* /tmp/pgcopydb/snapshot */
 	char schemadir[MAXPGPATH];        /* /tmp/pgcopydb/schema */
+	char schemafile[MAXPGPATH];       /* /tmp/pgcopydb/schema.json */
 	char rundir[MAXPGPATH];           /* /tmp/pgcopydb/run */
 	char tbldir[MAXPGPATH];           /* /tmp/pgcopydb/run/tables */
 	char idxdir[MAXPGPATH];           /* /tmp/pgcopydb/run/indexes */
@@ -282,6 +283,8 @@ typedef struct CopyDataSpec
 	Semaphore indexSemaphore;
 
 	DumpPaths dumpPaths;
+	SourceTableArray sourceTableArray;
+	SourceIndexArray sourceIndexArray;
 	CopyTableDataSpecsArray tableSpecsArray;
 	SourceSequenceArray sequenceArray;
 } CopyDataSpec;
@@ -358,6 +361,8 @@ bool copydb_wait_for_subprocesses(void);
 bool copydb_collect_finished_subprocesses(bool *allDone);
 
 bool copydb_copy_roles(CopyDataSpec *copySpecs);
+
+bool copydb_prepare_schema_json_file(CopyDataSpec *copySpecs);
 
 /* indexes.c */
 bool copydb_init_indexes_paths(CopyFilePaths *cfPaths,

--- a/src/bin/pgcopydb/table-data.c
+++ b/src/bin/pgcopydb/table-data.c
@@ -74,6 +74,21 @@ copydb_fetch_schema_and_prepare_specs(CopyDataSpec *specs)
 		}
 	}
 
+	/* fetch the list of all the indexes that are going to be created again */
+	if (specs->section == DATA_SECTION_ALL ||
+		specs->section == DATA_SECTION_INDEXES)
+	{
+		SourceIndexArray *indexArray = &(specs->sourceIndexArray);
+
+		if (!schema_list_all_indexes(src, &(specs->filters), indexArray))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+
+		log_info("Fetched information for %d indexes", indexArray->count);
+	}
+
 	if (specs->section == DATA_SECTION_ALL ||
 		specs->section == DATA_SECTION_SET_SEQUENCES)
 	{
@@ -99,6 +114,12 @@ copydb_fetch_schema_and_prepare_specs(CopyDataSpec *specs)
 			/* errors have already been logged */
 			return false;
 		}
+	}
+
+	if (!copydb_prepare_schema_json_file(specs))
+	{
+		/* errors have already been logged */
+		return false;
 	}
 
 	return true;
@@ -199,7 +220,7 @@ terminate:
 bool
 copydb_prepare_table_specs(CopyDataSpec *specs, PGSQL *pgsql)
 {
-	SourceTableArray tableArray = { 0, NULL };
+	SourceTableArray *tableArray = &(specs->sourceTableArray);
 	CopyTableDataSpecsArray *tableSpecsArray = &(specs->tableSpecsArray);
 
 	log_info("Listing ordinary tables in source database");
@@ -209,7 +230,7 @@ copydb_prepare_table_specs(CopyDataSpec *specs, PGSQL *pgsql)
 	 */
 	if (!schema_list_ordinary_tables(pgsql,
 									 &(specs->filters),
-									 &tableArray))
+									 tableArray))
 	{
 		/* errors have already been logged */
 		return false;
@@ -227,9 +248,9 @@ copydb_prepare_table_specs(CopyDataSpec *specs, PGSQL *pgsql)
 	 * Source table might be split in several concurrent COPY processes. In
 	 * that case we produce a CopyDataSpec entry for each COPY partition.
 	 */
-	for (int tableIndex = 0; tableIndex < tableArray.count; tableIndex++)
+	for (int tableIndex = 0; tableIndex < tableArray->count; tableIndex++)
 	{
-		SourceTable *source = &(tableArray.array[tableIndex]);
+		SourceTable *source = &(tableArray->array[tableIndex]);
 
 		if (specs->splitTablesLargerThan > 0 &&
 			specs->splitTablesLargerThan <= source->bytes)
@@ -304,10 +325,10 @@ copydb_prepare_table_specs(CopyDataSpec *specs, PGSQL *pgsql)
 	int specsIndex = 0;
 	CopyTableDataSpec *tableSpecs = &(tableSpecsArray->array[specsIndex]);
 
-	for (int tableIndex = 0; tableIndex < tableArray.count; tableIndex++)
+	for (int tableIndex = 0; tableIndex < tableArray->count; tableIndex++)
 	{
 		/* initialize our TableDataProcess entry now */
-		SourceTable *source = &(tableArray.array[tableIndex]);
+		SourceTable *source = &(tableArray->array[tableIndex]);
 
 		/*
 		 * The CopyTableDataSpec structure has its own memory area for the
@@ -355,12 +376,12 @@ copydb_prepare_table_specs(CopyDataSpec *specs, PGSQL *pgsql)
 
 	log_info("Fetched information for %d tables, "
 			 "with an estimated total of %s tuples and %s",
-			 tableArray.count,
+			 tableArray->count,
 			 relTuplesPretty,
 			 bytesPretty);
 
 	/* free our temporary memory that's been malloc'ed */
-	free(tableArray.array);
+	free(tableArray->array);
 
 	return true;
 }

--- a/src/bin/pgcopydb/table-data.c
+++ b/src/bin/pgcopydb/table-data.c
@@ -116,12 +116,6 @@ copydb_fetch_schema_and_prepare_specs(CopyDataSpec *specs)
 		}
 	}
 
-	if (!copydb_prepare_schema_json_file(specs))
-	{
-		/* errors have already been logged */
-		return false;
-	}
-
 	return true;
 }
 
@@ -379,9 +373,6 @@ copydb_prepare_table_specs(CopyDataSpec *specs, PGSQL *pgsql)
 			 tableArray->count,
 			 relTuplesPretty,
 			 bytesPretty);
-
-	/* free our temporary memory that's been malloc'ed */
-	free(tableArray->array);
 
 	return true;
 }

--- a/tests/pagila/copydb.sh
+++ b/tests/pagila/copydb.sh
@@ -41,4 +41,4 @@ psql -d ${PAGILA_SOURCE_PGURI} -1 -f /tmp/pagila-schema.sql
 psql -d ${PAGILA_SOURCE_PGURI} -1 -f /usr/src/pagila/pagila-data.sql
 
 # pgcopydb clone uses the environment variables
-pgcopydb clone --source ${PAGILA_SOURCE_PGURI} --target ${PAGILA_TARGET_PGURI} -vv
+pgcopydb clone --source ${PAGILA_SOURCE_PGURI} --target ${PAGILA_TARGET_PGURI}

--- a/tests/pagila/copydb.sh
+++ b/tests/pagila/copydb.sh
@@ -41,4 +41,4 @@ psql -d ${PAGILA_SOURCE_PGURI} -1 -f /tmp/pagila-schema.sql
 psql -d ${PAGILA_SOURCE_PGURI} -1 -f /usr/src/pagila/pagila-data.sql
 
 # pgcopydb clone uses the environment variables
-pgcopydb clone --source ${PAGILA_SOURCE_PGURI} --target ${PAGILA_TARGET_PGURI}
+pgcopydb clone --source ${PAGILA_SOURCE_PGURI} --target ${PAGILA_TARGET_PGURI} -vv


### PR DESCRIPTION
This allows an external process to list tables, indexes, and sequences that
pgcopydb is processing internally.

Fixes #78 