### PR TITLE
Only create pgcopydb schema and table_size table when --cache is used.

### DIFF
--- a/docs/ref/pgcopydb_list.rst
+++ b/docs/ref/pgcopydb_list.rst
@@ -78,15 +78,15 @@ tables to COPY the data from.
 
      --source            Postgres URI to the source database
      --filter <filename> Use the filters defined in <filename>
-     --cache             Cache table size in relation pgcopydb.table_size
-     --drop-cache        Drop relation pgcopydb.table_size
+     --cache             Cache table size in relation pgcopydb.pgcopydb_table_size
+     --drop-cache        Drop relation pgcopydb.pgcopydb_table_size
      --list-skipped      List only tables that are setup to be skipped
      --without-pkey      List only tables that have no primary key
 
 The ``--cache`` option allows caching the `pg_table_size()`__ result in the
-newly created table ``pgcopydb.table_size``. This is only useful in Postgres
-deployments where this computation is quite slow, and when the pgcopydb
-operation is going to be run multiple times.
+newly created table ``pgcopydb.pgcopydb_table_size``. This is only useful in
+Postgres deployments where this computation is quite slow, and when the
+pgcopydb operation is going to be run multiple times.
 
 __ https://www.postgresql.org/docs/15/functions-admin.html#FUNCTIONS-ADMIN-DBSIZE
 

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -209,6 +209,11 @@ typedef struct CopyDataSpec
 	Queue indexQueue;
 
 	DumpPaths dumpPaths;
