### PR TITLE
When transforming into a SQL file, write to a partial file first.

### DIFF
--- a/tests/cdc-test-decoding/copydb.sh
+++ b/tests/cdc-test-decoding/copydb.sh
@@ -64,7 +64,7 @@ pgcopydb stream prefetch --resume --endpos "${lsn}" -vv
 # now transform the JSON file into SQL
 SQLFILENAME=`basename ${WALFILE} .json`.sql
 
-pgcopydb stream transform -vv ${SHAREDIR}/${WALFILE} /tmp/${SQLFILENAME}
+pgcopydb stream transform --debug ${SHAREDIR}/${WALFILE} /tmp/${SQLFILENAME}
 
 # we should get the same result as `pgcopydb stream prefetch`
 diff ${SHAREDIR}/${SQLFILE} /tmp/${SQLFILENAME}


### PR DESCRIPTION
Writing directly to the output file opens a window where the file exists and can be read with partial content, either from pgcopydb itself, or from an external tooling. Using a temp filename then switching to the actual expected file protects again partial reads and parse failures.