### PR TITLE
Use OVERRIDING SYSTEM VALUE in INSERT statements in follow mode.

### DIFF
--- a/src/bin/pgcopydb/ld_transform.c
+++ b/src/bin/pgcopydb/ld_transform.c
@@ -1546,6 +1546,8 @@ stream_write_insert(FILE *out, LogicalMessageInsert *insert)
 		}
 		FFORMAT(out, "%s", ")");
 
+		FFORMAT(out, "%s", " overriding system value ");
+
 		/* now loop over VALUES rows */
 		FFORMAT(out, "%s", " VALUES ");
 


### PR DESCRIPTION
This allows bypassing GENERATED ALWAYS AS IDENTITY columns when replaying changes from the source database to the target database. This is an INSERT statement feature.

See https://www.postgresql.org/docs/current/sql-insert.html for details, including:

  OVERRIDING SYSTEM VALUE

  If this clause is specified, then any values supplied for identity columns
  will override the default sequence-generated values.

  For an identity column defined as GENERATED ALWAYS, it is an error to
  insert an explicit value (other than DEFAULT) without specifying either
  OVERRIDING SYSTEM VALUE or OVERRIDING USER VALUE. (For an identity column
  defined as GENERATED BY DEFAULT, OVERRIDING SYSTEM VALUE is the normal
  behavior and specifying it does nothing, but PostgreSQL allows it as an
  extension.)