### PR TITLE
When streaming into a JSON file, write to a partial file first.

### DIFF
--- a/src/bin/pgcopydb/file_utils.c
+++ b/src/bin/pgcopydb/file_utils.c
@@ -513,7 +513,9 @@ create_symbolic_link(char *sourcePath, char *targetPath)
 {
 	if (symlink(sourcePath, targetPath) != 0)
 	{
-		log_error("Failed to create symbolic link to \"%s\": %m", targetPath);
+		log_error("Failed to create symbolic link \"%s\" -> \"%s\": %m",
+				  targetPath,
+				  sourcePath);
 		return false;
 	}
 	return true;

--- a/src/bin/pgcopydb/ld_stream.h
+++ b/src/bin/pgcopydb/ld_stream.h
@@ -90,6 +90,7 @@ typedef struct StreamContext
 	uint32_t timeline;
 
 	uint64_t firstLSN;
+	char partialFileName[MAXPGPATH];
 	char walFileName[MAXPGPATH];
 	char sqlFileName[MAXPGPATH];
 	FILE *jsonFile;


### PR DESCRIPTION
Writing directly to the target JSON file creates a windows where the file exists and can be read with partial content, either by pgcopydb itself or from external tooling. Using a temp filename then switching to the actual expected file protects again partial reads and parse failures.