### PR TITLE
Fix working-directory issues in stream cleanup and other commands.

### DIFF
--- a/docs/ref/pgcopydb_stream.rst
+++ b/docs/ref/pgcopydb_stream.rst
@@ -135,7 +135,6 @@ step.
 
      --source         Postgres URI to the source database
      --target         Postgres URI to the target database
-     --dir            Work directory to use
      --restart        Allow restarting when temp files exist already
      --resume         Allow resuming operations after a failure
      --not-consistent Allow taking a new snapshot on the source database
@@ -217,7 +216,6 @@ plugin ``wal2json``.
    usage: pgcopydb create slot
 
      --source         Postgres URI to the source database
-     --dir            Work directory to use
      --snapshot       Use snapshot obtained with pg_export_snapshot
      --plugin         Output plugin to use (test_decoding, wal2json)
      --slot-name      Use this Postgres replication slot name
@@ -239,7 +237,6 @@ The starting LSN position ``--startpos`` is required.
    usage: pgcopydb stream create origin
 
      --target         Postgres URI to the target database
-     --dir            Work directory to use
      --origin         Use this Postgres origin name
      --start-pos      LSN position from where to start applying changes
 
@@ -260,7 +257,6 @@ name (that defaults to ``pgcopydb``).
    usage: pgcopydb stream drop slot
 
      --source         Postgres URI to the source database
-     --dir            Work directory to use
      --slot-name      Use this Postgres replication slot name
 
 .. _pgcopydb_stream_drop_origin:
@@ -279,7 +275,6 @@ given name (that defaults to ``pgcopydb``).
    usage: pgcopydb stream drop origin
 
      --target         Postgres URI to the target database
-     --dir            Work directory to use
      --origin         Use this Postgres origin name
 
 

--- a/src/bin/pgcopydb/cli_create.c
+++ b/src/bin/pgcopydb/cli_create.c
@@ -49,7 +49,6 @@ static CommandLine create_repl_slot_command =
 		"Create a replication slot in the source database",
 		" --source ... ",
 		"  --source         Postgres URI to the source database\n"
-		"  --dir            Work directory to use\n"
 		"  --snapshot       Use snapshot obtained with pg_export_snapshot\n"
 		"  --plugin         Output plugin to use (test_decoding, wal2json)\n" \
 		"  --slot-name      Use this Postgres replication slot name\n",
@@ -62,7 +61,6 @@ static CommandLine create_origin_command =
 		"Create a replication origin in the target database",
 		" --target ... ",
 		"  --target         Postgres URI to the target database\n"
-		"  --dir            Work directory to use\n"
 		"  --origin         Use this Postgres origin name\n"
 		"  --start-pos      LSN position from where to start applying changes\n",
 		cli_create_origin_getopts,
@@ -86,7 +84,6 @@ static CommandLine drop_repl_slot_command =
 		"Drop a replication slot in the source database",
 		" --source ... ",
 		"  --source         Postgres URI to the source database\n"
-		"  --dir            Work directory to use\n"
 		"  --slot-name      Use this Postgres replication slot name\n",
 		cli_create_slot_getopts,
 		cli_drop_slot);
@@ -97,7 +94,6 @@ static CommandLine drop_origin_command =
 		"Drop a replication origin in the target database",
 		" --target ... ",
 		"  --target         Postgres URI to the target database\n"
-		"  --dir            Work directory to use\n"
 		"  --origin         Use this Postgres origin name\n",
 		cli_create_origin_getopts,
 		cli_drop_origin);
