### PR TITLE
Implement new command: pgcopydb ping

### DIFF
--- a/docs/ref/pgcopydb.rst
+++ b/docs/ref/pgcopydb.rst
@@ -155,3 +155,31 @@ In JSON:
 The details about the Postgres version applies to the version that's been
 used to build pgcopydb from sources, so that's the version of the client
 library ``libpq`` really.
+
+
+pgcopydb ping
+-------------
+
+The ``pgcopydb ping`` command attempts to connect to both the source and the
+target Postgres databases, concurrently.
+
+::
+
+   pgcopydb ping: Copy the roles from the source instance to the target instance
+   usage: pgcopydb ping  --source ... --target ...
+
+     --source              Postgres URI to the source database
+     --target              Postgres URI to the target database
+
+An example output looks like the following:
+
+::
+
+   $ pgcopydb ping
+   18:04:48 84679 INFO   Running pgcopydb version 0.10.31.g7e5fbb8.dirty from "/Users/dim/dev/PostgreSQL/pgcopydb/src/bin/pgcopydb/pgcopydb"
+   18:04:48 84683 INFO   Successfully could connect to target database at "postgres://@:/plop?"
+   18:04:48 84682 INFO   Successfully could connect t source database at "postgres://@:/pagila?"
+
+This command implements a retry policy (named *Decorrelated Jitter*) and can
+be used in automation to make sure that the databases are ready to accept
+connections.