+
+	/* results from calling has_database_privilege() on the source */
+	bool hasDBCreatePrivilege;
+	bool hasDBTempPrivilege;
+
 	SourceExtensionArray extensionArray;
 	SourceCollationArray collationArray;
 	SourceTableArray sourceTableArray;

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -1095,6 +1095,157 @@ pgsql_set_transaction(PGSQL *pgsql,
 
 
 /*
+ * pgsql_is_in_recovery connects to PostgreSQL and sets the is_in_recovery
+ * boolean to the result of the SELECT pg_is_in_recovery() query. It returns
+ * false when something went wrong doing that.
+ */
+bool
+pgsql_is_in_recovery(PGSQL *pgsql, bool *is_in_recovery)
+{
+	SingleValueResultContext context = { { 0 }, PGSQL_RESULT_BOOL, false };
+	char *sql = "SELECT pg_is_in_recovery()";
+
+	if (!pgsql_execute_with_params(pgsql, sql, 0, NULL, NULL,
+								   &context, &parseSingleValueResult))
+	{
+		/* errors have been logged already */
+		return false;
+	}
+
+	if (!context.parsedOk)
+	{
+		log_error("Failed to get result from pg_is_in_recovery()");
+		return false;
+	}
+
+	*is_in_recovery = context.boolVal;
+
+	return true;
+}
+
+
+/*
+ * pgsql_has_database_privilege calls has_database_privilege() and copies the
+ * result in the granted boolean pointer given.
+ */
+bool
+pgsql_has_database_privilege(PGSQL *pgsql, const char *privilege, bool *granted)
+{
+	SingleValueResultContext parseContext = { { 0 }, PGSQL_RESULT_BOOL, false };
+
+	char *sql = "select has_database_privilege(current_database(), $1);";
+
+	int paramCount = 1;
+	Oid paramTypes[1] = { TEXTOID };
+	const char *paramValues[1] = { privilege };
+
+	if (!pgsql_execute_with_params(pgsql, sql,
+								   paramCount, paramTypes, paramValues,
+								   &parseContext, &parseSingleValueResult))
+	{
+		log_error("Failed to query database privileges");
+		return false;
+	}
+
+	if (!parseContext.parsedOk)
+	{
+		log_error("Failed to query database privileges");
+		return false;
+	}
+
+	*granted = parseContext.boolVal;
+
+	return true;
+}
+
+
+/*
+ * pgsql_get_search_path runs the query "show search_path" and copies the
+ * result in the given pre-allocated string buffer.
+ */
+bool
+pgsql_get_search_path(PGSQL *pgsql, char *search_path, size_t size)
+{
+	char *sql = "select current_setting('search_path')";
+
+	SingleValueResultContext parseContext = { { 0 }, PGSQL_RESULT_STRING, false };
+
+	if (!pgsql_execute_with_params(pgsql, sql, 0, NULL, NULL,
+								   &parseContext, &parseSingleValueResult))
+	{
+		log_error("Failed to get current search_path");
+		return false;
+	}
+
+	if (!parseContext.parsedOk)
+	{
+		log_error("Failed to get current search_path");
+		return false;
+	}
+
+	strlcpy(search_path, parseContext.strVal, size);
+
+	return true;
+}
+
+
+/*
+ * pgsql_set_search_path runs the query "set [ local ] search_path ..."
+ */
+bool
+pgsql_set_search_path(PGSQL *pgsql, char *search_path, bool local)
+{
+	char sql[BUFSIZE] = { 0 };
+
+	sformat(sql, sizeof(sql), "set %s search_path to %s",
+			local ? "local" : "", search_path);
+
+	if (!pgsql_execute(pgsql, sql))
+	{
+		log_error("Failed to set current search_path to: %s", search_path);
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * pgsql_prepend_search_path prepends Postgres search path with the given
+ * namespace, only for the current transaction, using SET LOCAL.
+ */
+bool
+pgsql_prepend_search_path(PGSQL *pgsql, const char *namespace)
+{
+	char search_path[BUFSIZE] = { 0 };
+
+	if (!pgsql_get_search_path(pgsql, search_path, sizeof(search_path)))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	if (IS_EMPTY_STRING_BUFFER(search_path))
+	{
+		return pgsql_set_search_path(pgsql, (char *) namespace, true);
+	}
+	else
+	{
+		char new_search_path[BUFSIZE] = { 0 };
+
+		sformat(new_search_path, sizeof(new_search_path),
+				"%s, %s",
+				namespace,
+				search_path);
+
+		return pgsql_set_search_path(pgsql, new_search_path, true);
+	}
+
+	return false;
+}
+
+
+/*
  * pgsql_export_snapshot calls pg_export_snapshot() and copies the text into
  * the given string buffer, that must have been allocated by the caller.
  */
@@ -2053,13 +2204,15 @@ pgsql_get_sequence(PGSQL *pgsql, const char *nspname, const char *relname,
 	if (!pgsql_execute_with_params(pgsql, sql, 0, NULL, NULL,
 								   &context, &getSequenceValue))
 	{
-		log_error("Failed to retrieve current state from the monitor");
+		log_error("Failed to retrieve metadata for sequence \"%s\".\"%s\"",
+				  nspname, relname);
 		return false;
 	}
 
 	if (!context.parsedOk)
 	{
-		log_error("Failed to parse current state from the monitor");
+		log_error("Failed to retrieve metadata for sequence \"%s\".\"%s\"",
+				  nspname, relname);
 		return false;
 	}
 

--- a/src/bin/pgcopydb/pgsql.h
+++ b/src/bin/pgcopydb/pgsql.h
@@ -251,11 +251,26 @@ void fetchedRows(void *ctx, PGresult *result);
 bool pgsql_begin(PGSQL *pgsql);
 bool pgsql_commit(PGSQL *pgsql);
 bool pgsql_rollback(PGSQL *pgsql);
+
 bool pgsql_server_version(PGSQL *pgsql);
+
 bool pgsql_set_transaction(PGSQL *pgsql,
-						   IsolationLevel level, bool readOnly, bool deferrable);
+						   IsolationLevel level,
+						   bool readOnly,
+						   bool deferrable);
+
+bool pgsql_is_in_recovery(PGSQL *pgsql, bool *is_in_recovery);
+
+bool pgsql_has_database_privilege(PGSQL *pgsql, const char *privilege,
+								  bool *granted);
+
+bool pgsql_get_search_path(PGSQL *pgsql, char *search_path, size_t size);
+bool pgsql_set_search_path(PGSQL *pgsql, char *search_path, bool local);
+bool pgsql_prepend_search_path(PGSQL *pgsql, const char *namespace);
+
 bool pgsql_export_snapshot(PGSQL *pgsql, char *snapshot, size_t size);
 bool pgsql_set_snapshot(PGSQL *pgsql, char *snapshot);
+
 bool pgsql_execute(PGSQL *pgsql, const char *sql);
 bool pgsql_execute_with_params(PGSQL *pgsql, const char *sql, int paramCount,
 							   const Oid *paramTypes, const char **paramValues,

--- a/src/bin/pgcopydb/pgsql.h
+++ b/src/bin/pgcopydb/pgsql.h
@@ -489,6 +489,11 @@ bool pgsql_drop_replication_slot(PGSQL *pgsql, const char *slotName);
 
 bool pgsql_role_exists(PGSQL *pgsql, const char *roleName, bool *exists);
 
+bool pgsql_table_exists(PGSQL *pgsql,
+						const char *relname,
+						const char *nspname,
+						bool *exists);
+
 
 /*
  * pgcopydb sentinel is a table that's created on the source database and

--- a/src/bin/pgcopydb/schema.c
+++ b/src/bin/pgcopydb/schema.c
@@ -147,6 +147,31 @@ struct FilteringQueries
 
 
 /*
+ * schema_query_privileges queries the given database connection to figure out
+ * if we can create a schema, and if we can create temporary objects.
+ */
+bool
+schema_query_privileges(PGSQL *pgsql,
+						bool *hasDBCreatePrivilage,
+						bool *hasDBTempPrivilege)
+{
+	if (!pgsql_has_database_privilege(pgsql, "create", hasDBCreatePrivilage))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	if (!pgsql_has_database_privilege(pgsql, "temp", hasDBTempPrivilege))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
  * schema_list_extensions grabs the list of extensions from the given source
  * Postgres instance and allocates a SourceExtension array with the result of
  * the query.
@@ -329,8 +354,6 @@ struct FilteringQueries listSourceTableSizeSQL[] = {
 	{
 		SOURCE_FILTER_TYPE_NONE,
 
-		"create table if not exists pgcopydb.table_size as "
-
 		"  select c.oid, pg_table_size(c.oid) as bytes "
 		"    from pg_catalog.pg_class c"
 		"         join pg_catalog.pg_namespace n on c.relnamespace = n.oid"
@@ -351,8 +374,6 @@ struct FilteringQueries listSourceTableSizeSQL[] = {
 
 	{
 		SOURCE_FILTER_TYPE_INCL,
-
-		"create table if not exists pgcopydb.table_size as "
 
 		"  select c.oid, pg_table_size(c.oid) as bytes "
 		"    from pg_catalog.pg_class c"
@@ -379,8 +400,6 @@ struct FilteringQueries listSourceTableSizeSQL[] = {
 
 	{
 		SOURCE_FILTER_TYPE_EXCL,
-
-		"create table if not exists pgcopydb.table_size as "
 
 		"  select c.oid, pg_table_size(c.oid) as bytes "
 		"    from pg_catalog.pg_class c"
@@ -422,8 +441,6 @@ struct FilteringQueries listSourceTableSizeSQL[] = {
 	{
 		SOURCE_FILTER_TYPE_LIST_NOT_INCL,
 
-		"create table if not exists pgcopydb.table_size as "
-
 		"  select c.oid, pg_table_size(c.oid) as bytes "
 		"    from pg_catalog.pg_class c"
 		"         join pg_catalog.pg_namespace n on c.relnamespace = n.oid"
@@ -452,8 +469,6 @@ struct FilteringQueries listSourceTableSizeSQL[] = {
 
 	{
 		SOURCE_FILTER_TYPE_LIST_EXCL,
-
-		"create table if not exists pgcopydb.table_size as "
 
 		"  select c.oid, pg_table_size(c.oid) as bytes "
 		"    from pg_catalog.pg_class c"
@@ -486,14 +501,16 @@ struct FilteringQueries listSourceTableSizeSQL[] = {
 
 
 /*
- * schema_prepare_pgcopydb_table_size creates a table named pgcopydb.table_size
+ * schema_prepare_pgcopydb_table_size creates a table named pgcopydb_table_size
  * on the given connection (typically, the source database). The creation is
  * skipped if the table already exists.
  */
 bool
 schema_prepare_pgcopydb_table_size(PGSQL *pgsql,
 								   SourceFilters *filters,
-								   bool force,
+								   bool hasDBCreatePrivilege,
+								   bool cache,
+								   bool dropCache,
 								   bool *createdTableSizeTable)
 {
 	log_trace("schema_prepare_pgcopydb_table_size");
@@ -532,101 +549,149 @@ schema_prepare_pgcopydb_table_size(PGSQL *pgsql,
 
 	log_debug("listSourceTablesSQL[%s]", filterTypeToString(filters->type));
 
-	char *createSchema = "create schema if not exists pgcopydb";
+	bool createTable = false;
 
-	if (!pgsql_execute(pgsql, createSchema))
+	if ((cache || dropCache) && !hasDBCreatePrivilege)
+	{
+		log_fatal("Connecting with a role that does not have CREATE privileges "
+				  "on the source database prevents pg_table_size() caching");
+		return false;
+	}
+
+	if (cache)
+	{
+		char *createSchema = "create schema if not exists pgcopydb";
+
+		if (!pgsql_execute(pgsql, createSchema))
+		{
+			log_error("Failed to compute table size, see above for details");
+			return false;
+		}
+
+		/*
+		 * When the dropCache option has been used, we DROP TABLE IF EXISTS and
+		 * then create it again (cache invalidation).
+		 */
+		if (dropCache)
+		{
+			if (!schema_drop_pgcopydb_table_size(pgsql))
+			{
+				/* errors have already been logged */
+				return false;
+			}
+
+			createTable = true;
+		}
+		else
+		{
+			char *existsQuery =
+				"select 1 "
+				"  from pg_class c "
+				"       join pg_namespace n on n.oid = c.relnamespace "
+				" where n.nspname = 'pgcopydb' "
+				"   and c.relname = 'pgcopydb_table_size'";
+
+			SingleValueResultContext context = { { 0 }, PGSQL_RESULT_INT, false };
+
+			if (!pgsql_execute_with_params(pgsql, existsQuery, 0, NULL, NULL,
+										   &context, &fetchedRows))
+			{
+				log_error("Failed to check if "
+						  "\"pgcopydb\".\"pgcopydd_table_size\" exists");
+				log_error("Failed to compute table size, "
+						  "see above for details");
+				return false;
+			}
+
+			if (!context.parsedOk)
+			{
+				log_error("Failed to check if "
+						  " \"pgcopydb\".\"pgcopydb_table_size\" exists");
+				log_error("Failed to compute table size, "
+						  "see above for details");
+				return false;
+			}
+
+			/*
+			 * If the exists query returns no rows, create our table:
+			 *  pgcopydb.pgcopydb_table_size
+			 */
+			createTable = context.intVal == 0;
+
+			log_trace("schema_prepare_pgcopydb_table_size: %d %s",
+					  context.intVal,
+					  createTable ? "create" : "skip");
+
+			if (!createTable)
+			{
+				*createdTableSizeTable = false;
+
+				log_notice("Table pgcopydb_table_size already exists, re-using it");
+
+				return true;
+			}
+		}
+	}
+
+	char *tablename = "pgcopydb_table_size";
+	char sql[BUFSIZE] = { 0 };
+	int len = 0;
+
+	if (cache)
+	{
+		len =
+			sformat(sql, sizeof(sql),
+					"create table if not exists pgcopydb.%s as %s",
+					tablename,
+					listSourceTableSizeSQL[filters->type].sql);
+	}
+	else
+	{
+		len =
+			sformat(sql, sizeof(sql),
+					"create temp table %s  on commit drop as %s",
+					tablename,
+					listSourceTableSizeSQL[filters->type].sql);
+	}
+
+	if (sizeof(sql) <= len)
+	{
+		log_error("Failed to prepare create pgcopydb_table_size query "
+				  "buffer: %lld bytes are needed, we allocated %lld only",
+				  (long long) len,
+				  (long long) sizeof(sql));
+		return false;
+	}
+
+	if (!pgsql_execute(pgsql, sql))
 	{
 		log_error("Failed to compute table size, see above for details");
 		return false;
 	}
 
-	/*
-	 * When the force option has been used, we DROP TABLE IF EXISTS and then
-	 * create it again (cache invalidation).
-	 */
-	bool createTable = false;
+	char *createIndex = "create index on pgcopydb_table_size(oid)";
 
-	if (force)
+	if (!pgsql_execute(pgsql, createIndex))
 	{
-		if (!schema_drop_pgcopydb_table_size(pgsql))
-		{
-			/* errors have already been logged */
-			return false;
-		}
-
-		createTable = true;
-	}
-	else
-	{
-		char *existsQuery =
-			"select 1 "
-			"  from pg_class c "
-			"       join pg_namespace n on n.oid = c.relnamespace "
-			" where n.nspname = 'pgcopydb' and c.relname = 'table_size'";
-
-		SingleValueResultContext context = { { 0 }, PGSQL_RESULT_INT, false };
-
-		if (!pgsql_execute_with_params(pgsql, existsQuery, 0, NULL, NULL,
-									   &context, &fetchedRows))
-		{
-			log_error("Failed to check if \"pgcopydb\".\"table_size\" exists");
-			log_error("Failed to compute table size, see above for details");
-			return false;
-		}
-
-		if (!context.parsedOk)
-		{
-			log_error("Failed to check if \"pgcopydb\".\"table_size\" exists");
-			log_error("Failed to compute table size, see above for details");
-			return false;
-		}
-
-		/* if the exists query returns no rows, create pgcopydb.table_size */
-		createTable = context.intVal == 0;
-
-		log_trace("schema_prepare_pgcopydb_table_size: %d %s",
-				  context.intVal,
-				  createTable ? "create" : "skip");
+		log_error("Failed to compute table size, see above for details");
+		return false;
 	}
 
-	if (createTable || force)
-	{
-		char *sql = listSourceTableSizeSQL[filters->type].sql;
-
-		if (!pgsql_execute(pgsql, sql))
-		{
-			log_error("Failed to compute table size, see above for details");
-			return false;
-		}
-
-		char *createIndex = "create index on pgcopydb.table_size(oid)";
-
-		if (!pgsql_execute(pgsql, createIndex))
-		{
-			log_error("Failed to compute table size, see above for details");
-			return false;
-		}
-
-		*createdTableSizeTable = true;
-	}
-	else
-	{
-		*createdTableSizeTable = false;
-
-		log_debug("Table pgcopydb.table_size already exists, re-using it");
-	}
+	/* we only consider that we created the cache when cache is true */
+	*createdTableSizeTable = cache;
 
 	return true;
 }
 
 
 /*
- * schema_drop_pgcopydb_table_size drops the pgcopydb.table_size table.
+ * schema_drop_pgcopydb_table_size drops the pgcopydb.pgcopydb_table_size
+ * table.
  */
 bool
 schema_drop_pgcopydb_table_size(PGSQL *pgsql)
 {
-	char *sql = "drop table if exists pgcopydb.table_size cascade";
+	char *sql = "drop table if exists pgcopydb.pgcopydb_table_size cascade";
 
 	if (!pgsql_execute(pgsql, sql))
 	{
@@ -658,7 +723,7 @@ struct FilteringQueries listSourceTablesSQL[] = {
 		"    from pg_catalog.pg_class c"
 		"         join pg_catalog.pg_namespace n on c.relnamespace = n.oid"
 		"         join pg_roles auth ON auth.oid = c.relowner"
-		"         left join pgcopydb.table_size ts on ts.oid = c.oid"
+		"         left join pgcopydb_table_size ts on ts.oid = c.oid"
 
 		/* find a copy partition key candidate */
 		"         left join lateral ("
@@ -715,7 +780,7 @@ struct FilteringQueries listSourceTablesSQL[] = {
 		"    from pg_catalog.pg_class c "
 		"         join pg_catalog.pg_namespace n on c.relnamespace = n.oid "
 		"         join pg_roles auth ON auth.oid = c.relowner"
-		"         left join pgcopydb.table_size ts on ts.oid = c.oid"
+		"         left join pgcopydb_table_size ts on ts.oid = c.oid"
 
 		/* include-only-table */
 		"         join pg_temp.filter_include_only_table inc "
@@ -774,7 +839,7 @@ struct FilteringQueries listSourceTablesSQL[] = {
 		"    from pg_catalog.pg_class c "
 		"         join pg_catalog.pg_namespace n on c.relnamespace = n.oid "
 		"         join pg_roles auth ON auth.oid = c.relowner"
-		"         left join pgcopydb.table_size ts on ts.oid = c.oid"
+		"         left join pgcopydb_table_size ts on ts.oid = c.oid"
 
 		/* exclude-schema */
 		"         left join pg_temp.filter_exclude_schema fn "
@@ -847,7 +912,7 @@ struct FilteringQueries listSourceTablesSQL[] = {
 		"    from pg_catalog.pg_class c "
 		"         join pg_catalog.pg_namespace n on c.relnamespace = n.oid "
 		"         join pg_roles auth ON auth.oid = c.relowner"
-		"         left join pgcopydb.table_size ts on ts.oid = c.oid"
+		"         left join pgcopydb_table_size ts on ts.oid = c.oid"
 
 		/* include-only-table */
 		"    left join pg_temp.filter_include_only_table inc "
@@ -909,7 +974,7 @@ struct FilteringQueries listSourceTablesSQL[] = {
 		"    from pg_catalog.pg_class c "
 		"         join pg_catalog.pg_namespace n on c.relnamespace = n.oid "
 		"         join pg_roles auth ON auth.oid = c.relowner"
-		"         left join pgcopydb.table_size ts on ts.oid = c.oid"
+		"         left join pgcopydb_table_size ts on ts.oid = c.oid"
 
 		/* exclude-schema */
 		"         left join pg_temp.filter_exclude_schema fn "
@@ -1049,7 +1114,7 @@ struct FilteringQueries listSourceTablesNoPKSQL[] = {
 		"    from pg_class r "
 		"         join pg_namespace n ON n.oid = r.relnamespace "
 		"         join pg_roles auth ON auth.oid = r.relowner"
-		"         left join pgcopydb.table_size ts on ts.oid = r.oid"
+		"         left join pgcopydb_table_size ts on ts.oid = r.oid"
 
 		"   where r.relkind = 'r' and r.relpersistence in ('p', 'u')  "
 		"     and n.nspname !~ '^pg_' and n.nspname <> 'information_schema' "
@@ -1090,7 +1155,7 @@ struct FilteringQueries listSourceTablesNoPKSQL[] = {
 		"    from pg_class r "
 		"         join pg_namespace n ON n.oid = r.relnamespace "
 		"         join pg_roles auth ON auth.oid = r.relowner"
-		"         left join pgcopydb.table_size ts on ts.oid = r.oid"
+		"         left join pgcopydb_table_size ts on ts.oid = r.oid"
 
 		/* include-only-table */
 		"         join pg_temp.filter_include_only_table inc "
@@ -1136,7 +1201,7 @@ struct FilteringQueries listSourceTablesNoPKSQL[] = {
 		"    from pg_class r "
 		"         join pg_namespace n ON n.oid = r.relnamespace "
 		"         join pg_roles auth ON auth.oid = r.relowner"
-		"         left join pgcopydb.table_size ts on ts.oid = r.oid"
+		"         left join pgcopydb_table_size ts on ts.oid = r.oid"
 
 		/* exclude-schema */
 		"         left join pg_temp.filter_exclude_schema fn "
@@ -1196,7 +1261,7 @@ struct FilteringQueries listSourceTablesNoPKSQL[] = {
 		"    from pg_class r "
 		"         join pg_namespace n ON n.oid = r.relnamespace "
 		"         join pg_roles auth ON auth.oid = r.relowner"
-		"         left join pgcopydb.table_size ts on ts.oid = r.oid"
+		"         left join pgcopydb_table_size ts on ts.oid = r.oid"
 
 		/* include-only-table */
 		"    left join pg_temp.filter_include_only_table inc "
@@ -1245,7 +1310,7 @@ struct FilteringQueries listSourceTablesNoPKSQL[] = {
 		"    from pg_class r "
 		"         join pg_namespace n ON n.oid = r.relnamespace "
 		"         join pg_roles auth ON auth.oid = r.relowner"
-		"         left join pgcopydb.table_size ts on ts.oid = r.oid"
+		"         left join pgcopydb_table_size ts on ts.oid = r.oid"
 
 		/* exclude-schema */
 		"         left join pg_temp.filter_exclude_schema fn "
@@ -2636,7 +2701,7 @@ schema_list_partitions(PGSQL *pgsql, SourceTable *table, uint64_t partSize)
 		" t (parts) as "
 		" ( "
 		"   select ceil(bytes::float / $1) as parts "
-		"     from pgcopydb.table_size "
+		"     from pgcopydb_table_size "
 		"     where oid = $2 "
 		"	union all "
 		"	select 1 as parts "

--- a/src/bin/pgcopydb/schema.h
+++ b/src/bin/pgcopydb/schema.h
@@ -224,6 +224,11 @@ typedef struct SourceDependArray
 	SourceDepend *array;         /* malloc'ed area */
 } SourceDependArray;
 
+
+bool schema_query_privileges(PGSQL *pgsql,
+							 bool *hasDBCreatePrivilage,
+							 bool *hasDBTempPrivilege);
+
 bool schema_list_ext_schemas(PGSQL *pgsql, SourceSchemaArray *array);
 
 bool schema_list_extensions(PGSQL *pgsql, SourceExtensionArray *extArray);
@@ -232,7 +237,9 @@ bool schema_list_collations(PGSQL *pgsql, SourceCollationArray *array);
 
 bool schema_prepare_pgcopydb_table_size(PGSQL *pgsql,
 										SourceFilters *filters,
-										bool force,
+										bool hasDBCreatePrivilege,
+										bool cache,
+										bool dropCache,
 										bool *createdTableSizeTable);
 
 bool schema_drop_pgcopydb_table_size(PGSQL *pgsql);

--- a/tests/unit/setup/4-list-table-split.sql
+++ b/tests/unit/setup/4-list-table-split.sql
@@ -47,7 +47,7 @@ drop schema if exists pgcopydb;
 
 create schema pgcopydb;
 
-create table pgcopydb.table_size (
+create table pgcopydb.pgcopydb_table_size (
     oid oid unique,
     bytes bigint
 );
@@ -63,7 +63,7 @@ with cache_table_size as ((
         select
             'table_2'::regclass::oid,
             51200))
-insert into pgcopydb.table_size (oid, bytes)
+insert into pgcopydb.pgcopydb_table_size (oid, bytes)
 select
     *
 from


### PR DESCRIPTION
Otherwise, create a temporary table instead, so that read-only roles can be used on the source database connection to drive the database copy.