### PR TITLE
Automatically switch from prefetch/catchup to live replay mode.

### DIFF
--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -248,6 +248,7 @@ bool copydb_init_workdir(CopyDataSpec *copySpecs,
 						 bool createWorkDir);
 
 bool copydb_acquire_pidfile(CopyFilePaths *cfPaths, char *serviceName);
+bool copydb_create_pidfile(const char *pidfile, pid_t pid, bool createPidFile);
 
 bool copydb_prepare_filepaths(CopyFilePaths *cfPaths,
 							  const char *topdir,

--- a/src/bin/pgcopydb/defaults.h
+++ b/src/bin/pgcopydb/defaults.h
@@ -57,7 +57,7 @@
 #define REPLICATION_PLUGIN "test_decoding"
 #define REPLICATION_SLOT_NAME "pgcopydb"
 
-#define CATCHINGUP_SLEEP_MS 10 * 1000 /* 10s */
+#define CATCHINGUP_SLEEP_MS 1 * 1000 /* 10s */
 
 /* internal default for allocating strings  */
 #define BUFSIZE 1024

--- a/src/bin/pgcopydb/file_utils.c
+++ b/src/bin/pgcopydb/file_utils.c
@@ -475,7 +475,6 @@ read_from_stream(FILE *stream, ReadFromStreamContext *context)
 			{
 				free(buf);
 				doneReading = true;
-				log_info("read_from_stream: read 0 bytes");
 				continue;
 			}
 			else if (bytes == s)

--- a/src/bin/pgcopydb/file_utils.h
+++ b/src/bin/pgcopydb/file_utils.h
@@ -68,6 +68,7 @@ bool search_path_first(const char *filename, char *result, int logLevel);
 bool search_path(const char *filename, SearchPath *result);
 bool search_path_deduplicate_symlinks(SearchPath *results, SearchPath *dedup);
 bool unlink_file(const char *filename);
+void close_fd_or_exit(int fd);
 bool set_program_absolute_path(char *program, int size);
 bool normalize_filename(const char *filename, char *dst, int size);
 

--- a/src/bin/pgcopydb/follow.c
+++ b/src/bin/pgcopydb/follow.c
@@ -259,7 +259,7 @@ follow_get_sentinel(StreamSpecs *specs, CopyDBSentinel *sentinel)
 
 
 /*
- * follow_main_loop Implements the main loop for the follow sub-process
+ * follow_main_loop implements the main loop for the follow sub-process
  * management. It loops between two modes of operations:
  *
  *  1. prefetch + catchup

--- a/src/bin/pgcopydb/indexes.c
+++ b/src/bin/pgcopydb/indexes.c
@@ -723,7 +723,7 @@ copydb_create_index(const char *pguri,
 		}
 	}
 
-	log_info("%s", summary->command);
+	log_notice("%s", summary->command);
 
 	if (!pgsql_init(&dst, (char *) pguri, PGSQL_CONN_TARGET))
 	{
@@ -1123,8 +1123,8 @@ copydb_create_constraints(CopyDataSpec *specs, SourceTable *table)
 			if (strcmp(index->constraintName, dstIndex->constraintName) == 0)
 			{
 				foundConstraintOnTarget = true;
-				log_info("Found constraint \"%s\" on target, skipping",
-						 index->constraintName);
+				log_notice("Found constraint \"%s\" on target, skipping",
+						   index->constraintName);
 				break;
 			}
 		}
@@ -1140,7 +1140,7 @@ copydb_create_constraints(CopyDataSpec *specs, SourceTable *table)
 
 		if (!foundConstraintOnTarget)
 		{
-			log_info("%s", summary.command);
+			log_notice("%s", summary.command);
 
 			/*
 			 * Constraints are built by the CREATE INDEX worker process that is

--- a/src/bin/pgcopydb/ld_apply.c
+++ b/src/bin/pgcopydb/ld_apply.c
@@ -150,7 +150,7 @@ stream_apply_catchup(StreamSpecs *specs)
 		{
 			context.reachedEndPos = true;
 
-			log_info("Applied reached end position %X/%X at %X/%X",
+			log_info("Apply reached end position %X/%X at %X/%X",
 					 LSN_FORMAT_ARGS(context.endpos),
 					 LSN_FORMAT_ARGS(context.previousLSN));
 		}
@@ -398,7 +398,7 @@ stream_apply_sql(StreamApplyContext *context,
 	{
 		case STREAM_ACTION_SWITCH:
 		{
-			log_debug("apply: SWITCH from %X/%X to %X/%X",
+			log_debug("SWITCH from %X/%X to %X/%X",
 					  LSN_FORMAT_ARGS(context->previousLSN),
 					  LSN_FORMAT_ARGS(metadata->lsn));
 
@@ -437,10 +437,6 @@ stream_apply_sql(StreamApplyContext *context,
 				context->endpos <= metadata->lsn)
 			{
 				context->reachedEndPos = true;
-
-				log_info("Apply reached end position %X/%X at %X/%X.",
-						 LSN_FORMAT_ARGS(context->endpos),
-						 LSN_FORMAT_ARGS(metadata->lsn));
 				break;
 			}
 
@@ -508,9 +504,9 @@ stream_apply_sql(StreamApplyContext *context,
 			{
 				context->reachedEndPos = true;
 
-				log_info("Apply reached end position %X/%X at %X/%X",
-						 LSN_FORMAT_ARGS(context->endpos),
-						 LSN_FORMAT_ARGS(context->previousLSN));
+				log_notice("Apply reached end position %X/%X at %X/%X",
+						   LSN_FORMAT_ARGS(context->endpos),
+						   LSN_FORMAT_ARGS(context->previousLSN));
 				break;
 			}
 
@@ -554,15 +550,17 @@ stream_apply_sql(StreamApplyContext *context,
 				context->endpos < metadata->lsn)
 			{
 				context->reachedEndPos = true;
-
-				log_info("Apply reached end position %X/%X at %X/%X.",
-						 LSN_FORMAT_ARGS(context->endpos),
-						 LSN_FORMAT_ARGS(metadata->lsn));
 				break;
 			}
 
 			/* actually skip this one if we didn't reach start pos yet */
 			if (!context->reachedStartPos)
+			{
+				return true;
+			}
+
+			/* skip KEEPALIVE message that won't make progress */
+			if (metadata->lsn == context->previousLSN)
 			{
 				return true;
 			}
@@ -606,9 +604,9 @@ stream_apply_sql(StreamApplyContext *context,
 			{
 				context->reachedEndPos = true;
 
-				log_info("Apply reached end position %X/%X at %X/%X",
-						 LSN_FORMAT_ARGS(context->endpos),
-						 LSN_FORMAT_ARGS(context->previousLSN));
+				log_notice("Apply reached end position %X/%X at %X/%X",
+						   LSN_FORMAT_ARGS(context->endpos),
+						   LSN_FORMAT_ARGS(context->previousLSN));
 				break;
 			}
 

--- a/src/bin/pgcopydb/ld_replay.c
+++ b/src/bin/pgcopydb/ld_replay.c
@@ -177,13 +177,14 @@ stream_replay_line(void *ctx, const char *line, bool *stop)
 	 * When syncing with the pgcopydb sentinel we might receive a
 	 * new endpos, and it might mean we're done already.
 	 */
-	if (context->endpos != InvalidXLogRecPtr &&
-		context->endpos <= context->previousLSN)
+	if (context->reachedEndPos ||
+		(context->endpos != InvalidXLogRecPtr &&
+		 context->endpos <= context->previousLSN))
 	{
 		*stop = true;
 		context->reachedEndPos = true;
 
-		log_info("Applied reached end position %X/%X at %X/%X",
+		log_info("Replay reached end position %X/%X at %X/%X",
 				 LSN_FORMAT_ARGS(context->endpos),
 				 LSN_FORMAT_ARGS(context->previousLSN));
 	}

--- a/src/bin/pgcopydb/ld_replay.c
+++ b/src/bin/pgcopydb/ld_replay.c
@@ -83,6 +83,15 @@ stream_apply_replay(StreamSpecs *specs)
 
 	if (context->endpos != InvalidXLogRecPtr)
 	{
+		if (context->endpos <= context->previousLSN)
+		{
+			log_info("Current endpos %X/%X was previously reached at %X/%X",
+					 LSN_FORMAT_ARGS(context->endpos),
+					 LSN_FORMAT_ARGS(context->previousLSN));
+
+			return true;
+		}
+
 		log_info("Replaying changes from LSN %X/%X up to endpos LSN %X/%X",
 				 LSN_FORMAT_ARGS(context->previousLSN),
 				 LSN_FORMAT_ARGS(context->endpos));
@@ -168,20 +177,15 @@ stream_replay_line(void *ctx, const char *line, bool *stop)
 	 * When syncing with the pgcopydb sentinel we might receive a
 	 * new endpos, and it might mean we're done already.
 	 */
-	if (!context->reachedEndPos &&
-		context->endpos != InvalidXLogRecPtr &&
+	if (context->endpos != InvalidXLogRecPtr &&
 		context->endpos <= context->previousLSN)
 	{
+		*stop = true;
 		context->reachedEndPos = true;
 
 		log_info("Applied reached end position %X/%X at %X/%X",
 				 LSN_FORMAT_ARGS(context->endpos),
 				 LSN_FORMAT_ARGS(context->previousLSN));
-	}
-
-	if (context->reachedEndPos)
-	{
-		*stop = true;
 	}
 
 	return true;

--- a/src/bin/pgcopydb/ld_stream.h
+++ b/src/bin/pgcopydb/ld_stream.h
@@ -539,6 +539,10 @@ bool follow_export_snapshot(CopyDataSpec *copySpecs, StreamSpecs *streamSpecs);
 bool follow_setup_databases(CopyDataSpec *copySpecs, StreamSpecs *streamSpecs);
 bool follow_reset_sequences(CopyDataSpec *copySpecs, StreamSpecs *streamSpecs);
 
+bool follow_init_sentinel(StreamSpecs *specs, CopyDBSentinel *sentinel);
+bool follow_get_sentinel(StreamSpecs *specs, CopyDBSentinel *sentinel);
+bool follow_main_loop(CopyDataSpec *copySpecs, StreamSpecs *streamSpecs);
+
 bool followDB(CopyDataSpec *copySpecs, StreamSpecs *streamSpecs);
 
 bool follow_start_subprocess(StreamSpecs *specs, FollowSubProcess *subprocess);

--- a/src/bin/pgcopydb/ld_stream.h
+++ b/src/bin/pgcopydb/ld_stream.h
@@ -100,6 +100,7 @@ typedef struct StreamContext
 	char walFileName[MAXPGPATH];
 	char sqlFileName[MAXPGPATH];
 	FILE *jsonFile;
+	FILE *sqlFile;
 
 	StreamCounters counters;
 } StreamContext;
@@ -348,6 +349,10 @@ bool stream_init_specs(StreamSpecs *specs,
 					   bool stdIn,
 					   bool stdOut);
 
+bool stream_init_for_mode(StreamSpecs *specs, LogicalStreamMode mode);
+
+char * LogicalStreamModeToString(LogicalStreamMode mode);
+
 bool stream_init_context(StreamContext *privateContext, StreamSpecs *specs);
 
 bool startLogicalStreaming(StreamSpecs *specs);
@@ -420,11 +425,16 @@ bool stream_compute_pathnames(uint32_t WalSegSz,
 							  char *walFileName,
 							  char *sqlFileName);
 
-bool stream_transform_stream(FILE * in, FILE *out);
+bool stream_transform_stream(StreamSpecs *specs);
 bool stream_transform_line(void *ctx, const char *line, bool *stop);
+
 bool stream_transform_message(char *message,
-							  LogicalMessage *currentMsg,
-							  bool *commit);
+							  LogicalMessageMetadata *metadata,
+							  LogicalMessage *currentMsg);
+
+bool stream_transform_rotate(StreamContext *privateContext,
+							 LogicalMessageMetadata *metadata);
+
 bool stream_transform_file(char *jsonfilename, char *sqlfilename);
 bool stream_write_message(FILE *out, LogicalMessage *msg);
 bool stream_write_transaction(FILE *out, LogicalTransaction *tx);

--- a/src/bin/pgcopydb/ld_transform.c
+++ b/src/bin/pgcopydb/ld_transform.c
@@ -34,6 +34,276 @@
 #include "summary.h"
 
 
+typedef struct TransformStreamCtx
+{
+	StreamContext *context;
+	uint64_t currentMsgIndex;
+	LogicalMessage currentMsg;
+	LogicalMessageMetadata metadata;
+} TransformStreamCtx;
+
+
+/*
+ * stream_transform_stream transforms a JSON formatted input stream (read line
+ * by line) as received from the wal2json logical decoding plugin into an SQL
+ * stream ready for applying to the target database.
+ */
+bool
+stream_transform_stream(StreamSpecs *specs)
+{
+	log_notice("Starting the transform service");
+
+	StreamContext *privateContext =
+		(StreamContext *) calloc(1, sizeof(StreamContext));
+
+	if (!stream_init_context(privateContext, specs))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* we need timeline and wal_segment_size to compute WAL filenames */
+	uint32_t WalSegSz;
+	IdentifySystem system = { 0 };
+
+	if (!stream_read_context(&(specs->paths),
+							 &system,
+							 &WalSegSz))
+	{
+		log_error("Failed to read the streaming context information "
+				  "from the source database, see above for details");
+		return false;
+	}
+
+	privateContext->WalSegSz = WalSegSz;
+	privateContext->timeline = system.timeline;
+
+	log_debug("Source database wal_segment_size is %u", WalSegSz);
+	log_debug("Source database timeline is %d", privateContext->timeline);
+
+	TransformStreamCtx ctx = {
+		.context = privateContext,
+		.currentMsgIndex = 0,
+		.currentMsg = { 0 },
+		.metadata = { 0 }
+	};
+
+	ReadFromStreamContext context = {
+		.callback = stream_transform_line,
+		.ctx = &ctx
+	};
+
+	/* switch out stream from block buffered to line buffered mode */
+	if (setvbuf(privateContext->out, NULL, _IOLBF, 0) != 0)
+	{
+		log_error("Failed to set stdout to line buffered mode: %m");
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+
+	if (!read_from_stream(privateContext->in, &context))
+	{
+		log_error("Failed to transform JSON messages from input stream, "
+				  "see above for details");
+		return false;
+	}
+
+	/* we might have stopped reading mid-file, let's close it. */
+	if (privateContext->sqlFile != NULL)
+	{
+		if (fclose(privateContext->sqlFile) != 0)
+		{
+			log_error("Failed to close file \"%s\": %m",
+					  privateContext->sqlFileName);
+			return false;
+		}
+
+		/* reset the jsonFile FILE * pointer to NULL, it's closed now */
+		privateContext->sqlFile = NULL;
+
+		log_info("Closed file \"%s\"", privateContext->sqlFileName);
+	}
+
+	log_notice("Transformed %lld messages and %lld transactions",
+			   (long long) context.lineno,
+			   (long long) ctx.currentMsgIndex + 1);
+
+	return true;
+}
+
+
+/*
+ * stream_transform_line is a callback function for the ReadFromStreamContext
+ * and read_from_stream infrastructure. It's called on each line read from a
+ * stream such as a unix pipe.
+ */
+bool
+stream_transform_line(void *ctx, const char *line, bool *stop)
+{
+	TransformStreamCtx *transformCtx = (TransformStreamCtx *) ctx;
+	StreamContext *privateContext = transformCtx->context;
+	LogicalMessage *currentMsg = &(transformCtx->currentMsg);
+	LogicalMessageMetadata *metadata = &(transformCtx->metadata);
+
+	static uint64_t lineno = 0;
+
+	log_trace("stream_transform_line[%lld]: %s", (long long) ++lineno, line);
+
+	/* clean-up from whatever was read previously */
+	LogicalMessageMetadata empty = { 0 };
+	*metadata = empty;
+
+	if (!stream_transform_message((char *) line, metadata, currentMsg))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	if (!stream_transform_rotate(privateContext, metadata))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/*
+	 * Is it time to close the current message and prepare a new one?
+	 */
+	if (metadata->action == STREAM_ACTION_COMMIT ||
+		metadata->action == STREAM_ACTION_KEEPALIVE ||
+		metadata->action == STREAM_ACTION_SWITCH)
+	{
+		/* now write the transaction out */
+		if (!stream_write_message(privateContext->out, currentMsg))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+
+		/* now write the transaction out also to file on-disk */
+		if (!stream_write_message(privateContext->sqlFile, currentMsg))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+
+		(void) FreeLogicalMessage(currentMsg);
+
+		/* then prepare a new one, reusing the same memory area */
+		LogicalMessage empty = { 0 };
+
+		*currentMsg = empty;
+		++(transformCtx->currentMsgIndex);
+	}
+
+	return true;
+}
+
+
+/*
+ * stream_transform_message transforms a single JSON message from our streaming
+ * output into a SQL statement, and appends it to the given opened transaction.
+ */
+bool
+stream_transform_message(char *message,
+						 LogicalMessageMetadata *metadata,
+						 LogicalMessage *currentMsg)
+{
+	JSON_Value *json = json_parse_string(message);
+
+	if (!parseMessageMetadata(metadata, message, json, false))
+	{
+		/* errors have already been logged */
+		json_value_free(json);
+		return false;
+	}
+
+	if (!parseMessage(currentMsg, metadata, message, json))
+	{
+		log_error("Failed to parse JSON message: %s", message);
+		json_value_free(json);
+		return false;
+	}
+
+	json_value_free(json);
+
+	return true;
+}
+
+
+/*
+ * stream_transform_rotate prepares the output file where we store the SQL
+ * commands on-disk, which is important for restartability of the process.
+ */
+bool
+stream_transform_rotate(StreamContext *privateContext,
+						LogicalMessageMetadata *metadata)
+{
+	/*
+	 * When streaming from stdin to stdout (or other streams), we also maintain
+	 * our SQL file on-disk using the WAL file naming strategy from Postgres,
+	 * allowing the whole logical decoding follower client to restart.
+	 */
+	char jsonFileName[MAXPGPATH] = { 0 };
+	char sqlFileName[MAXPGPATH] = { 0 };
+
+	if (!stream_compute_pathnames(privateContext->WalSegSz,
+								  privateContext->timeline,
+								  metadata->lsn,
+								  privateContext->paths.dir,
+								  jsonFileName,
+								  sqlFileName))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* in most cases, the file name is still the same */
+	if (streq(privateContext->sqlFileName, sqlFileName))
+	{
+		if (privateContext->sqlFile == NULL)
+		{
+			log_fatal("BUG: privateContext->sqlFile == NULL");
+			return false;
+		}
+		return true;
+	}
+
+	/* if we had a SQL file opened, close it now */
+	if (!IS_EMPTY_STRING_BUFFER(privateContext->sqlFileName) &&
+		privateContext->sqlFile != NULL)
+	{
+		log_debug("Closing file \"%s\"", privateContext->sqlFileName);
+
+		if (fclose(privateContext->sqlFile) != 0)
+		{
+			log_error("Failed to close file \"%s\": %m",
+					  privateContext->sqlFileName);
+			return false;
+		}
+
+		/* reset the jsonFile FILE * pointer to NULL, it's closed now */
+		privateContext->sqlFile = NULL;
+
+		log_info("Closed file \"%s\"", privateContext->sqlFileName);
+	}
+
+	log_info("Now transforming changes to \"%s\"", sqlFileName);
+	strlcpy(privateContext->walFileName, jsonFileName, MAXPGPATH);
+	strlcpy(privateContext->sqlFileName, sqlFileName, MAXPGPATH);
+
+	privateContext->sqlFile =
+		fopen_with_umask(sqlFileName, "ab", FOPEN_FLAGS_A, 0644);
+
+	if (privateContext->sqlFile == NULL)
+	{
+		/* errors have already been logged */
+		log_error("Failed to open file \"%s\": %m", sqlFileName);
+		return false;
+	}
+
+	return true;
+}
+
+
 /*
  * stream_transform_worker is a worker process that loops over messages
  * received from a queue, each message contains the WAL.json and the WAL.sql
@@ -70,15 +340,16 @@ stream_transform_worker(StreamSpecs *specs)
 	{
 		QMessage mesg = { 0 };
 
-		if (asked_to_stop || asked_to_stop_fast || asked_to_quit)
-		{
-			return false;
-		}
-
 		if (!queue_receive(transformQueue, &mesg))
 		{
 			/* errors have already been logged */
 			break;
+		}
+
+		if (asked_to_stop || asked_to_stop_fast || asked_to_quit)
+		{
+			log_debug("stream_transform_worker was asked to stop");
+			return true;
 		}
 
 		switch (mesg.type)
@@ -154,7 +425,7 @@ stream_compute_pathnames(uint32_t WalSegSz,
 	XLByteToSeg(lsn, segno, WalSegSz);
 	XLogFileName(wal, timeline, segno, WalSegSz);
 
-	log_debug("stream_compute_pathnames: %X/%X: %s", LSN_FORMAT_ARGS(lsn), wal);
+	log_trace("stream_compute_pathnames: %X/%X: %s", LSN_FORMAT_ARGS(lsn), wal);
 
 	sformat(walFileName, MAXPGPATH, "%s/%s.json", dir, wal);
 	sformat(sqlFileName, MAXPGPATH, "%s/%s.sql", dir, wal);
@@ -203,145 +474,6 @@ stream_transform_send_stop(Queue *queue)
 	{
 		/* errors have already been logged */
 		return false;
-	}
-
-	return true;
-}
-
-
-typedef struct TransformStreamCtx
-{
-	uint64_t currentMsgIndex;
-	LogicalMessage currentMsg;
-	FILE *out;
-} TransformStreamCtx;
-
-
-/*
- * stream_transform_stream transforms a JSON formatted input stream (read line
- * by line) as received from the wal2json logical decoding plugin into an SQL
- * stream ready for applying to the target database.
- */
-bool
-stream_transform_stream(FILE *in, FILE *out)
-{
-	log_notice("Starting the transform service");
-
-	TransformStreamCtx ctx = {
-		.currentMsgIndex = 0,
-		.currentMsg = { 0 },
-		.out = out
-	};
-
-	ReadFromStreamContext context = {
-		.callback = stream_transform_line,
-		.ctx = &ctx
-	};
-
-	/* switch out stream from block buffered to line buffered mode */
-	if (setvbuf(out, NULL, _IOLBF, 0) != 0)
-	{
-		log_error("Failed to set stdout to line buffered mode: %m");
-		exit(EXIT_CODE_INTERNAL_ERROR);
-	}
-
-	if (!read_from_stream(in, &context))
-	{
-		log_error("Failed to transform JSON messages from input stream, "
-				  "see above for details");
-		return false;
-	}
-
-	log_notice("Transformed %lld messages and %lld transactions",
-			   (long long) context.lineno,
-			   (long long) ctx.currentMsgIndex + 1);
-
-	return true;
-}
-
-
-/*
- * stream_transform_line is a callback function for the ReadFromStreamContext
- * and read_from_stream infrastructure. It's called on each line read from a
- * stream such as a unix pipe.
- */
-bool
-stream_transform_line(void *ctx, const char *line, bool *stop)
-{
-	TransformStreamCtx *transformCtx = (TransformStreamCtx *) ctx;
-	LogicalMessage *currentMsg = &(transformCtx->currentMsg);
-
-	static uint64_t lineno = 0;
-
-	log_trace("stream_transform_line[%lld]: %s", (long long) ++lineno, line);
-
-	bool commit = false;
-
-	if (!stream_transform_message((char *) line, currentMsg, &commit))
-	{
-		/* errors have already been logged */
-		return false;
-	}
-
-	/*
-	 * Prepare a new message when we just read the COMMIT message of an
-	 * opened transaction, closing it, or when we just read a standalone
-	 * non-transactional message (such as a KEEPALIVE or a SWITCH WAL
-	 * message).
-	 */
-	if (!currentMsg->isTransaction || commit)
-	{
-		/* now write the message out */
-		if (!stream_write_message(transformCtx->out, currentMsg))
-		{
-			/* errors have already been logged */
-			return false;
-		}
-
-		(void) FreeLogicalMessage(currentMsg);
-
-		/* then prepare a new one, reusing the same memory area */
-		LogicalMessage empty = { 0 };
-
-		*currentMsg = empty;
-		++(transformCtx->currentMsgIndex);
-	}
-
-	return true;
-}
-
-
-/*
- * stream_transform_message transforms a single JSON message from our streaming
- * output into a SQL statement, and appends it to the given opened transaction.
- */
-bool
-stream_transform_message(char *message,
-						 LogicalMessage *currentMsg,
-						 bool *commit)
-{
-	LogicalMessageMetadata metadata = { 0 };
-	JSON_Value *json = json_parse_string(message);
-
-	if (!parseMessageMetadata(&metadata, message, json, false))
-	{
-		/* errors have already been logged */
-		json_value_free(json);
-		return false;
-	}
-
-	if (!parseMessage(currentMsg, &metadata, message, json))
-	{
-		log_error("Failed to parse JSON message: %s", message);
-		json_value_free(json);
-		return false;
-	}
-
-	json_value_free(json);
-
-	if (metadata.action == STREAM_ACTION_COMMIT)
-	{
-		*commit = true;
 	}
 
 	return true;

--- a/src/bin/pgcopydb/ld_transform.c
+++ b/src/bin/pgcopydb/ld_transform.c
@@ -118,7 +118,7 @@ stream_transform_stream(StreamSpecs *specs)
 		/* reset the jsonFile FILE * pointer to NULL, it's closed now */
 		privateContext->sqlFile = NULL;
 
-		log_info("Closed file \"%s\"", privateContext->sqlFileName);
+		log_notice("Closed file \"%s\"", privateContext->sqlFileName);
 	}
 
 	log_notice("Transformed %lld messages and %lld transactions",
@@ -291,10 +291,10 @@ stream_transform_rotate(StreamContext *privateContext,
 		/* reset the jsonFile FILE * pointer to NULL, it's closed now */
 		privateContext->sqlFile = NULL;
 
-		log_info("Closed file \"%s\"", privateContext->sqlFileName);
+		log_notice("Closed file \"%s\"", privateContext->sqlFileName);
 	}
 
-	log_info("Now transforming changes to \"%s\"", sqlFileName);
+	log_notice("Now transforming changes to \"%s\"", sqlFileName);
 	strlcpy(privateContext->walFileName, jsonFileName, MAXPGPATH);
 	strlcpy(privateContext->sqlFileName, sqlFileName, MAXPGPATH);
 

--- a/src/bin/pgcopydb/ld_transform.c
+++ b/src/bin/pgcopydb/ld_transform.c
@@ -51,8 +51,6 @@ typedef struct TransformStreamCtx
 bool
 stream_transform_stream(StreamSpecs *specs)
 {
-	log_notice("Starting the transform service");
-
 	StreamContext *privateContext =
 		(StreamContext *) calloc(1, sizeof(StreamContext));
 
@@ -192,6 +190,16 @@ stream_transform_line(void *ctx, const char *line, bool *stop)
 
 		*currentMsg = empty;
 		++(transformCtx->currentMsgIndex);
+	}
+
+	if (privateContext->endpos != InvalidXLogRecPtr &&
+		privateContext->endpos <= metadata->lsn)
+	{
+		*stop = true;
+
+		log_info("Transform reached end position %X/%X at %X/%X",
+				 LSN_FORMAT_ARGS(privateContext->endpos),
+				 LSN_FORMAT_ARGS(metadata->lsn));
 	}
 
 	return true;

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -3697,17 +3697,6 @@ pgsqlSendFeedback(LogicalStreamClient *client,
 {
 	PGconn *conn = client->pgsql.connection;
 
-	/* call the callback function from the streaming client first */
-	if ((*client->feedbackFunction)(context))
-	{
-		/* we might have a new endpos from the client callback */
-		if (context->endpos != InvalidXLogRecPtr &&
-			context->endpos != client->endpos)
-		{
-			client->endpos = context->endpos;
-		}
-	}
-
 	char replybuf[1 + 8 + 8 + 8 + 8 + 1];
 	int len = 0;
 
@@ -3721,15 +3710,6 @@ pgsqlSendFeedback(LogicalStreamClient *client,
 		client->feedback.flushed_lsn == client->current.flushed_lsn)
 	{
 		return true;
-	}
-
-	if (client->current.written_lsn != InvalidXLogRecPtr ||
-		client->current.flushed_lsn != InvalidXLogRecPtr)
-	{
-		log_info("Report write_lsn %X/%X, flush_lsn %X/%X, replay_lsn %X/%X",
-				 LSN_FORMAT_ARGS(client->current.written_lsn),
-				 LSN_FORMAT_ARGS(client->current.flushed_lsn),
-				 LSN_FORMAT_ARGS(client->current.applied_lsn));
 	}
 
 	replybuf[len] = 'r';
@@ -3755,6 +3735,26 @@ pgsqlSendFeedback(LogicalStreamClient *client,
 		log_error("could not send feedback packet: %s",
 				  PQerrorMessage(conn));
 		return false;
+	}
+
+	/* call the callback function from the streaming client first */
+	if ((*client->feedbackFunction)(context))
+	{
+		/* we might have a new endpos from the client callback */
+		if (context->endpos != InvalidXLogRecPtr &&
+			context->endpos != client->endpos)
+		{
+			client->endpos = context->endpos;
+		}
+	}
+
+	if (client->current.written_lsn != InvalidXLogRecPtr ||
+		client->current.flushed_lsn != InvalidXLogRecPtr)
+	{
+		log_info("Report write_lsn %X/%X, flush_lsn %X/%X, replay_lsn %X/%X",
+				 LSN_FORMAT_ARGS(client->current.written_lsn),
+				 LSN_FORMAT_ARGS(client->current.flushed_lsn),
+				 LSN_FORMAT_ARGS(client->current.applied_lsn));
 	}
 
 	return true;
@@ -3798,7 +3798,12 @@ prepareToTerminate(LogicalStreamClient *client, bool keepalive, XLogRecPtr lsn)
 	(void) PQputCopyEnd(conn, NULL);
 	(void) PQflush(conn);
 
-	if (keepalive)
+	if (asked_to_stop || asked_to_stop_fast || asked_to_quit)
+	{
+		log_debug("received signal to stop streaming, currently at %X/%X",
+				  LSN_FORMAT_ARGS(client->current.written_lsn));
+	}
+	else if (keepalive)
 	{
 		log_debug("end position %X/%X reached by keepalive",
 				  LSN_FORMAT_ARGS(client->endpos));
@@ -4533,7 +4538,7 @@ pgsql_sync_sentinel_recv(PGSQL *pgsql,
 
 	char *sql =
 		"update pgcopydb.sentinel "
-		"set write_lsn = $1, flush_lsn = $2 "
+		"set startpos = $1, write_lsn = $1, flush_lsn = $2 "
 		"returning startpos, endpos, apply, write_lsn, flush_lsn, replay_lsn";
 
 	char writeLSN[PG_LSN_MAXLENGTH] = { 0 };

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -1213,7 +1213,7 @@ pgsql_execute_with_params(PGSQL *pgsql, const char *sql, int paramCount,
 			return false;
 		}
 
-		log_debug("%s", debugParameters->data);
+		log_notice("%s", debugParameters->data);
 	}
 
 	if (paramCount == 0)

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -3745,13 +3745,16 @@ pgsqlSendFeedback(LogicalStreamClient *client,
 			context->endpos != client->endpos)
 		{
 			client->endpos = context->endpos;
+			log_notice("endpos is now set to %X/%X",
+					   LSN_FORMAT_ARGS(client->endpos));
 		}
 	}
 
 	if (client->current.written_lsn != InvalidXLogRecPtr ||
 		client->current.flushed_lsn != InvalidXLogRecPtr)
 	{
-		log_info("Report write_lsn %X/%X, flush_lsn %X/%X, replay_lsn %X/%X",
+		/* use same terms as in pg_stat_replication view */
+		log_info("Reported write_lsn %X/%X, flush_lsn %X/%X, replay_lsn %X/%X",
 				 LSN_FORMAT_ARGS(client->current.written_lsn),
 				 LSN_FORMAT_ARGS(client->current.flushed_lsn),
 				 LSN_FORMAT_ARGS(client->current.applied_lsn));

--- a/src/bin/pgcopydb/pidfile.c
+++ b/src/bin/pgcopydb/pidfile.c
@@ -168,7 +168,7 @@ read_pidfile(const char *pidfile, pid_t *pid)
 bool
 remove_pidfile(const char *pidfile)
 {
-	if (remove(pidfile) != 0)
+	if (!unlink_file(pidfile))
 	{
 		log_error("Failed to remove pid file \"%s\": %m", pidfile);
 		return false;

--- a/src/bin/pgcopydb/queue_utils.c
+++ b/src/bin/pgcopydb/queue_utils.c
@@ -113,7 +113,7 @@ queue_receive(Queue *queue, QMessage *msg)
 	do {
 		if (asked_to_stop || asked_to_stop_fast || asked_to_quit)
 		{
-			return false;
+			return true;
 		}
 
 		if (firstLoop)

--- a/src/bin/pgcopydb/table-data.c
+++ b/src/bin/pgcopydb/table-data.c
@@ -524,8 +524,8 @@ copydb_table_is_being_processed(CopyDataSpec *specs,
 {
 	if (specs->dirState.tableCopyIsDone)
 	{
-		log_info("Skipping table %s, already done on a previous run",
-				 tableSpecs->qname);
+		log_notice("Skipping table %s, already done on a previous run",
+				   tableSpecs->qname);
 
 		*isDone = true;
 		*isBeingProcessed = false;
@@ -863,7 +863,7 @@ copydb_copy_table(CopyDataSpec *specs, CopyTableDataSpec *tableSpecs)
 	}
 
 	/* Now copy the data from source to target */
-	log_info("%s", summary->command);
+	log_notice("%s", summary->command);
 
 	/* COPY FROM tablename, or maybe COPY FROM (SELECT ... WHERE ...) */
 	char *copySource = tableSpecs->qname;

--- a/src/bin/pgcopydb/vacuum.c
+++ b/src/bin/pgcopydb/vacuum.c
@@ -190,7 +190,7 @@ vacuum_analyze_table_by_oid(CopyDataSpec *specs, uint32_t oid)
 			table.nspname,
 			table.relname);
 
-	log_info("%s;", vacuum);
+	log_notice("%s;", vacuum);
 
 	if (!pgsql_execute(&dst, vacuum))
 	{

--- a/tests/cdc-endpos-between-transaction/copydb.sh
+++ b/tests/cdc-endpos-between-transaction/copydb.sh
@@ -78,6 +78,9 @@ DIFFOPTS='-I BEGIN -I COMMIT -I KEEPALIVE -I SWITCH'
 
 diff ${DIFFOPTS} /usr/src/pgcopydb/${SQLFILE} ${SHAREDIR}/${SQLFILENAME}
 
+# now allow for replaying/catching-up changes
+pgcopydb stream sentinel set apply
+
 # now apply the SQL file to the target database shouldn't take more than 2s
 timeout 5s pgcopydb stream catchup --resume --endpos "${lsn}" -vv
 

--- a/tests/cdc-test-decoding/copydb.sh
+++ b/tests/cdc-test-decoding/copydb.sh
@@ -69,6 +69,9 @@ DIFFOPTS='-I BEGIN -I COMMIT -I KEEPALIVE -I SWITCH'
 
 diff ${DIFFOPTS} /usr/src/pgcopydb/${SQLFILE} ${SHAREDIR}/${SQLFILENAME}
 
+# now allow for replaying/catching-up changes
+pgcopydb stream sentinel set apply
+
 # now apply the SQL file to the target database
 pgcopydb stream catchup --resume --endpos "${lsn}" -vv
 

--- a/tests/cdc-wal2json/copydb.sh
+++ b/tests/cdc-wal2json/copydb.sh
@@ -68,6 +68,9 @@ DIFFOPTS='-I BEGIN -I COMMIT -I KEEPALIVE -I SWITCH'
 
 diff ${DIFFOPTS} /usr/src/pgcopydb/${SQLFILE} ${SHAREDIR}/${SQLFILENAME}
 
+# now allow for replaying/catching-up changes
+pgcopydb stream sentinel set apply
+
 # now apply the SQL file to the target database
 pgcopydb stream catchup --resume --endpos "${lsn}" -vv
 

--- a/tests/follow-wal2json/copydb.sh
+++ b/tests/follow-wal2json/copydb.sh
@@ -20,7 +20,7 @@ psql -o /tmp/d.out -d ${PGCOPYDB_SOURCE_PGURI} -1 -f /usr/src/pagila/pagila-data
 psql -d ${PGCOPYDB_SOURCE_PGURI} -f /usr/src/pgcopydb/ddl.sql
 
 # pgcopydb copy db uses the environment variables
-pgcopydb copy-db --follow --plugin wal2json --debug
+pgcopydb copy-db --follow --plugin wal2json
 
 # cleanup
 pgcopydb stream sentinel get

--- a/tests/follow-wal2json/copydb.sh
+++ b/tests/follow-wal2json/copydb.sh
@@ -20,7 +20,7 @@ psql -o /tmp/d.out -d ${PGCOPYDB_SOURCE_PGURI} -1 -f /usr/src/pagila/pagila-data
 psql -d ${PGCOPYDB_SOURCE_PGURI} -f /usr/src/pgcopydb/ddl.sql
 
 # pgcopydb copy db uses the environment variables
-pgcopydb copy-db --follow --plugin wal2json
+pgcopydb copy-db --follow --plugin wal2json --debug
 
 # cleanup
 pgcopydb stream sentinel get


### PR DESCRIPTION
When pgcopydb clone --follow is used, it is important to prefetch changes while the initial COPY is ongoing, and switch to catchup mode thereafter. That said, when we're all caught-up, we could switch to live replay mode where we have:

    stream | transform | replay