### PR TITLE
Refactor the transform process management.

### DIFF
--- a/src/bin/pgcopydb/cli_clone_follow.c
+++ b/src/bin/pgcopydb/cli_clone_follow.c
@@ -653,6 +653,7 @@ followDB(CopyDataSpec *copySpecs, StreamSpecs *streamSpecs)
 	}
 
 	pid_t prefetch = -1;
+	pid_t transform = -1;
 	pid_t catchup = -1;
 
 	if (!follow_start_prefetch(streamSpecs, &prefetch))
@@ -661,9 +662,12 @@ followDB(CopyDataSpec *copySpecs, StreamSpecs *streamSpecs)
 		return false;
 	}
 
-	/*
-	 * Second, start the catchup process.
-	 */
+	if (!follow_start_transform(streamSpecs, &transform))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
 	if (!follow_start_catchup(streamSpecs, &catchup))
 	{
 		/* errors have already been logged */
@@ -676,7 +680,7 @@ followDB(CopyDataSpec *copySpecs, StreamSpecs *streamSpecs)
 	 * This happens when the sentinel endpos is set, typically using the
 	 * command: pgcopydb stream sentinel set endpos --current.
 	 */
-	if (!follow_wait_subprocesses(streamSpecs, prefetch, catchup))
+	if (!follow_wait_subprocesses(streamSpecs, prefetch, transform, catchup))
 	{
 		/* errors have already been logged */
 		return false;

--- a/src/bin/pgcopydb/cli_clone_follow.c
+++ b/src/bin/pgcopydb/cli_clone_follow.c
@@ -68,6 +68,16 @@ CommandLine fork_command =
 		cli_copy_db_getopts,
 		cli_clone);
 
+/* pgcopydb copy db is an alias for pgcopydb clone */
+CommandLine copy__db_command =
+	make_command(
+		"copy-db",
+		"Clone an entire database from source to target",
+		" --source ... --target ... [ --table-jobs ... --index-jobs ... ] ",
+		PGCOPYDB_CLONE_GETOPTS_HELP,
+		cli_copy_db_getopts,
+		cli_clone);
+
 
 CommandLine follow_command =
 	make_command(
@@ -100,7 +110,6 @@ static bool start_follow_process(CopyDataSpec *copySpecs,
 static bool cli_clone_follow_wait_subprocess(const char *name, pid_t pid);
 
 static bool cloneDB(CopyDataSpec *copySpecs);
-static bool followDB(CopyDataSpec *copySpecs, StreamSpecs *streamSpecs);
 
 
 /*
@@ -127,7 +136,7 @@ cli_clone(int argc, char **argv)
 							   copyDBoptions.slotName,
 							   copyDBoptions.origin,
 							   copyDBoptions.endpos,
-							   STREAM_MODE_PREFETCH,
+							   STREAM_MODE_CATCHUP,
 							   copyDBoptions.stdIn,
 							   copyDBoptions.stdOut))
 		{
@@ -337,6 +346,9 @@ cli_clone(int argc, char **argv)
 		}
 	}
 
+	/* make sure all sub-processes are now finished */
+	success = success && copydb_wait_for_subprocesses();
+
 	if (!success)
 	{
 		exit(EXIT_CODE_INTERNAL_ERROR);
@@ -364,7 +376,7 @@ cli_follow(int argc, char **argv)
 						   copyDBoptions.slotName,
 						   copyDBoptions.origin,
 						   copyDBoptions.endpos,
-						   STREAM_MODE_PREFETCH,
+						   STREAM_MODE_CATCHUP,
 						   copyDBoptions.stdIn,
 						   copyDBoptions.stdOut))
 	{
@@ -414,7 +426,7 @@ start_clone_process(CopyDataSpec *copySpecs, pid_t *pid)
 		case 0:
 		{
 			/* child process runs the command */
-			log_debug("Starting the clone sub-process");
+			log_notice("Starting the clone sub-process");
 
 			if (!cloneDB(copySpecs))
 			{
@@ -608,7 +620,7 @@ start_follow_process(CopyDataSpec *copySpecs, StreamSpecs *streamSpecs,
 		case 0:
 		{
 			/* child process runs the command */
-			log_debug("Starting the follow sub-process");
+			log_notice("Starting the follow sub-process");
 
 			if (!followDB(copySpecs, streamSpecs))
 			{
@@ -625,65 +637,6 @@ start_follow_process(CopyDataSpec *copySpecs, StreamSpecs *streamSpecs,
 			*pid = fpid;
 			return true;
 		}
-	}
-
-	return true;
-}
-
-
-/*
- * followDB implements a logical decoding client for streaming changes from the
- * source database into the target database. The stream_setup_databases() must
- * have been called already so that the replication slot using wal2json is
- * ready, the pgcopydb.sentinel table exists, and the target database
- * replication origin has been created too.
- */
-static bool
-followDB(CopyDataSpec *copySpecs, StreamSpecs *streamSpecs)
-{
-	/*
-	 * Remove the possibly still existing stream context files from
-	 * previous round of operations (--resume, etc). We want to make sure
-	 * that the catchup process reads the files created on this connection.
-	 */
-	if (!stream_cleanup_context(streamSpecs))
-	{
-		/* errors have already been logged */
-		return false;
-	}
-
-	pid_t prefetch = -1;
-	pid_t transform = -1;
-	pid_t catchup = -1;
-
-	if (!follow_start_prefetch(streamSpecs, &prefetch))
-	{
-		/* errors have already been logged */
-		return false;
-	}
-
-	if (!follow_start_transform(streamSpecs, &transform))
-	{
-		/* errors have already been logged */
-		return false;
-	}
-
-	if (!follow_start_catchup(streamSpecs, &catchup))
-	{
-		/* errors have already been logged */
-		return false;
-	}
-
-	/*
-	 * Finally wait until the process are finished.
-	 *
-	 * This happens when the sentinel endpos is set, typically using the
-	 * command: pgcopydb stream sentinel set endpos --current.
-	 */
-	if (!follow_wait_subprocesses(streamSpecs, prefetch, transform, catchup))
-	{
-		/* errors have already been logged */
-		return false;
 	}
 
 	return true;

--- a/src/bin/pgcopydb/cli_copy.c
+++ b/src/bin/pgcopydb/cli_copy.c
@@ -29,31 +29,6 @@ static void cli_copy_indexes(int argc, char **argv);
 static void cli_copy_constraints(int argc, char **argv);
 static void cli_copy_blobs(int argc, char **argv);
 
-/* pgcopydb copy db is an alias for pgcopydb clone */
-CommandLine copy__db_command =
-	make_command(
-		"copy-db",
-		"Copy an entire database from source to target",
-		" --source ... --target ... [ --table-jobs ... --index-jobs ... ] ",
-		"  --source              Postgres URI to the source database\n"
-		"  --target              Postgres URI to the target database\n"
-		"  --dir                 Work directory to use\n"
-		"  --table-jobs          Number of concurrent COPY jobs to run\n"
-		"  --index-jobs          Number of concurrent CREATE INDEX jobs to run\n"
-		"  --drop-if-exists      On the target database, clean-up from a previous run first\n"
-		"  --roles               Also copy roles found on source to target\n"
-		"  --no-owner            Do not set ownership of objects to match the original database\n"
-		"  --no-acl              Prevent restoration of access privileges (grant/revoke commands).\n"
-		"  --no-comments         Do not output commands to restore comments\n"
-		"  --skip-large-objects  Skip copying large objects (blobs)\n"
-		"  --filters <filename>  Use the filters defined in <filename>\n"
-		"  --restart             Allow restarting when temp files exist already\n"
-		"  --resume              Allow resuming operations after a failure\n"
-		"  --not-consistent      Allow taking a new snapshot on the source database\n"
-		"  --snapshot            Use snapshot obtained with pg_export_snapshot\n",
-		cli_copy_db_getopts,
-		cli_clone);
-
 static CommandLine copy_db_command =
 	make_command(
 		"db",

--- a/src/bin/pgcopydb/cli_stream.c
+++ b/src/bin/pgcopydb/cli_stream.c
@@ -1121,23 +1121,7 @@ stream_start_in_mode(LogicalStreamMode mode)
 
 		case STREAM_MODE_PREFETCH:
 		{
-			pid_t prefetch = -1;
-			pid_t transform = -1;
-
-			if (!follow_start_prefetch(&specs, &prefetch))
-			{
-				/* errors have already been logged */
-				exit(EXIT_CODE_INTERNAL_ERROR);
-			}
-
-			if (!follow_start_transform(&specs, &transform))
-			{
-				/* errors have already been logged */
-				(void) copydb_wait_for_subprocesses();
-				exit(EXIT_CODE_INTERNAL_ERROR);
-			}
-
-			if (!follow_wait_subprocesses(&specs, prefetch, transform, -1))
+			if (!followDB(&copySpecs, &specs))
 			{
 				/* errors have already been logged */
 				exit(EXIT_CODE_INTERNAL_ERROR);

--- a/src/bin/pgcopydb/copydb.c
+++ b/src/bin/pgcopydb/copydb.c
@@ -740,14 +740,14 @@ copydb_init_specs(CopyDataSpec *specs,
 		specs->section == DATA_SECTION_TABLE_DATA)
 	{
 		/* create the VACUUM process queue */
-		if (!queue_create(&(specs->vacuumQueue)))
+		if (!queue_create(&(specs->vacuumQueue), "vacuum"))
 		{
 			log_error("Failed to create the VACUUM process queue");
 			return false;
 		}
 
 		/* create the CREATE INDEX process queue */
-		if (!queue_create(&(specs->indexQueue)))
+		if (!queue_create(&(specs->indexQueue), "create index"))
 		{
 			log_error("Failed to create the INDEX process queue");
 			return false;

--- a/src/bin/pgcopydb/follow.c
+++ b/src/bin/pgcopydb/follow.c
@@ -6,6 +6,7 @@
 #include <errno.h>
 #include <getopt.h>
 #include <inttypes.h>
+#include <signal.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -14,6 +15,137 @@
 #include "ld_stream.h"
 #include "log.h"
 #include "signals.h"
+
+
+/*
+ * followDB implements a logical decoding client for streaming changes from the
+ * source database into the target database.
+ *
+ * The source database is expected to have been setup already so that the
+ * replication slot using wal2json is ready, the pgcopydb.sentinel table
+ * exists, and the target database replication origin has been created too.
+ */
+bool
+followDB(CopyDataSpec *copySpecs, StreamSpecs *streamSpecs)
+{
+	/*
+	 * Remove the possibly still existing stream context files from
+	 * previous round of operations (--resume, etc). We want to make sure
+	 * that the catchup process reads the files created on this connection.
+	 */
+	if (!stream_cleanup_context(streamSpecs))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	if (streamSpecs->mode < STREAM_MODE_PREFETCH)
+	{
+		log_error("BUG: followDB with stream mode %d", streamSpecs->mode);
+		return false;
+	}
+
+	pid_t prefetch = -1;
+	pid_t transform = -1;
+	pid_t catchup = -1;
+
+	/*
+	 * When set to prefetch changes, we always also run the transform process
+	 * to prepare the SQL files from the JSON files. Also upper modes (catchup,
+	 * replay) does imply prefetching (and transform).
+	 */
+	if (streamSpecs->mode >= STREAM_MODE_PREFETCH)
+	{
+		if (!follow_start_prefetch(streamSpecs, &prefetch))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+
+		if (!follow_start_transform(streamSpecs, &transform))
+		{
+			log_error("Failed to start the transform process");
+
+			/*
+			 * When we fail to start the transform process, we stop the
+			 * prefetch process immediately and exit with error.
+			 */
+			if (!follow_terminate_subprocesses(prefetch, transform, catchup))
+			{
+				return false;
+			}
+
+			/* and return false anyways, we failed to start the process here */
+			return false;
+		}
+	}
+
+	/*
+	 * When set to catchup or replay mode, we also start the catchup process.
+	 */
+	if (streamSpecs->mode >= STREAM_MODE_CATCHUP)
+	{
+		if (!follow_start_catchup(streamSpecs, &catchup))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+	}
+
+	/*
+	 * Finally wait until the process are finished.
+	 *
+	 * This happens when the sentinel endpos is set, typically using the
+	 * command: pgcopydb stream sentinel set endpos --current.
+	 */
+	if (!follow_wait_subprocesses(prefetch, transform, catchup))
+	{
+		log_error("Failed to wait for follow sub-processes, "
+				  "see above for details");
+		return false;
+	}
+
+	/*
+	 * Once the sub-processes have exited, it's time to clean-up the shared
+	 * resources used for communication purposes.
+	 */
+	switch (streamSpecs->mode)
+	{
+		case STREAM_MODE_PREFETCH:
+		case STREAM_MODE_CATCHUP:
+		{
+			/*
+			 * Clean-up the message queue used to communicate between prefetch
+			 * and catch-up sub-processes.
+			 */
+			if (!queue_unlink(&(streamSpecs->transformQueue)))
+			{
+				/* errors have already been logged */
+				log_warn("HINT: use ipcrm -q %d to remove the queue",
+						 streamSpecs->transformQueue.qId);
+				return false;
+			}
+			break;
+		}
+
+		case STREAM_MODE_REPLAY:
+		{
+			/* no cleanup to do here */
+			break;
+		}
+
+		case STREAM_MODE_UNKNOW:
+		case STREAM_MODE_RECEIVE:
+		default:
+		{
+			log_error("BUG: followDB cleanup section reached in mode %d",
+					  streamSpecs->mode);
+			return false;
+		}
+	}
+
+	return true;
+}
 
 
 /*
@@ -37,22 +169,15 @@ follow_start_prefetch(StreamSpecs *specs, pid_t *pid)
 		case 0:
 		{
 			/* child process runs the command */
-			log_debug("Starting the prefetch sub-process");
+			log_notice("Starting the prefetch sub-process");
 
-			bool success = startLogicalStreaming(specs);
-
-			if (specs->mode == STREAM_MODE_PREFETCH)
+			if (!startLogicalStreaming(specs))
 			{
-				if (!queue_unlink(&(specs->transformQueue)))
-				{
-					/* errors have already been logged */
-					log_warn("HINT: use ipcrm -q %d to remove the queue",
-							 specs->transformQueue.qId);
-					exit(EXIT_CODE_INTERNAL_ERROR);
-				}
+				/* errors have already been logged */
+				exit(EXIT_CODE_SOURCE);
 			}
 
-			exit(success ? EXIT_CODE_QUIT : EXIT_CODE_SOURCE);
+			exit(EXIT_CODE_QUIT);
 		}
 
 		default:
@@ -93,7 +218,7 @@ follow_start_transform(StreamSpecs *specs, pid_t *pid)
 		case 0:
 		{
 			/* child process runs the command */
-			log_debug("Starting the transform sub-process");
+			log_notice("Starting the transform sub-process");
 			if (!stream_transform_worker(specs))
 			{
 				/* errors have already been logged */
@@ -136,7 +261,7 @@ follow_start_catchup(StreamSpecs *specs, pid_t *pid)
 		case 0:
 		{
 			/* child process runs the command */
-			log_debug("Starting the catchup sub-process");
+			log_notice("Starting the catchup sub-process");
 			if (!stream_apply_catchup(specs))
 			{
 				/* errors have already been logged */
@@ -158,86 +283,76 @@ follow_start_catchup(StreamSpecs *specs, pid_t *pid)
 }
 
 
+struct subprocess
+{
+	char *name;
+	pid_t pid;
+	bool exited;
+	int returnCode;
+};
+
+
 /*
  * follow_wait_subprocesses waits until both sub-processes are finished.
  */
 bool
-follow_wait_subprocesses(StreamSpecs *specs,
-						 pid_t prefetch, pid_t transform, pid_t catchup)
+follow_wait_subprocesses(pid_t prefetch, pid_t transform, pid_t catchup)
 {
 	/*
 	 * We might have started only a subset of these 3 processes, and in that
 	 * case processes that have not been started are assigned a pid of -1.
 	 */
-	bool prefetchExited = prefetch == -1;
-	bool transformExited = transform == -1;
-	bool catchupExited = catchup == -1;
+	struct subprocess processArray[] = {
+		{ "prefetch", prefetch, prefetch == -1, 0 },
+		{ "transform", transform, transform == -1, 0 },
+		{ "catchup", catchup, catchup == -1, 0 }
+	};
+
+	int count = sizeof(processArray) / sizeof(processArray[0]);
 
 	bool success = true;
+	int stillRunning = count;
 
-	while (!prefetchExited || !transformExited || !catchupExited)
+	/* only count sub-processes for which we have a positive pid */
+	for (int i = 0; i < count; i++)
 	{
-		if (!prefetchExited)
+		if (processArray[i].pid < 0)
 		{
-			int returnCode = -1;
-
-			if (!follow_wait_pid(prefetch, &prefetchExited, &returnCode))
-			{
-				/* errors have already been logged */
-				return false;
-			}
-
-			if (prefetchExited)
-			{
-				log_level(returnCode == 0 ? LOG_INFO : LOG_ERROR,
-						  "Prefetch process %d has terminated [%d]",
-						  prefetch,
-						  returnCode);
-			}
-
-			success = success || returnCode == 0;
+			--stillRunning;
 		}
+	}
 
-		if (!transformExited)
+	/* now the main loop, that waits until all given processes have exited */
+	while (stillRunning > 0)
+	{
+		for (int i = 0; i < count; i++)
 		{
-			int returnCode = -1;
+			if (processArray[i].pid <= 0 || processArray[i].exited)
+			{
+				continue;
+			}
 
-			if (!follow_wait_pid(transform, &transformExited, &returnCode))
+			/* follow_wait_pid is non-blocking: uses WNOHANG */
+			if (!follow_wait_pid(processArray[i].pid,
+								 &(processArray[i].exited),
+								 &(processArray[i].returnCode)))
 			{
 				/* errors have already been logged */
 				return false;
 			}
 
-			if (transformExited)
+			if (processArray[i].exited)
 			{
-				log_level(returnCode == 0 ? LOG_INFO : LOG_ERROR,
-						  "Transform process %d has terminated [%d]",
-						  transform,
-						  returnCode);
+				--stillRunning;
+
+				log_level(processArray[i].returnCode == 0 ? LOG_INFO : LOG_ERROR,
+						  "%s process %d has terminated [%d]",
+						  processArray[i].name,
+						  processArray[i].pid,
+						  processArray[i].returnCode);
 			}
 
-			success = success || returnCode == 0;
-		}
-
-		if (!catchupExited)
-		{
-			int returnCode = -1;
-
-			if (!follow_wait_pid(catchup, &catchupExited, &returnCode))
-			{
-				/* errors have already been logged */
-				return false;
-			}
-
-			if (catchupExited)
-			{
-				log_level(returnCode == 0 ? LOG_INFO : LOG_ERROR,
-						  "Catch-up process %d has terminated [%d]",
-						  catchup,
-						  returnCode);
-			}
-
-			success = success || returnCode == 0;
+			success = success || processArray[i].returnCode == 0;
 		}
 
 		/* avoid busy looping, wait for 150ms before checking again */
@@ -245,6 +360,48 @@ follow_wait_subprocesses(StreamSpecs *specs,
 	}
 
 	return true;
+}
+
+
+/*
+ * follow_terminate_subprocesses is used in case of errors in one sub-process
+ * to signal the other ones to quit early.
+ */
+bool
+follow_terminate_subprocesses(pid_t prefetch, pid_t transform, pid_t catchup)
+{
+	struct subprocess processArray[] = {
+		{ "prefetch", prefetch, prefetch == -1, 0 },
+		{ "transform", transform, transform == -1, 0 },
+		{ "catchup", catchup, catchup == -1, 0 }
+	};
+
+	int count = sizeof(processArray) / sizeof(processArray[0]);
+
+	/* first, signal the processes to exit as soon as possible */
+	for (int i = 0; i < count; i++)
+	{
+		if (processArray[i].pid <= 0 || processArray[i].exited)
+		{
+			continue;
+		}
+
+		if (kill(processArray[i].pid, SIGQUIT) != 0)
+		{
+			/* process might have exited on its own already */
+			if (errno != ESRCH)
+			{
+				log_error("Failed to signal %s process %d: %m",
+						  processArray[i].name,
+						  processArray[i].pid);
+
+				return false;
+			}
+		}
+	}
+
+	/* second, collect the processes exit statuses */
+	return follow_wait_subprocesses(prefetch, transform, catchup);
 }
 
 

--- a/src/bin/pgcopydb/ld_stream.c
+++ b/src/bin/pgcopydb/ld_stream.c
@@ -130,6 +130,19 @@ stream_init_specs(StreamSpecs *specs,
 
 
 	/*
+	 * Now create the message queue needed to communicate JSON files to
+	 * transform to SQL files on prefetch mode.
+	 */
+	if (specs->mode == STREAM_MODE_PREFETCH)
+	{
+		if (!queue_create(&(specs->transformQueue)))
+		{
+			log_error("Failed to create the transform process queue");
+			return false;
+		}
+	}
+
+	/*
 	 * Now create the unix pipes needed for inter-process communication (data
 	 * flow) when needed. We override command line arguments for --to-stdout
 	 * and --from-stdin when stream mode is set to STREAM_MODE_REPLAY.
@@ -174,34 +187,14 @@ stream_init_context(StreamContext *privateContext, StreamSpecs *specs)
 	privateContext->stdIn = specs->stdIn;
 	privateContext->stdOut = specs->stdOut;
 
+	privateContext->transformQueue = &(specs->transformQueue);
+
 	privateContext->paths = specs->paths;
 	privateContext->startpos = specs->startpos;
 
 	strlcpy(privateContext->source_pguri,
 			specs->source_pguri,
 			sizeof(privateContext->source_pguri));
-
-	if (!queue_create(&(privateContext->transformQueue)))
-	{
-		log_error("Failed to create the Stream Transform process queue");
-		return false;
-	}
-
-	return true;
-}
-
-
-/*
- * stream_close_specs unlinks the stream context queue.
- */
-bool
-stream_close_context(StreamContext *privateContext)
-{
-	if (!queue_unlink(&(privateContext->transformQueue)))
-	{
-		log_warn("Failed to remove the Transform Queue, see above for details");
-		return false;
-	}
 
 	return true;
 }
@@ -245,36 +238,13 @@ startLogicalStreaming(StreamSpecs *specs)
 
 	context.private = (void *) &(privateContext);
 
-	switch (specs->mode)
+	if (specs->mode == STREAM_MODE_RECEIVE && specs->stdOut)
 	{
-		case STREAM_MODE_PREFETCH:
+		/* switch stdout from block buffered to line buffered mode */
+		if (setvbuf(stdout, NULL, _IOLBF, 0) != 0)
 		{
-			if (!stream_transform_start_worker(&context))
-			{
-				/* errors have already been logged */
-				return false;
-			}
-			break;
-		}
-
-		case STREAM_MODE_RECEIVE:
-		{
-			if (specs->stdOut)
-			{
-				/* switch stdout from block buffered to line buffered mode */
-				if (setvbuf(stdout, NULL, _IOLBF, 0) != 0)
-				{
-					log_error("Failed to set stdout to line buffered mode: %m");
-					return false;
-				}
-			}
-			break;
-		}
-
-		/* nothing to do in other modes */
-		default:
-		{
-			break;
+			log_error("Failed to set stdout to line buffered mode: %m");
+			return false;
 		}
 	}
 
@@ -296,7 +266,6 @@ startLogicalStreaming(StreamSpecs *specs)
 							   specs->endpos))
 		{
 			/* errors have already been logged */
-			(void) stream_close_context(&privateContext);
 			return false;
 		}
 
@@ -307,7 +276,6 @@ startLogicalStreaming(StreamSpecs *specs)
 		if (!pgsql_start_replication(&stream))
 		{
 			/* errors have already been logged */
-			(void) stream_close_context(&privateContext);
 			return false;
 		}
 
@@ -315,7 +283,6 @@ startLogicalStreaming(StreamSpecs *specs)
 		if (!stream_write_context(specs, &stream))
 		{
 			/* errors have already been logged */
-			(void) stream_close_context(&privateContext);
 			return false;
 		}
 
@@ -349,12 +316,6 @@ startLogicalStreaming(StreamSpecs *specs)
 
 		/* sleep for one entire second before retrying */
 		(void) pg_usleep(1 * 1000 * 1000);
-	}
-
-	if (!stream_close_context(&privateContext))
-	{
-		/* errors have already been logged */
-		return false;
 	}
 
 	return true;
@@ -848,15 +809,10 @@ streamCloseFile(LogicalStreamContext *context, bool time_to_abort)
 		{
 			/*
 			 * Now is the time to transform the JSON file into SQL.
-			 *
-			 * The transformation of the file uses enough CPU that we'd prefer
-			 * to start it in a subprocess.
 			 */
-			Queue *transformQueue = &(privateContext->transformQueue);
-
 			if (privateContext->firstLSN != InvalidXLogRecPtr)
 			{
-				if (!stream_transform_add_file(transformQueue,
+				if (!stream_transform_add_file(privateContext->transformQueue,
 											   privateContext->firstLSN))
 				{
 					/* errors have already been logged */
@@ -874,13 +830,7 @@ streamCloseFile(LogicalStreamContext *context, bool time_to_abort)
 			 */
 			if (time_to_abort)
 			{
-				if (!stream_transform_send_stop(transformQueue))
-				{
-					/* errors have already been logged */
-					return false;
-				}
-
-				if (!streamWaitForSubprocess(context))
+				if (!stream_transform_send_stop(privateContext->transformQueue))
 				{
 					/* errors have already been logged */
 					return false;
@@ -1599,51 +1549,6 @@ StreamActionFromChar(char action)
 
 
 /*
- * streamWaitForSubprocess calls waitpid() and blocks until the current
- * subprocess is reported terminated by the Operating System.
- */
-bool
-streamWaitForSubprocess(LogicalStreamContext *context)
-{
-	StreamContext *privateContext = (StreamContext *) context->private;
-
-	/* if a subprocess had been started before, wait until it's done. */
-	if (privateContext->subprocess <= 0)
-	{
-		return true;
-	}
-	int status = 0;
-
-	if (waitpid(privateContext->subprocess, &status, 0) == -1)
-	{
-		log_error("Failed to wait for pid %d: %m",
-				  privateContext->subprocess);
-		return false;
-	}
-
-	int returnCode = WEXITSTATUS(status);
-
-	if (returnCode != 0)
-	{
-		log_error("Stream Transform Worker %d exited with code %d, "
-				  "see above for details",
-				  privateContext->subprocess,
-				  returnCode);
-	}
-	else
-	{
-		log_debug("Transform subprocess %d exited successfully [%d]",
-				  privateContext->subprocess,
-				  returnCode);
-	}
-
-	privateContext->subprocess = 0;
-
-	return returnCode == 0;
-}
-
-
-/*
  * stream_setup_source_database sets up the source database with a replication
  * slot, a sentinel table, and the target database with a replication origin.
  */
@@ -2193,6 +2098,16 @@ stream_read_context(CDCPaths *paths,
 		log_debug("stream_read_context: waiting for context files "
 				  "to have been created, retrying in %dms",
 				  sleepTimeMs);
+
+		log_debug("%s: %s",
+				  paths->walsegsizefile,
+				  file_exists(paths->walsegsizefile) ? "ok" : "ko");
+		log_debug("%s: %s",
+				  paths->tlifile,
+				  file_exists(paths->tlifile) ? "ok" : "ko");
+		log_debug("%s: %s",
+				  paths->tlihistfile,
+				  file_exists(paths->tlihistfile) ? "ok" : "ko");
 
 		/* we have milliseconds, pg_usleep() wants microseconds */
 		(void) pg_usleep(sleepTimeMs * 1000);

--- a/src/bin/pgcopydb/ld_stream.h
+++ b/src/bin/pgcopydb/ld_stream.h
@@ -88,7 +88,7 @@ typedef struct StreamContext
 	char *jsonBuffer;           /* malloc'ed area */
 	LogicalMessageMetadata metadata;
 
-	Queue transformQueue;
+	Queue *transformQueue;
 	uint32_t WalSegSz;
 	uint32_t timeline;
 
@@ -97,8 +97,6 @@ typedef struct StreamContext
 	char walFileName[MAXPGPATH];
 	char sqlFileName[MAXPGPATH];
 	FILE *jsonFile;
-
-	pid_t subprocess;
 
 	StreamCounters counters;
 } StreamContext;
@@ -275,6 +273,9 @@ typedef struct StreamSpecs
 	bool restart;
 	bool resume;
 
+	/* receive push json filenames to a queue for transform */
+	Queue transformQueue;
+
 	bool stdIn;                 /* read from stdin */
 	bool stdOut;                /* (also) write to stdout */
 
@@ -306,7 +307,6 @@ bool stream_init_specs(StreamSpecs *specs,
 					   bool stdOut);
 
 bool stream_init_context(StreamContext *privateContext, StreamSpecs *specs);
-bool stream_close_context(StreamContext *privateContext);
 
 bool startLogicalStreaming(StreamSpecs *specs);
 bool streamCheckResumePosition(StreamSpecs *specs);
@@ -367,14 +367,22 @@ bool stream_read_context(CDCPaths *paths,
 StreamAction StreamActionFromChar(char action);
 
 /* ld_transform.c */
-bool stream_transform_start_worker(LogicalStreamContext *context);
-bool stream_transform_worker(LogicalStreamContext *context);
+bool stream_transform_worker(StreamSpecs *specs);
 bool stream_transform_add_file(Queue *queue, uint64_t firstLSN);
 bool stream_transform_send_stop(Queue *queue);
-bool stream_compute_pathnames(LogicalStreamContext *context, uint64_t lsn);
+
+bool stream_compute_pathnames(uint32_t WalSegSz,
+							  uint32_t timeline,
+							  uint64_t lsn,
+							  char *dir,
+							  char *walFileName,
+							  char *sqlFileName);
 
 bool stream_transform_stream(FILE * in, FILE *out);
 bool stream_transform_line(void *ctx, const char *line, bool *stop);
+bool stream_transform_message(char *message,
+							  LogicalTransaction *currentTx,
+							  bool *commit);
 bool stream_transform_file(char *jsonfilename, char *sqlfilename);
 bool stream_write_transaction(FILE *out, LogicalTransaction *tx);
 bool stream_write_begin(FILE *out, LogicalTransaction *tx);
@@ -451,8 +459,14 @@ bool stream_replay_line(void *ctx, const char *line, bool *stop);
 
 /* follow.c */
 bool follow_start_prefetch(StreamSpecs *specs, pid_t *pid);
+bool follow_start_transform(StreamSpecs *specs, pid_t *pid);
 bool follow_start_catchup(StreamSpecs *specs, pid_t *pid);
-bool follow_wait_subprocesses(StreamSpecs *specs, pid_t prefetch, pid_t catchup);
+
+bool follow_wait_subprocesses(StreamSpecs *specs,
+							  pid_t prefetch,
+							  pid_t transform,
+							  pid_t catchup);
+
 bool follow_wait_pid(pid_t subprocess, bool *exited, int *returnCode);
 
 #endif /* LD_STREAM_H */

--- a/src/bin/pgcopydb/ld_stream.h
+++ b/src/bin/pgcopydb/ld_stream.h
@@ -458,14 +458,19 @@ bool stream_apply_replay(StreamSpecs *specs);
 bool stream_replay_line(void *ctx, const char *line, bool *stop);
 
 /* follow.c */
+bool followDB(CopyDataSpec *copySpecs, StreamSpecs *streamSpecs);
+
 bool follow_start_prefetch(StreamSpecs *specs, pid_t *pid);
 bool follow_start_transform(StreamSpecs *specs, pid_t *pid);
 bool follow_start_catchup(StreamSpecs *specs, pid_t *pid);
 
-bool follow_wait_subprocesses(StreamSpecs *specs,
-							  pid_t prefetch,
+bool follow_wait_subprocesses(pid_t prefetch,
 							  pid_t transform,
 							  pid_t catchup);
+
+bool follow_terminate_subprocesses(pid_t prefetch,
+								   pid_t transform,
+								   pid_t catchup);
 
 bool follow_wait_pid(pid_t subprocess, bool *exited, int *returnCode);
 

--- a/src/bin/pgcopydb/ld_transform.c
+++ b/src/bin/pgcopydb/ld_transform.c
@@ -121,8 +121,9 @@ stream_transform_worker(StreamSpecs *specs)
 
 			default:
 			{
-				log_error("Received unknown message type %ld on vacuum queue %d",
+				log_error("Received unknown message type %ld on %s queue %d",
 						  mesg.type,
+						  transformQueue->name,
 						  transformQueue->qId);
 				break;
 			}

--- a/src/bin/pgcopydb/ld_transform.c
+++ b/src/bin/pgcopydb/ld_transform.c
@@ -34,61 +34,6 @@
 #include "summary.h"
 
 
-static bool stream_transform_message(char *message,
-									 LogicalTransaction *currentTx,
-									 bool *commit);
-
-
-/*
- * stream_transform_start_worker creates a sub-process that transform JSON
- * files into SQL files as needed, consuming requests from a queue.
- */
-bool
-stream_transform_start_worker(LogicalStreamContext *context)
-{
-	StreamContext *privateContext = (StreamContext *) context->private;
-
-	/*
-	 * Flush stdio channels just before fork, to avoid double-output
-	 * problems.
-	 */
-	fflush(stdout);
-	fflush(stderr);
-
-	int fpid = fork();
-
-	switch (fpid)
-	{
-		case -1:
-		{
-			log_error("Failed to fork a stream transform worker process: %m");
-			return false;
-		}
-
-		case 0:
-		{
-			/* child process runs the command */
-			if (!stream_transform_worker(context))
-			{
-				/* errors have already been logged */
-				exit(EXIT_CODE_INTERNAL_ERROR);
-			}
-
-			exit(EXIT_CODE_QUIT);
-		}
-
-		default:
-		{
-			/* fork succeeded, in parent */
-			privateContext->subprocess = fpid;
-			break;
-		}
-	}
-
-	return true;
-}
-
-
 /*
  * stream_transform_worker is a worker process that loops over messages
  * received from a queue, each message contains the WAL.json and the WAL.sql
@@ -96,14 +41,30 @@ stream_transform_start_worker(LogicalStreamContext *context)
  * into the WAL.sql file.
  */
 bool
-stream_transform_worker(LogicalStreamContext *context)
+stream_transform_worker(StreamSpecs *specs)
 {
-	StreamContext *privateContext = (StreamContext *) context->private;
+	log_notice("Started Stream Transform worker %d [%d]", getpid(), getppid());
+
+	/*
+	 * The timeline and wal segment size are determined when connecting to the
+	 * source database, and stored to local files at that time. When the Stream
+	 * Transform Worker process is created, that information is read from our
+	 * local files.
+	 */
+	uint32_t WalSegSz;
+	IdentifySystem system = { 0 };
+
+	if (!stream_read_context(&(specs->paths), &system, &WalSegSz))
+	{
+		log_error("Failed to read the streaming context information "
+				  "from the source database, see above for details");
+		return false;
+	}
+
+	Queue *transformQueue = &(specs->transformQueue);
 
 	int errors = 0;
 	bool stop = false;
-
-	log_notice("Started Stream Transform worker %d [%d]", getpid(), getppid());
 
 	while (!stop)
 	{
@@ -114,7 +75,7 @@ stream_transform_worker(LogicalStreamContext *context)
 			return false;
 		}
 
-		if (!queue_receive(&(privateContext->transformQueue), &mesg))
+		if (!queue_receive(transformQueue, &mesg))
 		{
 			/* errors have already been logged */
 			break;
@@ -134,15 +95,22 @@ stream_transform_worker(LogicalStreamContext *context)
 				log_debug("stream_transform_worker received transform %X/%X",
 						  LSN_FORMAT_ARGS(mesg.data.lsn));
 
-				if (!stream_compute_pathnames(context, mesg.data.lsn))
+				char walFileName[MAXPGPATH] = { 0 };
+				char sqlFileName[MAXPGPATH] = { 0 };
+
+				if (!stream_compute_pathnames(WalSegSz,
+											  system.timeline,
+											  mesg.data.lsn,
+											  specs->paths.dir,
+											  walFileName,
+											  sqlFileName))
 				{
 					/* errors have already been logged, break from the loop */
 					++errors;
 					break;
 				}
 
-				if (!stream_transform_file(privateContext->walFileName,
-										   privateContext->sqlFileName))
+				if (!stream_transform_file(walFileName, sqlFileName))
 				{
 					/* errors have already been logged, break from the loop */
 					++errors;
@@ -155,7 +123,7 @@ stream_transform_worker(LogicalStreamContext *context)
 			{
 				log_error("Received unknown message type %ld on vacuum queue %d",
 						  mesg.type,
-						  privateContext->transformQueue.qId);
+						  transformQueue->qId);
 				break;
 			}
 		}
@@ -171,51 +139,24 @@ stream_transform_worker(LogicalStreamContext *context)
  * we need to find the name of.
  */
 bool
-stream_compute_pathnames(LogicalStreamContext *context, uint64_t lsn)
+stream_compute_pathnames(uint32_t WalSegSz,
+						 uint32_t timeline,
+						 uint64_t lsn,
+						 char *dir,
+						 char *walFileName,
+						 char *sqlFileName)
 {
-	StreamContext *privateContext = (StreamContext *) context->private;
-
 	char wal[MAXPGPATH] = { 0 };
-
-	/*
-	 * The timeline and wal segment size are determined when connecting to the
-	 * source database, and stored to local files at that time. When the Stream
-	 * Transform Worker process is created, we don't have that information yet,
-	 * so the first time we process an LSN from the queue we go and fetch the
-	 * information from our local files.
-	 */
-	if (context->timeline == 0)
-	{
-		uint32_t WalSegSz;
-		IdentifySystem system = { 0 };
-
-		if (!stream_read_context(&(privateContext->paths), &system, &WalSegSz))
-		{
-			log_error("Failed to read the streaming context information "
-					  "from the source database, see above for details");
-			return false;
-		}
-
-		context->timeline = system.timeline;
-		context->WalSegSz = WalSegSz;
-	}
 
 	/* compute the WAL filename that would host the current LSN */
 	XLogSegNo segno;
-	XLByteToSeg(lsn, segno, context->WalSegSz);
-	XLogFileName(wal, context->timeline, segno, context->WalSegSz);
+	XLByteToSeg(lsn, segno, WalSegSz);
+	XLogFileName(wal, timeline, segno, WalSegSz);
 
-	sformat(privateContext->walFileName,
-			sizeof(privateContext->walFileName),
-			"%s/%s.json",
-			privateContext->paths.dir,
-			wal);
+	log_debug("stream_compute_pathnames: %X/%X: %s", LSN_FORMAT_ARGS(lsn), wal);
 
-	sformat(privateContext->sqlFileName,
-			sizeof(privateContext->sqlFileName),
-			"%s/%s.sql",
-			privateContext->paths.dir,
-			wal);
+	sformat(walFileName, MAXPGPATH, "%s/%s.json", dir, wal);
+	sformat(sqlFileName, MAXPGPATH, "%s/%s.sql", dir, wal);
 
 	return true;
 }
@@ -368,7 +309,7 @@ stream_transform_line(void *ctx, const char *line, bool *stop)
  * stream_transform_message transforms a single JSON message from our streaming
  * output into a SQL statement, and appends it to the given opened transaction.
  */
-static bool
+bool
 stream_transform_message(char *message,
 						 LogicalTransaction *currentTx,
 						 bool *commit)

--- a/src/bin/pgcopydb/queue_utils.h
+++ b/src/bin/pgcopydb/queue_utils.h
@@ -16,6 +16,7 @@
 
 typedef struct Queue
 {
+	char *name;
 	int qId;
 	pid_t owner;
 } Queue;
@@ -45,7 +46,7 @@ typedef struct QMessage
 	} data;
 } QMessage;
 
-bool queue_create(Queue *queue);
+bool queue_create(Queue *queue, char *name);
 bool queue_unlink(Queue *queue);
 
 bool queue_send(Queue *queue, QMessage *msg);

--- a/tests/cdc-endpos-between-transaction/docker-compose.yml
+++ b/tests/cdc-endpos-between-transaction/docker-compose.yml
@@ -31,7 +31,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: shubhamtemp
     environment:
       PGSSLMODE: "require"
       PGCOPYDB_SOURCE_PGURI: postgres://postgres:h4ckm3@source/postgres


### PR DESCRIPTION
Make the transform process a sibling process to the receive and catchup processes, where it was started by the receive process before. This refactoring simplifies our process management and prepares for being able to transition from the prefetch model to the live replay model.