### PR TITLE
Implement pgcopydb stream replay.

### DIFF
--- a/src/bin/pgcopydb/cli_stream.c
+++ b/src/bin/pgcopydb/cli_stream.c
@@ -566,7 +566,7 @@ cli_stream_setup(int argc, char **argv)
 						   1,   /* indexJobs */
 						   0,   /* skip threshold */
 						   "",  /* skip threshold pretty printed */
-						   DATA_SECTION_ALL,
+						   DATA_SECTION_NONE,
 						   streamDBoptions.snapshot,
 						   restoreOptions,
 						   false, /* roles */
@@ -621,7 +621,7 @@ cli_stream_cleanup(int argc, char **argv)
 						   1,   /* indexJobs */
 						   0,   /* skip threshold */
 						   "",  /* skip threshold pretty printed */
-						   DATA_SECTION_ALL,
+						   DATA_SECTION_NONE,
 						   streamDBoptions.snapshot,
 						   restoreOptions,
 						   false, /* roles */
@@ -692,7 +692,7 @@ cli_stream_catchup(int argc, char **argv)
 						   1,   /* indexJobs */
 						   0,   /* skip threshold */
 						   "",  /* skip threshold pretty printed */
-						   DATA_SECTION_ALL,
+						   DATA_SECTION_NONE,
 						   streamDBoptions.snapshot,
 						   restoreOptions,
 						   false, /* roles */
@@ -786,7 +786,7 @@ cli_stream_replay(int argc, char **argv)
 						   1,   /* indexJobs */
 						   0,   /* skip threshold */
 						   "",  /* skip threshold pretty printed */
-						   DATA_SECTION_ALL,
+						   DATA_SECTION_NONE,
 						   streamDBoptions.snapshot,
 						   restoreOptions,
 						   false, /* roles */
@@ -935,7 +935,7 @@ cli_stream_apply(int argc, char **argv)
 						   1,   /* indexJobs */
 						   0,   /* skip threshold */
 						   "",  /* skip threshold pretty printed */
-						   DATA_SECTION_ALL,
+						   DATA_SECTION_NONE,
 						   streamDBoptions.snapshot,
 						   restoreOptions,
 						   false, /* roles */
@@ -1056,7 +1056,7 @@ stream_start_in_mode(LogicalStreamMode mode)
 						   1,   /* indexJobs */
 						   0,   /* skip threshold */
 						   "",  /* skip threshold pretty printed */
-						   DATA_SECTION_ALL,
+						   DATA_SECTION_NONE,
 						   streamDBoptions.snapshot,
 						   restoreOptions,
 						   false, /* roles */

--- a/src/bin/pgcopydb/cli_stream.c
+++ b/src/bin/pgcopydb/cli_stream.c
@@ -812,28 +812,17 @@ cli_stream_replay(int argc, char **argv)
 						   streamDBoptions.origin,
 						   streamDBoptions.endpos,
 						   STREAM_MODE_REPLAY,
-						   streamDBoptions.stdIn,
-						   streamDBoptions.stdOut))
+						   true,  /* stdin */
+						   true)) /* stdout */
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);
 	}
 
-	/*
-	 * Now remove the possibly still existing stream context files from
-	 * previous round of operations (--resume, etc). We want to make sure that
-	 * the catchup process reads the files created on this connection.
-	 */
-	if (!stream_cleanup_context(&specs))
+	if (!followDB(&copySpecs, &specs))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);
-	}
-
-	if (!stream_replay(&specs))
-	{
-		/* errors have already been logged */
-		exit(EXIT_CODE_TARGET);
 	}
 }
 
@@ -873,16 +862,7 @@ cli_stream_transform(int argc, char **argv)
 		FILE *in = stdin;
 		FILE *out = stdout;
 
-		if (streq(sqlfilename, "-"))
-		{
-			/* switch out stream from block buffered to line buffered mode */
-			if (setvbuf(out, NULL, _IOLBF, 0) != 0)
-			{
-				log_error("Failed to set stdout to line buffered mode: %m");
-				exit(EXIT_CODE_INTERNAL_ERROR);
-			}
-		}
-		else
+		if (!streq(sqlfilename, "-"))
 		{
 			out = fopen_with_umask(sqlfilename, "w", FOPEN_FLAGS_W, 0644);
 
@@ -1000,6 +980,8 @@ cli_stream_apply(int argc, char **argv)
 			exit(EXIT_CODE_INTERNAL_ERROR);
 		}
 