@@ -280,7 +276,7 @@ cli_create_snapshot(int argc, char **argv)
 	bool createWorkDir = true;
 
 	if (!copydb_init_workdir(&copySpecs,
-							 NULL,
+							 createSNoptions.dir,
 							 createSNoptions.restart,
 							 createSNoptions.resume,
 							 createWorkDir,
@@ -561,20 +557,6 @@ cli_create_slot(int argc, char **argv)
 
 	(void) find_pg_commands(&(copySpecs.pgPaths));
 
-	bool auxilliary = false;
-	bool createWorkDir = false;
-
-	if (!copydb_init_workdir(&copySpecs,
-							 NULL,
-							 createSlotOptions.restart,
-							 createSlotOptions.resume,
-							 createWorkDir,
-							 auxilliary))
-	{
-		/* errors have already been logged */
-		exit(EXIT_CODE_INTERNAL_ERROR);
-	}
-
 	RestoreOptions restoreOptions = { 0 };
 
 	if (!copydb_init_specs(&copySpecs,
@@ -619,22 +601,6 @@ static void
 cli_drop_slot(int argc, char **argv)
 {
 	CopyDataSpec copySpecs = { 0 };
-
-	(void) find_pg_commands(&(copySpecs.pgPaths));
-
-	bool auxilliary = false;
-	bool createWorkDir = false;
-
-	if (!copydb_init_workdir(&copySpecs,
-							 NULL,
-							 createSlotOptions.restart,
-							 createSlotOptions.resume,
-							 createWorkDir,
-							 auxilliary))
-	{
-		/* errors have already been logged */
-		exit(EXIT_CODE_INTERNAL_ERROR);
-	}
 
 	RestoreOptions restoreOptions = { 0 };
 
@@ -883,20 +849,6 @@ cli_create_origin(int argc, char **argv)
 
 	(void) find_pg_commands(&(copySpecs.pgPaths));
 
-	bool auxilliary = false;
-	bool createWorkDir = false;
-
-	if (!copydb_init_workdir(&copySpecs,
-							 NULL,
-							 createOriginOptions.restart,
-							 createOriginOptions.resume,
-							 createWorkDir,
-							 auxilliary))
-	{
-		/* errors have already been logged */
-		exit(EXIT_CODE_INTERNAL_ERROR);
-	}
-
 	RestoreOptions restoreOptions = { 0 };
 
 	if (!copydb_init_specs(&copySpecs,
@@ -940,20 +892,6 @@ cli_drop_origin(int argc, char **argv)
 	CopyDataSpec copySpecs = { 0 };
 
 	(void) find_pg_commands(&(copySpecs.pgPaths));
-
-	bool auxilliary = false;
-	bool createWorkDir = false;
-
-	if (!copydb_init_workdir(&copySpecs,
-							 NULL,
-							 createOriginOptions.restart,
-							 createOriginOptions.resume,
-							 createWorkDir,
-							 auxilliary))
-	{
-		/* errors have already been logged */
-		exit(EXIT_CODE_INTERNAL_ERROR);
-	}
 
 	RestoreOptions restoreOptions = { 0 };
 

--- a/src/bin/pgcopydb/cli_sentinel.c
+++ b/src/bin/pgcopydb/cli_sentinel.c
@@ -335,20 +335,6 @@ cli_sentinel_create(int argc, char **argv)
 
 	(void) find_pg_commands(&(copySpecs.pgPaths));
 
-	bool auxilliary = false;
-	bool createWorkDir = false;
-
-	if (!copydb_init_workdir(&copySpecs,
-							 NULL,
-							 sentinelDBoptions.restart,
-							 sentinelDBoptions.resume,
-							 createWorkDir,
-							 auxilliary))
-	{
-		/* errors have already been logged */
-		exit(EXIT_CODE_INTERNAL_ERROR);
-	}
-
 	RestoreOptions restoreOptions = { 0 };
 
 	if (!copydb_init_specs(&copySpecs,

--- a/src/bin/pgcopydb/cli_stream.c
+++ b/src/bin/pgcopydb/cli_stream.c
@@ -64,7 +64,6 @@ static CommandLine stream_cleanup_command =
 		"",
 		"  --source         Postgres URI to the source database\n"
 		"  --target         Postgres URI to the target database\n"
-		"  --dir            Work directory to use\n"
 		"  --restart        Allow restarting when temp files exist already\n"
 		"  --resume         Allow resuming operations after a failure\n"
 		"  --not-consistent Allow taking a new snapshot on the source database\n"
@@ -510,7 +509,7 @@ cli_stream_setup(int argc, char **argv)
 	bool createWorkDir = true;
 
 	if (!copydb_init_workdir(&copySpecs,
-							 NULL,
+							 streamDBoptions.dir,
 							 streamDBoptions.restart,
 							 streamDBoptions.resume,
 							 createWorkDir,
@@ -574,19 +573,6 @@ cli_stream_cleanup(int argc, char **argv)
 
 	bool resume = true;         /* pretend --resume has been used */
 	bool restart = false;       /* pretend --restart has NOT been used */
-	bool auxilliary = false;
-	bool createWorkDir = false;
-
-	if (!copydb_init_workdir(&copySpecs,
-							 NULL,
-							 restart,
-							 resume,
-							 createWorkDir,
-							 auxilliary))
-	{
-		/* errors have already been logged */
-		exit(EXIT_CODE_INTERNAL_ERROR);
-	}
 
 	RestoreOptions restoreOptions = { 0 };
 
@@ -643,7 +629,7 @@ cli_stream_catchup(int argc, char **argv)
 	bool createWorkDir = false;
 
 	if (!copydb_init_workdir(&copySpecs,
-							 NULL,
+							 streamDBoptions.dir,
 							 streamDBoptions.restart,
 							 streamDBoptions.resume,
 							 createWorkDir,
@@ -756,7 +742,7 @@ cli_stream_apply(int argc, char **argv)
 	bool createWorkDir = false;
 
 	if (!copydb_init_workdir(&copySpecs,
-							 NULL,
+							 streamDBoptions.dir,
 							 streamDBoptions.restart,
 							 streamDBoptions.resume,
 							 createWorkDir,
@@ -840,7 +826,7 @@ stream_start_in_mode(LogicalStreamMode mode)
 	bool createWorkDir = false;
 
 	if (!copydb_init_workdir(&copySpecs,
-							 NULL,
+							 streamDBoptions.dir,
 							 streamDBoptions.restart,
 							 streamDBoptions.resume,
 							 createWorkDir,


### PR DESCRIPTION
Address the failure when `stream cleanup` is used after `clone follow` caused by `dir` is passed as `NULL` to `copydb_init_workdir`, which leads `copydb_prepare_filepaths` to set `topdir` to an undesired location.

Includes cleanup of commands that do not require working directory, by removing `copydb_init_workdir`. And, sets `dir` to appropriate value that do requires working directory.