### PR TITLE
Fix `lsn` for KEEPALIVE action.

### DIFF
--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -3454,6 +3454,7 @@ pgsql_stream_logical(LogicalStreamClient *client, LogicalStreamContext *context)
 			}
 
 			/* call the keepaliveFunction callback now, ignore errors */
+			context->cur_record_lsn = walEnd;
 			context->now = client->now;
 
 			(void) (*client->keepaliveFunction)(context);

--- a/tests/cdc-endpos-between-transaction/000000010000000000000002.json
+++ b/tests/cdc-endpos-between-transaction/000000010000000000000002.json
@@ -1,3 +1,4 @@
+{"action":"K","lsn":"0/22E2660","timestamp":"2022-12-08 14:45:10.227733+0000"}
 {"action":"B","xid":"489","lsn":"0/22E2760","timestamp":"2022-12-08 14:45:11.357737+0000","message":{"action":"B","xid":489}}
 {"action":"C","xid":"489","lsn":"0/22E5170","timestamp":"2022-12-08 14:45:11.357898+0000","message":{"action":"C","xid":489}}
 {"action":"B","xid":"490","lsn":"0/22E51E0","timestamp":"2022-12-08 14:45:11.358500+0000","message":{"action":"B","xid":490}}

--- a/tests/cdc-test-decoding/000000010000000000000002.json
+++ b/tests/cdc-test-decoding/000000010000000000000002.json
@@ -1,3 +1,4 @@
+{"action":"K","lsn":"0/22E1E18","timestamp":"2022-11-24 17:42:06.381610+0000"}
 {"action":"B","xid":"489","lsn":"0/22E1E18","timestamp":"2022-11-24 17:42:06.382610+0000","message":"BEGIN 489"}
 {"action":"C","xid":"489","lsn":"0/22E4840","timestamp":"2022-11-24 17:42:06.382905+0000","message":"COMMIT 489"}
 {"action":"B","xid":"490","lsn":"0/22E48B0","timestamp":"2022-11-24 17:42:06.383183+0000","message":"BEGIN 490"}

--- a/tests/cdc-wal2json/000000010000000000000002.json
+++ b/tests/cdc-wal2json/000000010000000000000002.json
@@ -1,3 +1,4 @@
+{"action":"K","lsn":"0/22E1EB0","timestamp":"2022-11-23 13:43:44.314034+0000"}
 {"action":"B","xid":"489","lsn":"0/22E1EB0","timestamp":"2022-11-23 13:43:44.329082+0000","message":{"action":"B","xid":489}}
 {"action":"C","xid":"489","lsn":"0/22E48D8","timestamp":"2022-11-23 13:43:44.329356+0000","message":{"action":"C","xid":489}}
 {"action":"B","xid":"490","lsn":"0/22E4948","timestamp":"2022-11-23 13:43:44.329575+0000","message":{"action":"B","xid":490}}


### PR DESCRIPTION
It fixes an issue under the following conditions,
1. Source doesn't have any activity.
2. `endpos` is set to `current` LSN.
3. The action that crosses the `endpos` is `KEEPALIVE`.

in this case, the written `lsn` that corresponds to `KEEPALIVE` isn't correct, i.e. less than `endpos`. This ultimately leads to Apply process waiting for a statement `>= endpos` which never happens, hence it never terminates.