### PR TITLE
Fix/index jobs

### DIFF
--- a/docs/ref/pgcopydb_clone.rst
+++ b/docs/ref/pgcopydb_clone.rst
@@ -96,15 +96,15 @@ The ``pgcopydb clone`` command implements the following steps:
      catalog query on the source database, and also the list of indexes, and
      the list of sequences with their current values.
 
-	 When filtering is used, the list of objects OIDs that are meant to be
-	 filtered out is built during this step.
+     When filtering is used, the list of objects OIDs that are meant to be
+     filtered out is built during this step.
 
   3. The ``pre-data`` section of the dump is restored on the target database
      using the ``pg_restore`` command, creating all the Postgres objects
      from the source database into the target database.
 
-	 When filtering is used, the ``pg_restore --use-list`` feature is used
-	 to filter the list of objects to restore in this step.
+     When filtering is used, the ``pg_restore --use-list`` feature is used
+     to filter the list of objects to restore in this step.
 
   4. Then as many as ``--table-jobs`` COPY sub-processes are started to
      share the workload and COPY the data from the source to the target
@@ -149,13 +149,13 @@ The ``pgcopydb clone`` command implements the following steps:
      For each sequence, pgcopydb then calls ``pg_catalog.setval()`` on the
      target database with the information obtained on the source database.
 
- 10. The final stage consists now of running the ``pg_restore`` command for
-     the ``post-data`` section script for the whole database, and that's
-     where the foreign key constraints and other elements are created.
+  10. The final stage consists now of running the ``pg_restore`` command for
+      the ``post-data`` section script for the whole database, and that's
+      where the foreign key constraints and other elements are created.
 
-     The *post-data* script is filtered out using the ``pg_restore
-     --use-list`` option so that indexes and primary key constraints already
-     created in steps 6 and 7 are properly skipped now.
+      The *post-data* script is filtered out using the ``pg_restore
+      --use-list`` option so that indexes and primary key constraints
+      already created in steps 6 and 7 are properly skipped now.
 
 .. _change_data_capture:
 

--- a/docs/ref/pgcopydb_clone.rst
+++ b/docs/ref/pgcopydb_clone.rst
@@ -92,22 +92,30 @@ The ``pgcopydb clone`` command implements the following steps:
      and the ``post-data`` sections of the dump using Postgres custom
      format.
 
-  2. The ``pre-data`` section of the dump is restored on the target database
+  2. ``pgcopydb`` gets the list of ordinary and partitioned tables from a
+     catalog query on the source database, and also the list of indexes, and
+     the list of sequences with their current values.
+
+	 When filtering is used, the list of objects OIDs that are meant to be
+	 filtered out is built during this step.
+
+  3. The ``pre-data`` section of the dump is restored on the target database
      using the ``pg_restore`` command, creating all the Postgres objects
      from the source database into the target database.
 
-  3. ``pgcopydb`` gets the list of ordinary and partitioned tables and for
-     each of them runs COPY the data from the source to the target in a
-     dedicated sub-process, and starts and control the sub-processes until
-     all the data has been copied over.
+	 When filtering is used, the ``pg_restore --use-list`` feature is used
+	 to filter the list of objects to restore in this step.
+
+  4. Then as many as ``--table-jobs`` COPY sub-processes are started to
+     share the workload and COPY the data from the source to the target
+     database one table at a time, in a loop.
 
      A Postgres connection and a SQL query to the Postgres catalog table
      pg_class is used to get the list of tables with data to copy around,
-     and the `reltuples` is used to start with the tables with the greatest
-     number of rows first, as an attempt to minimize the copy time.
+     and the `reltuples` statistic is used to start with the tables with the
+     greatest number of rows first, as an attempt to minimize the copy time.
 
-  4. An auxiliary process is started concurrently to the main COPY workers.
-     This auxiliary process loops through all the Large Objects found on the
+  5. An auxiliary process loops through all the Large Objects found on the
      source database and copies its data parts over to the target database,
      much like pg_dump itself would.
 
@@ -115,35 +123,39 @@ The ``pgcopydb clone`` command implements the following steps:
      parts, except that there isn't a good way to do just that with the
      tooling.
 
-  5. In each copy table sub-process, as soon as the data copying is done,
-     then ``pgcopydb`` gets the list of index definitions attached to the
-     current target table and creates them in parallel.
+  6. As many as ``--index-jobs`` CREATE INDEX sub-processes are started to
+     share the workload and build indexes. In order to make sure to start
+     the CREATE INDEX commands only after the COPY operation has completed,
+     a queue mechanism is used. As soon as a table data COPY has completed,
+     all the indexes for the table are queued for processing by the CREATE
+     INDEX sub-processes.
 
      The primary indexes are created as UNIQUE indexes at this stage.
 
-  6. Then the PRIMARY KEY constraints are created USING the just built
+  7. Then the PRIMARY KEY constraints are created USING the just built
      indexes. This two-steps approach allows the primary key index itself to
      be created in parallel with other indexes on the same table, avoiding
      an EXCLUSIVE LOCK while creating the index.
 
-  7. Then ``VACUUM ANALYZE`` is run on each target table as soon as the data
-     and indexes are all created.
+  8. As many as ``-table-jobs`` VACUUM ANALYZE sub-processes are started to
+     share the workload. As soon as a table data COPY has completed, the
+     table is queued for processing by the VACUUM ANALYZE sub-processes.
 
-  8. Then pgcopydb gets the list of the sequences on the source database and
-     for each of them runs a separate query on the source to fetch the
-     ``last_value`` and the ``is_called`` metadata the same way that pg_dump
-     does.
+  9. An auxilliary process is loops over the sequences on the source
+     database and for each of them runs a separate query on the source to
+     fetch the ``last_value`` and the ``is_called`` metadata the same way
+     that pg_dump does.
 
      For each sequence, pgcopydb then calls ``pg_catalog.setval()`` on the
      target database with the information obtained on the source database.
 
-  9. The final stage consists now of running the ``pg_restore`` command for
+ 10. The final stage consists now of running the ``pg_restore`` command for
      the ``post-data`` section script for the whole database, and that's
      where the foreign key constraints and other elements are created.
 
      The *post-data* script is filtered out using the ``pg_restore
      --use-list`` option so that indexes and primary key constraints already
-     created in step 4. are properly skipped now.
+     created in steps 6 and 7 are properly skipped now.
 
 .. _change_data_capture:
 

--- a/src/bin/pgcopydb/cli_clone_follow.c
+++ b/src/bin/pgcopydb/cli_clone_follow.c
@@ -446,8 +446,6 @@ cloneDB(CopyDataSpec *copySpecs)
 		return false;
 	}
 
-	log_info("STEP 2: restore the pre-data section to the target database");
-
 	/* make sure that we have our own process local connection */
 	TransactionSnapshot snapshot = { 0 };
 
@@ -467,6 +465,9 @@ cloneDB(CopyDataSpec *copySpecs)
 	}
 
 	/* fetch schema information from source catalogs, including filtering */