+		specs.in = stdin;
+
 		if (!stream_apply_replay(&specs))
 		{
 			/* errors have already been logged */
@@ -1111,6 +1093,8 @@ stream_start_in_mode(LogicalStreamMode mode)
 	{
 		case STREAM_MODE_RECEIVE:
 		{
+			specs.out = stdout;
+
 			if (!startLogicalStreaming(&specs))
 			{
 				/* errors have already been logged */

--- a/src/bin/pgcopydb/file_utils.c
+++ b/src/bin/pgcopydb/file_utils.c
@@ -397,9 +397,10 @@ read_from_stream(FILE *stream, ReadFromStreamContext *context)
 		 * When asked_to_stop || asked_to_stop_fast still continue reading
 		 * through EOF on the input stream, then quit normally.
 		 */
-		if (asked_to_quit)
+		if (asked_to_stop || asked_to_stop_fast || asked_to_quit)
 		{
-			return false;
+			log_info("read_from_stream was asked to stop or quit");
+			return true;
 		}
 
 		FD_ZERO(&readFileDescriptorSet);
@@ -489,10 +490,11 @@ read_from_stream(FILE *stream, ReadFromStreamContext *context)
 			{
 				char *line = lines[i];
 
-				if (asked_to_quit)
+				/* on normal interrupt, finish processing the received buffer */
+				if (asked_to_stop_fast || asked_to_quit)
 				{
 					free(buf);
-					return false;
+					return true;
 				}
 
 				/* we count stream input lines as if reading from a file */

--- a/src/bin/pgcopydb/follow.c
+++ b/src/bin/pgcopydb/follow.c
@@ -201,8 +201,11 @@ followDB(CopyDataSpec *copySpecs, StreamSpecs *streamSpecs)
 bool
 follow_start_prefetch(StreamSpecs *specs)
 {
-	/* arrange to write to the receive-transform pipe */
-	specs->out = fdopen(specs->pipe_rt[1], "a");
+	if (specs->mode == STREAM_MODE_REPLAY)
+	{
+		/* arrange to write to the receive-transform pipe */
+		specs->out = fdopen(specs->pipe_rt[1], "a");
+	}
 
 	return startLogicalStreaming(specs);
 }
@@ -388,8 +391,6 @@ follow_wait_subprocesses(FollowSubProcess *prefetch,
 						  "see above for details");
 				return false;
 			}
-
-			return true;
 		}
 
 		for (int i = 0; i < count; i++)

--- a/src/bin/pgcopydb/ld_replay.c
+++ b/src/bin/pgcopydb/ld_replay.c
@@ -24,33 +24,6 @@
 #include "string_utils.h"
 
 
-/*
- * stream_replay sets 3 sub-processes up to implement "live replay" of the
- * changes from the source database directly to the target database.
- *
- * The process is split three-ways and sub-processes then communicate data
- * using a unix pipe mechanism, as if running the following synthetic command
- * line:
- *
- *    pgcopydb stream receive --to-stdout
- *  | pgcopydb stream transform - -
- *  | pgcopydb stream apply --from-stdin
- *
- */
-bool
-stream_replay(StreamSpecs *specs)
-{
-	if (specs->mode != STREAM_MODE_REPLAY)
-	{
-		log_fatal("BUG: stream_replay called with specs->mode %d", specs->mode);
-		return false;
-	}
-
-	log_error("pgcopydb stream replay is not implemented yet");
-	return false;
-}
-
-
 typedef struct ReplayStreamCtx
 {
 	StreamApplyContext applyContext;
@@ -66,13 +39,6 @@ stream_apply_replay(StreamSpecs *specs)
 {
 	ReplayStreamCtx ctx = { 0 };
 	StreamApplyContext *context = &(ctx.applyContext);
-
-	if (specs->mode == STREAM_MODE_REPLAY)
-	{
-		log_error("BUG: stream_apply_replay called with specs->mode %d",
-				  specs->mode);
-		return false;
-	}
 
 	if (!specs->stdIn)
 	{
@@ -132,7 +98,7 @@ stream_apply_replay(StreamSpecs *specs)
 		.ctx = &ctx
 	};
 
-	if (!read_from_stream(stdin, &readerContext))
+	if (!read_from_stream(specs->in, &readerContext))
 	{
 		log_error("Failed to transform JSON messages from input stream, "
 				  "see above for details");

--- a/src/bin/pgcopydb/ld_stream.h
+++ b/src/bin/pgcopydb/ld_stream.h
@@ -85,6 +85,9 @@ typedef struct StreamContext
 	bool stdIn;
 	bool stdOut;
 
+	FILE *in;
+	FILE *out;
+
 	char *jsonBuffer;           /* malloc'ed area */
 	LogicalMessageMetadata metadata;
 
@@ -276,12 +279,16 @@ typedef struct StreamSpecs
 	/* receive push json filenames to a queue for transform */
 	Queue transformQueue;
 
-	bool stdIn;                 /* read from stdin */
-	bool stdOut;                /* (also) write to stdout */
+	bool stdIn;                 /* read from stdin? */
+	bool stdOut;                /* (also) write to stdout? */
 
 	/* STREAM_MODE_REPLAY (and other operations) requires two unix pipes */
 	int pipe_rt[2];     /* receive-transform pipe */
 	int pipe_ta[2];     /* transform-apply pipe */
+
+	/* The previous pipe ends are connected to in/out for the sub-processes */
+	FILE *in;
+	FILE *out;
 } StreamSpecs;
 
 typedef struct StreamContent

--- a/src/bin/pgcopydb/ld_stream.h
+++ b/src/bin/pgcopydb/ld_stream.h
@@ -465,19 +465,36 @@ bool stream_apply_replay(StreamSpecs *specs);
 bool stream_replay_line(void *ctx, const char *line, bool *stop);
 
 /* follow.c */
+typedef bool (*FollowSubCommand) (StreamSpecs *specs);
+
+typedef struct FollowSubProcess
+{
+	char *name;
+	FollowSubCommand command;
+	pid_t pid;
+	bool exited;
+	int returnCode;
+} FollowSubProcess;
+
 bool followDB(CopyDataSpec *copySpecs, StreamSpecs *streamSpecs);
 
-bool follow_start_prefetch(StreamSpecs *specs, pid_t *pid);
-bool follow_start_transform(StreamSpecs *specs, pid_t *pid);
-bool follow_start_catchup(StreamSpecs *specs, pid_t *pid);
+bool follow_start_subprocess(StreamSpecs *specs, FollowSubProcess *subprocess);
 
-bool follow_wait_subprocesses(pid_t prefetch,
-							  pid_t transform,
-							  pid_t catchup);
+bool follow_start_prefetch(StreamSpecs *specs);
+bool follow_start_transform(StreamSpecs *specs);
+bool follow_start_catchup(StreamSpecs *specs);
 
-bool follow_terminate_subprocesses(pid_t prefetch,
-								   pid_t transform,
-								   pid_t catchup);
+void follow_exit_early(FollowSubProcess *prefetch,
+					   FollowSubProcess *transform,
+					   FollowSubProcess *catchup);
+
+bool follow_wait_subprocesses(FollowSubProcess *prefetch,
+							  FollowSubProcess *transform,
+							  FollowSubProcess *catchup);
+
+bool follow_terminate_subprocesses(FollowSubProcess *prefetch,
+								   FollowSubProcess *transform,
+								   FollowSubProcess *catchup);
 
 bool follow_wait_pid(pid_t subprocess, bool *exited, int *returnCode);
 

--- a/src/bin/pgcopydb/ld_transform.c
+++ b/src/bin/pgcopydb/ld_transform.c
@@ -225,7 +225,7 @@ typedef struct TransformStreamCtx
 bool
 stream_transform_stream(FILE *in, FILE *out)
 {
-	log_info("Starting the transform service");
+	log_notice("Starting the transform service");
 
 	TransformStreamCtx ctx = {
 		.currentTxIndex = 0,

--- a/src/bin/pgcopydb/ld_transform.c
+++ b/src/bin/pgcopydb/ld_transform.c
@@ -238,6 +238,13 @@ stream_transform_stream(FILE *in, FILE *out)
 		.ctx = &ctx
 	};
 
+	/* switch out stream from block buffered to line buffered mode */
+	if (setvbuf(out, NULL, _IOLBF, 0) != 0)
+	{
+		log_error("Failed to set stdout to line buffered mode: %m");
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+
 	if (!read_from_stream(in, &context))
 	{
 		log_error("Failed to transform JSON messages from input stream, "

--- a/src/bin/pgcopydb/pidfile.c
+++ b/src/bin/pgcopydb/pidfile.c
@@ -144,7 +144,7 @@ read_pidfile(const char *pidfile, pid_t *pid)
 		*pid = 0;
 
 		log_debug("Found a stale pidfile at \"%s\"", pidfile);
-		log_notice("Removing the stale pid file \"%s\"", pidfile);
+		log_debug("Removing the stale pid file \"%s\"", pidfile);
 
 		/*
 		 * We must return false here, after having determined that the

--- a/tests/cdc-low-level/copydb.sh
+++ b/tests/cdc-low-level/copydb.sh
@@ -93,5 +93,15 @@ pgcopydb stream receive --debug --resume --endpos "${lsn}" --to-stdout \
  | pgcopydb stream transform --debug --endpos "${lsn}" - -             \
  | pgcopydb stream apply --debug --resume --endpos "${lsn}" -
 
+#
+# now the same thing, this time using the stream replay command
+#
+psql -d ${PGCOPYDB_SOURCE_PGURI} -f /usr/src/pgcopydb/dml.sql
+
+# grab the current LSN, it's going to be our streaming end position
+lsn=`psql -At -d ${PGCOPYDB_SOURCE_PGURI} -c 'select pg_current_wal_lsn()'`
+
+pgcopydb stream replay --debug --resume --endpos "${lsn}"
+
 # cleanup
 pgcopydb stream cleanup


### PR DESCRIPTION
The idea is to have an integrated command that does the same as the following unix pipe command:

    $ pgcopydb stream receive --to-stdout
      | pgcopydb stream transform - -
	  | pgcopydb stream apply -

The command takes care of setting up the unix pipes and the process tree internally. Makes it easier to use, and the implementation is needed for intagration in the end-user API (pgcopydb clone --follow) anyway.