### PR TITLE
Implement --debug and --trace, adding to --verbose.

### DIFF
--- a/docs/ref/pgcopydb_clone.rst
+++ b/docs/ref/pgcopydb_clone.rst
@@ -472,6 +472,23 @@ The following options are available to ``pgcopydb clone``:
 
   __ https://www.postgresql.org/docs/current/replication-origins.html
 
+--verbose
+
+  Increase current verbosity. The default level of verbosity is INFO. In
+  ascending order pgcopydb knows about the following verbosity levels:
+  FATAL, ERROR, WARN, INFO, NOTICE, DEBUG, TRACE.
+
+--debug
+
+  Set current verbosity to DEBUG level.
+
+--trace
+
+  Set current verbosity to TRACE level.
+
+--quiet
+
+  Set current verbosity to ERROR level.
 
 Environment
 -----------

--- a/docs/ref/pgcopydb_copy.rst
+++ b/docs/ref/pgcopydb_copy.rst
@@ -443,6 +443,25 @@ The following options are available to ``pgcopydb copy`` sub-commands:
   ``pg_export_snapshot()`` it is possible for pgcopydb to re-use an already
   exported snapshot.
 
+--verbose
+
+  Increase current verbosity. The default level of verbosity is INFO. In
+  ascending order pgcopydb knows about the following verbosity levels:
+  FATAL, ERROR, WARN, INFO, NOTICE, DEBUG, TRACE.
+
+--debug
+
+  Set current verbosity to DEBUG level.
+
+--trace
+
+  Set current verbosity to TRACE level.
+
+--quiet
+
+  Set current verbosity to ERROR level.
+
+
 Environment
 -----------
 

--- a/docs/ref/pgcopydb_dump.rst
+++ b/docs/ref/pgcopydb_dump.rst
@@ -136,6 +136,24 @@ The following options are available to ``pgcopydb dump schema``:
   ``pg_export_snapshot()`` it is possible for pgcopydb to re-use an already
   exported snapshot.
 
+--verbose
+
+  Increase current verbosity. The default level of verbosity is INFO. In
+  ascending order pgcopydb knows about the following verbosity levels:
+  FATAL, ERROR, WARN, INFO, NOTICE, DEBUG, TRACE.
+
+--debug
+
+  Set current verbosity to DEBUG level.
+
+--trace
+
+  Set current verbosity to TRACE level.
+
+--quiet
+
+  Set current verbosity to ERROR level.
+
 Environment
 -----------
 

--- a/docs/ref/pgcopydb_follow.rst
+++ b/docs/ref/pgcopydb_follow.rst
@@ -214,6 +214,24 @@ The following options are available to ``pgcopydb follow``:
 
   __ https://www.postgresql.org/docs/current/replication-origins.html
 
+--verbose
+
+  Increase current verbosity. The default level of verbosity is INFO. In
+  ascending order pgcopydb knows about the following verbosity levels:
+  FATAL, ERROR, WARN, INFO, NOTICE, DEBUG, TRACE.
+
+--debug
+
+  Set current verbosity to DEBUG level.
+
+--trace
+
+  Set current verbosity to TRACE level.
+
+--quiet
+
+  Set current verbosity to ERROR level.
+
 Environment
 -----------
 

--- a/docs/ref/pgcopydb_list.rst
+++ b/docs/ref/pgcopydb_list.rst
@@ -217,6 +217,25 @@ The following options are available to ``pgcopydb dump schema``:
   The output of the command is formatted in JSON, when supported. Ignored
   otherwise.
 
+--verbose
+
+  Increase current verbosity. The default level of verbosity is INFO. In
+  ascending order pgcopydb knows about the following verbosity levels:
+  FATAL, ERROR, WARN, INFO, NOTICE, DEBUG, TRACE.
+
+--debug
+
+  Set current verbosity to DEBUG level.
+
+--trace
+
+  Set current verbosity to TRACE level.
+
+--quiet
+
+  Set current verbosity to ERROR level.
+
+
 Environment
 -----------
 

--- a/docs/ref/pgcopydb_restore.rst
+++ b/docs/ref/pgcopydb_restore.rst
@@ -291,6 +291,24 @@ The following options are available to ``pgcopydb restore schema``:
   ``pg_export_snapshot()`` it is possible for pgcopydb to re-use an already
   exported snapshot.
 
