### PR TITLE
Set idle_in_transaction_session_timeout to zero.

### DIFF
--- a/src/bin/pgcopydb/copydb.c
+++ b/src/bin/pgcopydb/copydb.c
@@ -29,6 +29,7 @@
 GUC srcSettings[] = {
 	COMMON_GUC_SETTINGS
 	{ "tcp_keepalives_idle", "'60s'" },
+	{ "idle_in_transaction_session_timeout", "0" },
 	{ NULL, NULL },
 };
 


### PR DESCRIPTION
In the context of the main session that holds onto the snapshot and does nothing, we really want to avoid that session getting killed by Postgres because of the idle_in_transaction_session_timeout.