### PR TITLE
Enforce argc == 0 for commands without arguments.

### DIFF
--- a/docs/ref/pgcopydb_stream.rst
+++ b/docs/ref/pgcopydb_stream.rst
@@ -102,7 +102,7 @@ __ https://github.com/eulerto/wal2json/
 ::
 
    pgcopydb stream setup: Setup source and target systems for logical decoding
-   usage: pgcopydb stream setup  --source ... --target ... --dir ...
+   usage: pgcopydb stream setup
 
      --source         Postgres URI to the source database
      --target         Postgres URI to the target database
@@ -128,7 +128,7 @@ step.
 ::
 
    pgcopydb stream cleanup: cleanup source and target systems for logical decoding
-   usage: pgcopydb stream cleanup  --source ... --target ... --dir ...
+   usage: pgcopydb stream cleanup
 
      --source         Postgres URI to the source database
      --target         Postgres URI to the target database
@@ -163,7 +163,7 @@ SQL file.
 ::
 
    pgcopydb stream prefetch: Stream JSON changes from the source database and transform them to SQL
-   usage: pgcopydb stream prefetch  --source ...
+   usage: pgcopydb stream prefetch
 
      --source         Postgres URI to the source database
      --dir            Work directory to use
@@ -188,7 +188,7 @@ applies changes from the SQL files that have been prepared with the
 ::
 
    pgcopydb stream catchup: Apply prefetched changes from SQL files to the target database
-   usage: pgcopydb stream catchup  --source ... --target ...
+   usage: pgcopydb stream catchup
 
      --source         Postgres URI to the source database
      --target         Postgres URI to the target database
@@ -214,7 +214,7 @@ plugin ``wal2json``.
 ::
 
    pgcopydb create slot: Create a replication slot in the source database
-   usage: pgcopydb create slot  --source ...
+   usage: pgcopydb create slot
 
      --source         Postgres URI to the source database
      --dir            Work directory to use
@@ -235,7 +235,7 @@ The starting LSN position ``--startpos`` is required.
 ::
 
    pgcopydb stream create origin: Create a replication origin in the target database
-   usage: pgcopydb stream create origin  --target ...
+   usage: pgcopydb stream create origin
 
      --target         Postgres URI to the target database
      --dir            Work directory to use
@@ -256,7 +256,7 @@ name (that defaults to ``pgcopydb``).
 ::
 
    pgcopydb stream drop slot: Drop a replication slot in the source database
-   usage: pgcopydb stream drop slot  --source ...
+   usage: pgcopydb stream drop slot
 
      --source         Postgres URI to the source database
      --dir            Work directory to use
@@ -275,7 +275,7 @@ given name (that defaults to ``pgcopydb``).
 
 ::
 
-   usage: pgcopydb stream drop origin  --target ...
+   usage: pgcopydb stream drop origin
 
      --target         Postgres URI to the target database
      --dir            Work directory to use
@@ -295,7 +295,7 @@ catchup processes of the logical decoding implementation in pgcopydb.
 ::
 
    pgcopydb stream sentinel create: Create the sentinel table on the source database
-   usage: pgcopydb stream sentinel create  --source ...
+   usage: pgcopydb stream sentinel create
 
      --source      Postgres URI to the source database
      --startpos    Start replaying changes when reaching this LSN
@@ -315,7 +315,7 @@ catchup processes of the logical decoding implementation in pgcopydb.
 ::
 
    pgcopydb stream sentinel drop: Drop the sentinel table on the source database
-   usage: pgcopydb stream sentinel drop  --source ...
+   usage: pgcopydb stream sentinel drop
 
      --source      Postgres URI to the source database
 
@@ -329,7 +329,7 @@ pgcopydb stream sentinel get - Get the sentinel table values on the source datab
 ::
 
    pgcopydb stream sentinel get: Get the sentinel table values on the source database
-   usage: pgcopydb stream sentinel get  --source ...
+   usage: pgcopydb stream sentinel get
 
      --source      Postgres URI to the source database
      --json        Format the output using JSON
@@ -344,7 +344,7 @@ pgcopydb stream sentinel set startpos - Set the sentinel start position LSN on t
 ::
 
    pgcopydb stream sentinel set startpos: Set the sentinel start position LSN on the source database
-   usage: pgcopydb stream sentinel set startpos  --source ... <start LSN>
+   usage: pgcopydb stream sentinel set startpos <start LSN>
 
      --source      Postgres URI to the source database
 
@@ -358,7 +358,7 @@ pgcopydb stream sentinel set endpos - Set the sentinel end position LSN on the s
 ::
 
    pgcopydb stream sentinel set endpos: Set the sentinel end position LSN on the source database
-   usage: pgcopydb stream sentinel set endpos  --source ... <end LSN>
+   usage: pgcopydb stream sentinel set endpos <end LSN>
 
      --source      Postgres URI to the source database
      --current     Use pg_current_wal_flush_lsn() as the endpos