+--verbose
+
+  Increase current verbosity. The default level of verbosity is INFO. In
+  ascending order pgcopydb knows about the following verbosity levels:
+  FATAL, ERROR, WARN, INFO, NOTICE, DEBUG, TRACE.
+
+--debug
+
+  Set current verbosity to DEBUG level.
+
+--trace
+
+  Set current verbosity to TRACE level.
+
+--quiet
+
+  Set current verbosity to ERROR level.
+
 Environment
 -----------
 

--- a/docs/ref/pgcopydb_snapshot.rst
+++ b/docs/ref/pgcopydb_snapshot.rst
@@ -80,6 +80,24 @@ drop`` subcommands:
   source database system, in order to properly bootstrap pgcopydb logical
   decoding.
 
+--verbose
+
+  Increase current verbosity. The default level of verbosity is INFO. In
+  ascending order pgcopydb knows about the following verbosity levels:
+  FATAL, ERROR, WARN, INFO, NOTICE, DEBUG, TRACE.
+
+--debug
+
+  Set current verbosity to DEBUG level.
+
+--trace
+
+  Set current verbosity to TRACE level.
+
+--quiet
+
+  Set current verbosity to ERROR level.
+
 Environment
 -----------
 

--- a/docs/ref/pgcopydb_stream.rst
+++ b/docs/ref/pgcopydb_stream.rst
@@ -551,6 +551,24 @@ The following options are available to ``pgcopydb stream`` sub-commands:
   source database system, in order to properly bootstrap pgcopydb logical
   decoding.
 
+--verbose
+
+  Increase current verbosity. The default level of verbosity is INFO. In
+  ascending order pgcopydb knows about the following verbosity levels:
+  FATAL, ERROR, WARN, INFO, NOTICE, DEBUG, TRACE.
+
+--debug
+
+  Set current verbosity to DEBUG level.
+
+--trace
+
+  Set current verbosity to TRACE level.
+
+--quiet
+
+  Set current verbosity to ERROR level.
+
 Environment
 -----------
 

