### PR TITLE
Trivial: Write index OIDs as unsigned integers correctly to the summary file & fix partitioning for tables with bigint primary keys with values greater than 2^32

### DIFF
--- a/src/bin/pgcopydb/schema.c
+++ b/src/bin/pgcopydb/schema.c
@@ -2636,7 +2636,7 @@ schema_list_partitions(PGSQL *pgsql, SourceTable *table, uint64_t partSize)
 		"           x as a, "
 		"           coalesce((lead(x, 1) over(order by n)) - 1, max) as b "
 		"      from t, "
-		"           generate_series(min, max, ((max-min+1)/parts)::integer + 1) "
+		"           generate_series(min, max, ((max-min+1)/parts)::bigint + 1) "
 		"           with ordinality as s(x, n) "
 		"  ) "
 		" "

--- a/src/bin/pgcopydb/summary.c
+++ b/src/bin/pgcopydb/summary.c
@@ -260,8 +260,8 @@ create_table_index_file(SourceTable *table, char *filename)
 	{
 		SourceIndex *index = indexListEntry->index;
 
-		appendPQExpBuffer(content, "%d\n", index->indexOid);
-		appendPQExpBuffer(content, "%d\n", index->constraintOid);
+		appendPQExpBuffer(content, "%u\n", index->indexOid);
+		appendPQExpBuffer(content, "%u\n", index->constraintOid);
 	}
 
 	/* memory allocation could have failed while building string */


### PR DESCRIPTION
# Reson for changes to `summary.c`

While trying to use this tool I kept getting errors which looked like the following:

```
22:34:34 83685 ERROR summary.c:331 Failed to read the index oid "-1885211746" in file "data/pgcopydb_limited/run/tables/17093.idx" at line 10
```

After some digging I tracked it down to the fact the number format being used was `%d` when it should be `%u` for unsigned 32 bit integers.

# Reson for changes to `summary.c`

Partitioning of tables with bigint primary keys was failing

# Also

Thanks so much for creating this tool!