### PR TITLE
Bug fixes for the transform process.

### DIFF
--- a/docs/design.rst
+++ b/docs/design.rst
@@ -91,7 +91,7 @@ The process tree then looks like the following:
 
      * pgcopydb stream receive
 
-       * pgcopydb stream transform
+     * pgcopydb stream transform
 
      * pgcopydb stream catchup
 
@@ -151,9 +151,9 @@ Here is a description of the process tree:
     - One process implements :ref:`pgcopydb_stream_receive` to fetch changes
       in the JSON format and pre-fetch them in JSON files.
 
-    - As soon as JSON file is completed, then a new process is
-      opportunistically started to transform the JSON file into SQL, as if
-      by calling the command :ref:`pgcopydb_stream_transform`.
+    - As soon as JSON file is completed, the pgcopydb stream transform
+      worker transforms the JSON file into SQL, as if by calling the command
+      :ref:`pgcopydb_stream_transform`.
 
     - Another process implements :ref:`pgcopydb_stream_catchup` to apply SQL
       changes to the target Postgres instance. This process loops over

--- a/src/bin/pgcopydb/indexes.c
+++ b/src/bin/pgcopydb/indexes.c
@@ -112,7 +112,7 @@ copydb_index_worker(CopyDataSpec *specs)
 
 			case QMSG_TYPE_INDEXOID:
 			{
-				if (!copydb_create_index_by_oid(specs, mesg.oid))
+				if (!copydb_create_index_by_oid(specs, mesg.data.oid))
 				{
 					++errors;
 				}
@@ -336,13 +336,13 @@ copydb_add_table_indexes(CopyDataSpec *specs, CopyTableDataSpec *tableSpecs)
 
 		QMessage mesg = {
 			.type = QMSG_TYPE_INDEXOID,
-			.oid = index->indexOid
+			.data.oid = index->indexOid
 		};
 
 		log_trace("Queueing index \"%s\".\"%s\" [%u] for table %s [%u]",
 				  index->indexNamespace,
 				  index->indexRelname,
-				  mesg.oid,
+				  mesg.data.oid,
 				  tableSpecs->qname,
 				  tableSpecs->sourceTable->oid);
 
@@ -369,7 +369,7 @@ copydb_index_workers_send_stop(CopyDataSpec *specs)
 {
 	for (int i = 0; i < specs->indexJobs; i++)
 	{
-		QMessage stop = { .type = QMSG_TYPE_STOP, .oid = 0 };
+		QMessage stop = { .type = QMSG_TYPE_STOP, .data.oid = 0 };
 
 		log_debug("Send STOP message to CREATE INDEX queue %d",
 				  specs->indexQueue.qId);

--- a/src/bin/pgcopydb/ld_apply.c
+++ b/src/bin/pgcopydb/ld_apply.c
@@ -51,7 +51,9 @@ stream_apply_catchup(StreamSpecs *specs)
 		}
 	}
 
-	if (!stream_read_context(specs, &(context.system), &(context.WalSegSz)))
+	if (!stream_read_context(&(specs->paths),
+							 &(context.system),
+							 &(context.WalSegSz)))
 	{
 		log_error("Failed to read the streaming context information "
 				  "from the source database, see above for details");

--- a/src/bin/pgcopydb/queue_utils.c
+++ b/src/bin/pgcopydb/queue_utils.c
@@ -87,10 +87,9 @@ queue_send(Queue *queue, QMessage *msg)
 	if (errStatus < 0)
 	{
 		log_error("Failed to send a message to queue %d "
-				  "with type %ld and oid %u: %m",
+				  "with type %ld: %m",
 				  queue->qId,
-				  msg->type,
-				  msg->oid);
+				  msg->type);
 		return false;
 	}
 

--- a/src/bin/pgcopydb/queue_utils.h
+++ b/src/bin/pgcopydb/queue_utils.h
@@ -31,13 +31,18 @@ typedef enum
 	QMSG_TYPE_UNKNOWN = 0,
 	QMSG_TYPE_TABLEOID,
 	QMSG_TYPE_INDEXOID,
+	QMSG_TYPE_STREAM_TRANSFORM,
 	QMSG_TYPE_STOP
 } QMessageType;
 
 typedef struct QMessage
 {
 	long type;
-	uint32_t oid;
+	union
+	{
+		uint32_t oid;
+		uint64_t lsn;
+	} data;
 } QMessage;
 
 bool queue_create(Queue *queue);

--- a/src/bin/pgcopydb/stream.h
+++ b/src/bin/pgcopydb/stream.h
@@ -77,6 +77,12 @@ typedef struct StreamContext
 	bool apply;
 
 	LogicalMessageMetadata metadata;
