### PR TITLE
Ensure clean-up of System V resources.

### DIFF
--- a/src/bin/pgcopydb/lock_utils.c
+++ b/src/bin/pgcopydb/lock_utils.c
@@ -11,6 +11,7 @@
 #include <sys/sem.h>
 #include <unistd.h>
 
+#include "copydb.h"
 #include "defaults.h"
 #include "file_utils.h"
 #include "env_utils.h"
@@ -134,7 +135,7 @@ semaphore_create(Semaphore *semaphore)
 	}
 
 	/* to see this log line, change the default log level in set_logger() */
-	log_notice("Created semaphore %d (cleanup with ipcrm -s)", semaphore->semId);
+	log_debug("Created semaphore %d (cleanup with ipcrm -s)", semaphore->semId);
 
 	/* by default the Semaphore struct is initialized to { 0 }, fix it */
 	semaphore->initValue = semaphore->initValue == 0 ? 1 : semaphore->initValue;
@@ -145,6 +146,13 @@ semaphore_create(Semaphore *semaphore)
 		/* the semaphore_log_lock_function has not been set yet */
 		log_fatal("Failed to set semaphore %d/%d to value %d : %m\n",
 				  semaphore->semId, 0, semun.val);
+		return false;
+	}
+
+	/* register the semaphore to the System V resources clean-up array */
+	if (!copydb_register_sysv_semaphore(&system_res_array, semaphore))
+	{
+		/* errors have already been logged */
 		return false;
 	}
 
@@ -183,7 +191,7 @@ semaphore_open(Semaphore *semaphore)
 	}
 
 	/* to see this log line, change the default log level in set_logger() */
-	log_trace("Using semaphore %d", semaphore->semId);
+	log_debug("Using semaphore %d", semaphore->semId);
 
 	/* we have the semaphore identifier, no need to call semget(2), done */
 	return true;
@@ -200,11 +208,18 @@ semaphore_unlink(Semaphore *semaphore)
 
 	semun.val = 0;              /* unused, but keep compiler quiet */
 
-	log_trace("ipcrm -s %d\n", semaphore->semId);
+	log_debug("ipcrm -s %d", semaphore->semId);
 
 	if (semctl(semaphore->semId, 0, IPC_RMID, semun) < 0)
 	{
 		fformat(stderr, "Failed to remove semaphore %d: %m", semaphore->semId);
+		return false;
+	}
+
+	/* mark the queue as unlinekd to the System V resources clean-up array */
+	if (!copydb_unlink_sysv_semaphore(&system_res_array, semaphore))
+	{
+		/* errors have already been logged */
 		return false;
 	}
 

--- a/src/bin/pgcopydb/queue_utils.c
+++ b/src/bin/pgcopydb/queue_utils.c
@@ -12,6 +12,7 @@
 #include <sys/msg.h>
 #include <unistd.h>
 
+#include "copydb.h"
 #include "defaults.h"
 #include "log.h"
 #include "queue_utils.h"
@@ -34,9 +35,16 @@ queue_create(Queue *queue, char *name)
 		return false;
 	}
 
-	log_notice("Created message %s queue %d (cleanup with ipcrm -q)",
-			   queue->name,
-			   queue->qId);
+	/* register the queue to the System V resources clean-up array */
+	if (!copydb_register_sysv_queue(&system_res_array, queue))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	log_debug("Created message %s queue %d (cleanup with ipcrm -q)",
+			  queue->name,
+			  queue->qId);
 
 	return true;
 }
@@ -48,13 +56,20 @@ queue_create(Queue *queue, char *name)
 bool
 queue_unlink(Queue *queue)
 {
-	log_notice("iprm -q %d (%s)", queue->qId, queue->name);
+	log_debug("iprm -q %d (%s)", queue->qId, queue->name);
 
 	if (msgctl(queue->qId, IPC_RMID, NULL) != 0)
 	{
-		log_error("Failed to delete message %s queue %d: %m",
+		log_error("Failed to delete %s message queue %d: %m",
 				  queue->name,
 				  queue->qId);
+		return false;
+	}
+
+	/* mark the queue as unlinekd to the System V resources clean-up array */
+	if (!copydb_unlink_sysv_queue(&system_res_array, queue))
+	{
+		/* errors have already been logged */
 		return false;
 	}
 


### PR DESCRIPTION
Sytem V resources are created for sub-process communication within pgcopydb run-time. At exit, we need to ensure that we clean-up those resources, which are not automatically reclaimed by the OS.

We used to do that correctly with an atexit(3) handle function for the main logging semaphore, now this is done systematically for all the semaphores and queues created. This also ensures that the same process creates and unlinks the resources, which wasn't always the case in the previous coding.