### PR TITLE
Error out early when work dir does not exists and is expected to.

### DIFF
--- a/src/bin/pgcopydb/cli_common.c
+++ b/src/bin/pgcopydb/cli_common.c
@@ -973,12 +973,14 @@ cli_copy_prepare_specs(CopyDataSpec *copySpecs, CopyDataSection section)
 		? NULL
 		: copyDBoptions.dir;
 
+	bool createWorkDir = true;
 	bool auxilliary = false;
 
 	if (!copydb_init_workdir(copySpecs,
 							 dir,
 							 copyDBoptions.restart,
 							 copyDBoptions.resume,
+							 createWorkDir,
 							 auxilliary))
 	{
 		/* errors have already been logged */

--- a/src/bin/pgcopydb/cli_create.c
+++ b/src/bin/pgcopydb/cli_create.c
@@ -277,11 +277,13 @@ cli_create_snapshot(int argc, char **argv)
 	(void) find_pg_commands(&(copySpecs.pgPaths));
 
 	bool auxilliary = true;
+	bool createWorkDir = true;
 
 	if (!copydb_init_workdir(&copySpecs,
 							 NULL,
 							 createSNoptions.restart,
 							 createSNoptions.resume,
+							 createWorkDir,
 							 auxilliary))
 	{
 		/* errors have already been logged */
@@ -560,11 +562,13 @@ cli_create_slot(int argc, char **argv)
 	(void) find_pg_commands(&(copySpecs.pgPaths));
 
 	bool auxilliary = false;
+	bool createWorkDir = false;
 
 	if (!copydb_init_workdir(&copySpecs,
 							 NULL,
 							 createSlotOptions.restart,
 							 createSlotOptions.resume,
+							 createWorkDir,
 							 auxilliary))
 	{
 		/* errors have already been logged */
@@ -619,11 +623,13 @@ cli_drop_slot(int argc, char **argv)
 	(void) find_pg_commands(&(copySpecs.pgPaths));
 
 	bool auxilliary = false;
+	bool createWorkDir = false;
 
 	if (!copydb_init_workdir(&copySpecs,
 							 NULL,
 							 createSlotOptions.restart,
 							 createSlotOptions.resume,
+							 createWorkDir,
 							 auxilliary))
 	{
 		/* errors have already been logged */
@@ -878,11 +884,13 @@ cli_create_origin(int argc, char **argv)
 	(void) find_pg_commands(&(copySpecs.pgPaths));
 
 	bool auxilliary = false;
+	bool createWorkDir = false;
 
 	if (!copydb_init_workdir(&copySpecs,
 							 NULL,
 							 createOriginOptions.restart,
 							 createOriginOptions.resume,
+							 createWorkDir,
 							 auxilliary))
 	{
 		/* errors have already been logged */
@@ -934,11 +942,13 @@ cli_drop_origin(int argc, char **argv)
 	(void) find_pg_commands(&(copySpecs.pgPaths));
 
 	bool auxilliary = false;
+	bool createWorkDir = false;
 
 	if (!copydb_init_workdir(&copySpecs,
 							 NULL,
 							 createOriginOptions.restart,
 							 createOriginOptions.resume,
+							 createWorkDir,
 							 auxilliary))
 	{
 		/* errors have already been logged */

--- a/src/bin/pgcopydb/cli_dump.c
+++ b/src/bin/pgcopydb/cli_dump.c
@@ -339,11 +339,15 @@ cli_dump_schema_section(CopyDBOptions *dumpDBoptions,
 		? NULL
 		: dumpDBoptions->dir;
 
+	bool auxilliary = false;
+	bool createWorkDir = true;
+
 	if (!copydb_init_workdir(&copySpecs,
 							 dir,
 							 dumpDBoptions->restart,
 							 dumpDBoptions->resume,
-							 false))
+							 createWorkDir,
+							 auxilliary))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);

--- a/src/bin/pgcopydb/cli_list.c
+++ b/src/bin/pgcopydb/cli_list.c
@@ -1175,11 +1175,13 @@ cli_list_schema(int argc, char **argv)
 	 * process being active.
 	 */
 	bool auxilliary = true;
+	bool createWorkDir = true;
 
 	if (!copydb_init_workdir(&copySpecs,
 							 NULL,
 							 false, /* restart */
 							 true, /* resume */
+							 createWorkDir,
 							 auxilliary))
 	{
 		/* errors have already been logged */
@@ -1279,11 +1281,13 @@ cli_list_progress(int argc, char **argv)
 	 * process being active.
 	 */
 	bool auxilliary = true;
+	bool createWorkDir = false;
 
 	if (!copydb_init_workdir(&copySpecs,
 							 dir,
 							 false, /* restart */
 							 true, /* resume */
+							 createWorkDir,
 							 auxilliary))
 	{
 		/* errors have already been logged */

--- a/src/bin/pgcopydb/cli_restore.c
+++ b/src/bin/pgcopydb/cli_restore.c
@@ -540,11 +540,15 @@ cli_restore_prepare_specs(CopyDataSpec *copySpecs)
 		? NULL
 		: restoreDBoptions.dir;
 
+	bool auxilliary = false;
+	bool createWorkDir = true;
+
 	if (!copydb_init_workdir(copySpecs,
 							 dir,
 							 restoreDBoptions.restart,
 							 restoreDBoptions.resume,
-							 false))
+							 createWorkDir,
+							 auxilliary))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);

--- a/src/bin/pgcopydb/cli_sentinel.c
+++ b/src/bin/pgcopydb/cli_sentinel.c
@@ -336,11 +336,13 @@ cli_sentinel_create(int argc, char **argv)
 	(void) find_pg_commands(&(copySpecs.pgPaths));
 
 	bool auxilliary = false;
+	bool createWorkDir = false;
 
 	if (!copydb_init_workdir(&copySpecs,
 							 NULL,
 							 sentinelDBoptions.restart,
 							 sentinelDBoptions.resume,
+							 createWorkDir,
 							 auxilliary))
 	{
 		/* errors have already been logged */

--- a/src/bin/pgcopydb/cli_stream.c
+++ b/src/bin/pgcopydb/cli_stream.c
@@ -507,11 +507,13 @@ cli_stream_setup(int argc, char **argv)
 	(void) find_pg_commands(&(copySpecs.pgPaths));
 
 	bool auxilliary = false;
+	bool createWorkDir = true;
 
 	if (!copydb_init_workdir(&copySpecs,
 							 NULL,
 							 streamDBoptions.restart,
 							 streamDBoptions.resume,
+							 createWorkDir,
 							 auxilliary))
 	{
 		/* errors have already been logged */
@@ -573,11 +575,13 @@ cli_stream_cleanup(int argc, char **argv)
 	bool resume = true;         /* pretend --resume has been used */
 	bool restart = false;       /* pretend --restart has NOT been used */
 	bool auxilliary = false;
+	bool createWorkDir = false;
 
 	if (!copydb_init_workdir(&copySpecs,
 							 NULL,
 							 restart,
 							 resume,
+							 createWorkDir,
 							 auxilliary))
 	{
 		/* errors have already been logged */
@@ -636,11 +640,13 @@ cli_stream_catchup(int argc, char **argv)
 	(void) find_pg_commands(&(copySpecs.pgPaths));
 
 	bool auxilliary = false;
+	bool createWorkDir = false;
 
 	if (!copydb_init_workdir(&copySpecs,
 							 NULL,
 							 streamDBoptions.restart,
 							 streamDBoptions.resume,
+							 createWorkDir,
 							 auxilliary))
 	{
 		/* errors have already been logged */
@@ -746,11 +752,15 @@ cli_stream_apply(int argc, char **argv)
 
 	(void) find_pg_commands(&(copySpecs.pgPaths));
 
+	bool auxilliary = false;
+	bool createWorkDir = false;
+
 	if (!copydb_init_workdir(&copySpecs,
 							 NULL,
 							 streamDBoptions.restart,
 							 streamDBoptions.resume,
-							 false))
+							 createWorkDir,
+							 auxilliary))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);
@@ -826,11 +836,15 @@ stream_start_in_mode(LogicalStreamMode mode)
 
 	(void) find_pg_commands(&(copySpecs.pgPaths));
 
+	bool auxilliary = false;
+	bool createWorkDir = false;
+
 	if (!copydb_init_workdir(&copySpecs,
 							 NULL,
 							 streamDBoptions.restart,
 							 streamDBoptions.resume,
-							 false))
+							 createWorkDir,
+							 auxilliary))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);

--- a/src/bin/pgcopydb/copydb.c
+++ b/src/bin/pgcopydb/copydb.c
@@ -110,6 +110,17 @@ copydb_init_workdir(CopyDataSpec *copySpecs,
 		}
 	}
 