+
+	Queue transformQueue;
+	uint32_t WalSegSz;
+	uint32_t timeline;
+
+	uint64_t firstLSN;
 	char walFileName[MAXPGPATH];
 	char sqlFileName[MAXPGPATH];
 	FILE *jsonFile;
@@ -273,7 +279,6 @@ bool streamFeedback(LogicalStreamContext *context);
 bool streamRotateFile(LogicalStreamContext *context);
 bool streamCloseFile(LogicalStreamContext *context, bool time_to_abort);
 
-bool streamTransformFileInSubprocess(LogicalStreamContext *context);
 bool streamWaitForSubprocess(LogicalStreamContext *context);
 
 bool parseMessageMetadata(LogicalMessageMetadata *metadata,
@@ -306,13 +311,19 @@ bool stream_create_sentinel(CopyDataSpec *copySpecs,
 
 bool stream_write_context(StreamSpecs *specs, LogicalStreamClient *stream);
 bool stream_cleanup_context(StreamSpecs *specs);
-bool stream_read_context(StreamSpecs *specs,
+bool stream_read_context(CDCPaths *paths,
 						 IdentifySystem *system,
 						 uint32_t *WalSegSz);
 
 StreamAction StreamActionFromChar(char action);
 
 /* ld_transform.c */
+bool stream_transform_start_worker(LogicalStreamContext *context);
+bool stream_transform_worker(LogicalStreamContext *context);
+bool stream_transform_add_file(Queue *queue, uint64_t firstLSN);
+bool stream_transform_send_stop(Queue *queue);
+bool stream_compute_pathnames(LogicalStreamContext *context, uint64_t lsn);
+
 bool stream_transform_file(char *jsonfilename, char *sqlfilename);
 bool stream_write_transaction(FILE *out, LogicalTransaction *tx);
 bool stream_write_insert(FILE *out, LogicalMessageInsert *insert);

--- a/src/bin/pgcopydb/vacuum.c
+++ b/src/bin/pgcopydb/vacuum.c
@@ -110,7 +110,7 @@ vacuum_worker(CopyDataSpec *specs)
 			case QMSG_TYPE_TABLEOID:
 			{
 				/* ignore errors */
-				if (!vacuum_analyze_table_by_oid(specs, mesg.oid))
+				if (!vacuum_analyze_table_by_oid(specs, mesg.data.oid))
 				{
 					++errors;
 				}
@@ -213,7 +213,7 @@ vacuum_add_table(CopyDataSpec *specs, CopyTableDataSpec *tableSpecs)
 {
 	QMessage mesg = {
 		.type = QMSG_TYPE_TABLEOID,
-		.oid = tableSpecs->sourceTable->oid
+		.data.oid = tableSpecs->sourceTable->oid
 	};
 
 	if (!queue_send(&(specs->vacuumQueue), &mesg))
@@ -237,7 +237,7 @@ vacuum_send_stop(CopyDataSpec *specs)
 {
 	for (int i = 0; i < specs->vacuumJobs; i++)
 	{
-		QMessage stop = { .type = QMSG_TYPE_STOP, .oid = 0 };
+		QMessage stop = { .type = QMSG_TYPE_STOP, .data.oid = 0 };
 
 		log_debug("Send STOP message to VACUUM queue %d",
 				  specs->vacuumQueue.qId);

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,31 +1,31 @@
 # Copyright (c) 2021 The PostgreSQL Global Development Group.
 # Licensed under the PostgreSQL License.
 
-all: pagila pagila-multi-steps blobs unit filtering cdc ;
+all: pagila pagila-multi-steps blobs unit filtering cdc follow extensions ;
 
 pagila: build
-	$(MAKE) -C pagila
+	$(MAKE) -C $@
 
 pagila-multi-steps: build
-	$(MAKE) -C pagila-multi-steps
+	$(MAKE) -C $@
 
 blobs: build
-	$(MAKE) -C blobs
+	$(MAKE) -C $@
 
 unit: build
-	$(MAKE) -C unit
+	$(MAKE) -C $@
 
 filtering: build
-	$(MAKE) -C filtering
+	$(MAKE) -C $@
 
 cdc: build
-	$(MAKE) -C cdc
+	$(MAKE) -C $@
 
 follow: build
-	$(MAKE) -C cdc
+	$(MAKE) -C $@
 
 extensions: build
-	$(MAKE) -C extensions
+	$(MAKE) -C $@
 
 build:
 	docker build -t pagila -f Dockerfile.pagila .


### PR DESCRIPTION
 - make sure to reset the FILE * pointer to NULL after closing the file.
 - use a stable sub-process to transform JSON files into SQL.

For the second point, we re-use the queuing infrastructure introduced in a recent patch. This allows to have a single sub-process started that will handle all the JSON to SQL transformations during replay.