@@ -374,7 +374,7 @@ pgcopydb stream sentinel set apply - Set the sentinel apply mode on the source d
 ::
 
    pgcopydb stream sentinel set apply: Set the sentinel apply mode on the source database
-   usage: pgcopydb stream sentinel set apply  --source ... <true|false>
+   usage: pgcopydb stream sentinel set apply
 
      --source      Postgres URI to the source database
 
@@ -389,7 +389,7 @@ pgcopydb stream sentinel set prefetch - Set the sentinel prefetch mode on the so
 ::
 
    pgcopydb stream sentinel set prefetch: Set the sentinel prefetch mode on the source database
-   usage: pgcopydb stream sentinel set prefetch  --source ... <true|false>
+   usage: pgcopydb stream sentinel set prefetch
 
      --source      Postgres URI to the source database
 
@@ -439,7 +439,7 @@ per line.
 ::
 
    pgcopydb stream transform: Transform changes from the source database into SQL commands
-   usage: pgcopydb stream transform  [ --source ... ] <json filename> <sql filename>
+   usage: pgcopydb stream transform  <json filename> <sql filename>
 
      --source         Postgres URI to the source database
      --dir            Work directory to use
@@ -463,7 +463,7 @@ __ https://www.postgresql.org/docs/current/replication-origins.html
 ::
 
    pgcopydb stream apply: Apply changes from the source database into the target database
-   usage: pgcopydb stream apply  --target ... <sql filename>
+   usage: pgcopydb stream apply <sql filename>
 
      --target         Postgres URI to the target database
      --dir            Work directory to use

--- a/src/bin/pgcopydb/cli_sentinel.c
+++ b/src/bin/pgcopydb/cli_sentinel.c
@@ -83,7 +83,7 @@ CommandLine sentinel_set_apply_command =
 	make_command(
 		"apply",
 		"Set the sentinel apply mode on the source database",
-		" --source ... <true|false>",
+		"",
 		"  --source      Postgres URI to the source database\n",
 		cli_sentinel_getopts,
 		cli_sentinel_set_apply);
@@ -92,7 +92,7 @@ CommandLine sentinel_set_prefetch_command =
 	make_command(
 		"prefetch",
 		"Set the sentinel prefetch mode on the source database",
-		" --source ... <true|false>",
+		"",
 		"  --source      Postgres URI to the source database\n",
 		cli_sentinel_getopts,
 		cli_sentinel_set_prefetch);
