### PR TITLE
Fix internal return value that prevented error handling.

### DIFF
--- a/src/bin/pgcopydb/table-data.c
+++ b/src/bin/pgcopydb/table-data.c
@@ -877,12 +877,16 @@ copydb_copy_table(CopyDataSpec *specs, CopyTableDataSpec *tableSpecs)
 	int maxAttempts = 5;        /* allow 5 attempts total, 4 retries */
 
 	bool retry = true;
+	bool success = false;
 
-	while (retry)
+	while (!success && retry)
 	{
 		++attempts;
 
-		if (pg_copy(src, &dst, copySource, tableSpecs->qname, truncate))
+		/* ignore previous attempts, we need only one success here */
+		success = pg_copy(src, &dst, copySource, tableSpecs->qname, truncate);
+
+		if (success)
 		{
 			/* success, get out of the retry loop */
 			if (attempts > 1)
@@ -930,5 +934,5 @@ copydb_copy_table(CopyDataSpec *specs, CopyTableDataSpec *tableSpecs)
 		}
 	}
 
-	return true;
+	return success;
 }


### PR DESCRIPTION
In case of early exit without retries from function copydb_copy_table we would break out of the retry loop and return true, allowing pgcopydb to continue working and report a successful return code to the OS.

In passing, also review error handling in lower-level pg_copy function to prevent trying to COMMIT a transaction in an already failed connection.

Finally, we could have either a client-side connection error or a server-side reported connection error: improve our code to take both the situations into account.

Should fix #201.