### PR TITLE
Fix when we VACUUM ANALYZE.

### DIFF
--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -491,7 +491,7 @@ bool copydb_copy_blobs(CopyDataSpec *specs);
 bool vacuum_start_workers(CopyDataSpec *specs);
 bool vacuum_worker(CopyDataSpec *specs);
 bool vacuum_analyze_table_by_oid(CopyDataSpec *specs, uint32_t oid);
-bool vacuum_add_table(CopyDataSpec *specs, CopyTableDataSpec *tableSpecs);
+bool vacuum_add_table(CopyDataSpec *specs, uint32_t oid);
 bool vacuum_send_stop(CopyDataSpec *specs);
 
 /* summary.c */

--- a/src/bin/pgcopydb/table-data.c
+++ b/src/bin/pgcopydb/table-data.c
@@ -426,8 +426,6 @@ copydb_process_table_data_worker(CopyDataSpec *specs)
 		 * 2. Send the indexes and constraints attached to this table to the
 		 *    index job queue.
 		 *
-		 * 3. Send the table to the VACUUM ANALYZE job queue.
-		 *
 		 * If a partial COPY is happening, check that all the other parts are
 		 * done. This check should be done in the critical section too. Only
 		 * one process can see all parts as done already, and that's the one
@@ -458,19 +456,6 @@ copydb_process_table_data_worker(CopyDataSpec *specs)
 						 "see above for details",
 						 tableSpecs->qname);
 				log_warn("Consider `pgcopydb copy indexes` to try again");
-				++errors;
-
-				if (specs->failFast)
-				{
-					return false;
-				}
-			}
-
-			if (!vacuum_add_table(specs, tableSpecs))
-			{
-				log_warn("Failed to queue VACUUM ANALYZE %s [%u]",
-						 tableSpecs->qname,
-						 tableSpecs->sourceTable->oid);
 				++errors;
 
 				if (specs->failFast)

--- a/src/bin/pgcopydb/vacuum.c
+++ b/src/bin/pgcopydb/vacuum.c
@@ -230,11 +230,11 @@ vacuum_analyze_table_by_oid(CopyDataSpec *specs, uint32_t oid)
  * given table.
  */
 bool
-vacuum_add_table(CopyDataSpec *specs, CopyTableDataSpec *tableSpecs)
+vacuum_add_table(CopyDataSpec *specs, uint32_t oid)
 {
 	QMessage mesg = {
 		.type = QMSG_TYPE_TABLEOID,
-		.data.oid = tableSpecs->sourceTable->oid
+		.data.oid = oid
 	};
 
 	if (!queue_send(&(specs->vacuumQueue), &mesg))


### PR DESCRIPTION
Careful reading of the Explicit Locking chapter of Postgres documentation shows that VACUUM and ANALYZE take a SHARE UPDATE EXCLUSIVE lock against the target table, and CREATE INDEX take a SHARE lock, which conflicts with the former one.

  https://www.postgresql.org/docs/current/explicit-locking.html

So we can't actually VACUUM ANALYZE a table while building the indexes and then constraints on top of that. The queueing of the VACUUM operations is now done after the indexes and constraints are built.