@@ -327,6 +327,12 @@ cli_sentinel_create(int argc, char **argv)
 {
 	CopyDataSpec copySpecs = { 0 };
 
+	if (argc > 0)
+	{
+		commandline_help(stderr);
+		exit(EXIT_CODE_BAD_ARGS);
+	}
+
 	(void) find_pg_commands(&(copySpecs.pgPaths));
 
 	bool auxilliary = false;
@@ -382,6 +388,12 @@ cli_sentinel_drop(int argc, char **argv)
 {
 	char *pguri = (char *) sentinelDBoptions.source_pguri;
 	PGSQL pgsql = { 0 };
+
+	if (argc > 0)
+	{
+		commandline_help(stderr);
+		exit(EXIT_CODE_BAD_ARGS);
+	}
 
 	if (!pgsql_init(&pgsql, pguri, PGSQL_CONN_SOURCE))
 	{
@@ -571,6 +583,12 @@ cli_sentinel_set_apply(int argc, char **argv)
 	char *pguri = (char *) sentinelDBoptions.source_pguri;
 	PGSQL pgsql = { 0 };
 
+	if (argc > 0)
+	{
+		commandline_help(stderr);
+		exit(EXIT_CODE_BAD_ARGS);
+	}
+
 	if (!pgsql_init(&pgsql, pguri, PGSQL_CONN_SOURCE))
 	{
 		/* errors have already been logged */
@@ -596,6 +614,12 @@ cli_sentinel_set_prefetch(int argc, char **argv)
 	char *pguri = (char *) sentinelDBoptions.source_pguri;
 	PGSQL pgsql = { 0 };
 
+	if (argc > 0)
+	{
+		commandline_help(stderr);
+		exit(EXIT_CODE_BAD_ARGS);
+	}
+
 	if (!pgsql_init(&pgsql, pguri, PGSQL_CONN_SOURCE))
 	{
 		/* errors have already been logged */
@@ -618,6 +642,12 @@ cli_sentinel_get(int argc, char **argv)
 {
 	char *pguri = (char *) sentinelDBoptions.source_pguri;
 	PGSQL pgsql = { 0 };
+
+	if (argc > 0)
+	{
+		commandline_help(stderr);
+		exit(EXIT_CODE_BAD_ARGS);
+	}
 
 	if (!pgsql_init(&pgsql, pguri, PGSQL_CONN_SOURCE))
 	{

--- a/src/bin/pgcopydb/cli_stream.c
+++ b/src/bin/pgcopydb/cli_stream.c
@@ -43,7 +43,7 @@ static CommandLine stream_setup_command =
 	make_command(
 		"setup",
 		"Setup source and target systems for logical decoding",
-		" --source ... --target ... --dir ...",
+		"",
 		"  --source         Postgres URI to the source database\n"
 		"  --target         Postgres URI to the target database\n"
 		"  --dir            Work directory to use\n"
@@ -60,7 +60,7 @@ static CommandLine stream_cleanup_command =
 	make_command(
 		"cleanup",
 		"cleanup source and target systems for logical decoding",
-		" --source ... --target ... --dir ...",
+		"",
 		"  --source         Postgres URI to the source database\n"
 		"  --target         Postgres URI to the target database\n"
 		"  --dir            Work directory to use\n"
@@ -77,7 +77,7 @@ static CommandLine stream_prefetch_command =
 	make_command(
 		"prefetch",
 		"Stream JSON changes from the source database and transform them to SQL",
-		" --source ... ",
+		"",
 		"  --source         Postgres URI to the source database\n"
 		"  --dir            Work directory to use\n"
 		"  --restart        Allow restarting when temp files exist already\n"
@@ -92,7 +92,7 @@ static CommandLine stream_catchup_command =
 	make_command(
 		"catchup",
 		"Apply prefetched changes from SQL files to the target database",
-		" --source ... --target ...",
+		"",
 		"  --source         Postgres URI to the source database\n"
 		"  --target         Postgres URI to the target database\n"
 		"  --dir            Work directory to use\n"
@@ -109,7 +109,7 @@ static CommandLine stream_receive_command =
 	make_command(
 		"receive",
 		"Stream changes from the source database",
-		" --source ... ",
+		"",
 		"  --source         Postgres URI to the source database\n"
 		"  --dir            Work directory to use\n"
 		"  --restart        Allow restarting when temp files exist already\n"
@@ -124,7 +124,7 @@ static CommandLine stream_transform_command =
 	make_command(
 		"transform",
 		"Transform changes from the source database into SQL commands",
-		" [ --source ... ] <json filename> <sql filename> ",
+		" <json filename> <sql filename> ",
 		"  --source         Postgres URI to the source database\n"
 		"  --dir            Work directory to use\n"
 		"  --restart        Allow restarting when temp files exist already\n"
@@ -137,7 +137,7 @@ static CommandLine stream_apply_command =
 	make_command(
 		"apply",
 		"Apply changes from the source database into the target database",
-		" --target ... <sql filename> ",
+		" <sql filename> ",
 		"  --target         Postgres URI to the target database\n"
 		"  --dir            Work directory to use\n"
 		"  --restart        Allow restarting when temp files exist already\n"
@@ -433,6 +433,12 @@ cli_stream_getopts(int argc, char **argv)
 static void
 cli_stream_receive(int argc, char **argv)
 {
+	if (argc > 0)
+	{
+		commandline_help(stderr);
+		exit(EXIT_CODE_BAD_ARGS);
+	}
+
 	(void) stream_start_in_mode(STREAM_MODE_RECEIVE);
 }
 
@@ -444,6 +450,12 @@ cli_stream_receive(int argc, char **argv)
 static void
 cli_stream_prefetch(int argc, char **argv)
 {
+	if (argc > 0)
+	{
+		commandline_help(stderr);
+		exit(EXIT_CODE_BAD_ARGS);
+	}
+
 	(void) stream_start_in_mode(STREAM_MODE_PREFETCH);
 }
 
@@ -460,6 +472,12 @@ static void
 cli_stream_setup(int argc, char **argv)
 {
 	CopyDataSpec copySpecs = { 0 };
+
+	if (argc > 0)
+	{
+		commandline_help(stderr);
+		exit(EXIT_CODE_BAD_ARGS);
+	}
 
 	(void) find_pg_commands(&(copySpecs.pgPaths));
 
@@ -516,6 +534,12 @@ static void
 cli_stream_cleanup(int argc, char **argv)
 {
 	CopyDataSpec copySpecs = { 0 };
+
+	if (argc > 0)
+	{
+		commandline_help(stderr);
+		exit(EXIT_CODE_BAD_ARGS);
+	}
 
 	(void) find_pg_commands(&(copySpecs.pgPaths));
 
@@ -574,6 +598,12 @@ static void
 cli_stream_catchup(int argc, char **argv)
 {
 	CopyDataSpec copySpecs = { 0 };
+
+	if (argc > 0)
+	{
+		commandline_help(stderr);
+		exit(EXIT_CODE_BAD_ARGS);
+	}
 
 	(void) find_pg_commands(&(copySpecs.pgPaths));
 


### PR DESCRIPTION
This reduces confusion when using the commands, when the previous behaviour would accept any argument on the command line. Also fixes the help strings for pgcopcydb stream sentinet set apply|prefetch command, that doesn't take the <true|false> argument anymore (never did, really).