+	/*
+	 * An auxilliary process piggy-backs on the work directory that has been
+	 * created by the main pgcopydb command, so it expects the work directory
+	 * to have been created already.
+	 */
+	if (auxilliary && !directory_exists(cfPaths->topdir))
+	{
+		log_fatal("Work directory \"%s\" does not exists", cfPaths->topdir);
+		return false;
+	}
+
 	bool removeDir = false;
 
 	if (restart)

--- a/src/bin/pgcopydb/copydb.c
+++ b/src/bin/pgcopydb/copydb.c
@@ -71,6 +71,7 @@ copydb_init_workdir(CopyDataSpec *copySpecs,
 					char *dir,
 					bool restart,
 					bool resume,
+					bool createWorkDir,
 					bool auxilliary)
 {
 	CopyFilePaths *cfPaths = &(copySpecs->cfPaths);
@@ -111,11 +112,11 @@ copydb_init_workdir(CopyDataSpec *copySpecs,
 	}
 
 	/*
-	 * An auxilliary process piggy-backs on the work directory that has been
+	 * Some inspection commands piggy-back on the work directory that has been
 	 * created by the main pgcopydb command, so it expects the work directory
 	 * to have been created already.
 	 */
-	if (auxilliary && !directory_exists(cfPaths->topdir))
+	if (!createWorkDir && !directory_exists(cfPaths->topdir))
 	{
 		log_fatal("Work directory \"%s\" does not exists", cfPaths->topdir);
 		return false;

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -245,6 +245,7 @@ bool copydb_init_workdir(CopyDataSpec *copySpecs,
 						 char *dir,
 						 bool restart,
 						 bool resume,
+						 bool createWorkDir,
 						 bool auxilliary);
 
 bool copydb_prepare_filepaths(CopyFilePaths *cfPaths,


### PR DESCRIPTION
Auxilliary commands such as pgcopydb list progress expect the work directory to have been created already. Check that early in the code.