+
+	log_info("STEP 2: fetch source database tables, indexes, and sequences");
+
 	if (!copydb_fetch_schema_and_prepare_specs(copySpecs))
 	{
 		/* errors have already been logged */
@@ -482,6 +483,8 @@ cloneDB(CopyDataSpec *copySpecs)
 
 	(void) summary_set_current_time(timings, TIMING_STEP_BEFORE_PREPARE_SCHEMA);
 
+	log_info("STEP 3: restore the pre-data section to the target database");
+
 	if (!copydb_target_prepare_schema(copySpecs))
 	{
 		/* errors have already been logged */
@@ -490,9 +493,10 @@ cloneDB(CopyDataSpec *copySpecs)
 
 	(void) summary_set_current_time(timings, TIMING_STEP_AFTER_PREPARE_SCHEMA);
 
-	log_info("STEP 3: copy data from source to target in sub-processes");
-	log_info("STEP 4: create indexes and constraints in parallel");
-	log_info("STEP 5: vacuum analyze each table");
+	log_info("STEP 4: copy data from source to target in %d sub-processes",
+			 copySpecs->tableJobs);
+
+	/* STEPs 5, 6, 7, 8, and 9 are printed when starting the sub-processes */
 
 	if (!copydb_copy_all_table_data(copySpecs))
 	{
@@ -503,7 +507,7 @@ cloneDB(CopyDataSpec *copySpecs)
 	/* close our snapshot: commit transaction and finish connection */
 	(void) copydb_close_snapshot(copySpecs);
 
-	log_info("STEP 7: restore the post-data section to the target database");
+	log_info("STEP 10: restore the post-data section to the target database");
 
 	(void) summary_set_current_time(timings, TIMING_STEP_BEFORE_FINALIZE_SCHEMA);
 

--- a/src/bin/pgcopydb/cli_clone_follow.c
+++ b/src/bin/pgcopydb/cli_clone_follow.c
@@ -375,7 +375,7 @@ start_clone_process(CopyDataSpec *copySpecs, pid_t *pid)
 	{
 		case -1:
 		{
-			log_error("Failed to fork a subprocess to prefetch changes");
+			log_error("Failed to fork a subprocess to prefetch changes: %m");
 			return -1;
 		}
 
@@ -560,7 +560,7 @@ start_follow_process(CopyDataSpec *copySpecs, StreamSpecs *streamSpecs,
 	{
 		case -1:
 		{
-			log_error("Failed to fork a subprocess to prefetch changes");
+			log_error("Failed to fork a subprocess to prefetch changes: %m");
 			return -1;
 		}
 

--- a/src/bin/pgcopydb/copydb.c
+++ b/src/bin/pgcopydb/copydb.c
@@ -1083,7 +1083,7 @@ copydb_start_vacuum_table(CopyTableDataSpec *tableSpecs)
 	{
 		case -1:
 		{
-			log_error("Failed to fork a worker process");
+			log_error("Failed to fork a worker process: %m");
 			return false;
 		}
 

--- a/src/bin/pgcopydb/copydb.c
+++ b/src/bin/pgcopydb/copydb.c
@@ -103,62 +103,64 @@ copydb_init_workdir(CopyDataSpec *copySpecs,
 
 	bool removeDir = false;
 
-	if (!copydb_inspect_workdir(cfPaths, dirState))
+	if (restart)
 	{
-		/* errors have already been logged */
-		return false;
+		removeDir = true;
 	}
-
-	if (dirState->directoryExists)
+	else
 	{
-		if (restart)
+		if (!copydb_inspect_workdir(cfPaths, dirState))
 		{
-			removeDir = true;
-		}
-
-		/* if we did nothing yet, just act as if --resume was used */
-		else if (!dirState->schemaDumpIsDone)
-		{
-			log_debug("schema dump has not been done yet, just continue");
-		}
-
-		/* if --resume has been used, we just continue */
-		else if (resume)
-		{
-			/* no-op */
-			(void) 0;
-		}
-		else if (dirState->allDone)
-		{
-			log_fatal("Please use --restart to allow for removing files "
-					  "that belong to a completed previous run.");
-			return false;
-		}
-		else if (!resume)
-		{
-			log_fatal("Please use --resume --not-consistent to allow "
-					  "for resuming from the previous run, "
-					  "which failed before completion.");
+			/* errors have already been logged */
 			return false;
 		}
 
-		/*
-		 * Here we should have restart true or resume true or we didn't even do
-		 * the schema dump on the previous run.
-		 */
+		if (dirState->directoryExists)
+		{
+			/* if we did nothing yet, just act as if --resume was used */
+			if (!dirState->schemaDumpIsDone)
+			{
+				log_notice("Schema dump has not been done yet, just continue");
+			}
+
+			/* if --resume has been used, we just continue */
+			else if (resume)
+			{
+				/* no-op */
+				(void) 0;
+			}
+			else if (dirState->allDone)
+			{
+				log_fatal("Please use --restart to allow for removing files "
+						  "that belong to a completed previous run.");
+				return false;
+			}
+			else if (!resume)
+			{
+				log_fatal("Please use --resume --not-consistent to allow "
+						  "for resuming from the previous run, "
+						  "which failed before completion.");
+				return false;
+			}
+
+			/*
+			 * Here we should have restart true or resume true or we didn't even do
+			 * the schema dump on the previous run.
+			 */
+		}
 	}
 
 	/* warn about trashing data from a previous run */
 	if (removeDir && !restart)
 	{
-		log_info("Inspection of \"%s\" shows that it is safe "
-				 "to remove it and continue",
-				 cfPaths->topdir);
+		log_notice("Inspection of \"%s\" shows that it is safe "
+				   "to remove it and continue",
+				   cfPaths->topdir);
 	}
 
 	if (removeDir)
 	{
-		log_info("Removing directory \"%s\"", cfPaths->topdir);
+		log_notice("Removing directory \"%s\"", cfPaths->topdir);
 	}
 
 	/* make sure the directory exists, possibly making it empty */
@@ -559,9 +561,19 @@ copydb_init_specs(CopyDataSpec *specs,
 
 		.tableJobs = tableJobs,
 		.indexJobs = indexJobs,
+
+		/* at the moment we don't have --vacuumJobs separately */
+		.vacuumJobs = tableJobs,
+
 		.splitTablesLargerThan = splitTablesLargerThan,
 
-		.indexSemaphore = { 0 }
+		.tableSemaphore = { 0 },
+		.indexSemaphore = { 0 },
+
+		.vacuumQueue = { 0 },
+		.indexQueue = { 0 },
+
+		.sourceTableHashByOid = NULL
 	};
 
 	/* initialize the connection strings */
@@ -608,14 +620,28 @@ copydb_init_specs(CopyDataSpec *specs,
 		return false;
 	}
 
-	/* create the index semaphore (allow jobs to start) */
-	specs->indexSemaphore.initValue = indexJobs;
+	/* create the index semaphore (critical section, one at a time please) */
+	specs->indexSemaphore.initValue = 1;
 
 	if (!semaphore_create(&(specs->indexSemaphore)))
 	{
 		log_error("Failed to create the index concurrency semaphore "
-				  "to orchestrate up to %d CREATE INDEX jobs at the same time",
+				  "to orchestrate %d CREATE INDEX jobs",
 				  indexJobs);
+		return false;
+	}
+
+	/* create the VACUUM process queue */
+	if (!queue_create(&(specs->vacuumQueue)))
+	{
+		log_error("Failed to create the VACUUM process queue");
+		return false;
+	}
+
+	/* create the CREATE INDEX process queue */
+	if (!queue_create(&(specs->indexQueue)))
+	{
+		log_error("Failed to create the INDEX process queue");
 		return false;
 	}
 
@@ -657,12 +683,13 @@ copydb_init_table_specs(CopyTableDataSpec *tableSpecs,
 		.section = specs->section,
 		.resume = specs->resume,
 
-		.sourceTable = { 0 },
+		.sourceTable = source,
 		.indexArray = NULL,
 		.summary = NULL,
 
 		.tableJobs = specs->tableJobs,
 		.indexJobs = specs->indexJobs,
+
 		.indexSemaphore = &(specs->indexSemaphore)
 	};
 
@@ -677,17 +704,14 @@ copydb_init_table_specs(CopyTableDataSpec *tableSpecs,
 		return false;
 	}
 
-	/* copy the SourceTable into our memory area */
-	tmpTableSpecs.sourceTable = *source;
-
 	/* copy the structure as a whole memory area to the target place */
 	*tableSpecs = tmpTableSpecs;
 
 	/* compute the table fully qualified name */
 	sformat(tableSpecs->qname, sizeof(tableSpecs->qname),
 			"\"%s\".\"%s\"",
-			tableSpecs->sourceTable.nspname,
-			tableSpecs->sourceTable.relname);
+			tableSpecs->sourceTable->nspname,
+			tableSpecs->sourceTable->relname);
 
 	/* This CopyTableDataSpec might be for a partial COPY */
 	if (source->partsArray.count >= 1)
@@ -719,8 +743,9 @@ copydb_init_table_specs(CopyTableDataSpec *tableSpecs,
 				(long long) tableSpecs->part.max);
 
 		/* now compute the table-specific paths we are using in copydb */
-		if (!copydb_init_tablepaths_for_part(tableSpecs,
+		if (!copydb_init_tablepaths_for_part(tableSpecs->cfPaths,
 											 &(tableSpecs->tablePaths),
+											 tableSpecs->sourceTable->oid,
 											 partNumber))
 		{
 			log_error("Failed to prepare pathnames for partition %d of table %s",
@@ -756,18 +781,40 @@ copydb_init_table_specs(CopyTableDataSpec *tableSpecs,
 		}
 
 		/* now compute the table-specific paths we are using in copydb */
-		sformat(tableSpecs->tablePaths.lockFile, MAXPGPATH, "%s/%d",
-				tableSpecs->cfPaths->rundir,
-				source->oid);
-
-		sformat(tableSpecs->tablePaths.doneFile, MAXPGPATH, "%s/%d.done",
-				tableSpecs->cfPaths->tbldir,
-				source->oid);
-
-		sformat(tableSpecs->tablePaths.idxListFile, MAXPGPATH, "%s/%u.idx",
-				tableSpecs->cfPaths->tbldir,
-				source->oid);
+		if (!copydb_init_tablepaths(tableSpecs->cfPaths,
+									&(tableSpecs->tablePaths),
+									tableSpecs->sourceTable->oid))
+		{
+			log_error("Failed to prepare pathnames for table %u",
+					  tableSpecs->sourceTable->oid);
+			return false;
+		}
 	}
+
+	return true;
+}
+
+
+/*
+ * copydb_init_tablepaths computes the lockFile, doneFile, and idxListFile
+ * pathnames for a given table oid and global cfPaths setup.
+ */
+bool
+copydb_init_tablepaths(CopyFilePaths *cfPaths,
+					   TableFilePaths *tablePaths,
+					   uint32_t oid)
+{
+	sformat(tablePaths->lockFile, MAXPGPATH, "%s/%d",
+			cfPaths->rundir,
+			oid);
+
+	sformat(tablePaths->doneFile, MAXPGPATH, "%s/%d.done",
+			cfPaths->tbldir,
+			oid);
+
+	sformat(tablePaths->idxListFile, MAXPGPATH, "%s/%u.idx",
+			cfPaths->tbldir,
+			oid);
 
 	return true;
 }
@@ -778,18 +825,19 @@ copydb_init_table_specs(CopyTableDataSpec *tableSpecs,
  * for a given COPY partition of a table.
  */
 bool
-copydb_init_tablepaths_for_part(CopyTableDataSpec *tableSpecs,
+copydb_init_tablepaths_for_part(CopyFilePaths *cfPaths,
 								TableFilePaths *tablePaths,
+								uint32_t oid,
 								int partNumber)
 {
 	sformat(tablePaths->lockFile, MAXPGPATH, "%s/%d.%d",
-			tableSpecs->cfPaths->rundir,
-			tableSpecs->sourceTable.oid,
+			cfPaths->rundir,
+			oid,
 			partNumber);
 
 	sformat(tablePaths->doneFile, MAXPGPATH, "%s/%d.%d.done",
-			tableSpecs->cfPaths->tbldir,
-			tableSpecs->sourceTable.oid,
+			cfPaths->tbldir,
+			oid,
 			partNumber);
 
 	return true;
@@ -1060,78 +1108,6 @@ copydb_prepare_snapshot(CopyDataSpec *copySpecs)
 
 
 /*
- * copydb_start_vacuum_table runs VACUUM ANALYSE on the given table.
- */
-bool
-copydb_start_vacuum_table(CopyTableDataSpec *tableSpecs)
-{
-	if (tableSpecs->section != DATA_SECTION_VACUUM &&
-		tableSpecs->section != DATA_SECTION_ALL)
-	{
-		return true;
-	}
-
-	/*
-	 * Flush stdio channels just before fork, to avoid double-output problems.
-	 */
-	fflush(stdout);
-	fflush(stderr);
-
-	int fpid = fork();
-
-	switch (fpid)
-	{
-		case -1:
-		{
-			log_error("Failed to fork a worker process: %m");
-			return false;
-		}
-
-		case 0:
-		{
-			/* child process runs the command */
-			PGSQL dst = { 0 };
-
-			/* initialize our connection to the target database */
-			if (!pgsql_init(&dst, tableSpecs->target_pguri, PGSQL_CONN_TARGET))
-			{
-				/* errors have already been logged */
-				return false;
-			}
-
-			/* finally, vacuum analyze the table and its indexes */
-			char vacuum[BUFSIZE] = { 0 };
-
-			sformat(vacuum, sizeof(vacuum),
-					"VACUUM ANALYZE %s",
-					tableSpecs->qname);
-
-			log_info("%s;", vacuum);
-
-			if (!pgsql_execute(&dst, vacuum))
-			{
-				/* errors have already been logged */
-				exit(EXIT_CODE_INTERNAL_ERROR);
-			}
-
-			(void) pgsql_finish(&dst);
-
-			exit(EXIT_CODE_QUIT);
-		}
-
-		default:
-		{
-			/* fork succeeded, in parent */
-			break;
-		}
-	}
-
-	/* now we're done, and we want async behavior, do not wait */
-	return true;
-}
-
-
-/*
  * copydb_fatal_exit sends a termination signal to all the subprocess and waits
  * until all the known subprocess are finished, then returns true.
  */
@@ -1177,6 +1153,7 @@ copydb_wait_for_subprocesses()
 				if (errno == ECHILD)
 				{
 					/* no more childrens */
+					log_debug("copydb_wait_for_subprocesses: no more children");
 					return allReturnCodeAreZero;
 				}
 
@@ -1210,6 +1187,8 @@ copydb_wait_for_subprocesses()
 					log_error("Sub-processes %d exited with code %d",
 							  pid, returnCode);
 				}
+
+				break;
 			}
 		}
 	}

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -389,7 +389,9 @@ bool copydb_index_workers_send_stop(CopyDataSpec *specs);
 
 bool copydb_table_indexes_are_done(CopyDataSpec *specs,
 								   SourceTable *table,
-								   bool *indexesAreDone);
+								   TableFilePaths *tablePaths,
+								   bool *indexesAreDone,
+								   bool *constraintsAreBeingBuilt);
 
 bool copydb_init_index_paths(CopyFilePaths *cfPaths,
 							 SourceIndex *index,

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -8,6 +8,7 @@
 
 #include "filtering.h"
 #include "lock_utils.h"
+#include "queue_utils.h"
 #include "pgcmd.h"
 #include "pgsql.h"
 #include "schema.h"
@@ -185,7 +186,7 @@ typedef struct CopyTableDataSpec
 	bool resume;
 
 	char qname[NAMEDATALEN * 2 + 1];
-	SourceTable sourceTable;
+	SourceTable *sourceTable;
 	CopyTableSummary *summary;
 	SourceIndexArray *indexArray;
 
@@ -276,17 +277,25 @@ typedef struct CopyDataSpec
 
 	int tableJobs;
 	int indexJobs;
+	int vacuumJobs;
+
 	uint64_t splitTablesLargerThan;
 	char splitTablesLargerThanPretty[NAMEDATALEN];
 
 	Semaphore tableSemaphore;
 	Semaphore indexSemaphore;
 
+	Queue vacuumQueue;
+	Queue indexQueue;
+
 	DumpPaths dumpPaths;
 	SourceTableArray sourceTableArray;
 	SourceIndexArray sourceIndexArray;
 	CopyTableDataSpecsArray tableSpecsArray;
 	SourceSequenceArray sequenceArray;
+
+	SourceTable *sourceTableHashByOid;
+	SourceIndex *sourceIndexHashByOid;
 } CopyDataSpec;
 
 
@@ -343,8 +352,13 @@ bool copydb_init_table_specs(CopyTableDataSpec *tableSpecs,
 							 SourceTable *source,
 							 int partNumber);
 
-bool copydb_init_tablepaths_for_part(CopyTableDataSpec *tableSpecs,
+bool copydb_init_tablepaths(CopyFilePaths *cfPaths,
+							TableFilePaths *tablePaths,
+							uint32_t oid);
+
+bool copydb_init_tablepaths_for_part(CopyFilePaths *cfPaths,
 									 TableFilePaths *tablePaths,
+									 uint32_t oid,
 									 int partNumber);
 
 bool copydb_export_snapshot(TransactionSnapshot *snapshot);
@@ -354,7 +368,7 @@ bool copydb_prepare_snapshot(CopyDataSpec *copySpecs);
 bool copydb_set_snapshot(CopyDataSpec *copySpecs);
 bool copydb_close_snapshot(CopyDataSpec *copySpecs);
 
-bool copydb_start_vacuum_table(CopyTableDataSpec *tableSpecs);
+/* bool copydb_start_vacuum_table(CopyTableDataSpec *tableSpecs); */
 
 bool copydb_fatal_exit(void);
 bool copydb_wait_for_subprocesses(void);
@@ -363,6 +377,24 @@ bool copydb_collect_finished_subprocesses(bool *allDone);
 bool copydb_copy_roles(CopyDataSpec *copySpecs);
 
 /* indexes.c */
+
+bool copydb_start_index_workers(CopyDataSpec *specs);
+bool copydb_index_worker(CopyDataSpec *specs);
+bool copydb_create_index_by_oid(CopyDataSpec *specs, uint32_t indexOid);
+
+bool copydb_add_table_indexes(CopyDataSpec *specs,
+							  CopyTableDataSpec *tableSpecs);
+
+bool copydb_index_workers_send_stop(CopyDataSpec *specs);
+
+bool copydb_table_indexes_are_done(CopyDataSpec *specs,
+								   SourceTable *table,
+								   bool *indexesAreDone);
+
+bool copydb_init_index_paths(CopyFilePaths *cfPaths,
+							 SourceIndex *index,
+							 IndexFilePaths *indexPaths);
+
 bool copydb_init_indexes_paths(CopyFilePaths *cfPaths,
 							   SourceIndexArray *indexArray,
 							   IndexFilePathsArray *indexPathsArray);
@@ -375,14 +407,12 @@ bool copydb_start_index_processes(CopyDataSpec *specs,
 
 bool copydb_start_index_process(CopyDataSpec *specs,
 								SourceIndexArray *indexArray,
-								IndexFilePathsArray *indexPathsArray,
-								Semaphore *lockFileSemaphore);
+								IndexFilePathsArray *indexPathsArray);
 
 bool copydb_create_index(const char *pguri,
 						 SourceIndex *index,
 						 IndexFilePaths *indexPaths,
 						 Semaphore *lockFileSemaphore,
-						 Semaphore *createIndexSemaphore,
 						 bool constraint,
 						 bool ifNotExists);
 
@@ -410,6 +440,8 @@ bool copydb_prepare_create_constraint_command(SourceIndex *index,
 											  char *command,
 											  size_t size);
 
+bool copydb_create_constraints(CopyDataSpec *spec, SourceTable *table);
+
 /* dump_restore.c */
 bool copydb_dump_source_schema(CopyDataSpec *specs,
 							   const char *snapshot,
@@ -422,8 +454,9 @@ bool copydb_objectid_has_been_processed_already(CopyDataSpec *specs,
 
 bool copydb_write_restore_list(CopyDataSpec *specs, PostgresDumpSection section);
 
-/* sequence.c */
+/* sequences.c */
 bool copydb_copy_all_sequences(CopyDataSpec *specs);
+bool copydb_start_seq_process(CopyDataSpec *specs);
 bool copydb_prepare_sequence_specs(CopyDataSpec *specs, PGSQL *pgsql);
 
 /* table-data.c */
@@ -442,12 +475,9 @@ bool copydb_copy_all_table_data(CopyDataSpec *specs);
 bool copydb_process_table_data(CopyDataSpec *specs);
 bool copydb_process_table_data_worker(CopyDataSpec *specs);
 
+bool copydb_process_table_data_with_workers(CopyDataSpec *specs);
+
 bool copydb_copy_table(CopyDataSpec *specs, CopyTableDataSpec *tableSpecs);
-
-bool copydb_copy_table_indexes(CopyTableDataSpec *tableSpecs);
-bool copydb_create_table_indexes(CopyTableDataSpec *tableSpecs);
-
-bool copydb_create_constraints(CopyTableDataSpec *tableSpecs);
 
 bool copydb_table_is_being_processed(CopyDataSpec *specs,
 									 CopyTableDataSpec *tableSpecs,
@@ -464,6 +494,13 @@ bool copydb_table_parts_are_all_done(CopyDataSpec *specs,
 
 bool copydb_start_blob_process(CopyDataSpec *specs);
 bool copydb_copy_blobs(CopyDataSpec *specs);
+
+/* vacuum.c */
+bool vacuum_start_workers(CopyDataSpec *specs);
+bool vacuum_worker(CopyDataSpec *specs);
+bool vacuum_analyze_table_by_oid(CopyDataSpec *specs, uint32_t oid);
+bool vacuum_add_table(CopyDataSpec *specs, CopyTableDataSpec *tableSpecs);
+bool vacuum_send_stop(CopyDataSpec *specs);
 
 /* summary.c */
 bool prepare_summary_table(Summary *summary, CopyDataSpec *specs);

--- a/src/bin/pgcopydb/dump_restore.c
+++ b/src/bin/pgcopydb/dump_restore.c
@@ -289,21 +289,21 @@ copydb_write_restore_list(CopyDataSpec *specs, PostgresDumpSection section)
 		{
 			prefix = ";";
 
-			log_debug("Skipping already processed dumpId %d: %s %u %s",
-					  contents.array[i].dumpId,
-					  contents.array[i].desc,
-					  contents.array[i].objectOid,
-					  contents.array[i].restoreListName);
+			log_notice("Skipping already processed dumpId %d: %s %u %s",
+					   contents.array[i].dumpId,
+					   contents.array[i].desc,
+					   contents.array[i].objectOid,
+					   contents.array[i].restoreListName);
 		}
 		else if (copydb_objectid_is_filtered_out(specs, oid, name))
 		{
 			prefix = ";";
 
-			log_debug("Skipping filtered-out dumpId %d: %s %u %s",
-					  contents.array[i].dumpId,
-					  contents.array[i].desc,
-					  contents.array[i].objectOid,
-					  contents.array[i].restoreListName);
+			log_notice("Skipping filtered-out dumpId %d: %s %u %s",
+					   contents.array[i].dumpId,
+					   contents.array[i].desc,
+					   contents.array[i].objectOid,
+					   contents.array[i].restoreListName);
 		}
 
 		appendPQExpBuffer(listContents, "%s%d; %u %u %s %s\n",

--- a/src/bin/pgcopydb/file_utils.c
+++ b/src/bin/pgcopydb/file_utils.c
@@ -56,6 +56,34 @@ file_exists(const char *filename)
 
 
 /*
+ * file_is_empty returns true if the given filename is known to exist on the
+ * file system and is empty: its content is "".
+ */
+bool
+file_is_empty(const char *filename)
+{
+	if (file_exists(filename))
+	{
+		char *fileContents;
+		long fileSize;
+
+		if (!read_file(filename, &fileContents, &fileSize))
+		{
+			/* errors are logged */
+			return false;
+		}
+
+		if (fileSize == 0)
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+
+
+/*
  * directory_exists returns whether the given path is the name of a directory that
  * exists on the file system or not.
  */

--- a/src/bin/pgcopydb/file_utils.h
+++ b/src/bin/pgcopydb/file_utils.h
@@ -34,6 +34,7 @@ typedef struct SearchPath
 
 
 bool file_exists(const char *filename);
+bool file_is_empty(const char *filename);
 bool directory_exists(const char *path);
 bool ensure_empty_dir(const char *dirname, int mode);
 FILE * fopen_with_umask(const char *filePath, const char *modes, int flags, mode_t umask);

--- a/src/bin/pgcopydb/follow.c
+++ b/src/bin/pgcopydb/follow.c
@@ -30,7 +30,7 @@ follow_start_prefetch(StreamSpecs *specs, pid_t *pid)
 	{
 		case -1:
 		{
-			log_error("Failed to fork a subprocess to prefetch changes");
+			log_error("Failed to fork a subprocess to prefetch changes: %m");
 			return -1;
 		}
 
@@ -73,7 +73,7 @@ follow_start_catchup(StreamSpecs *specs, pid_t *pid)
 	{
 		case -1:
 		{
-			log_error("Failed to fork a subprocess to prefetch changes");
+			log_error("Failed to fork a subprocess to prefetch changes: %m");
 			return -1;
 		}
 

--- a/src/bin/pgcopydb/indexes.c
+++ b/src/bin/pgcopydb/indexes.c
@@ -168,7 +168,7 @@ copydb_start_index_processes(CopyDataSpec *specs,
 		{
 			case -1:
 			{
-				log_error("Failed to fork a worker process");
+				log_error("Failed to fork a worker process: %m");
 				return false;
 			}
 

--- a/src/bin/pgcopydb/indexes.c
+++ b/src/bin/pgcopydb/indexes.c
@@ -27,7 +27,8 @@
 bool
 copydb_start_index_workers(CopyDataSpec *specs)
 {
-	log_info("Now starting %d CREATE INDEX processes", specs->indexJobs);
+	log_info("STEP 6: starting %d CREATE INDEX processes", specs->indexJobs);
+	log_info("STEP 7: constraints are built by the CREATE INDEX processes");
 
 	for (int i = 0; i < specs->indexJobs; i++)
 	{

--- a/src/bin/pgcopydb/indexes.c
+++ b/src/bin/pgcopydb/indexes.c
@@ -21,8 +21,379 @@
 
 
 /*
- * copydb_init_index_file_paths prepares a given index (and constraint) file
- * paths to help orchestrate the concurrent operations.
+ * copydb_start_index_workers create as many sub-process as needed, per
+ * --index-jobs.
+ */
+bool
+copydb_start_index_workers(CopyDataSpec *specs)
+{
+	log_info("Now starting %d CREATE INDEX processes", specs->indexJobs);
+
+	for (int i = 0; i < specs->indexJobs; i++)
+	{
+		/*
+		 * Flush stdio channels just before fork, to avoid double-output
+		 * problems.
+		 */
+		fflush(stdout);
+		fflush(stderr);
+
+		int fpid = fork();
+
+		switch (fpid)
+		{
+			case -1:
+			{
+				log_error("Failed to fork a worker process: %m");
+				return false;
+			}
+
+			case 0:
+			{
+				/* child process runs the command */
+				if (!copydb_index_worker(specs))
+				{
+					/* errors have already been logged */
+					exit(EXIT_CODE_INTERNAL_ERROR);
+				}
+
+				exit(EXIT_CODE_QUIT);
+			}
+
+			default:
+			{
+				/* fork succeeded, in parent */
+				break;
+			}
+		}
+	}
+
+	return true;
+}
+
+
+/*
+ * copydb_index_worker is a worker process that loops over messages received
+ * from a queue, each message being the Oid of an index to create on the target
+ * database.
+ */
+bool
+copydb_index_worker(CopyDataSpec *specs)
+{
+	int errors = 0;
+	bool stop = false;
+
+	log_notice("Started CREATE INDEX worker %d [%d]", getpid(), getppid());
+
+	while (!stop)
+	{
+		QMessage mesg = { 0 };
+
+		if (asked_to_stop || asked_to_stop_fast || asked_to_quit)
+		{
+			return false;
+		}
+
+		if (!queue_receive(&(specs->indexQueue), &mesg))
+		{
+			/* errors have already been logged */
+			break;
+		}
+
+		switch (mesg.type)
+		{
+			case QMSG_TYPE_STOP:
+			{
+				stop = true;
+				log_debug("Stop message received by create index worker");
+				break;
+			}
+
+			case QMSG_TYPE_INDEXOID:
+			{
+				if (!copydb_create_index_by_oid(specs, mesg.oid))
+				{
+					++errors;
+				}
+				break;
+			}
+
+			default:
+			{
+				log_error("Received unknown message type %ld on index queue %d",
+						  mesg.type,
+						  specs->indexQueue.qId);
+				break;
+			}
+		}
+	}
+
+	return stop == true && errors == 0;
+}
+
+
+/*
+ * copydb_create_index_by_oid finds the SourceIndex entry by its OID and then
+ * creates the index on the target database.
+ */
+bool
+copydb_create_index_by_oid(CopyDataSpec *specs, uint32_t indexOid)
+{
+	uint32_t oid = indexOid;
+
+	SourceTable *table = NULL;
+	SourceIndex *index = NULL;
+
+	log_trace("copydb_create_index_by_oid: %u", indexOid);
+
+	HASH_FIND(hh, specs->sourceIndexHashByOid, &oid, sizeof(oid), index);
+
+	if (index == NULL)
+	{
+		log_error("Failed to find index %u in sourceIndexHashByOid", oid);
+		return false;
+	}
+
+	IndexFilePaths indexPaths = { 0 };
+
+	if (!copydb_init_index_paths(&(specs->cfPaths), index, &indexPaths))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	oid = index->tableOid;
+	HASH_FIND(hh, specs->sourceTableHashByOid, &oid, sizeof(oid), table);
+
+	if (table == NULL)
+	{
+		log_error("Failed to find table %u (\"%s\".\"%s\") "
+				  " in sourceTableHashByOid",
+				  oid,
+				  index->tableNamespace,
+				  index->tableRelname);
+		return false;
+	}
+
+	TableFilePaths tablePaths = { 0 };
+
+	if (!copydb_init_tablepaths(&(specs->cfPaths), &tablePaths, oid))
+	{
+		log_error("Failed to prepare pathnames for table %u", oid);
+		return false;
+	}
+
+	log_trace("copydb_create_index_by_oid: %u \"%s.%s\" on \"%s\".\"%s\"",
+			  indexOid,
+			  index->indexNamespace,
+			  index->indexRelname,
+			  table->nspname,
+			  table->relname);
+
+	/*
+	 * Add IF NOT EXISTS clause when the --resume option has been used, or when
+	 * the command is `pgcopydb copy indexes`, in which cases we don't know
+	 * what to expect on the target database.
+	 */
+	bool ifNotExists =
+		specs->resume || specs->section == DATA_SECTION_INDEXES;
+
+	/* child process runs the command */
+	if (!copydb_create_index(specs->target_pguri,
+							 index,
+							 &indexPaths,
+							 &(specs->indexSemaphore),
+							 false, /* constraint */
+							 ifNotExists))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/*
+	 * Now if that was the last index built for a given table, it's time to
+	 * also create the constraints associated with the indexes. We wait until
+	 * all the indexes are done because constraints are built with ALTER TABLE,
+	 * which takes an exclusive lock on the table.
+	 */
+	bool builtAllIndexes = false;
+
+	if (!copydb_table_indexes_are_done(specs, table, &builtAllIndexes))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	if (builtAllIndexes)
+	{
+		if (!copydb_create_constraints(specs, table))
+		{
+			log_error("Failed to create constraints for table \"%s\".\"%s\"",
+					  table->nspname,
+					  table->relname);
+			return false;
+		}
+
+		/*
+		 * Create an index list file for the table, so that we can easily
+		 * find relevant indexing information from the table itself.
+		 */
+		if (!create_table_index_file(table, tablePaths.idxListFile))
+		{
+			/* this only means summary is missing some indexing information */
+			log_warn("Failed to create table \"%s\".\"%s\" index list file \"%s\"",
+					 table->nspname,
+					 table->relname,
+					 tablePaths.idxListFile);
+		}
+	}
+
+	return true;
+}
+
+
+/*
+ * copydb_table_indexes_are_done checks that all indexes for a given table have
+ * been built already.
+ */
+bool
+copydb_table_indexes_are_done(CopyDataSpec *specs,
+							  SourceTable *table,
+							  bool *indexesAreDone)
+{
+	bool builtAllIndexes = true;
+
+	/* enter the index lockfile/donefile critical section */
+	(void) semaphore_lock(&(specs->indexSemaphore));
+
+	SourceIndexList *indexListEntry = table->firstIndex;
+
+	for (; indexListEntry != NULL; indexListEntry = indexListEntry->next)
+	{
+		SourceIndex *index = indexListEntry->index;
+		IndexFilePaths indexPaths = { 0 };
+
+		if (!copydb_init_index_paths(&(specs->cfPaths), index, &indexPaths))
+		{
+			/* errors have already been logged */
+			(void) semaphore_unlock(&(specs->indexSemaphore));
+			return false;
+		}
+
+		builtAllIndexes = builtAllIndexes && file_exists(indexPaths.doneFile);
+	}
+
+	*indexesAreDone = builtAllIndexes;
+
+	/* end of the critical section around lockfile and donefile handling */
+	(void) semaphore_unlock(&(specs->indexSemaphore));
+
+	return true;
+}
+
+
+/*
+ * copydb_add_table_indexes sends a message to the CREATE INDEX process queue
+ * to process indexes attached to the given table.
+ */
+bool
+copydb_add_table_indexes(CopyDataSpec *specs, CopyTableDataSpec *tableSpecs)
+{
+	SourceIndexList *indexListEntry = tableSpecs->sourceTable->firstIndex;
+
+	for (; indexListEntry != NULL; indexListEntry = indexListEntry->next)
+	{
+		SourceIndex *index = indexListEntry->index;
+
+		QMessage mesg = {
+			.type = QMSG_TYPE_INDEXOID,
+			.oid = index->indexOid
+		};
+
+		log_trace("Queueing index \"%s\".\"%s\" [%u] for table %s [%u]",
+				  index->indexNamespace,
+				  index->indexRelname,
+				  mesg.oid,
+				  tableSpecs->qname,
+				  tableSpecs->sourceTable->oid);
+
+		if (!queue_send(&(specs->indexQueue), &mesg))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+	}
+
+	return true;
+}
+
+
+/*
+ * copydb_index_workers_send_stop sends the STOP message to the CREATE INDEX
+ * workers.
+ *
+ * Each worker will consume one STOP message before stopping, so we need to
+ * send as many STOP messages as we have started worker processes.
+ */
+bool
+copydb_index_workers_send_stop(CopyDataSpec *specs)
+{
+	for (int i = 0; i < specs->indexJobs; i++)
+	{
+		QMessage stop = { .type = QMSG_TYPE_STOP, .oid = 0 };
+
+		log_debug("Send STOP message to CREATE INDEX queue %d",
+				  specs->indexQueue.qId);
+
+		if (!queue_send(&(specs->indexQueue), &stop))
+		{
+			/* errors have already been logged */
+			continue;
+		}
+	}
+
+	return true;
+}
+
+
+/*
+ * copydb_init_index_paths prepares a given index (and constraint) file paths
+ * to help orchestrate the concurrent operations.
+ */
+bool
+copydb_init_index_paths(CopyFilePaths *cfPaths,
+						SourceIndex *index,
+						IndexFilePaths *indexPaths)
+{
+	sformat(indexPaths->lockFile, sizeof(indexPaths->lockFile),
+			"%s/%u",
+			cfPaths->rundir,
+			index->indexOid);
+
+	sformat(indexPaths->doneFile, sizeof(indexPaths->doneFile),
+			"%s/%u.done",
+			cfPaths->idxdir,
+			index->indexOid);
+
+	sformat(indexPaths->constraintLockFile,
+			sizeof(indexPaths->constraintLockFile),
+			"%s/%u",
+			cfPaths->rundir,
+			index->constraintOid);
+
+	sformat(indexPaths->constraintDoneFile,
+			sizeof(indexPaths->constraintDoneFile),
+			"%s/%u.done",
+			cfPaths->idxdir,
+			index->constraintOid);
+
+	return true;
+}
+
+
+/*
+ * copydb_init_indexes_paths prepares a given index (and constraint) file paths
+ * to help orchestrate the concurrent operations.
  */
 bool
 copydb_init_indexes_paths(CopyFilePaths *cfPaths,
@@ -31,34 +402,14 @@ copydb_init_indexes_paths(CopyFilePaths *cfPaths,
 {
 	indexPathsArray->count = indexArray->count;
 	indexPathsArray->array =
-		(IndexFilePaths *) malloc(indexArray->count * sizeof(IndexFilePaths));
+		(IndexFilePaths *) calloc(indexArray->count, sizeof(IndexFilePaths));
 
 	for (int i = 0; i < indexArray->count; i++)
 	{
 		SourceIndex *index = &(indexArray->array[i]);
 		IndexFilePaths *indexPaths = &(indexPathsArray->array[i]);
 
-		sformat(indexPaths->lockFile, sizeof(indexPaths->lockFile),
-				"%s/%u",
-				cfPaths->rundir,
-				index->indexOid);
-
-		sformat(indexPaths->doneFile, sizeof(indexPaths->doneFile),
-				"%s/%u.done",
-				cfPaths->idxdir,
-				index->indexOid);
-
-		sformat(indexPaths->constraintLockFile,
-				sizeof(indexPaths->constraintLockFile),
-				"%s/%u",
-				cfPaths->rundir,
-				index->constraintOid);
-
-		sformat(indexPaths->constraintDoneFile,
-				sizeof(indexPaths->constraintDoneFile),
-				"%s/%u.done",
-				cfPaths->idxdir,
-				index->constraintOid);
+		(void) copydb_init_index_paths(cfPaths, index, indexPaths);
 	}
 
 	return true;
@@ -91,22 +442,12 @@ copydb_copy_all_indexes(CopyDataSpec *specs)
 		return true;
 	}
 
-	PGSQL *src = &(specs->sourceSnapshot.pgsql);
-
-	SourceIndexArray indexArray = { 0, NULL };
+	SourceIndexArray *indexArray = &(specs->sourceIndexArray);
 	IndexFilePathsArray indexPathsArray = { 0, NULL };
-
-	log_info("Listing indexes in source database");
-
-	if (!schema_list_all_indexes(src, &(specs->filters), &indexArray))
-	{
-		/* errors have already been logged */
-		return false;
-	}
 
 	/* build the index file paths we need for the upcoming operations */
 	if (!copydb_init_indexes_paths(&(specs->cfPaths),
-								   &indexArray,
+								   indexArray,
 								   &indexPathsArray))
 	{
 		/* errors have already been logged */
@@ -114,17 +455,16 @@ copydb_copy_all_indexes(CopyDataSpec *specs)
 	}
 
 	log_info("Creating %d indexes in the target database using %d processes",
-			 indexArray.count,
+			 indexArray->count,
 			 specs->indexJobs);
 
-	if (!copydb_start_index_processes(specs, &indexArray, &indexPathsArray))
+	if (!copydb_start_index_processes(specs, indexArray, &indexPathsArray))
 	{
 		/* errors have already been logged */
 		return false;
 	}
 
 	/* free malloc'ed memory area */
-	free(indexArray.array);
 	free(indexPathsArray.array);
 
 	return true;
@@ -141,18 +481,6 @@ copydb_start_index_processes(CopyDataSpec *specs,
 							 SourceIndexArray *indexArray,
 							 IndexFilePathsArray *indexPathsArray)
 {
-	Semaphore lockFileSemaphore = { 0 };
-
-	lockFileSemaphore.initValue = 1;
-
-	if (!semaphore_create(&lockFileSemaphore))
-	{
-		log_error("Failed to create the same-index concurrency semaphore "
-				  "to orchestrate %d CREATE INDEX jobs",
-				  specs->indexJobs);
-		return false;
-	}
-
 	for (int i = 0; i < specs->indexJobs; i++)
 	{
 		/*
@@ -177,8 +505,7 @@ copydb_start_index_processes(CopyDataSpec *specs,
 				/* child process runs the command */
 				if (!copydb_start_index_process(specs,
 												indexArray,
-												indexPathsArray,
-												&lockFileSemaphore))
+												indexPathsArray))
 				{
 					/* errors have already been logged */
 					exit(EXIT_CODE_INTERNAL_ERROR);
@@ -204,11 +531,11 @@ copydb_start_index_processes(CopyDataSpec *specs,
 				 specs->cfPaths.done.indexes);
 	}
 
-	if (!semaphore_finish(&lockFileSemaphore))
+	if (!semaphore_finish(&specs->indexSemaphore))
 	{
 		log_warn("Failed to remove same-index concurrency semaphore %d, "
 				 "see above for details",
-				 lockFileSemaphore.semId);
+				 specs->indexSemaphore.semId);
 	}
 
 	return success;
@@ -230,8 +557,7 @@ copydb_start_index_processes(CopyDataSpec *specs,
 bool
 copydb_start_index_process(CopyDataSpec *specs,
 						   SourceIndexArray *indexArray,
-						   IndexFilePathsArray *indexPathsArray,
-						   Semaphore *lockFileSemaphore)
+						   IndexFilePathsArray *indexPathsArray)
 {
 	int errors = 0;
 	bool constraint = specs->section == DATA_SECTION_CONSTRAINTS;
@@ -246,7 +572,6 @@ copydb_start_index_process(CopyDataSpec *specs,
 		if (!copydb_create_index(specs->target_pguri,
 								 index,
 								 indexPaths,
-								 lockFileSemaphore,
 								 &(specs->indexSemaphore),
 								 constraint,
 								 ifNotExists))
@@ -257,12 +582,6 @@ copydb_start_index_process(CopyDataSpec *specs,
 		}
 	}
 
-	if (!copydb_wait_for_subprocesses())
-	{
-		/* errors have already been logged */
-		++errors;
-	}
-
 	return errors == 0;
 }
 
@@ -271,22 +590,15 @@ copydb_start_index_process(CopyDataSpec *specs,
  * copydb_create_indexes creates all the indexes for a given table in
  * parallel, using a sub-process to send each index command.
  *
- * This function uses two distinct semaphores:
- *
- * - the lockFileSemaphore allows multiple worker process to lock around the
- *   choice of the next index to process, guaranteeing that any single index is
- *   processed by only one worker: same-index concurrency.
- *
- * - the createIndexSemaphore should be initialized with indexJobs as its
- *   initValue to enable creating up to that number of indexes at the same time
- *   on the target system.
+ * The lockFileSemaphore allows multiple worker process to lock around the
+ * choice of the next index to process, guaranteeing that any single index is
+ * processed by only one worker: no same-index concurrency.
  */
 bool
 copydb_create_index(const char *pguri,
 					SourceIndex *index,
 					IndexFilePaths *indexPaths,
 					Semaphore *lockFileSemaphore,
-					Semaphore *createIndexSemaphore,
 					bool constraint,
 					bool ifNotExists)
 {
@@ -340,7 +652,6 @@ copydb_create_index(const char *pguri,
 		return true;
 	}
 
-	/* deal with same-index concurrency if we have to */
 	if (!copydb_index_is_being_processed(index,
 										 indexPaths,
 										 constraint,
@@ -359,9 +670,6 @@ copydb_create_index(const char *pguri,
 				  index->indexRelname);
 		return true;
 	}
-
-	/* now grab an index semaphore lock if we have one */
-	(void) semaphore_lock(createIndexSemaphore);
 
 	/* prepare the create index command, maybe adding IF NOT EXISTS */
 	if (constraint)
@@ -390,8 +698,6 @@ copydb_create_index(const char *pguri,
 
 	if (!pgsql_init(&dst, (char *) pguri, PGSQL_CONN_TARGET))
 	{
-		/* errors have already been logged */
-		(void) semaphore_unlock(createIndexSemaphore);
 		return false;
 	}
 
@@ -406,14 +712,10 @@ copydb_create_index(const char *pguri,
 	if (!pgsql_execute(&dst, summary->command))
 	{
 		/* errors have already been logged */
-		(void) semaphore_unlock(createIndexSemaphore);
 		return false;
 	}
 
 	(void) pgsql_finish(&dst);
-
-	/* the CREATE INDEX command is done, release our lock */
-	(void) semaphore_unlock(createIndexSemaphore);
 
 	if (!copydb_mark_index_as_done(index,
 								   indexPaths,
@@ -455,7 +757,6 @@ copydb_index_is_being_processed(SourceIndex *index,
 		if (!open_index_summary(summary, lockFile, constraint))
 		{
 			log_info("Failed to create the lock file at \"%s\"", lockFile);
-			(void) semaphore_unlock(lockFileSemaphore);
 			return false;
 		}
 
@@ -564,6 +865,8 @@ copydb_mark_index_as_done(SourceIndex *index,
 	}
 
 	/* create the doneFile for the index */
+	log_notice("Creating summary file \"%s\"", doneFile);
+
 	if (!finish_index_summary(summary, doneFile, constraint))
 	{
 		log_info("Failed to create the summary file at \"%s\"", doneFile);
@@ -676,4 +979,183 @@ copydb_prepare_create_constraint_command(SourceIndex *index,
 	}
 
 	return true;
+}
+
+
+/*
+ * copydb_create_constraints loops over the index definitions for a given table
+ * and creates all the associated constraints, one after the other.
+ */
+bool
+copydb_create_constraints(CopyDataSpec *specs, SourceTable *table)
+{
+	int errors = 0;
+
+	const char *pguri = specs->target_pguri;
+	PGSQL dst = { 0 };
+
+	if (!pgsql_init(&dst, (char *) pguri, PGSQL_CONN_TARGET))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* also set our GUC values for the target connection */
+	if (!pgsql_set_gucs(&dst, dstSettings))
+	{
+		log_fatal("Failed to set our GUC settings on the target connection, "
+				  "see above for details");
+		return false;
+	}
+
+	/*
+	 * Postgres doesn't implement ALTER TABLE ... ADD CONSTRAINT ... IF NOT
+	 * EXISTS, which we would be using here in some cases otherwise.
+	 *
+	 * When --resume is used, for instance, the previous run could have been
+	 * interrupted after a constraint creation on the target database, but
+	 * before the creation of its constraintDoneFile.
+	 */
+	SourceIndexArray dstIndexArray = { 0, NULL };
+
+	if (!schema_list_table_indexes(&dst,
+								   table->nspname,
+								   table->relname,
+								   &dstIndexArray))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	if (dstIndexArray.count > 0)
+	{
+		/*
+		 * It's expected that we find indexes on the target database when
+		 * running the pgcopydb clone command: we just created them before
+		 * reaching to the constraint code.
+		 *
+		 * When running pgcopydb create constraints, that information is more
+		 * relevant.
+		 */
+		int logLevel =
+			specs->section == DATA_SECTION_ALL ? LOG_NOTICE : LOG_INFO;
+
+		log_level(logLevel,
+				  "Found %d indexes on target database for table \"%s\".\"%s\"",
+				  dstIndexArray.count,
+				  table->nspname,
+				  table->relname);
+	}
+
+	SourceIndexList *indexListEntry = table->firstIndex;
+
+	for (; indexListEntry != NULL; indexListEntry = indexListEntry->next)
+	{
+		SourceIndex *index = indexListEntry->index;
+		IndexFilePaths indexPaths = { 0 };
+
+		if (!copydb_init_index_paths(&(specs->cfPaths), index, &indexPaths))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+
+		/* some indexes are not attached to a constraint at all */
+		if (index->constraintOid <= 0 ||
+			IS_EMPTY_STRING_BUFFER(index->constraintName))
+		{
+			continue;
+		}
+
+		/* First, write the lockFile, with a summary of what's going-on */
+		CopyIndexSummary summary = {
+			.pid = getpid(),
+			.index = index,
+			.command = { 0 }
+		};
+
+		/* we only install constraints in this part of the code */
+		bool constraint = true;
+		char *lockFile = indexPaths.constraintLockFile;
+
+		if (!open_index_summary(&summary, lockFile, constraint))
+		{
+			log_info("Failed to create the lock file at \"%s\"", lockFile);
+			continue;
+		}
+
+		/* skip constraints that already exist on the target database */
+		bool foundConstraintOnTarget = false;
+
+		for (int dstI = 0; dstI < dstIndexArray.count; dstI++)
+		{
+			SourceIndex *dstIndex = &(dstIndexArray.array[dstI]);
+
+			if (strcmp(index->constraintName, dstIndex->constraintName) == 0)
+			{
+				foundConstraintOnTarget = true;
+				log_info("Found constraint \"%s\" on target, skipping",
+						 index->constraintName);
+				break;
+			}
+		}
+
+		if (!copydb_prepare_create_constraint_command(index,
+													  summary.command,
+													  sizeof(summary.command)))
+		{
+			log_warn("Failed to prepare SQL command to create constraint \"%s\"",
+					 index->constraintName);
+			continue;
+		}
+
+		if (!foundConstraintOnTarget)
+		{
+			log_info("%s", summary.command);
+
+			/*
+			 * Constraints are built by the CREATE INDEX worker process that is
+			 * the last one to finish an index for a given table. We do not
+			 * have to care about concurrency here: no semaphore locking.
+			 */
+			if (!pgsql_execute(&dst, summary.command))
+			{
+				/* errors have already been logged */
+				return false;
+			}
+		}
+
+		/*
+		 * Create the doneFile for the constraint when we know it exists on the
+		 * target database, the main use of this doneFile is to filter out
+		 * already existing objects from the pg_restore --section post-data
+		 * later.
+		 */
+		char *doneFile = indexPaths.constraintDoneFile;
+
+		log_info("copydb_create_constraints: writing \"%s\"", doneFile);
+
+		if (!finish_index_summary(&summary, doneFile, constraint))
+		{
+			log_warn("Failed to create the constraint done file at \"%s\"",
+					 doneFile);
+			log_warn("Restoring the --post-data part of the schema "
+					 "might fail because of already existing objects");
+			continue;
+		}
+
+		if (!unlink_file(lockFile))
+		{
+			log_error("Failed to remove the lockFile \"%s\"", lockFile);
+			continue;
+		}
+	}
+
+	/* close connection to the target database now */
+	(void) pgsql_finish(&dst);
+
+	/* free malloc'ed memory area */
+	free(dstIndexArray.array);
+
+	return errors == 0;
 }

--- a/src/bin/pgcopydb/pgcmd.c
+++ b/src/bin/pgcopydb/pgcmd.c
@@ -814,7 +814,7 @@ pg_restore_list(PostgresPaths *pgPaths, const char *filename,
 	char command[BUFSIZE] = { 0 };
 	(void) snprintf_program_command_line(&prog, command, BUFSIZE);
 
-	log_debug("%s", command);
+	log_notice("%s", command);
 
 	if (prog.returnCode != 0)
 	{

--- a/src/bin/pgcopydb/queue_utils.c
+++ b/src/bin/pgcopydb/queue_utils.c
@@ -1,0 +1,135 @@
+/*
+ * src/bin/pgcopydb/queue_utils.c
+ *   Utility functions for inter-process queueing
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <signal.h>
+#include <sys/types.h>
+#include <sys/ipc.h>
+#include <sys/msg.h>
+#include <unistd.h>
+
+#include "defaults.h"
+#include "log.h"
+#include "queue_utils.h"
+#include "signals.h"
+
+
+/*
+ * queue_create creates a new message queue.
+ */
+bool
+queue_create(Queue *queue)
+{
+	queue->owner = getpid();
+	queue->qId = msgget(IPC_PRIVATE, 0600);
+
+	if (queue->qId < 0)
+	{
+		log_fatal("Failed to create message queue: %m");
+		return false;
+	}
+
+	log_trace("Created message queue %d", queue->qId);
+
+	return true;
+}
+
+
+/*
+ * queue_unlink removes an existing message queue.
+ */
+bool
+queue_unlink(Queue *queue)
+{
+	log_trace("iprm -q %d", queue->qId);
+
+	if (msgctl(queue->qId, IPC_RMID, NULL) != 0)
+	{
+		log_error("Failed to delete message queue %d: %m", queue->qId);
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * queue_send sends a message on the queue.
+ */
+bool
+queue_send(Queue *queue, QMessage *msg)
+{
+	int errStatus;
+	bool firstLoop = true;
+
+	do {
+		if (asked_to_stop || asked_to_stop_fast || asked_to_quit)
+		{
+			return false;
+		}
+
+		if (firstLoop)
+		{
+			firstLoop = false;
+		}
+		else
+		{
+			pg_usleep(10 * 1000); /* 10 ms */
+		}
+
+		errStatus = msgsnd(queue->qId, msg, sizeof(QMessage), IPC_NOWAIT);
+	} while (errStatus < 0 && (errno == EINTR || errno == EAGAIN));
+
+	if (errStatus < 0)
+	{
+		log_error("Failed to send a message to queue %d "
+				  "with type %ld and oid %u: %m",
+				  queue->qId,
+				  msg->type,
+				  msg->oid);
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * queue_receive receives a message from the queue.
+ */
+bool
+queue_receive(Queue *queue, QMessage *msg)
+{
+	int errStatus;
+	bool firstLoop = true;
+
+	do {
+		if (asked_to_stop || asked_to_stop_fast || asked_to_quit)
+		{
+			return false;
+		}
+
+		if (firstLoop)
+		{
+			firstLoop = false;
+		}
+		else
+		{
+			pg_usleep(10 * 1000); /* 10 ms */
+		}
+
+		errStatus = msgrcv(queue->qId, msg, sizeof(QMessage), 0, IPC_NOWAIT);
+	} while (errStatus < 0 && (errno == EINTR || errno == ENOMSG));
+
+	if (errStatus < 0)
+	{
+		log_error("Failed to receive a message from queue %d: %m", queue->qId);
+		return false;
+	}
+
+	return true;
+}

--- a/src/bin/pgcopydb/queue_utils.h
+++ b/src/bin/pgcopydb/queue_utils.h
@@ -1,0 +1,49 @@
+/*
+ * src/bin/pgcopydb/queue_utils.h
+ *   Utility functions for inter-process queueing
+ */
+
+#ifndef QUEUE_UTILS_H
+#define QUEUE_UTILS_H
+
+#include <stdbool.h>
+
+#include <sys/types.h>
+#include <sys/ipc.h>
+#include <sys/msg.h>
+
+#include "postgres.h"
+
+typedef struct Queue
+{
+	int qId;
+	pid_t owner;
+} Queue;
+
+
+/*
+ * Message types that we send on the queue. The only messages we send are Oid
+ * from either table (to drive a vacuum analyze job) or an index oid (to drive
+ * a CREATE INDEX job).
+ */
+typedef enum
+{
+	QMSG_TYPE_UNKNOWN = 0,
+	QMSG_TYPE_TABLEOID,
+	QMSG_TYPE_INDEXOID,
+	QMSG_TYPE_STOP
+} QMessageType;
+
+typedef struct QMessage
+{
+	long type;
+	uint32_t oid;
+} QMessage;
+
+bool queue_create(Queue *queue);
+bool queue_unlink(Queue *queue);
+
+bool queue_send(Queue *queue, QMessage *msg);
+bool queue_receive(Queue *queue, QMessage *msg);
+
+#endif /* QUEUE_UTILS_H */

--- a/src/bin/pgcopydb/schema.h
+++ b/src/bin/pgcopydb/schema.h
@@ -39,6 +39,9 @@ typedef struct SourceTablePartsArray
 } SourceTablePartsArray;
 
 
+/* forward declaration */
+struct SourceIndexList;
+
 typedef struct SourceTable
 {
 	uint32_t oid;
@@ -52,6 +55,11 @@ typedef struct SourceTable
 	char restoreListName[RESTORE_LIST_NAMEDATALEN];
 	char partKey[NAMEDATALEN];
 	SourceTablePartsArray partsArray;
+
+	struct SourceIndexList *firstIndex;
+	struct SourceIndexList *lastIndex;
+
+	UT_hash_handle hh;          /* makes this structure hashable */
 } SourceTable;
 
 
@@ -105,6 +113,8 @@ typedef struct SourceIndex
 	char constraintDef[BUFSIZE];
 	char indexRestoreListName[RESTORE_LIST_NAMEDATALEN];
 	char constraintRestoreListName[RESTORE_LIST_NAMEDATALEN];
+
+	UT_hash_handle hh;          /* makes this structure hashable */
 } SourceIndex;
 
 
@@ -113,6 +123,13 @@ typedef struct SourceIndexArray
 	int count;
 	SourceIndex *array;         /* malloc'ed area */
 } SourceIndexArray;
+
+
+typedef struct SourceIndexList
+{
+	SourceIndex *index;
+	struct SourceIndexList *next;
+} SourceIndexList;
 
 
 /*

--- a/src/bin/pgcopydb/sequences.c
+++ b/src/bin/pgcopydb/sequences.c
@@ -64,6 +64,53 @@ copydb_prepare_sequence_specs(CopyDataSpec *specs, PGSQL *pgsql)
 
 
 /*
+ * copydb_start_seq_process create a single sub-process that connects to the
+ * target database to issue the setval() calls to reset sequences.
+ */
+bool
+copydb_start_seq_process(CopyDataSpec *specs)
+{
+	/*
+	 * Flush stdio channels just before fork, to avoid double-output
+	 * problems.
+	 */
+	fflush(stdout);
+	fflush(stderr);
+
+	int fpid = fork();
+
+	switch (fpid)
+	{
+		case -1:
+		{
+			log_error("Failed to fork a worker process: %m");
+			return false;
+		}
+
+		case 0:
+		{
+			/* child process runs the command */
+			if (!copydb_copy_all_sequences(specs))
+			{
+				/* errors have already been logged */
+				exit(EXIT_CODE_INTERNAL_ERROR);
+			}
+
+			exit(EXIT_CODE_QUIT);
+		}
+
+		default:
+		{
+			/* fork succeeded, in parent */
+			break;
+		}
+	}
+
+	return true;
+}
+
+
+/*
  * copydb_copy_all_sequences fetches the list of sequences from the source
  * database and then for each of them runs a SELECT last_value, is_called FROM
  * the sequence on the source database and then calls SELECT setval(); on the
@@ -72,6 +119,8 @@ copydb_prepare_sequence_specs(CopyDataSpec *specs, PGSQL *pgsql)
 bool
 copydb_copy_all_sequences(CopyDataSpec *specs)
 {
+	log_notice("Now starting setval process %d [%d]", getpid(), getppid());
+
 	if (specs->dirState.sequenceCopyIsDone)
 	{
 		log_info("Skipping sequences, already done on a previous run");
@@ -130,12 +179,20 @@ copydb_copy_all_sequences(CopyDataSpec *specs)
 		++errors;
 	}
 
-	/* and write that we successfully finished copying all tables */
+	/* and write that we successfully finished copying all sequences */
 	if (!write_file("", 0, specs->cfPaths.done.sequences))
 	{
 		log_warn("Failed to write the tracking file \%s\"",
 				 specs->cfPaths.done.sequences);
 	}
 
-	return errors == 0;
+	if (errors > 0)
+	{
+		log_warn("Failed to set values for %d sequences, "
+				 "see above for details",
+				 errors);
+		return false;
+	}
+
+	return true;
 }

--- a/src/bin/pgcopydb/sequences.c
+++ b/src/bin/pgcopydb/sequences.c
@@ -70,6 +70,8 @@ copydb_prepare_sequence_specs(CopyDataSpec *specs, PGSQL *pgsql)
 bool
 copydb_start_seq_process(CopyDataSpec *specs)
 {
+	log_info("STEP 9: reset sequences values");
+
 	/*
 	 * Flush stdio channels just before fork, to avoid double-output
 	 * problems.

--- a/src/bin/pgcopydb/stream.c
+++ b/src/bin/pgcopydb/stream.c
@@ -1114,7 +1114,7 @@ streamTransformFileInSubprocess(LogicalStreamContext *context)
 		case -1:
 		{
 			log_error("Failed to fork a subprocess to transform "
-					  "JSON file \"%s\" into SQL",
+					  "JSON file \"%s\" into SQL: %m",
 					  privateContext->walFileName);
 			return -1;
 		}

--- a/src/bin/pgcopydb/summary.h
+++ b/src/bin/pgcopydb/summary.h
@@ -163,9 +163,7 @@ bool prepare_table_summary_as_json(CopyTableSummary *summary,
 								   JSON_Object *jsobj,
 								   const char *key);
 
-bool create_table_index_file(CopyTableSummary *summary,
-							 SourceIndexArray *indexArray,
-							 char *filename);
+bool create_table_index_file(SourceTable *table, char *filename);
 bool read_table_index_file(SourceIndexArray *indexArray, char *filename);
 
 bool write_blobs_summary(CopyBlobsSummary *summary, char *filename);

--- a/src/bin/pgcopydb/table-data.c
+++ b/src/bin/pgcopydb/table-data.c
@@ -90,6 +90,85 @@ copydb_fetch_schema_and_prepare_specs(CopyDataSpec *specs)
 		log_info("Fetched information for %d indexes", indexArray->count);
 	}
 
+	/*
+	 * Now build a SourceIndexList per table, when we retrieved both the table
+	 * list and the indexes list.
+	 */
+	if (specs->section == DATA_SECTION_ALL)
+	{
+		/* now build the index hash-table */
+		SourceIndex *sourceIndexHashByOid = NULL;
+		SourceIndexArray *indexArray = &(specs->sourceIndexArray);
+
+		for (int i = 0; i < indexArray->count; i++)
+		{
+			SourceIndex *index = &(indexArray->array[i]);
+
+			/* add the current table to the index Hash-by-OID */
+			HASH_ADD(hh, sourceIndexHashByOid, indexOid, sizeof(uint32_t), index);
+
+			/* find the index table, update its index list */
+			uint32_t oid = index->tableOid;
+			SourceTable *table = NULL;
+
+			HASH_FIND(hh, specs->sourceTableHashByOid, &oid, sizeof(oid), table);
+
+			if (table == NULL)
+			{
+				log_error("Failed to find table %u (\"%s\".\"%s\") "
+						  " in sourceTableHashByOid",
+						  oid,
+						  indexArray->array[i].tableNamespace,
+						  indexArray->array[i].tableRelname);
+				return false;
+			}
+
+			log_trace("Adding index %u %s to table %u %s",
+					  indexArray->array[i].indexOid,
+					  indexArray->array[i].indexRelname,
+					  table->oid,
+					  table->relname);
+
+			if (table->firstIndex == NULL)
+			{
+				table->firstIndex =
+					(SourceIndexList *) calloc(1, sizeof(SourceIndexList));
+
+				if (table->firstIndex == NULL)
+				{
+					log_error(ALLOCATION_FAILED_ERROR);
+					return false;
+				}
+
+				table->firstIndex->index = index;
+				table->firstIndex->next = NULL;
+
+				table->lastIndex = table->firstIndex;
+			}
+			else
+			{
+				SourceIndexList *current = table->lastIndex;
+
+				table->lastIndex =
+					(SourceIndexList *) calloc(1, sizeof(SourceIndexList));
+
+				if (table->lastIndex == NULL)
+				{
+					log_error(ALLOCATION_FAILED_ERROR);
+					return false;
+				}
+
+				table->lastIndex->index = index;
+				table->lastIndex->next = NULL;
+
+				current->next = table->lastIndex;
+			}
+		}
+
+		/* now attach the final hash table head to the specs */
+		specs->sourceIndexHashByOid = sourceIndexHashByOid;
+	}
+
 	if (specs->section == DATA_SECTION_ALL ||
 		specs->section == DATA_SECTION_SET_SEQUENCES)
 	{
@@ -178,16 +257,9 @@ copydb_copy_all_table_data(CopyDataSpec *specs)
 
 terminate:
 
-	/* now we have a unknown count of subprocesses still running */
-	if (!copydb_wait_for_subprocesses())
-	{
-		/* errors have already been logged */
-		++errors;
-	}
-
 	/*
-	 * Now that all the sub-processes are done, we can also unlink the index
-	 * concurrency semaphore.
+	 * Now that all the sub-processes are done, we can also unlink the table
+	 * and index concurrency semaphore, and the vacuum and create index queues.
 	 */
 	if (!semaphore_finish(&(specs->tableSemaphore)))
 	{
@@ -201,6 +273,20 @@ terminate:
 		log_warn("Failed to remove index concurrency semaphore %d, "
 				 "see above for details",
 				 specs->indexSemaphore.semId);
+	}
+
+	if (!queue_unlink(&(specs->vacuumQueue)))
+	{
+		log_warn("Failed to remove VACUUM process queue %d, "
+				 "see above for details",
+				 specs->vacuumQueue.qId);
+	}
+
+	if (!queue_unlink(&(specs->indexQueue)))
+	{
+		log_warn("Failed to remove CREATE INDEX process queue %d, "
+				 "see above for details",
+				 specs->indexQueue.qId);
 	}
 
 	return errors == 0;
@@ -239,6 +325,9 @@ copydb_prepare_table_specs(CopyDataSpec *specs, PGSQL *pgsql)
 				 specs->splitTablesLargerThanPretty);
 	}
 
+	/* prepare a SourceTable hash table, indexed by Oid */
+	SourceTable *sourceTableHashByOid = NULL;
+
 	/*
 	 * Source table might be split in several concurrent COPY processes. In
 	 * that case we produce a CopyDataSpec entry for each COPY partition.
@@ -246,6 +335,9 @@ copydb_prepare_table_specs(CopyDataSpec *specs, PGSQL *pgsql)
 	for (int tableIndex = 0; tableIndex < tableArray->count; tableIndex++)
 	{
 		SourceTable *source = &(tableArray->array[tableIndex]);
+
+		/* add the current table to the Hash-by-OID */
+		HASH_ADD(hh, sourceTableHashByOid, oid, sizeof(uint32_t), source);
 
 		if (specs->splitTablesLargerThan > 0 &&
 			specs->splitTablesLargerThan <= source->bytes)
@@ -299,6 +391,9 @@ copydb_prepare_table_specs(CopyDataSpec *specs, PGSQL *pgsql)
 			++copySpecsCount;
 		}
 	}
+
+	/* now attach the final hash table head to the specs */
+	specs->sourceTableHashByOid = sourceTableHashByOid;
 
 	/* only use as many processes as required */
 	if (copySpecsCount < specs->tableJobs)
@@ -667,6 +762,25 @@ copydb_process_table_data(CopyDataSpec *specs)
 	int errors = 0;
 
 	/*
+	 * Now create as many VACUUM ANALYZE sub-processes as needed, per
+	 * --table-jobs. Could be exposed separately as --vacuumJobs too, but
+	 * that's not been done at this time.
+	 */
+	log_trace("copydb_process_table_data: \"%s\"", specs->cfPaths.tbldir);
+
+	if (!vacuum_start_workers(specs))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	if (!copydb_start_index_workers(specs))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/*
 	 * Are blobs table data? well pg_dump --section sayth yes.
 	 */
 	if (!copydb_start_blob_process(specs))
@@ -675,86 +789,179 @@ copydb_process_table_data(CopyDataSpec *specs)
 		return false;
 	}
 
-	/*
-	 * Now create as many sub-process as needed, per --table-jobs.
-	 */
-	log_info("Now starting %d processes", specs->tableJobs);
-
-	for (int i = 0; i < specs->tableJobs; i++)
+	if (!copydb_start_seq_process(specs))
 	{
-		/*
-		 * Flush stdio channels just before fork, to avoid double-output
-		 * problems.
-		 */
-		fflush(stdout);
-		fflush(stderr);
-
-		int fpid = fork();
-
-		switch (fpid)
-		{
-			case -1:
-			{
-				log_error("Failed to fork a worker process: %m");
-				return false;
-			}
-
-			case 0:
-			{
-				/* child process runs the command */
-				if (!copydb_process_table_data_worker(specs))
-				{
-					/* errors have already been logged */
-					exit(EXIT_CODE_INTERNAL_ERROR);
-				}
-
-				exit(EXIT_CODE_QUIT);
-			}
-
-			default:
-			{
-				/* fork succeeded, in parent */
-				break;
-			}
-		}
+		/* errors have already been logged */
+		return false;
 	}
 
 	/*
-	 * Now is a good time to reset sequences: we're waiting for the TABLE DATA
-	 * sections and the CREATE INDEX, CONSTRAINTS and VACUUM ANALYZE to be done
-	 * with. Sequences can be reset to their expected values while the COPY are
-	 * still running, as COPY won't drain identifiers from the sequences
-	 * anyway.
+	 * Now create as many sub-process as needed, per --table-jobs.
 	 */
-	if (!copydb_copy_all_sequences(specs))
+	if (copydb_process_table_data_with_workers(specs))
+	{
+		/* write that we successfully finished copying all tables */
+		if (!write_file("", 0, specs->cfPaths.done.tables))
+		{
+			log_warn("Failed to write the tracking file \%s\"",
+					 specs->cfPaths.done.tables);
+		}
+	}
+	else
+	{
+		/* errors have been logged, make sure to send stop messages */
+		++errors;
+	}
+
+	log_info("COPY phase is done, "
+			 "now waiting for vacuum, index, blob, and sequences processes");
+
+	/*
+	 * Now that the COPY processes are done, signal this is the end to the
+	 * vacuum and CREATE INDEX sub-processes by adding the STOP message to
+	 * their queues.
+	 */
+	if (!vacuum_send_stop(specs))
 	{
 		/* errors have already been logged */
 		++errors;
 	}
 
-	bool allDone = false;
-
-	while (!allDone)
+	if (!copydb_index_workers_send_stop(specs))
 	{
-		if (!copydb_collect_finished_subprocesses(&allDone))
-		{
-			/* errors have already been logged */
-			(void) copydb_fatal_exit();
+		/* errors have already been logged */
+		++errors;
+	}
 
+	if (!copydb_wait_for_subprocesses())
+	{
+		log_error("Some sub-processes have exited with error status, "
+				  "see above for details");
+		++errors;
+	}
+
+	if (errors > 0)
+	{
+		log_error("Errors detected, see above for details");
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * copydb_start_table_data_workers create a supervisor COPY process, and then
+ * as sub-process of that supervisor process creates as many sub-processes as
+ * needed, per --table-jobs.
+ *
+ * The supervisor is needed to make this function sync: we can then just wait
+ * until all the known sub-processes are done, without having to take into
+ * consideration other processes not in the sub-tree.
+ */
+bool
+copydb_process_table_data_with_workers(CopyDataSpec *specs)
+{
+	log_info("Now starting %d COPY processes", specs->tableJobs);
+
+	/*
+	 * Flush stdio channels just before fork, to avoid double-output
+	 * problems.
+	 */
+	fflush(stdout);
+	fflush(stderr);
+
+	int fpid = fork();
+
+	switch (fpid)
+	{
+		case -1:
+		{
+			log_error("Failed to fork the COPY supervisor process: %m");
 			return false;
 		}
 
-		pg_usleep(100 * 1000); /* 100 ms */
+		case 0:
+		{
+			/* child process runs the command */
+			log_info("Started COPY supervisor %d [%d]", getpid(), getppid());
+
+			for (int i = 0; i < specs->tableJobs; i++)
+			{
+				/*
+				 * Flush stdio channels just before fork, to avoid
+				 * double-output problems.
+				 */
+				fflush(stdout);
+				fflush(stderr);
+
+				int fpid = fork();
+
+				switch (fpid)
+				{
+					case -1:
+					{
+						log_error("Failed to fork a COPY worker process: %m");
+						exit(EXIT_CODE_INTERNAL_ERROR);
+					}
+
+					case 0:
+					{
+						/* child process runs the command */
+						if (!copydb_process_table_data_worker(specs))
+						{
+							/* errors have already been logged */
+							exit(EXIT_CODE_INTERNAL_ERROR);
+						}
+
+						exit(EXIT_CODE_QUIT);
+					}
+
+					default:
+					{
+						/* fork succeeded, in parent */
+						break;
+					}
+				}
+			}
+
+			/* the COPY supervisor waits for the COPY workers */
+			if (!copydb_wait_for_subprocesses())
+			{
+				log_error("Some COPY worker process(es) have exited with error, "
+						  "see above for details");
+				exit(EXIT_CODE_INTERNAL_ERROR);
+			}
+
+			exit(EXIT_CODE_QUIT);
+		}
+
+		default:
+		{
+			/* fork succeeded, in parent */
+			break;
+		}
 	}
 
-	/* and write that we successfully finished copying all tables */
-	if (!write_file("", 0, specs->cfPaths.done.tables))
+	/* wait until the supervisor process exits */
+	int status;
+
+	if (waitpid(fpid, &status, 0) != fpid)
 	{
-		log_warn("Failed to write the tracking file \%s\"",
-				 specs->cfPaths.done.tables);
+		log_error("Failed to wait for COPY supervisor process %d: %m", fpid);
+		return false;
 	}
 
-	return errors == 0;
+	int returnCode = WEXITSTATUS(status);
+
+	if (returnCode != 0)
+	{
+		log_error("COPY supervisor process exited with return code %d",
+				  returnCode);
+		return false;
+	}
+
+	return true;
 }
 
 
@@ -775,6 +982,9 @@ bool
 copydb_process_table_data_worker(CopyDataSpec *specs)
 {
 	int errors = 0;
+	int copies = 0;
+
+	log_info("Started COPY worker %d [%d]", getpid(), getppid());
 
 	CopyTableDataSpecsArray *tableSpecsArray = &(specs->tableSpecsArray);
 
@@ -815,36 +1025,51 @@ copydb_process_table_data_worker(CopyDataSpec *specs)
 		}
 
 		/*
+		 * Skip tables that have been entirely done already either on a
+		 * previous run, or by a concurrent process while we were busy with our
+		 * own work.
+		 *
+		 * Also skip tables that have been claimed by another of the COPY
+		 * worker processes.
+		 */
+		if (isDone || isBeingProcessed)
+		{
+			continue;
+		}
+
+		/*
 		 * 1. Now COPY the TABLE DATA from the source to the destination.
 		 */
-		if (!isDone && !isBeingProcessed)
-		{
-			/* check for exclude-table-data filtering */
-			if (!tableSpecs->sourceTable.excludeData)
-			{
-				if (!copydb_copy_table(specs, tableSpecs))
-				{
-					/* errors have already been logged */
-					return false;
-				}
-			}
 
-			/* enter the critical section to communicate that we're done */
-			if (!copydb_mark_table_as_done(specs, tableSpecs))
+		/* check for exclude-table-data filtering */
+		if (!tableSpecs->sourceTable->excludeData)
+		{
+			++copies;
+
+			if (!copydb_copy_table(specs, tableSpecs))
 			{
 				/* errors have already been logged */
 				return false;
 			}
 		}
 
+		/* enter the critical section to communicate that we're done */
+		if (!copydb_mark_table_as_done(specs, tableSpecs))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+
 		/*
-		 * 2. Fetch the list of indexes and constraints attached to this table
-		 *    and create them in a background process.
+		 * 2. Send the indexes and constraints attached to this table to the
+		 *    index job queue.
 		 *
-		 * When done, if a partial COPY is happening, check that all the other
-		 * parts are done too. Whenever the last part is done, that's when we
-		 * kick the indexing. This check should be done in the critical section
-		 * too.
+		 * 3. Send the table to the VACUUM ANALYZE job queue.
+		 *
+		 * If a partial COPY is happening, check that all the other parts are
+		 * done. This check should be done in the critical section too. Only
+		 * one process can see all parts as done already, and that's the one
+		 * finishing last.
 		 */
 		bool allPartsDone = false;
 		bool indexesAreBeingProcessed = false;
@@ -863,66 +1088,33 @@ copydb_process_table_data_worker(CopyDataSpec *specs)
 		{
 			log_info("Skipping indexes, already done on a previous run");
 		}
-		else if (!isDone && !isBeingProcessed)
+		else if (allPartsDone && !indexesAreBeingProcessed)
 		{
-			/* take care of same-table concurrency too */
-			if (allPartsDone && !indexesAreBeingProcessed)
+			if (!copydb_add_table_indexes(specs, tableSpecs))
 			{
-				if (!copydb_copy_table_indexes(tableSpecs))
-				{
-					log_warn("Failed to create all the indexes for %s, "
-							 "see above for details",
-							 tableSpecs->qname);
-					log_warn("Consider `pgcopydb copy indexes` to try again");
-					++errors;
-				}
+				log_warn("Failed to add the indexes for %s, "
+						 "see above for details",
+						 tableSpecs->qname);
+				log_warn("Consider `pgcopydb copy indexes` to try again");
+				++errors;
 			}
-		}
 
-		/*
-		 * 3. Now start the VACUUM ANALYZE parts of the processing, in a
-		 *    concurrent sub-process. The sub-process is running in parallel to
-		 *    the CREATE INDEX and constraints processes.
-		 */
-		if (!isDone && !isBeingProcessed)
-		{
-			/* take care of same-table concurrency too */
-			if (allPartsDone && !isBeingProcessed)
+			if (!vacuum_add_table(specs, tableSpecs))
 			{
-				if (!copydb_start_vacuum_table(tableSpecs))
-				{
-					log_warn("Failed to VACUUM ANALYZE %s", tableSpecs->qname);
-					++errors;
-				}
+				log_warn("Failed to queue VACUUM ANALYZE %s [%u]",
+						 tableSpecs->qname,
+						 tableSpecs->sourceTable->oid);
+				++errors;
 			}
-		}
-
-		/*
-		 * 4. Opportunistically see if some CREATE INDEX processed have
-		 *    finished already.
-		 */
-		bool allDone = false;
-
-		if (!copydb_collect_finished_subprocesses(&allDone))
-		{
-			/* errors have already been logged */
-			++errors;
 		}
 	}
 
 	/* terminate our connection to the source database now */
 	(void) copydb_close_snapshot(specs);
 
-	/*
-	 * When this process has finished looping over all the tables in the table
-	 * array, then it waits until all the sub-processes are done. That's the
-	 * CREATE INDEX workers and the VACUUM workers.
-	 */
-	if (!copydb_wait_for_subprocesses())
-	{
-		/* errors have already been logged */
-		++errors;
-	}
+	log_debug("copydb_process_table_data_worker: done %d copies, %d errors",
+			  copies,
+			  errors);
 
 	return errors == 0;
 }
@@ -981,7 +1173,7 @@ copydb_table_is_being_processed(CopyDataSpec *specs,
 		 *
 		 * So check for that situation before returning with the happy path.
 		 */
-		CopyTableSummary tableSummary = { .table = &(tableSpecs->sourceTable) };
+		CopyTableSummary tableSummary = { .table = tableSpecs->sourceTable };
 
 		if (!read_table_summary(&tableSummary, tableSpecs->tablePaths.lockFile))
 		{
@@ -1038,7 +1230,7 @@ copydb_table_is_being_processed(CopyDataSpec *specs,
 	*summary = emptySummary;
 
 	summary->pid = getpid();
-	summary->table = &(tableSpecs->sourceTable);
+	summary->table = tableSpecs->sourceTable;
 
 	if (IS_EMPTY_STRING_BUFFER(tableSpecs->part.copyQuery))
 	{
@@ -1099,11 +1291,15 @@ copydb_mark_table_as_done(CopyDataSpec *specs,
 	if (!finish_table_summary(tableSpecs->summary,
 							  tableSpecs->tablePaths.doneFile))
 	{
-		log_info("Failed to create the summary file at \"%s\"",
-				 tableSpecs->tablePaths.doneFile);
+		log_error("Failed to create the summary file at \"%s\"",
+				  tableSpecs->tablePaths.doneFile);
 		(void) semaphore_unlock(&(specs->tableSemaphore));
 		return false;
 	}
+
+	log_debug("Wrote summary for table %s at \"%s\"",
+			  tableSpecs->qname,
+			  tableSpecs->tablePaths.doneFile);
 
 	/* end of the critical section */
 	(void) semaphore_unlock(&(specs->tableSemaphore));
@@ -1147,11 +1343,14 @@ copydb_table_parts_are_all_done(CopyDataSpec *specs,
 
 	bool allDone = true;
 
+	CopyFilePaths *cfPaths = &(specs->cfPaths);
+	uint32_t oid = tableSpecs->sourceTable->oid;
+
 	for (int i = 0; i < tableSpecs->part.partCount; i++)
 	{
 		TableFilePaths partPaths = { 0 };
 
-		(void) copydb_init_tablepaths_for_part(tableSpecs, &partPaths, i);
+		(void) copydb_init_tablepaths_for_part(cfPaths, &partPaths, oid, i);
 
 		if (!file_exists(partPaths.doneFile))
 		{
@@ -1295,399 +1494,6 @@ copydb_copy_table(CopyDataSpec *specs, CopyTableDataSpec *tableSpecs)
 
 
 /*
- * copydb_copy_table_indexes fetches the index definitions attached to the
- * given source table, and starts as many processes as we have definitions to
- * create all indexes in parallel to each other.
- */
-bool
-copydb_copy_table_indexes(CopyTableDataSpec *tableSpecs)
-{
-	if (tableSpecs->section != DATA_SECTION_INDEXES &&
-		tableSpecs->section != DATA_SECTION_CONSTRAINTS &&
-		tableSpecs->section != DATA_SECTION_ALL)
-	{
-		log_debug("Skipping index creation in section %d", tableSpecs->section);
-		return true;
-	}
-
-	SourceIndexArray indexArray = { 0 };
-
-	tableSpecs->indexArray = &indexArray;
-
-	if (!schema_list_table_indexes(&(tableSpecs->sourceSnapshot.pgsql),
-								   tableSpecs->sourceTable.nspname,
-								   tableSpecs->sourceTable.relname,
-								   tableSpecs->indexArray))
-	{
-		/* errors have already been logged */
-		return false;
-	}
-
-	/* build the index file paths we need for the upcoming operations */
-	if (!copydb_init_indexes_paths(tableSpecs->cfPaths,
-								   tableSpecs->indexArray,
-								   &(tableSpecs->indexPathsArray)))
-	{
-		/* errors have already been logged */
-		return false;
-	}
-
-	/*
-	 * Indexes are created all-at-once in parallel, a sub-process is
-	 * forked per index definition to send each SQL/DDL command to the
-	 * Postgres server.
-	 */
-	if (tableSpecs->indexArray->count >= 1)
-	{
-		log_info("Creating %d index%s for table %s",
-				 tableSpecs->indexArray->count,
-				 tableSpecs->indexArray->count > 1 ? "es" : "",
-				 tableSpecs->qname);
-	}
-	else
-	{
-		log_debug("Table %s has no index attached", tableSpecs->qname);
-		return true;
-	}
-
-	/*
-	 * Flush stdio channels just before fork, to avoid double-output problems.
-	 */
-	fflush(stdout);
-	fflush(stderr);
-
-	int fpid = fork();
-
-	switch (fpid)
-	{
-		case -1:
-		{
-			log_error("Failed to fork a worker process: %m");
-			return false;
-		}
-
-		case 0:
-		{
-			/* child process runs the command */
-			if (!copydb_create_table_indexes(tableSpecs))
-			{
-				log_error("Failed to create indexes, see above for details");
-				exit(EXIT_CODE_INTERNAL_ERROR);
-			}
-
-			/*
-			 * When done as part of the full copy, we also create each index's
-			 * constraint as soon as the parallel index built is done.
-			 */
-			if (tableSpecs->section == DATA_SECTION_ALL ||
-				tableSpecs->section == DATA_SECTION_CONSTRAINTS)
-			{
-				if (!copydb_create_constraints(tableSpecs))
-				{
-					log_error("Failed to create constraints, "
-							  "see above for details");
-					exit(EXIT_CODE_INTERNAL_ERROR);
-				}
-			}
-
-			/*
-			 * Create an index list file for the table, so that we can easily
-			 * find relevant indexing information from the table itself.
-			 */
-			if (!create_table_index_file(tableSpecs->summary,
-										 tableSpecs->indexArray,
-										 tableSpecs->tablePaths.idxListFile))
-			{
-				/* this only means summary is missing some indexing information */
-				log_warn("Failed to create table %s index list file \"%s\"",
-						 tableSpecs->qname,
-						 tableSpecs->tablePaths.idxListFile);
-			}
-
-			exit(EXIT_CODE_QUIT);
-		}
-
-		default:
-		{
-			/* fork succeeded, in parent */
-			break;
-		}
-	}
-
-	/* now we're done, and we want async behavior, do not wait */
-	return true;
-}
-
-
-/*
- * copydb_create_indexes creates all the indexes for a given table in parallel,
- * using a sub-process to send each index command.
- */
-bool
-copydb_create_table_indexes(CopyTableDataSpec *tableSpecs)
-{
-	SourceTable *sourceTable = &(tableSpecs->sourceTable);
-	SourceIndexArray *indexArray = tableSpecs->indexArray;
-	IndexFilePathsArray *indexPathsArray = &(tableSpecs->indexPathsArray);
-
-	for (int i = 0; i < indexArray->count; i++)
-	{
-		/*
-		 * Fork a sub-process for each index, so that they're created in
-		 * parallel. Flush stdio channels just before fork, to avoid
-		 * double-output problems.
-		 */
-		fflush(stdout);
-		fflush(stderr);
-
-		/* time to create the node_active sub-process */
-		int fpid = fork();
-
-		switch (fpid)
-		{
-			case -1:
-			{
-				log_error("Failed to fork a process for creating index for "
-						  "table \"%s\".\"%s\": %m",
-						  sourceTable->nspname,
-						  sourceTable->relname);
-				return -1;
-			}
-
-			case 0:
-			{
-				SourceIndex *index = &(indexArray->array[i]);
-				IndexFilePaths *indexPaths = &(indexPathsArray->array[i]);
-
-				/*
-				 * Add IF NOT EXISTS clause when the --resume option has been
-				 * used, or when the command is `pgcopydb copy indexes`, in
-				 * which cases we don't know what to expect on the target
-				 * database.
-				 */
-				bool ifNotExists =
-					tableSpecs->resume ||
-					tableSpecs->section == DATA_SECTION_INDEXES;
-
-				/* by design, we don't have same-index concurrency */
-				Semaphore *lockFileSemaphore = NULL;
-
-				/* child process runs the command */
-				if (!copydb_create_index(tableSpecs->target_pguri,
-										 index,
-										 indexPaths,
-										 lockFileSemaphore,
-										 tableSpecs->indexSemaphore,
-										 false, /* constraint */
-										 ifNotExists))
-				{
-					/* errors have already been logged */
-					exit(EXIT_CODE_INTERNAL_ERROR);
-				}
-
-				exit(EXIT_CODE_QUIT);
-			}
-
-			default:
-			{
-				/* fork succeeded, in parent */
-				break;
-			}
-		}
-	}
-
-	/*
-	 * Here we need to be sync, so that the caller can continue with creating
-	 * the constraints from the indexes right when all the indexes have been
-	 * built.
-	 */
-	return copydb_wait_for_subprocesses();
-}
-
-
-/*
- * copydb_create_constraints loops over the index definitions for a given table
- * and creates all the associated constraints, one after the other.
- */
-bool
-copydb_create_constraints(CopyTableDataSpec *tableSpecs)
-{
-	int errors = 0;
-	SourceIndexArray *indexArray = tableSpecs->indexArray;
-
-	const char *pguri = tableSpecs->target_pguri;
-	PGSQL dst = { 0 };
-
-	if (!pgsql_init(&dst, (char *) pguri, PGSQL_CONN_TARGET))
-	{
-		/* errors have already been logged */
-		return false;
-	}
-
-	/* also set our GUC values for the target connection */
-	if (!pgsql_set_gucs(&dst, dstSettings))
-	{
-		log_fatal("Failed to set our GUC settings on the target connection, "
-				  "see above for details");
-		return false;
-	}
-
-	/*
-	 * Postgres doesn't implement ALTER TABLE ... ADD CONSTRAINT ... IF NOT
-	 * EXISTS, which we would be using here in some cases otherwise.
-	 *
-	 * When --resume is used, for instance, the previous run could have been
-	 * interrupted after a constraint creation on the target database, but
-	 * before the creation of its constraintDoneFile.
-	 */
-	SourceIndexArray dstIndexArray = { 0, NULL };
-
-	if (!schema_list_table_indexes(&dst,
-								   tableSpecs->sourceTable.nspname,
-								   tableSpecs->sourceTable.relname,
-								   &dstIndexArray))
-	{
-		/* errors have already been logged */
-		return false;
-	}
-
-	if (dstIndexArray.count > 0)
-	{
-		log_info("Found %d/%d indexes on target database for table %s",
-				 dstIndexArray.count,
-				 indexArray->count,
-				 tableSpecs->qname);
-	}
-
-	for (int i = 0; i < indexArray->count; i++)
-	{
-		SourceIndex *index = &(indexArray->array[i]);
-		IndexFilePaths *indexPaths = &(tableSpecs->indexPathsArray.array[i]);
-
-		/* some indexes are not attached to a constraint at all */
-		if (index->constraintOid <= 0 ||
-			IS_EMPTY_STRING_BUFFER(index->constraintName))
-		{
-			continue;
-		}
-
-		/* First, write the lockFile, with a summary of what's going-on */
-		CopyIndexSummary summary = {
-			.pid = getpid(),
-			.index = index,
-			.command = { 0 }
-		};
-
-		/* we only install constraints in this part of the code */
-		bool constraint = true;
-		char *lockFile = indexPaths->constraintLockFile;
-
-		if (!open_index_summary(&summary, lockFile, constraint))
-		{
-			log_info("Failed to create the lock file at \"%s\"", lockFile);
-			continue;
-		}
-
-		/* skip constraints that already exist on the target database */
-		bool foundConstraintOnTarget = false;
-
-		for (int dstI = 0; dstI < dstIndexArray.count; dstI++)
-		{
-			SourceIndex *dstIndex = &(dstIndexArray.array[dstI]);
-
-			if (strcmp(index->constraintName, dstIndex->constraintName) == 0)
-			{
-				foundConstraintOnTarget = true;
-				log_info("Found constraint \"%s\" on target, skipping",
-						 index->constraintName);
-				break;
-			}
-		}
-
-		if (!copydb_prepare_create_constraint_command(index,
-													  summary.command,
-													  sizeof(summary.command)))
-		{
-			log_warn("Failed to prepare SQL command to create constraint \"%s\"",
-					 index->constraintName);
-			continue;
-		}
-
-		if (!foundConstraintOnTarget)
-		{
-			log_info("%s", summary.command);
-
-			/*
-			 * Unique and Primary Key indexes have been built already, in the
-			 * other cases the index is built within the ALTER TABLE ... ADD
-			 * CONSTRAINT command.
-			 */
-			bool buildingIndex = !(index->isPrimary || index->isUnique);
-
-			if (!buildingIndex)
-			{
-				if (!pgsql_execute(&dst, summary.command))
-				{
-					/* errors have already been logged */
-					return false;
-				}
-			}
-			else
-			{
-				/*
-				 * If we're building the index, then we want to acquire the
-				 * index semaphore first.
-				 */
-				Semaphore *createIndexSemaphore = tableSpecs->indexSemaphore;
-
-				(void) semaphore_lock(createIndexSemaphore);
-
-				if (!pgsql_execute(&dst, summary.command))
-				{
-					/* errors have already been logged */
-					(void) semaphore_unlock(createIndexSemaphore);
-					return false;
-				}
-
-				(void) semaphore_unlock(createIndexSemaphore);
-			}
-		}
-
-		/*
-		 * Create the doneFile for the constraint when we know it exists on the
-		 * target database, the main use of this doneFile is to filter out
-		 * already existing objects from the pg_restore --section post-data
-		 * later.
-		 */
-		char *doneFile = indexPaths->constraintDoneFile;
-
-		if (!finish_index_summary(&summary, doneFile, constraint))
-		{
-			log_warn("Failed to create the constraint done file at \"%s\"",
-					 doneFile);
-			log_warn("Restoring the --post-data part of the schema "
-					 "might fail because of already existing objects");
-			continue;
-		}
-
-		if (!unlink_file(lockFile))
-		{
-			log_error("Failed to remove the lockFile \"%s\"", lockFile);
-			continue;
-		}
-	}
-
-	/* close connection to the target database now */
-	(void) pgsql_finish(&dst);
-
-	/* free malloc'ed memory area */
-	free(dstIndexArray.array);
-
-	return errors == 0;
-}
-
-
-/*
  * copydb_start_blob_process starts an auxilliary process that copies the large
  * objects (blobs) from the source database into the target database.
  */
@@ -1698,6 +1504,8 @@ copydb_start_blob_process(CopyDataSpec *specs)
 	{
 		return true;
 	}
+
+	log_info("Now starting 1 BLOB process");
 
 	/*
 	 * Flush stdio channels just before fork, to avoid double-output problems.
@@ -1749,6 +1557,8 @@ copydb_copy_blobs(CopyDataSpec *specs)
 	instr_time startTime;
 
 	INSTR_TIME_SET_CURRENT(startTime);
+
+	log_notice("Started BLOB worker %d [%d]", getpid(), getppid());
 
 	PGSQL *src = NULL;
 	PGSQL pgsql = { 0 };

--- a/src/bin/pgcopydb/table-data.c
+++ b/src/bin/pgcopydb/table-data.c
@@ -694,7 +694,7 @@ copydb_process_table_data(CopyDataSpec *specs)
 		{
 			case -1:
 			{
-				log_error("Failed to fork a worker process");
+				log_error("Failed to fork a worker process: %m");
 				return false;
 			}
 
@@ -1361,7 +1361,7 @@ copydb_copy_table_indexes(CopyTableDataSpec *tableSpecs)
 	{
 		case -1:
 		{
-			log_error("Failed to fork a worker process");
+			log_error("Failed to fork a worker process: %m");
 			return false;
 		}
 
@@ -1447,7 +1447,7 @@ copydb_create_table_indexes(CopyTableDataSpec *tableSpecs)
 			case -1:
 			{
 				log_error("Failed to fork a process for creating index for "
-						  "table \"%s\".\"%s\"",
+						  "table \"%s\".\"%s\": %m",
 						  sourceTable->nspname,
 						  sourceTable->relname);
 				return -1;
@@ -1710,7 +1710,7 @@ copydb_start_blob_process(CopyDataSpec *specs)
 	{
 		case -1:
 		{
-			log_error("Failed to fork a worker process");
+			log_error("Failed to fork a worker process: %m");
 			return false;
 		}
 

--- a/src/bin/pgcopydb/table-data.c
+++ b/src/bin/pgcopydb/table-data.c
@@ -76,7 +76,8 @@ copydb_fetch_schema_and_prepare_specs(CopyDataSpec *specs)
 
 	/* fetch the list of all the indexes that are going to be created again */
 	if (specs->section == DATA_SECTION_ALL ||
-		specs->section == DATA_SECTION_INDEXES)
+		specs->section == DATA_SECTION_INDEXES ||
+		specs->section == DATA_SECTION_CONSTRAINTS)
 	{
 		SourceIndexArray *indexArray = &(specs->sourceIndexArray);
 

--- a/src/bin/pgcopydb/vacuum.c
+++ b/src/bin/pgcopydb/vacuum.c
@@ -1,0 +1,253 @@
+/*
+ * src/bin/pgcopydb/vacuum.c
+ *     Implementation of a CLI to copy a database between two Postgres instances
+ */
+
+#include <errno.h>
+#include <inttypes.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "copydb.h"
+#include "env_utils.h"
+#include "lock_utils.h"
+#include "log.h"
+#include "signals.h"
+#include "summary.h"
+
+/*
+ * vacuum_start_workers create as many sub-process as needed, per --table-jobs.
+ * Could be exposed separately as --vacuumJobs too, but that's not been done at
+ * this time.
+ */
+bool
+vacuum_start_workers(CopyDataSpec *specs)
+{
+	log_info("Now starting %d VACUUM processes", specs->vacuumJobs);
+	log_trace("vacuum_start_workers: \"%s\"", specs->cfPaths.tbldir);
+
+	for (int i = 0; i < specs->vacuumJobs; i++)
+	{
+		/*
+		 * Flush stdio channels just before fork, to avoid double-output
+		 * problems.
+		 */
+		fflush(stdout);
+		fflush(stderr);
+
+		int fpid = fork();
+
+		switch (fpid)
+		{
+			case -1:
+			{
+				log_error("Failed to fork a worker process: %m");
+				return false;
+			}
+
+			case 0:
+			{
+				/* child process runs the command */
+				if (!vacuum_worker(specs))
+				{
+					/* errors have already been logged */
+					exit(EXIT_CODE_INTERNAL_ERROR);
+				}
+
+				exit(EXIT_CODE_QUIT);
+			}
+
+			default:
+			{
+				/* fork succeeded, in parent */
+				break;
+			}
+		}
+	}
+
+	return true;
+}
+
+
+/*
+ * vacuum_worker is a worker process that loops over messages received from a
+ * queue, each message being the Oid of a table to vacuum on the target
+ * database.
+ */
+bool
+vacuum_worker(CopyDataSpec *specs)
+{
+	int errors = 0;
+	bool stop = false;
+
+	log_notice("Started VACUUM worker %d [%d]", getpid(), getppid());
+	log_trace("vacuum_worker: \"%s\"", specs->cfPaths.tbldir);
+
+	while (!stop)
+	{
+		QMessage mesg = { 0 };
+
+		if (asked_to_stop || asked_to_stop_fast || asked_to_quit)
+		{
+			return false;
+		}
+
+		if (!queue_receive(&(specs->vacuumQueue), &mesg))
+		{
+			/* errors have already been logged */
+			break;
+		}
+
+		switch (mesg.type)
+		{
+			case QMSG_TYPE_STOP:
+			{
+				stop = true;
+				log_debug("Stop message received by vacuum worker");
+				break;
+			}
+
+			case QMSG_TYPE_TABLEOID:
+			{
+				/* ignore errors */
+				if (!vacuum_analyze_table_by_oid(specs, mesg.oid))
+				{
+					++errors;
+				}
+				break;
+			}
+
+			default:
+			{
+				log_error("Received unknown message type %ld on vacuum queue %d",
+						  mesg.type,
+						  specs->vacuumQueue.qId);
+				break;
+			}
+		}
+	}
+
+	return stop == true && errors == 0;
+}
+
+
+/*
+ * vacuum_analyze_table_by_oid reads the done file for the given table OID,
+ * fetches the schemaname and relname from there, and then connects to the
+ * target database to issue a VACUUM ANALYZE command.
+ */
+bool
+vacuum_analyze_table_by_oid(CopyDataSpec *specs, uint32_t oid)
+{
+	CopyFilePaths *cfPaths = &(specs->cfPaths);
+	TableFilePaths tablePaths = { 0 };
+
+	log_trace("vacuum_analyze_table_by_oid: \"%s\"", specs->cfPaths.tbldir);
+
+	if (!copydb_init_tablepaths(cfPaths, &tablePaths, oid))
+	{
+		log_error("Failed to prepare pathnames for table %u", oid);
+		return false;
+	}
+
+	/* the source table COPY might have been partionned */
+	if (!file_exists(tablePaths.doneFile))
+	{
+		int part = 0;
+
+		if (!copydb_init_tablepaths_for_part(cfPaths, &tablePaths, oid, part))
+		{
+			log_error("Failed to prepare pathnames for table %u", oid);
+			return false;
+		}
+	}
+
+	log_trace("vacuum_analyze_table_by_oid: %s", tablePaths.doneFile);
+
+	SourceTable table = { .oid = oid };
+	CopyTableSummary tableSummary = { .table = &table };
+
+	if (!read_table_summary(&tableSummary, tablePaths.doneFile))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	PGSQL dst = { 0 };
+
+	/* initialize our connection to the target database */
+	if (!pgsql_init(&dst, specs->target_pguri, PGSQL_CONN_TARGET))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* finally, vacuum analyze the table and its indexes */
+	char vacuum[BUFSIZE] = { 0 };
+
+	sformat(vacuum, sizeof(vacuum),
+			"VACUUM ANALYZE \"%s\".\"%s\"",
+			table.nspname,
+			table.relname);
+
+	log_info("%s;", vacuum);
+
+	if (!pgsql_execute(&dst, vacuum))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	(void) pgsql_finish(&dst);
+
+	return true;
+}
+
+
+/*
+ * vacuum_add_table sends a message to the VACUUM process queue to process
+ * given table.
+ */
+bool
+vacuum_add_table(CopyDataSpec *specs, CopyTableDataSpec *tableSpecs)
+{
+	QMessage mesg = {
+		.type = QMSG_TYPE_TABLEOID,
+		.oid = tableSpecs->sourceTable->oid
+	};
+
+	if (!queue_send(&(specs->vacuumQueue), &mesg))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * vacuum_send_stop sends the STOP message to the VACUUM workers.
+ *
+ * Each worker will consume one STOP message before stopping, so we need to
+ * send as many STOP messages as we have started worker processes.
+ */
+bool
+vacuum_send_stop(CopyDataSpec *specs)
+{
+	for (int i = 0; i < specs->vacuumJobs; i++)
+	{
+		QMessage stop = { .type = QMSG_TYPE_STOP, .oid = 0 };
+
+		log_debug("Send STOP message to VACUUM queue %d",
+				  specs->vacuumQueue.qId);
+
+		if (!queue_send(&(specs->vacuumQueue), &stop))
+		{
+			/* errors have already been logged */
+			continue;
+		}
+	}
+
+	return true;
+}

--- a/src/bin/pgcopydb/vacuum.c
+++ b/src/bin/pgcopydb/vacuum.c
@@ -23,7 +23,7 @@
 bool
 vacuum_start_workers(CopyDataSpec *specs)
 {
-	log_info("Now starting %d VACUUM processes", specs->vacuumJobs);
+	log_info("STEP 8: starting %d VACUUM processes", specs->vacuumJobs);
 	log_trace("vacuum_start_workers: \"%s\"", specs->cfPaths.tbldir);
 
 	for (int i = 0; i < specs->vacuumJobs; i++)

--- a/tests/pagila-multi-steps/copydb.sh
+++ b/tests/pagila-multi-steps/copydb.sh
@@ -20,6 +20,10 @@ pgcopydb list tables --source ${PGCOPYDB_TARGET_PGURI}
 psql -d ${PGCOPYDB_SOURCE_PGURI} -1 -f /usr/src/pagila/pagila-schema.sql
 psql -d ${PGCOPYDB_SOURCE_PGURI} -1 -f /usr/src/pagila/pagila-data.sql
 
+psql -d ${PGCOPYDB_TARGET_PGURI} <<EOF
+alter database pagila connection limit 2;
+EOF
+
 #
 # pgcopydb uses the environment variables
 #

--- a/tests/pagila-multi-steps/docker-compose.yml
+++ b/tests/pagila-multi-steps/docker-compose.yml
@@ -21,5 +21,5 @@ services:
     environment:
       PGCOPYDB_SOURCE_PGURI: postgres://postgres:h4ckm3@source/postgres
       PGCOPYDB_TARGET_PGURI: postgres://postgres:h4ckm3@target/postgres
-      PGCOPYDB_TABLE_JOBS: 4
+      PGCOPYDB_TABLE_JOBS: 2
       PGCOPYDB_INDEX_JOBS: 2

--- a/tests/pagila/copydb.sh
+++ b/tests/pagila/copydb.sh
@@ -23,13 +23,13 @@ pgcopydb list tables --source ${PGCOPYDB_TARGET_PGURI}
 #
 psql ${PGCOPYDB_SOURCE_PGURI} <<EOF
 create role pagila NOSUPERUSER CREATEDB NOCREATEROLE LOGIN PASSWORD '0wn3d';
-create database pagila owner pagila;
+create database pagila owner pagila connection limit 8;
 EOF
 
 pgcopydb copy roles
 
 psql ${PGCOPYDB_TARGET_PGURI} <<EOF
-create database pagila owner pagila;
+create database pagila owner pagila connection limit 10;
 EOF
 
 PAGILA_SOURCE_PGURI="postgres://pagila:0wn3d@source/pagila"

--- a/tests/pagila/docker-compose.yml
+++ b/tests/pagila/docker-compose.yml
@@ -31,5 +31,5 @@ services:
       PGCOPYDB_SOURCE_PGURI: postgres://postgres:h4ckm3@source/postgres
       PGCOPYDB_TARGET_PGURI: postgres://postgres:h4ckm3@target/postgres
       PGCOPYDB_TABLE_JOBS: 4
-      PGCOPYDB_INDEX_JOBS: 2
+      PGCOPYDB_INDEX_JOBS: 4
       PGCOPYDB_SPLIT_TABLES_LARGER_THAN: 200kB


### PR DESCRIPTION
Review the process model for pgcopydb.

In order to handle database schemas with a very large number of objects,
change the pgcopydb process model to use a stable number of processes during
all operations.

To be able to do that, we need a communication system between processes so
that we can start the CREATE INDEX commands for a given table only when that
table data are known to have been COPYd entirely already. For that we
introduce a support layer for System V message queues (see msgget(2) etc).

In passing, also improve the schema querying done by pgcopydb: at startup
catalog queries are used to fetch the list of all tables to handle, and all
indexex to handle. Previous to this work, pgcopydb would still run a
separate query for each table to list its indexes. Instead, pgcopydb now
links the indexes to their table in its in-memory data structures for the
source schema, in a way that we don't have to run more queries later.

Finally, prior to this work VACUUM ANALYZE jobs would be created as soon as
a table COPY would complete, creating as many sub-processes as we have
tables total. Now a static set of VACUUM ANALYZE sub-processes are created
and a message queue is used to start working on a table when it is ready.

Fixes #104.