--- a/src/bin/pgcopydb/cli_ping.c
+++ b/src/bin/pgcopydb/cli_ping.c
@@ -1,0 +1,286 @@
+/*
+ * src/bin/pgcopydb/cli_copy.c
+ *     Implementation of a CLI which lets you run individual routines
+ *     directly
+ */
+
+#include <errno.h>
+#include <getopt.h>
+#include <inttypes.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "cli_common.h"
+#include "cli_root.h"
+#include "copydb.h"
+#include "commandline.h"
+#include "log.h"
+#include "pgsql.h"
+
+static void cli_ping(int argc, char **argv);
+int cli_ping_getopts(int argc, char **argv);
+
+CommandLine ping_command =
+	make_command(
+		"ping",
+		"Copy the roles from the source instance to the target instance",
+		" --source ... --target ... ",
+		"  --source              Postgres URI to the source database\n"
+		"  --target              Postgres URI to the target database\n",
+		cli_ping_getopts,
+		cli_ping);
+
+
+/*
+ * cli_ping_getopts parses the CLI options for the `pgcopydb ping` command.
+ */
+int
+cli_ping_getopts(int argc, char **argv)
+{
+	CopyDBOptions options = { 0 };
+	int c, option_index = 0, errors = 0;
+	int verboseCount = 0;
+
+	static struct option long_options[] = {
+		{ "source", required_argument, NULL, 'S' },
+		{ "target", required_argument, NULL, 'T' },
+		{ "version", no_argument, NULL, 'V' },
+		{ "verbose", no_argument, NULL, 'v' },
+		{ "debug", no_argument, NULL, 'd' },
+		{ "trace", no_argument, NULL, 'z' },
+		{ "quiet", no_argument, NULL, 'q' },
+		{ "help", no_argument, NULL, 'h' },
+		{ NULL, 0, NULL, 0 }
+	};
+	optind = 0;
+
+
+	/* read values from the environment */
+	if (!cli_copydb_getenv(&options))
+	{
+		log_fatal("Failed to read default values from the environment");
+		exit(EXIT_CODE_BAD_ARGS);
+	}
+
+	while ((c = getopt_long(argc, argv, "S:T:Vvdzqh",
+							long_options, &option_index)) != -1)
+	{
+		switch (c)
+		{
+			case 'S':
+			{
+				if (!validate_connection_string(optarg))
+				{
+					log_fatal("Failed to parse --source connection string, "
+							  "see above for details.");
+					++errors;
+				}
+				strlcpy(options.source_pguri, optarg, MAXCONNINFO);
+				log_trace("--source %s", options.source_pguri);
+				break;
+			}
+
+			case 'T':
+			{
+				if (!validate_connection_string(optarg))
+				{
+					log_fatal("Failed to parse --target connection string, "
+							  "see above for details.");
+					++errors;
+				}
+				strlcpy(options.target_pguri, optarg, MAXCONNINFO);
+				log_trace("--target %s", options.target_pguri);
+				break;
+			}
+
+			case 'V':
+			{
+				/* keeper_cli_print_version prints version and exits. */
+				cli_print_version(argc, argv);
+				break;
+			}
+
+			case 'v':
+			{
+				++verboseCount;
+				switch (verboseCount)
+				{
+					case 1:
+					{
+						log_set_level(LOG_NOTICE);
+						break;
+					}
+
+					case 2:
+					{
+						log_set_level(LOG_DEBUG);
+						break;
+					}
+
+					default:
+					{
+						log_set_level(LOG_TRACE);
+						break;
+					}
+				}
+				break;
+			}
+
+			case 'd':
+			{
+				verboseCount = 2;
+				log_set_level(LOG_DEBUG);
+				break;
+			}
+
+			case 'z':
+			{
+				verboseCount = 3;
+				log_set_level(LOG_TRACE);
+				break;
+			}
+
+			case 'q':
+			{
+				log_set_level(LOG_ERROR);
+				break;
+			}
+
+			case 'h':
+			{
+				commandline_help(stderr);
+				exit(EXIT_CODE_QUIT);
+				break;
+			}
+		}
+	}
+
+	if (IS_EMPTY_STRING_BUFFER(options.source_pguri) ||
+		IS_EMPTY_STRING_BUFFER(options.target_pguri))
+	{
+		log_fatal("Options --source and --target are mandatory");
+		exit(EXIT_CODE_BAD_ARGS);
+	}
+
+	/* publish our option parsing in the global variable */
+	copyDBoptions = options;
+
+	return optind;
+}
+
+
+/*
+ * cli_ping implements the pgcopydb ping command line.
+ */
+static void
+cli_ping(int argc, char **argv)
+{
+	int errors = 0;
+	char scrubbedSourceURI[MAXCONNINFO] = { 0 };
+	char scrubbedTargetURI[MAXCONNINFO] = { 0 };
+
+	char *source = copyDBoptions.source_pguri;
+	char *target = copyDBoptions.target_pguri;
+
+	(void) parse_and_scrub_connection_string(source, scrubbedSourceURI);
+	(void) parse_and_scrub_connection_string(target, scrubbedTargetURI);
+
+	/* ping both source and target databases concurrently */
+	pid_t sPid = fork();
+
+	switch (sPid)
+	{
+		case -1:
+		{
+			log_error("Failed to fork a subprocess to ping source db: %m");
+			++errors;
+			break;
+		}
+
+		case 0:
+		{
+			/* child process runs the command */
+			PGSQL src = { 0 };
+
+			if (!pgsql_init(&src, source, PGSQL_CONN_SOURCE))
+			{
+				/* errors have already been logged */
+				exit(EXIT_CODE_SOURCE);
+			}
+
+			if (!pgsql_set_gucs(&src, srcSettings))
+			{
+				log_fatal("Failed to set our GUC settings on the target connection, "
+						  "see above for details");
+				pgsql_finish(&src);
+				exit(EXIT_CODE_TARGET);
+			}
+
+			log_info("Successfully could connect t source database at \"%s\"",
+					 scrubbedSourceURI);
+
+			pgsql_finish(&src);
+
+			/* and we're done */
+			exit(EXIT_CODE_QUIT);
+		}
+
+		default:
+		{
+			/* pass */
+			break;
+		}
+	}
+
+	pid_t tPid = fork();
+
+	switch (tPid)
+	{
+		case -1:
+		{
+			log_error("Failed to fork a subprocess to ping target db: %m");
+			++errors;
+			break;
+		}
+
+		case 0:
+		{
+			/* child process runs the command */
+			PGSQL dst = { 0 };
+
+			if (!pgsql_init(&dst, target, PGSQL_CONN_TARGET))
+			{
+				/* errors have already been logged */
+				exit(EXIT_CODE_TARGET);
+			}
+
+			if (!pgsql_set_gucs(&dst, dstSettings))
+			{
+				log_fatal("Failed to set our GUC settings on the target connection, "
+						  "see above for details");
+				pgsql_finish(&dst);
+				exit(EXIT_CODE_TARGET);
+			}
+
+			log_info("Successfully could connect to target database at \"%s\"",
+					 scrubbedTargetURI);
+
+			pgsql_finish(&dst);
+
+			/* and we're done */
+			exit(EXIT_CODE_QUIT);
+		}
+
+		default:
+		{
+			/* pass */
+			break;
+		}
+	}
+
+	if (!copydb_wait_for_subprocesses())
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+}