--- a/src/bin/lib/log/src/log.c
+++ b/src/bin/lib/log/src/log.c
@@ -42,11 +42,23 @@ static struct {
 
 
 static const char *level_names[] = {
-  "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL"
+	"TRACE",
+	"DEBUG",
+	"NOTICE",
+	"INFO",
+	"WARN",
+	"ERROR",
+	"FATAL"
 };
 
 static const char *level_colors[] = {
-  "\x1b[94m", "\x1b[36m", "\x1b[32m", "\x1b[33m", "\x1b[31m", "\x1b[35m"
+  "\x1b[90m",					/* TRACE:  bright black (light gray) */
+  "\x1b[34m",					/* DEBUG:  blue */
+  "\x1b[36m",					/* NOTICE: cyan */
+  "\x1b[32m",					/* INFO:   green */
+  "\x1b[33m",					/* WARN:   yellow */
+  "\x1b[31m",					/* ERROR:  red */
+  "\x1b[35m"					/* FATAL:  magenta */
 };
 
 
@@ -128,7 +140,7 @@ void log_log(int level, const char *file, int line, const char *fmt, ...)
 
 	if (L.useColors)
 	{
-		pg_fprintf(stderr, "%s %d %s%-5s\x1b[0m ",
+		pg_fprintf(stderr, "%s %d %s%-6s\x1b[0m ",
 				   buf,
 				   getpid(),
 				   level_colors[level],

--- a/src/bin/lib/log/src/log.h
+++ b/src/bin/lib/log/src/log.h
@@ -15,10 +15,19 @@
 
 typedef void (*log_LockFn)(void *udata, int lock);
 
-enum { LOG_TRACE, LOG_DEBUG, LOG_INFO, LOG_WARN, LOG_ERROR, LOG_FATAL };
+enum {
+	LOG_TRACE,
+	LOG_DEBUG,
+	LOG_NOTICE,
+	LOG_INFO,
+	LOG_WARN,
+	LOG_ERROR,
+	LOG_FATAL
+};
 
 #define log_trace(...) log_log(LOG_TRACE, __FILE__, __LINE__, __VA_ARGS__)
 #define log_debug(...) log_log(LOG_DEBUG, __FILE__, __LINE__, __VA_ARGS__)
+#define log_notice(...)  log_log(LOG_NOTICE,  __FILE__, __LINE__, __VA_ARGS__)
 #define log_info(...)  log_log(LOG_INFO,  __FILE__, __LINE__, __VA_ARGS__)
 #define log_warn(...)  log_log(LOG_WARN,  __FILE__, __LINE__, __VA_ARGS__)
 #define log_error(...) log_log(LOG_ERROR, __FILE__, __LINE__, __VA_ARGS__)

--- a/src/bin/pgcopydb/cli_common.c
+++ b/src/bin/pgcopydb/cli_common.c
@@ -59,6 +59,8 @@ cli_print_version_getopts(int argc, char **argv)
 		{ "json", no_argument, NULL, 'J' },
 		{ "version", no_argument, NULL, 'V' },
 		{ "verbose", no_argument, NULL, 'v' },
+		{ "debug", no_argument, NULL, 'd' },
+		{ "trace", no_argument, NULL, 'z' },
 		{ "quiet", no_argument, NULL, 'q' },
 		{ "help", no_argument, NULL, 'h' },
 		{ NULL, 0, NULL, 0 }
@@ -75,7 +77,7 @@ cli_print_version_getopts(int argc, char **argv)
 	 */
 	unsetenv("POSIXLY_CORRECT");
 
-	while ((c = getopt_long(argc, argv, "JVvqh",
+	while ((c = getopt_long(argc, argv, "JVvdzqh",
 							long_options, &option_index)) != -1)
 	{
 		switch (c)
@@ -502,6 +504,8 @@ cli_copy_db_getopts(int argc, char **argv)
 		{ "endpos", required_argument, NULL, 'E' },
 		{ "version", no_argument, NULL, 'V' },
 		{ "verbose", no_argument, NULL, 'v' },
+		{ "debug", no_argument, NULL, 'd' },
+		{ "trace", no_argument, NULL, 'z' },
 		{ "quiet", no_argument, NULL, 'q' },
 		{ "help", no_argument, NULL, 'h' },
 		{ NULL, 0, NULL, 0 }
@@ -525,7 +529,8 @@ cli_copy_db_getopts(int argc, char **argv)
 	strlcpy(options.slotName, REPLICATION_SLOT_NAME, sizeof(options.slotName));
 	strlcpy(options.origin, REPLICATION_ORIGIN, sizeof(options.origin));
 
-	while ((c = getopt_long(argc, argv, "S:T:D:J:I:L:cOBrRCN:xXCtfo:s:E:F:Vvqh",
+	while ((c = getopt_long(argc, argv,
+							"S:T:D:J:I:L:cOBrRCN:xXCtfo:s:E:F:Vvdzqh",
 							long_options, &option_index)) != -1)
 	{
 		switch (c)
@@ -758,7 +763,7 @@ cli_copy_db_getopts(int argc, char **argv)
 				{
 					case 1:
 					{
-						log_set_level(LOG_INFO);
+						log_set_level(LOG_NOTICE);
 						break;
 					}
 
@@ -774,6 +779,20 @@ cli_copy_db_getopts(int argc, char **argv)
 						break;
 					}
 				}
+				break;
+			}
+
+			case 'd':
+			{
+				verboseCount = 2;
+				log_set_level(LOG_DEBUG);
+				break;
+			}
+
+			case 'z':
+			{
+				verboseCount = 3;
+				log_set_level(LOG_TRACE);
 				break;
 			}
 

--- a/src/bin/pgcopydb/cli_create.c
+++ b/src/bin/pgcopydb/cli_create.c
@@ -128,6 +128,8 @@ cli_create_snapshot_getopts(int argc, char **argv)
 		{ "dir", required_argument, NULL, 'D' },
 		{ "version", no_argument, NULL, 'V' },
 		{ "verbose", no_argument, NULL, 'v' },
+		{ "debug", no_argument, NULL, 'd' },
+		{ "trace", no_argument, NULL, 'z' },
 		{ "quiet", no_argument, NULL, 'q' },
 		{ "help", no_argument, NULL, 'h' },
 		{ NULL, 0, NULL, 0 }
@@ -142,7 +144,7 @@ cli_create_snapshot_getopts(int argc, char **argv)
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 
-	while ((c = getopt_long(argc, argv, "S:T:D:Vvqh",
+	while ((c = getopt_long(argc, argv, "S:T:D:Vvdzqh",
 							long_options, &option_index)) != -1)
 	{
 		switch (c)
@@ -181,7 +183,7 @@ cli_create_snapshot_getopts(int argc, char **argv)
 				{
 					case 1:
 					{
-						log_set_level(LOG_INFO);
+						log_set_level(LOG_NOTICE);
 						break;
 					}
 
@@ -197,6 +199,20 @@ cli_create_snapshot_getopts(int argc, char **argv)
 						break;
 					}
 				}
+				break;
+			}
+
+			case 'd':
+			{
+				verboseCount = 2;
+				log_set_level(LOG_DEBUG);
+				break;
+			}
+
+			case 'z':
+			{
+				verboseCount = 3;
+				log_set_level(LOG_TRACE);
 				break;
 			}
 
@@ -339,6 +355,8 @@ cli_create_slot_getopts(int argc, char **argv)
 		{ "snapshot", required_argument, NULL, 'N' },
 		{ "version", no_argument, NULL, 'V' },
 		{ "verbose", no_argument, NULL, 'v' },
+		{ "debug", no_argument, NULL, 'd' },
+		{ "trace", no_argument, NULL, 'z' },
 		{ "quiet", no_argument, NULL, 'q' },
 		{ "help", no_argument, NULL, 'h' },
 		{ NULL, 0, NULL, 0 }
@@ -356,7 +374,7 @@ cli_create_slot_getopts(int argc, char **argv)
 	/* pretend that --resume was used */
 	options.resume = true;
 
-	while ((c = getopt_long(argc, argv, "S:T:D:Vvqh",
+	while ((c = getopt_long(argc, argv, "S:T:D:Vvdzqh",
 							long_options, &option_index)) != -1)
 	{
 		switch (c)
@@ -409,7 +427,7 @@ cli_create_slot_getopts(int argc, char **argv)
 				{
 					case 1:
 					{
-						log_set_level(LOG_INFO);
+						log_set_level(LOG_NOTICE);
 						break;
 					}
 
@@ -425,6 +443,20 @@ cli_create_slot_getopts(int argc, char **argv)
 						break;
 					}
 				}
+				break;
+			}
+
+			case 'd':
+			{
+				verboseCount = 2;
+				log_set_level(LOG_DEBUG);
+				break;
+			}
+
+			case 'z':
+			{
+				verboseCount = 3;
+				log_set_level(LOG_TRACE);
 				break;
 			}
 
@@ -624,6 +656,8 @@ cli_create_origin_getopts(int argc, char **argv)
 		{ "startpos", required_argument, NULL, 's' },
 		{ "version", no_argument, NULL, 'V' },
 		{ "verbose", no_argument, NULL, 'v' },
+		{ "debug", no_argument, NULL, 'd' },
+		{ "trace", no_argument, NULL, 'z' },
 		{ "quiet", no_argument, NULL, 'q' },
 		{ "help", no_argument, NULL, 'h' },
 		{ NULL, 0, NULL, 0 }
@@ -641,7 +675,7 @@ cli_create_origin_getopts(int argc, char **argv)
 	/* pretend that --resume was used */
 	options.resume = true;
 
-	while ((c = getopt_long(argc, argv, "T:D:o:s:Vvqh",
+	while ((c = getopt_long(argc, argv, "T:D:o:s:Vvdzqh",
 							long_options, &option_index)) != -1)
 	{
 		switch (c)
@@ -700,7 +734,7 @@ cli_create_origin_getopts(int argc, char **argv)
 				{
 					case 1:
 					{
-						log_set_level(LOG_INFO);
+						log_set_level(LOG_NOTICE);
 						break;
 					}
 
@@ -716,6 +750,20 @@ cli_create_origin_getopts(int argc, char **argv)
 						break;
 					}
 				}
+				break;
+			}
+
+			case 'd':
+			{
+				verboseCount = 2;
+				log_set_level(LOG_DEBUG);
+				break;
+			}
+
+			case 'z':
+			{
+				verboseCount = 3;
+				log_set_level(LOG_TRACE);
 				break;
 			}
 

--- a/src/bin/pgcopydb/cli_dump.c
+++ b/src/bin/pgcopydb/cli_dump.c
@@ -111,6 +111,8 @@ cli_dump_schema_getopts(int argc, char **argv)
 		{ "snapshot", required_argument, NULL, 'N' },
 		{ "version", no_argument, NULL, 'V' },
 		{ "verbose", no_argument, NULL, 'v' },
+		{ "debug", no_argument, NULL, 'd' },
+		{ "trace", no_argument, NULL, 'z' },
 		{ "quiet", no_argument, NULL, 'q' },
 		{ "help", no_argument, NULL, 'h' },
 		{ NULL, 0, NULL, 0 }
@@ -125,7 +127,7 @@ cli_dump_schema_getopts(int argc, char **argv)
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 
-	while ((c = getopt_long(argc, argv, "S:T:Vvqh",
+	while ((c = getopt_long(argc, argv, "S:T:Vvdzqh",
 							long_options, &option_index)) != -1)
 	{
 		switch (c)
@@ -205,7 +207,7 @@ cli_dump_schema_getopts(int argc, char **argv)
 				{
 					case 1:
 					{
-						log_set_level(LOG_INFO);
+						log_set_level(LOG_NOTICE);
 						break;
 					}
 
@@ -221,6 +223,20 @@ cli_dump_schema_getopts(int argc, char **argv)
 						break;
 					}
 				}
+				break;
+			}
+
+			case 'd':
+			{
+				verboseCount = 2;
+				log_set_level(LOG_DEBUG);
+				break;
+			}
+
+			case 'z':
+			{
+				verboseCount = 3;
+				log_set_level(LOG_TRACE);
 				break;
 			}
 

--- a/src/bin/pgcopydb/cli_list.c
+++ b/src/bin/pgcopydb/cli_list.c
@@ -154,6 +154,8 @@ cli_list_db_getopts(int argc, char **argv)
 		{ "split-at", required_argument, NULL, 'L' },
 		{ "json", no_argument, NULL, 'J' },
 		{ "version", no_argument, NULL, 'V' },
+		{ "debug", no_argument, NULL, 'd' },
+		{ "trace", no_argument, NULL, 'z' },
 		{ "verbose", no_argument, NULL, 'v' },
 		{ "quiet", no_argument, NULL, 'q' },
 		{ "help", no_argument, NULL, 'h' },
@@ -162,7 +164,7 @@ cli_list_db_getopts(int argc, char **argv)
 
 	optind = 0;
 
-	while ((c = getopt_long(argc, argv, "S:T:j:s:t:PL:JVvqh",
+	while ((c = getopt_long(argc, argv, "S:T:j:s:t:PL:JVvdzqh",
 							long_options, &option_index)) != -1)
 	{
 		switch (c)
@@ -262,7 +264,7 @@ cli_list_db_getopts(int argc, char **argv)
 				{
 					case 1:
 					{
-						log_set_level(LOG_INFO);
+						log_set_level(LOG_NOTICE);
 						break;
 					}
 
@@ -278,6 +280,20 @@ cli_list_db_getopts(int argc, char **argv)
 						break;
 					}
 				}
+				break;
+			}
+
+			case 'd':
+			{
+				verboseCount = 2;
+				log_set_level(LOG_DEBUG);
+				break;
+			}
+
+			case 'z':
+			{
+				verboseCount = 3;
+				log_set_level(LOG_TRACE);
 				break;
 			}
 

--- a/src/bin/pgcopydb/cli_restore.c
+++ b/src/bin/pgcopydb/cli_restore.c
@@ -155,6 +155,8 @@ cli_restore_schema_getopts(int argc, char **argv)
 		{ "snapshot", required_argument, NULL, 'N' },
 		{ "version", no_argument, NULL, 'V' },
 		{ "verbose", no_argument, NULL, 'v' },
+		{ "debug", no_argument, NULL, 'd' },
+		{ "trace", no_argument, NULL, 'z' },
 		{ "quiet", no_argument, NULL, 'q' },
 		{ "help", no_argument, NULL, 'h' },
 		{ NULL, 0, NULL, 0 }
@@ -169,7 +171,7 @@ cli_restore_schema_getopts(int argc, char **argv)
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 
-	while ((c = getopt_long(argc, argv, "S:T:cOxXVvqh",
+	while ((c = getopt_long(argc, argv, "S:T:cOxXVvdzqh",
 							long_options, &option_index)) != -1)
 	{
 		switch (c)
@@ -291,7 +293,7 @@ cli_restore_schema_getopts(int argc, char **argv)
 				{
 					case 1:
 					{
-						log_set_level(LOG_INFO);
+						log_set_level(LOG_NOTICE);
 						break;
 					}
 
@@ -307,6 +309,20 @@ cli_restore_schema_getopts(int argc, char **argv)
 						break;
 					}
 				}
+				break;
+			}
+
+			case 'd':
+			{
+				verboseCount = 2;
+				log_set_level(LOG_DEBUG);
+				break;
+			}
+
+			case 'z':
+			{
+				verboseCount = 3;
+				log_set_level(LOG_TRACE);
 				break;
 			}
 

--- a/src/bin/pgcopydb/cli_root.c
+++ b/src/bin/pgcopydb/cli_root.c
@@ -82,6 +82,8 @@ root_options(int argc, char **argv)
 	static struct option long_options[] = {
 		{ "version", no_argument, NULL, 'V' },
 		{ "verbose", no_argument, NULL, 'v' },
+		{ "debug", no_argument, NULL, 'd' },
+		{ "trace", no_argument, NULL, 'z' },
 		{ "json", no_argument, NULL, 'J' },
 		{ "quiet", no_argument, NULL, 'q' },
 		{ "help", no_argument, NULL, 'h' },
@@ -92,7 +94,7 @@ root_options(int argc, char **argv)
 
 	optind = 0;
 
-	while ((c = getopt_long(argc, argv, "JVvqh",
+	while ((c = getopt_long(argc, argv, "JVvdzqh",
 							long_options, &option_index)) != -1)
 	{
 		switch (c)
@@ -117,7 +119,7 @@ root_options(int argc, char **argv)
 				{
 					case 1:
 					{
-						log_set_level(LOG_INFO);
+						log_set_level(LOG_NOTICE);
 						break;
 					}
 
@@ -133,6 +135,20 @@ root_options(int argc, char **argv)
 						break;
 					}
 				}
+				break;
+			}
+
+			case 'd':
+			{
+				verboseCount = 2;
+				log_set_level(LOG_DEBUG);
+				break;
+			}
+
+			case 'z':
+			{
+				verboseCount = 3;
+				log_set_level(LOG_TRACE);
 				break;
 			}
 

--- a/src/bin/pgcopydb/cli_sentinel.c
+++ b/src/bin/pgcopydb/cli_sentinel.c
@@ -140,6 +140,8 @@ cli_sentinel_getopts(int argc, char **argv)
 		{ "current", no_argument, NULL, 'C' },
 		{ "version", no_argument, NULL, 'V' },
 		{ "verbose", no_argument, NULL, 'v' },
+		{ "debug", no_argument, NULL, 'd' },
+		{ "trace", no_argument, NULL, 'z' },
 		{ "quiet", no_argument, NULL, 'q' },
 		{ "help", no_argument, NULL, 'h' },
 		{ NULL, 0, NULL, 0 }
@@ -154,7 +156,7 @@ cli_sentinel_getopts(int argc, char **argv)
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 
-	while ((c = getopt_long(argc, argv, "S:s:E:CVvqh",
+	while ((c = getopt_long(argc, argv, "S:s:E:CVvdzqh",
 							long_options, &option_index)) != -1)
 	{
 		switch (c)
@@ -220,7 +222,7 @@ cli_sentinel_getopts(int argc, char **argv)
 				{
 					case 1:
 					{
-						log_set_level(LOG_INFO);
+						log_set_level(LOG_NOTICE);
 						break;
 					}
 
@@ -236,6 +238,20 @@ cli_sentinel_getopts(int argc, char **argv)
 						break;
 					}
 				}
+				break;
+			}
+
+			case 'd':
+			{
+				verboseCount = 2;
+				log_set_level(LOG_DEBUG);
+				break;
+			}
+
+			case 'z':
+			{
+				verboseCount = 3;
+				log_set_level(LOG_TRACE);
 				break;
 			}
 

--- a/src/bin/pgcopydb/cli_stream.c
+++ b/src/bin/pgcopydb/cli_stream.c
@@ -191,6 +191,8 @@ cli_stream_getopts(int argc, char **argv)
 		{ "not-consistent", no_argument, NULL, 'C' },
 		{ "version", no_argument, NULL, 'V' },
 		{ "verbose", no_argument, NULL, 'v' },
+		{ "debug", no_argument, NULL, 'd' },
+		{ "trace", no_argument, NULL, 'z' },
 		{ "quiet", no_argument, NULL, 'q' },
 		{ "help", no_argument, NULL, 'h' },
 		{ NULL, 0, NULL, 0 }
@@ -205,7 +207,7 @@ cli_stream_getopts(int argc, char **argv)
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 
-	while ((c = getopt_long(argc, argv, "S:T:j:s:o:t:PVvqh",
+	while ((c = getopt_long(argc, argv, "S:T:j:s:o:t:PVvdzqh",
 							long_options, &option_index)) != -1)
 	{
 		switch (c)
@@ -323,7 +325,7 @@ cli_stream_getopts(int argc, char **argv)
 				{
 					case 1:
 					{
-						log_set_level(LOG_INFO);
+						log_set_level(LOG_NOTICE);
 						break;
 					}
 
@@ -339,6 +341,20 @@ cli_stream_getopts(int argc, char **argv)
 						break;
 					}
 				}
+				break;
+			}
+
+			case 'd':
+			{
+				verboseCount = 2;
+				log_set_level(LOG_DEBUG);
+				break;
+			}
+
+			case 'z':
+			{
+				verboseCount = 3;
+				log_set_level(LOG_TRACE);
 				break;
 			}
 

--- a/src/bin/pgcopydb/copydb.c
+++ b/src/bin/pgcopydb/copydb.c
@@ -75,7 +75,7 @@ copydb_init_workdir(CopyDataSpec *copySpecs,
 		return false;
 	}
 
-	log_info("Using work dir \"%s\"", cfPaths->topdir);
+	log_notice("Using work dir \"%s\"", cfPaths->topdir);
 
 	/* check to see if there is already another pgcopydb running */
 	if (directory_exists(cfPaths->topdir))
@@ -261,7 +261,7 @@ copydb_inspect_workdir(CopyFilePaths *cfPaths, DirectoryState *dirState)
 		dirState->blobsCopyIsDone;
 
 	/* let's be verbose about our inspection results */
-	log_info("Work directory \"%s\" already exists", cfPaths->topdir);
+	log_notice("Work directory \"%s\" already exists", cfPaths->topdir);
 
 	if (dirState->allDone)
 	{

--- a/src/bin/pgcopydb/main.c
+++ b/src/bin/pgcopydb/main.c
@@ -168,7 +168,6 @@ main(int argc, char **argv)
 static void
 set_logger()
 {
-	/* we're verbose by default */
 	log_set_level(LOG_INFO);
 
 	/*

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -1076,7 +1076,7 @@ pgsql_execute_with_params(PGSQL *pgsql, const char *sql, int paramCount,
 	char *endpoint =
 		pgsql->connectionType == PGSQL_CONN_SOURCE ? "SOURCE" : "TARGET";
 
-	log_debug("[%s] %s;", endpoint, sql);
+	log_notice("[%s] %s;", endpoint, sql);
 
 	if (paramCount > 0)
 	{

--- a/src/bin/pgcopydb/pidfile.c
+++ b/src/bin/pgcopydb/pidfile.c
@@ -144,7 +144,7 @@ read_pidfile(const char *pidfile, pid_t *pid)
 		*pid = 0;
 
 		log_debug("Found a stale pidfile at \"%s\"", pidfile);
-		log_info("Removing the stale pid file \"%s\"", pidfile);
+		log_notice("Removing the stale pid file \"%s\"", pidfile);
 
 		/*
 		 * We must return false here, after having determined that the

--- a/src/bin/pgcopydb/progress.c
+++ b/src/bin/pgcopydb/progress.c
@@ -107,8 +107,8 @@ copydb_prepare_schema_json_file(CopyDataSpec *copySpecs)
 	char *serialized_string = json_serialize_to_string_pretty(js);
 	size_t len = strlen(serialized_string);
 
-	log_debug("Storing migration schema in JSON file \"%s\"",
-			  copySpecs->cfPaths.schemafile);
+	log_notice("Storing migration schema in JSON file \"%s\"",
+			   copySpecs->cfPaths.schemafile);
 
 	if (!write_file(serialized_string, len, copySpecs->cfPaths.schemafile))
 	{


### PR DESCRIPTION
Some users are confused by the Unix way of using -vvv to mean “very, very verbose” and accumulate verbosity that way. Introduce --debug as a synonym to -vv and --trace as a synonym to -vvv.

The only drawback to also implement --debug and --trace when we could use --verbose several times is to use yet another short option letter. It seems to be worth it given the user feedback though.

Also introduce a new log level NOTICE between INFO (default verbosity) and DEBUG (extra verbosity) so that we have a new verbose setting that makes sense. The log_notice() macro isn't used much as yet, following patches and PRs will introduce more usage for it.