### PR TITLE
Improve clone --follow sub-process error handling.

### DIFF
--- a/src/bin/pgcopydb/ld_apply.c
+++ b/src/bin/pgcopydb/ld_apply.c
@@ -201,7 +201,9 @@ stream_apply_wait_for_sentinel(StreamSpecs *specs, StreamApplyContext *context)
 	{
 		if (asked_to_stop || asked_to_stop_fast || asked_to_quit)
 		{
-			log_info("Received a shutdown signal, quitting now");
+			log_info("Apply process received a shutdown signal "
+					 "while waiting for apply mode, "
+					 "quitting now");
 			return false;
 		}
 


### PR DESCRIPTION
Specifically, if the clone sub-process fails there is no point for the follow process to continue looping until we're ready to apply the changes, that won't happen. It's best to let know the user that something went wrong, even if that means we stop pre-fetching.