### PR TITLE
Extend the internal notion of auxilliary process to "services".

### DIFF
--- a/src/bin/pgcopydb/cli_common.c
+++ b/src/bin/pgcopydb/cli_common.c
@@ -974,14 +974,25 @@ cli_copy_prepare_specs(CopyDataSpec *copySpecs, CopyDataSection section)
 		: copyDBoptions.dir;
 
 	bool createWorkDir = true;
-	bool auxilliary = false;
+	bool service = true;
+	char *serviceName = NULL;   /* this is the "main" service */
+
+	/*
+	 * Commands that won't set a work directory certainly are not running a
+	 * service, they won't even have a pidfile.
+	 */
+	if (dir == NULL)
+	{
+		service = false;
+	}
 
 	if (!copydb_init_workdir(copySpecs,
 							 dir,
+							 service,
+							 serviceName,
 							 copyDBoptions.restart,
 							 copyDBoptions.resume,
-							 createWorkDir,
-							 auxilliary))
+							 createWorkDir))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);

--- a/src/bin/pgcopydb/cli_create.c
+++ b/src/bin/pgcopydb/cli_create.c
@@ -272,15 +272,17 @@ cli_create_snapshot(int argc, char **argv)
 
 	(void) find_pg_commands(&(copySpecs.pgPaths));
 
-	bool auxilliary = true;
 	bool createWorkDir = true;
+	bool service = true;
+	char *serviceName = "snapshot";
 
 	if (!copydb_init_workdir(&copySpecs,
 							 createSNoptions.dir,
+							 service,
+							 serviceName,
 							 createSNoptions.restart,
 							 createSNoptions.resume,
-							 createWorkDir,
-							 auxilliary))
+							 createWorkDir))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);

--- a/src/bin/pgcopydb/cli_dump.c
+++ b/src/bin/pgcopydb/cli_dump.c
@@ -339,15 +339,15 @@ cli_dump_schema_section(CopyDBOptions *dumpDBoptions,
 		? NULL
 		: dumpDBoptions->dir;
 
-	bool auxilliary = false;
 	bool createWorkDir = true;
 
 	if (!copydb_init_workdir(&copySpecs,
 							 dir,
+							 false, /* service */
+							 NULL,  /* serviceName */
 							 dumpDBoptions->restart,
 							 dumpDBoptions->resume,
-							 createWorkDir,
-							 auxilliary))
+							 createWorkDir))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);

--- a/src/bin/pgcopydb/cli_list.c
+++ b/src/bin/pgcopydb/cli_list.c
@@ -1174,15 +1174,15 @@ cli_list_schema(int argc, char **argv)
 	 * Assume --resume so that we can run the command alongside the main
 	 * process being active.
 	 */
-	bool auxilliary = true;
 	bool createWorkDir = true;
 
 	if (!copydb_init_workdir(&copySpecs,
 							 NULL,
+							 false, /* service */
+							 NULL,  /* serviceName */
 							 false, /* restart */
 							 true, /* resume */
-							 createWorkDir,
-							 auxilliary))
+							 createWorkDir))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);
@@ -1280,15 +1280,15 @@ cli_list_progress(int argc, char **argv)
 	 * Assume --resume so that we can run the command alongside the main
 	 * process being active.
 	 */
-	bool auxilliary = true;
 	bool createWorkDir = false;
 
 	if (!copydb_init_workdir(&copySpecs,
 							 dir,
+							 false, /* service */
+							 NULL,  /* serviceName */
 							 false, /* restart */
 							 true, /* resume */
-							 createWorkDir,
-							 auxilliary))
+							 createWorkDir))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);

--- a/src/bin/pgcopydb/cli_restore.c
+++ b/src/bin/pgcopydb/cli_restore.c
@@ -540,15 +540,15 @@ cli_restore_prepare_specs(CopyDataSpec *copySpecs)
 		? NULL
 		: restoreDBoptions.dir;
 
-	bool auxilliary = false;
 	bool createWorkDir = true;
 
 	if (!copydb_init_workdir(copySpecs,
 							 dir,
+							 false, /* service */
+							 NULL,  /* serviceName */
 							 restoreDBoptions.restart,
 							 restoreDBoptions.resume,
-							 createWorkDir,
-							 auxilliary))
+							 createWorkDir))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);

--- a/src/bin/pgcopydb/cli_stream.c
+++ b/src/bin/pgcopydb/cli_stream.c
@@ -505,15 +505,15 @@ cli_stream_setup(int argc, char **argv)
 
 	(void) find_pg_commands(&(copySpecs.pgPaths));
 
