### PR TITLE
Also install tcp_keepalives_idle timeout on the target connection.

### DIFF
--- a/src/bin/pgcopydb/copydb.c
+++ b/src/bin/pgcopydb/copydb.c
@@ -36,6 +36,7 @@ GUC srcSettings[] = {
 
 GUC dstSettings[] = {
 	COMMON_GUC_SETTINGS
+	{ "tcp_keepalives_idle", "'60s'" },
 	{ "maintenance_work_mem", "'1 GB'" },
 	{ "synchronous_commit", "'off'" },
 	{ NULL, NULL },


### PR DESCRIPTION
While a CREATE INDEX command or an ALTER TABLE command is running, at the tcp level we're entirely quiet. When that command runs for more than 2 hours, with the default Linux settings, our connection might get interrupted. Prevent against that.