### PR TITLE
Fix huge memory allocations in copydb_prepare_table_specs.

### DIFF
--- a/src/bin/pgcopydb/copydb.c
+++ b/src/bin/pgcopydb/copydb.c
@@ -709,14 +709,8 @@ copydb_init_table_specs(CopyTableDataSpec *tableSpecs,
 		.cfPaths = &(specs->cfPaths),
 		.pgPaths = &(specs->pgPaths),
 
-		.source_pguri = { 0 },
-		.target_pguri = { 0 },
-		.sourceSnapshot = {
-			.pgsql = { 0 },
-			.pguri = { 0 },
-			.connectionType = specs->sourceSnapshot.connectionType,
-			.snapshot = { 0 }
-		},
+		.source_pguri = &(specs->source_pguri),
+		.target_pguri = &(specs->target_pguri),
 
 		.section = specs->section,
 		.resume = specs->resume,
@@ -730,17 +724,6 @@ copydb_init_table_specs(CopyTableDataSpec *tableSpecs,
 
 		.indexSemaphore = &(specs->indexSemaphore)
 	};
-
-	/* initialize the connection strings */
-	strlcpy(tmpTableSpecs.source_pguri, specs->source_pguri, MAXCONNINFO);
-	strlcpy(tmpTableSpecs.target_pguri, specs->target_pguri, MAXCONNINFO);
-
-	/* initialize the sourceSnapshot buffers */
-	if (!copydb_copy_snapshot(specs, &(tmpTableSpecs.sourceSnapshot)))
-	{
-		/* errors have already been logged */
-		return false;
-	}
 
 	/* copy the structure as a whole memory area to the target place */
 	*tableSpecs = tmpTableSpecs;
@@ -910,8 +893,8 @@ copydb_fatal_exit()
 bool
 copydb_wait_for_subprocesses()
 {
-	bool allReturnCodeAreZero = true;
 
+	bool allReturnCodeAreZero = true;
 	log_debug("Waiting for sub-processes to finish");
 
 	for (;;)

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -90,10 +90,8 @@ typedef struct CopyTableDataSpec
 	CopyFilePaths *cfPaths;
 	PostgresPaths *pgPaths;
 
-	char source_pguri[MAXCONNINFO];
-	char target_pguri[MAXCONNINFO];
-
-	TransactionSnapshot sourceSnapshot;
+	char *source_pguri;
+	char *target_pguri;
 
 	CopyDataSection section;
 	bool resume;

--- a/src/bin/pgcopydb/table-data.c
+++ b/src/bin/pgcopydb/table-data.c
@@ -381,9 +381,6 @@ copydb_process_table_data_worker(CopyDataSpec *specs)
 		/* initialize our TableDataProcess entry now */
 		CopyTableDataSpec *tableSpecs = &(tableSpecsArray->array[tableIndex]);
 
-		/* reuse the same connection to the source database */
-		tableSpecs->sourceSnapshot = specs->sourceSnapshot;
-
 		if (asked_to_quit || asked_to_stop || asked_to_stop_fast)
 		{
 			int signal = get_current_signal(SIGTERM);
@@ -803,7 +800,7 @@ copydb_copy_table(CopyDataSpec *specs, CopyTableDataSpec *tableSpecs)
 	}
 
 	/* we want to set transaction snapshot to the main one on the source */
-	PGSQL *src = &(tableSpecs->sourceSnapshot.pgsql);
+	PGSQL *src = &(specs->sourceSnapshot.pgsql);
 	PGSQL dst = { 0 };
 
 	CopyTableSummary *summary = tableSpecs->summary;


### PR DESCRIPTION
For a migration with a huge number of tables, I'm observing large heap memory allocation. In our case, it was 9K tables occupying 11.7 GB heap. This was happening because of,
https://github.com/dimitri/pgcopydb/blob/c2760a02322fc3e73c44a622d6cdb6a3338c1e10/src/bin/pgcopydb/copydb_schema.c#L283-L285

On investigation, I found that it was due to,
```sh
print sizeof(CopyTableDataSpec)
$1 = 1215480
# which has
print sizeof(TransactionSnapshot)
$7 = 1210040
# which has
print sizeof(LogicalStreamClient)
$8 = 1206768
```

I have changed a few members of `CopyTableDataSpec` to pointers which drastically reduced these allocations.

After this fix,
```sh
print sizeof(CopyTableDataSpec)
$1 = 5440
```