--- a/src/bin/pgcopydb/cli_root.c
+++ b/src/bin/pgcopydb/cli_root.c
@@ -32,6 +32,7 @@ CommandLine *root_subcommands_with_debug[] = {
 	&restore_commands,
 	&list_commands,
 	&stream_commands,
+	&ping_command,
 	&help,
 	&version,
 	NULL
@@ -57,6 +58,7 @@ CommandLine *root_subcommands[] = {
 	&restore_commands,
 	&list_commands,
 	&stream_commands,
+	&ping_command,
 	&help,
 	&version,
 	NULL

--- a/src/bin/pgcopydb/cli_root.h
+++ b/src/bin/pgcopydb/cli_root.h
@@ -51,6 +51,9 @@ extern CommandLine drop_commands;
 /* cli_dump.h */
 extern CommandLine dump_commands;
 
+/* cli_ping.h */
+extern CommandLine ping_command;
+
 /* cli_restore.h */
 extern CommandLine restore_commands;
 

--- a/tests/blobs/copydb.sh
+++ b/tests/blobs/copydb.sh
@@ -10,12 +10,8 @@ set -e
 #  - PGCOPYDB_TABLE_JOBS
 #  - PGCOPYDB_INDEX_JOBS
 
-#
-# pgcopydb list extensions include a retry loop, so we use that as a proxy
-# to depend on the source/target Postgres images to be ready
-#
-pgcopydb list extensions --source ${PGCOPYDB_SOURCE_PGURI}
-pgcopydb list extensions --source ${PGCOPYDB_TARGET_PGURI}
+# make sure source and target databases are ready
+pgcopydb ping
 
 psql -d ${PGCOPYDB_SOURCE_PGURI} -1 -f /usr/src/pgcopydb/import.sql
 

--- a/tests/cdc-endpos-between-transaction/copydb.sh
+++ b/tests/cdc-endpos-between-transaction/copydb.sh
@@ -10,13 +10,8 @@ set -e
 #  - PGCOPYDB_TABLE_JOBS
 #  - PGCOPYDB_INDEX_JOBS
 
-
-#
-# pgcopydb list extensions include a retry loop, so we use that as a proxy
-# to depend on the source/target Postgres images to be ready
-#
-pgcopydb list extensions --source ${PGCOPYDB_SOURCE_PGURI}
-pgcopydb list extensions --source ${PGCOPYDB_TARGET_PGURI}
+# make sure source and target databases are ready
+pgcopydb ping
 
 psql -o /tmp/s.out -d ${PGCOPYDB_SOURCE_PGURI} -1 -f /usr/src/pagila/pagila-schema.sql
 psql -o /tmp/d.out -d ${PGCOPYDB_SOURCE_PGURI} -1 -f /usr/src/pagila/pagila-data.sql

--- a/tests/cdc-low-level/copydb.sh
+++ b/tests/cdc-low-level/copydb.sh
@@ -12,12 +12,8 @@ set -o pipefail
 #  - PGCOPYDB_INDEX_JOBS
 
 
-#
-# pgcopydb list extensions include a retry loop, so we use that as a proxy
-# to depend on the source/target Postgres images to be ready
-#
-pgcopydb list extensions --source ${PGCOPYDB_SOURCE_PGURI}
-pgcopydb list extensions --source ${PGCOPYDB_TARGET_PGURI}
+# make sure source and target databases are ready
+pgcopydb ping
 
 psql -o /tmp/s.out -d ${PGCOPYDB_SOURCE_PGURI} -1 -f /usr/src/pagila/pagila-schema.sql
 psql -o /tmp/d.out -d ${PGCOPYDB_SOURCE_PGURI} -1 -f /usr/src/pagila/pagila-data.sql

--- a/tests/cdc-test-decoding/copydb.sh
+++ b/tests/cdc-test-decoding/copydb.sh
@@ -10,13 +10,8 @@ set -e
 #  - PGCOPYDB_TABLE_JOBS
 #  - PGCOPYDB_INDEX_JOBS
 
-
-#
-# pgcopydb list extensions include a retry loop, so we use that as a proxy
-# to depend on the source/target Postgres images to be ready
-#
-pgcopydb list extensions --source ${PGCOPYDB_SOURCE_PGURI}
-pgcopydb list extensions --source ${PGCOPYDB_TARGET_PGURI}
+# make sure source and target databases are ready
+pgcopydb ping
 
 psql -o /tmp/s.out -d ${PGCOPYDB_SOURCE_PGURI} -1 -f /usr/src/pagila/pagila-schema.sql
 psql -o /tmp/d.out -d ${PGCOPYDB_SOURCE_PGURI} -1 -f /usr/src/pagila/pagila-data.sql

--- a/tests/cdc-wal2json/copydb.sh
+++ b/tests/cdc-wal2json/copydb.sh
@@ -10,13 +10,8 @@ set -e
 #  - PGCOPYDB_TABLE_JOBS
 #  - PGCOPYDB_INDEX_JOBS
 
-
-#
-# pgcopydb list extensions include a retry loop, so we use that as a proxy
-# to depend on the source/target Postgres images to be ready
-#
-pgcopydb list extensions --source ${PGCOPYDB_SOURCE_PGURI}
-pgcopydb list extensions --source ${PGCOPYDB_TARGET_PGURI}
+# make sure source and target databases are ready
+pgcopydb ping
 
 psql -o /tmp/s.out -d ${PGCOPYDB_SOURCE_PGURI} -1 -f /usr/src/pagila/pagila-schema.sql
 psql -o /tmp/d.out -d ${PGCOPYDB_SOURCE_PGURI} -1 -f /usr/src/pagila/pagila-data.sql

--- a/tests/extensions/copydb.sh
+++ b/tests/extensions/copydb.sh
@@ -10,12 +10,8 @@ set -e
 #  - PGCOPYDB_TABLE_JOBS
 #  - PGCOPYDB_INDEX_JOBS
 
-#
-# pgcopydb list extensions include a retry loop, so we use that as a proxy
-# to depend on the source/target Postgres images to be ready
-#
-pgcopydb list extensions --source ${POSTGRES_SOURCE}
-pgcopydb list extensions --source ${POSTGRES_TARGET}
+# make sure source and target databases are ready
+pgcopydb ping --source ${POSTGRES_SOURCE} --target ${POSTGRES_TARGET}
 
 psql -a ${POSTGRES_SOURCE} <<EOF
 create role pagila NOSUPERUSER CREATEDB NOCREATEROLE LOGIN PASSWORD '0wn3d';

--- a/tests/filtering/copydb.sh
+++ b/tests/filtering/copydb.sh
@@ -10,13 +10,8 @@ set -e
 #  - PGCOPYDB_TABLE_JOBS
 #  - PGCOPYDB_INDEX_JOBS
 
-
-#
-# pgcopydb list extensions include a retry loop, so we use that as a proxy to
-# depend on the source/target Postgres images to be ready
-#
-pgcopydb list extensions --source ${PGCOPYDB_SOURCE_PGURI}
-pgcopydb list extensions --source ${PGCOPYDB_TARGET_PGURI}
+# make sure source and target databases are ready
+pgcopydb ping
 
 psql -o /tmp/s.out -d ${PGCOPYDB_SOURCE_PGURI} -1 -f /usr/src/pagila/pagila-schema.sql
 psql -o /tmp/d.out -d ${PGCOPYDB_SOURCE_PGURI} -1 -f /usr/src/pagila/pagila-data.sql

--- a/tests/follow-9.6/copydb.sh
+++ b/tests/follow-9.6/copydb.sh
@@ -10,13 +10,8 @@ set -e
 #  - PGCOPYDB_TABLE_JOBS
 #  - PGCOPYDB_INDEX_JOBS
 
-
-#
-# pgcopydb list extensions include a retry loop, so we use that as a proxy
-# to depend on the source/target Postgres images to be ready
-#
-pgcopydb list extensions --source ${PGCOPYDB_SOURCE_PGURI}
-pgcopydb list extensions --source ${PGCOPYDB_TARGET_PGURI}
+# make sure source and target databases are ready
+pgcopydb ping
 
 #
 # Hack the pagila schema to make it compatible with Postgres 9.6. Remove:

--- a/tests/follow-wal2json/copydb.sh
+++ b/tests/follow-wal2json/copydb.sh
@@ -10,13 +10,8 @@ set -e
 #  - PGCOPYDB_TABLE_JOBS
 #  - PGCOPYDB_INDEX_JOBS
 
-
-#
-# pgcopydb list extensions include a retry loop, so we use that as a proxy
-# to depend on the source/target Postgres images to be ready
-#
-pgcopydb list extensions --source ${PGCOPYDB_SOURCE_PGURI}
-pgcopydb list extensions --source ${PGCOPYDB_TARGET_PGURI}
+# make sure source and target databases are ready
+pgcopydb ping
 
 psql -o /tmp/s.out -d ${PGCOPYDB_SOURCE_PGURI} -1 -f /usr/src/pagila/pagila-schema.sql
 psql -o /tmp/d.out -d ${PGCOPYDB_SOURCE_PGURI} -1 -f /usr/src/pagila/pagila-data.sql

--- a/tests/pagila-multi-steps/copydb.sh
+++ b/tests/pagila-multi-steps/copydb.sh
@@ -10,12 +10,8 @@ set -e
 #  - PGCOPYDB_TABLE_JOBS
 #  - PGCOPYDB_INDEX_JOBS
 
-#
-# pgcopydb list extensions include a retry loop, so we use that as a proxy
-# to depend on the source/target Postgres images to be ready
-#
-pgcopydb list extensions --source ${PGCOPYDB_SOURCE_PGURI}
-pgcopydb list extensions --source ${PGCOPYDB_TARGET_PGURI}
+# make sure source and target databases are ready
+pgcopydb ping
 
 psql -o /tmp/d.out -d ${PGCOPYDB_SOURCE_PGURI} -1 -f /usr/src/pagila/pagila-schema.sql
 psql -o /tmp/s.out -d ${PGCOPYDB_SOURCE_PGURI} -1 -f /usr/src/pagila/pagila-data.sql

--- a/tests/pagila/copydb.sh
+++ b/tests/pagila/copydb.sh
@@ -10,13 +10,8 @@ set -e
 #  - PGCOPYDB_TABLE_JOBS
 #  - PGCOPYDB_INDEX_JOBS
 
-
-#
-# pgcopydb list extensions include a retry loop, so we use that as a proxy
-# to depend on the source/target Postgres images to be ready
-#
-pgcopydb list extensions --source ${PGCOPYDB_SOURCE_PGURI}
-pgcopydb list extensions --source ${PGCOPYDB_TARGET_PGURI}
+# make sure source and target databases are ready
+pgcopydb ping
 
 #
 # Now create a user that's going to be the owner of our database

--- a/tests/unit/copydb.sh
+++ b/tests/unit/copydb.sh
@@ -10,11 +10,8 @@ set -e
 #  - PGCOPYDB_TABLE_JOBS
 #  - PGCOPYDB_INDEX_JOBS
 
-#
-# pgcopydb list extensions include a retry loop, so we use that as a proxy
-# to depend on the source/target Postgres images to be ready
-#
-pgcopydb list extensions --source "${PGCOPYDB_SOURCE_PGURI}"
+# make sure source and target databases are ready
+pgcopydb ping
 
 psql -a -d "${PGCOPYDB_SOURCE_PGURI}" -1 -f ./setup/setup.sql
 


### PR DESCRIPTION
The main use case is in the test-suite where we can use our retry policy to make sure the environment is ready for running the test script. Because it's useful for the project in the context of its unit testing suite, it might be useful also for any project using pgcopydb with some automation around it.