### PR TITLE
Implement our own --drop-if-exists approach.

### DIFF
--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -373,6 +373,7 @@ bool copydb_dump_source_schema(CopyDataSpec *specs,
 							   const char *snapshot,
 							   PostgresDumpSection section);
 bool copydb_target_prepare_schema(CopyDataSpec *specs);
+bool copydb_target_drop_tables(CopyDataSpec *specs);
 bool copydb_target_finalize_schema(CopyDataSpec *specs);
 
 bool copydb_objectid_has_been_processed_already(CopyDataSpec *specs,


### PR DESCRIPTION
Postgres pg_restore is easily confused with SQL object dependencies when the archive is filtered (either using --section or --use-list, or both). To avoid that problem, issue a DROP TABLE IF EXISTS ... CASCADE; for all the tables we are going to process when --drop-if-exists is in use.

Fixes #126.