### PR TITLE
Implement pgcopydb list tables --drop-cache.

### DIFF
--- a/docs/ref/pgcopydb_list.rst
+++ b/docs/ref/pgcopydb_list.rst
@@ -57,6 +57,7 @@ tables to COPY the data from.
      --source            Postgres URI to the source database
      --filter <filename> Use the filters defined in <filename>
      --cache             Cache table size in relation pgcopydb.table_size
+     --drop-cache        Drop relation pgcopydb.table_size
      --list-skipped      List only tables that are setup to be skipped
      --without-pkey      List only tables that have no primary key
 

--- a/src/bin/pgcopydb/cli_list.h
+++ b/src/bin/pgcopydb/cli_list.h
@@ -27,6 +27,7 @@ typedef struct ListDBOptions
 	bool listSkipped;
 	bool noPKey;
 	bool cache;
+	bool dropCache;
 
 	uint64_t splitTablesLargerThan;
 	char splitTablesLargerThanPretty[NAMEDATALEN];


### PR DESCRIPTION
This allows to manually drop the cache created with --cache option.