-	bool auxilliary = false;
 	bool createWorkDir = true;
 
 	if (!copydb_init_workdir(&copySpecs,
 							 streamDBoptions.dir,
+							 false, /* service */
+							 NULL,  /* serviceName */
 							 streamDBoptions.restart,
 							 streamDBoptions.resume,
-							 createWorkDir,
-							 auxilliary))
+							 createWorkDir))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);
@@ -625,15 +625,21 @@ cli_stream_catchup(int argc, char **argv)
 
 	(void) find_pg_commands(&(copySpecs.pgPaths));
 
-	bool auxilliary = false;
+	/*
+	 * Both the catchup and the replay command starts the "apply" service, so
+	 * that they conflict with each other.
+	 */
 	bool createWorkDir = false;
+	bool service = true;
+	char *serviceName = "apply";
 
 	if (!copydb_init_workdir(&copySpecs,
 							 streamDBoptions.dir,
+							 service,
+							 serviceName,
 							 streamDBoptions.restart,
 							 streamDBoptions.resume,
-							 createWorkDir,
-							 auxilliary))
+							 createWorkDir))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);
@@ -738,15 +744,15 @@ cli_stream_apply(int argc, char **argv)
 
 	(void) find_pg_commands(&(copySpecs.pgPaths));
 
-	bool auxilliary = false;
 	bool createWorkDir = false;
 
 	if (!copydb_init_workdir(&copySpecs,
 							 streamDBoptions.dir,
+							 false, /* false */
+							 NULL,  /* serviceName */
 							 streamDBoptions.restart,
 							 streamDBoptions.resume,
-							 createWorkDir,
-							 auxilliary))
+							 createWorkDir))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);
@@ -822,15 +828,21 @@ stream_start_in_mode(LogicalStreamMode mode)
 
 	(void) find_pg_commands(&(copySpecs.pgPaths));
 
-	bool auxilliary = false;
+	/*
+	 * Both the receive and the prefetch command starts the "receive" service,
+	 * so that they conflict with each other.
+	 */
 	bool createWorkDir = false;
+	bool service = true;
+	char *serviceName = "receive";
 
 	if (!copydb_init_workdir(&copySpecs,
 							 streamDBoptions.dir,
+							 service,
+							 serviceName,
 							 streamDBoptions.restart,
 							 streamDBoptions.resume,
-							 createWorkDir,
-							 auxilliary))
+							 createWorkDir))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -241,14 +241,18 @@ void cli_copy_prepare_specs(CopyDataSpec *copySpecs, CopyDataSection section);
 
 bool copydb_init_workdir(CopyDataSpec *copySpecs,
 						 char *dir,
+						 bool service,
+						 char *serviceName,
 						 bool restart,
 						 bool resume,
-						 bool createWorkDir,
-						 bool auxilliary);
+						 bool createWorkDir);
+
+bool copydb_acquire_pidfile(CopyFilePaths *cfPaths, char *serviceName);
 
 bool copydb_prepare_filepaths(CopyFilePaths *cfPaths,
 							  const char *topdir,
-							  bool auxilliary);
+							  const char *serviceName);
+
 bool copydb_inspect_workdir(CopyFilePaths *cfPaths, DirectoryState *dirState);
 
 bool copydb_rmdir_or_mkdir(const char *dir, bool removeDir);

--- a/src/bin/pgcopydb/copydb_paths.h
+++ b/src/bin/pgcopydb/copydb_paths.h
@@ -59,6 +59,7 @@ typedef struct CopyFilePaths
 {
 	char topdir[MAXPGPATH];           /* /tmp/pgcopydb */
 	char pidfile[MAXPGPATH];          /* /tmp/pgcopydb/pgcopydb.pid */
+	char spidfile[MAXPGPATH];         /* /tmp/pgcopydb/pgcopydb.service.pid */
 	char snfile[MAXPGPATH];           /* /tmp/pgcopydb/snapshot */
 	char schemadir[MAXPGPATH];        /* /tmp/pgcopydb/schema */
 	char schemafile[MAXPGPATH];       /* /tmp/pgcopydb/schema.json */

--- a/tests/pagila-multi-steps/copydb.sh
+++ b/tests/pagila-multi-steps/copydb.sh
@@ -30,11 +30,11 @@ EOF
 # we need to export a snapshot, and keep it while the indivual steps are
 # running, one at a time
 
-coproc ( pgcopydb snapshot -vv )
+coproc ( pgcopydb snapshot --debug )
 
 sleep 1
 
-pgcopydb dump schema --resume -vv
+pgcopydb dump schema --resume --debug
 pgcopydb restore pre-data --resume
 
 pgcopydb copy table-data --resume


### PR DESCRIPTION
This allows multiple unrelated subcommands to run at once, each with their own service specific pidfile. Also, most sub-commands do not need a pidfile at all and now can bypass checking for stale pids etc entirely.