### PR TITLE
Refactor copydb_init_specs to use a CopyDBOptions struct.

### DIFF
--- a/src/bin/pgcopydb/cli_common.c
+++ b/src/bin/pgcopydb/cli_common.c
@@ -1005,25 +1005,7 @@ cli_copy_prepare_specs(CopyDataSpec *copySpecs, CopyDataSection section)
 		exit(EXIT_CODE_INTERNAL_ERROR);
 	}
 
-	if (!copydb_init_specs(copySpecs,
-						   copyDBoptions.source_pguri,
-						   copyDBoptions.target_pguri,
-						   copyDBoptions.tableJobs,
-						   copyDBoptions.indexJobs,
-						   copyDBoptions.splitTablesLargerThan,
-						   copyDBoptions.splitTablesLargerThanPretty,
-						   section,
-						   copyDBoptions.snapshot,
-						   copyDBoptions.restoreOptions,
-						   copyDBoptions.roles,
-						   copyDBoptions.skipLargeObjects,
-						   copyDBoptions.skipExtensions,
-						   copyDBoptions.skipCollations,
-						   copyDBoptions.noRolesPasswords,
-						   copyDBoptions.failFast,
-						   copyDBoptions.restart,
-						   copyDBoptions.resume,
-						   !copyDBoptions.notConsistent))
+	if (!copydb_init_specs(copySpecs, &copyDBoptions, section))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);

--- a/src/bin/pgcopydb/cli_create.c
+++ b/src/bin/pgcopydb/cli_create.c
@@ -289,27 +289,7 @@ cli_create_snapshot(int argc, char **argv)
 		exit(EXIT_CODE_INTERNAL_ERROR);
 	}
 
-	RestoreOptions restoreOptions = { 0 };
-
-	if (!copydb_init_specs(&copySpecs,
-						   createSNoptions.source_pguri,
-						   createSNoptions.target_pguri,
-						   1,   /* tableJobs */
-						   1,   /* indexJobs */
-						   0,   /* skip threshold */
-						   "",  /* skip threshold pretty printed */
-						   DATA_SECTION_ALL,
-						   createSNoptions.snapshot,
-						   restoreOptions,
-						   false, /* roles */
-						   false, /* skipLargeObjects */
-						   false, /* skipExtensions */
-						   false, /* skipCollations */
-						   false, /* noRolesPasswords */
-						   false, /* failFast */
-						   createSNoptions.restart,
-						   createSNoptions.resume,
-						   !createSNoptions.notConsistent))
+	if (!copydb_init_specs(&copySpecs, &createSNoptions, DATA_SECTION_ALL))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);
@@ -563,27 +543,7 @@ cli_create_slot(int argc, char **argv)
 
 	(void) find_pg_commands(&(copySpecs.pgPaths));
 
-	RestoreOptions restoreOptions = { 0 };
-
-	if (!copydb_init_specs(&copySpecs,
-						   createSlotOptions.source_pguri,
-						   createSlotOptions.target_pguri,
-						   1,   /* tableJobs */
-						   1,   /* indexJobs */
-						   0,   /* skip threshold */
-						   "",  /* skip threshold pretty printed */
-						   DATA_SECTION_ALL,
-						   createSlotOptions.snapshot,
-						   restoreOptions,
-						   false, /* roles */
-						   false, /* skipLargeObjects */
-						   false, /* skipExtensions */
-						   false, /* skipCollations */
-						   false, /* noRolesPasswords */
-						   false, /* failFast */
-						   createSlotOptions.restart,
-						   createSlotOptions.resume,
-						   !createSlotOptions.notConsistent))
+	if (!copydb_init_specs(&copySpecs, &createSlotOptions, DATA_SECTION_ALL))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);
@@ -610,27 +570,7 @@ cli_drop_slot(int argc, char **argv)
 {
 	CopyDataSpec copySpecs = { 0 };
 
-	RestoreOptions restoreOptions = { 0 };
-
-	if (!copydb_init_specs(&copySpecs,
-						   createSlotOptions.source_pguri,
-						   createSlotOptions.target_pguri,
-						   1,   /* tableJobs */
-						   1,   /* indexJobs */
-						   0,   /* skip threshold */
-						   "",  /* skip threshold pretty printed */
-						   DATA_SECTION_ALL,
-						   createSlotOptions.snapshot,
-						   restoreOptions,
-						   false, /* roles */
-						   false, /* skipLargeObjects */
-						   false, /* skipExtensions */
-						   false, /* skipCollations */
-						   false, /* noRolesPasswords */
-						   false, /* failFast */
-						   createSlotOptions.restart,
-						   createSlotOptions.resume,
-						   !createSlotOptions.notConsistent))
+	if (!copydb_init_specs(&copySpecs, &createSlotOptions, DATA_SECTION_ALL))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);
@@ -860,27 +800,7 @@ cli_create_origin(int argc, char **argv)
 
 	(void) find_pg_commands(&(copySpecs.pgPaths));
 
-	RestoreOptions restoreOptions = { 0 };
-
-	if (!copydb_init_specs(&copySpecs,
-						   createOriginOptions.source_pguri,
-						   createOriginOptions.target_pguri,
-						   1,   /* tableJobs */
-						   1,   /* indexJobs */
-						   0,   /* skip threshold */
-						   "",  /* skip threshold pretty printed */
-						   DATA_SECTION_ALL,
-						   createOriginOptions.snapshot,
-						   restoreOptions,
-						   false, /* roles */
-						   false, /* skipLargeObjects */
-						   false, /* skipExtensions */
-						   false, /* skipCollations */
-						   false, /* noRolesPasswords */
-						   false, /* failFast */
-						   createOriginOptions.restart,
-						   createOriginOptions.resume,
-						   !createOriginOptions.notConsistent))
+	if (!copydb_init_specs(&copySpecs, &createOriginOptions, DATA_SECTION_ALL))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);
@@ -906,27 +826,7 @@ cli_drop_origin(int argc, char **argv)
 
 	(void) find_pg_commands(&(copySpecs.pgPaths));
 
-	RestoreOptions restoreOptions = { 0 };
-
-	if (!copydb_init_specs(&copySpecs,
-						   createOriginOptions.source_pguri,
-						   createOriginOptions.target_pguri,
-						   1,   /* tableJobs */
-						   1,   /* indexJobs */
-						   0,   /* skip threshold */
-						   "",  /* skip threshold pretty printed */
-						   DATA_SECTION_ALL,
-						   createOriginOptions.snapshot,
-						   restoreOptions,
-						   false, /* roles */
-						   false, /* skipLargeObjects */
-						   false, /* skipExtensions */
-						   false, /* skipCollations */
-						   false, /* noRolesPasswords */
-						   false, /* failFast */
-						   createOriginOptions.restart,
-						   createOriginOptions.resume,
-						   !createOriginOptions.notConsistent))
+	if (!copydb_init_specs(&copySpecs, &createOriginOptions, DATA_SECTION_ALL))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);

--- a/src/bin/pgcopydb/cli_dump.c
+++ b/src/bin/pgcopydb/cli_dump.c
@@ -364,27 +364,7 @@ cli_dump_schema_section(CopyDBOptions *dumpDBoptions,
 		exit(EXIT_CODE_INTERNAL_ERROR);
 	}
 
-	RestoreOptions restoreOptions = { 0 };
-
-	if (!copydb_init_specs(&copySpecs,
-						   dumpDBoptions->source_pguri,
-						   NULL, /* target_pguri */
-						   1,    /* table jobs */
-						   1,    /* index jobs */
-						   0,   /* skip threshold */
-						   "",  /* skip threshold pretty printed */
-						   DATA_SECTION_NONE,
-						   dumpDBoptions->snapshot,
-						   restoreOptions,
-						   false, /* roles */
-						   false, /* skipLargeObjects */
-						   false, /* skipExtensions */
-						   false, /* skipCollations */
-						   false, /* failFast */
-						   dumpDBoptions->noRolesPasswords,
-						   dumpDBoptions->restart,
-						   dumpDBoptions->resume,
-						   !dumpDBoptions->notConsistent))
+	if (!copydb_init_specs(&copySpecs, dumpDBoptions, DATA_SECTION_NONE))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);

--- a/src/bin/pgcopydb/cli_restore.c
+++ b/src/bin/pgcopydb/cli_restore.c
@@ -557,25 +557,7 @@ cli_restore_prepare_specs(CopyDataSpec *copySpecs)
 
 	log_info("Restoring database from existing files at \"%s\"", cfPaths->topdir);
 
-	if (!copydb_init_specs(copySpecs,
-						   restoreDBoptions.source_pguri,
-						   restoreDBoptions.target_pguri,
-						   1,    /* table jobs */
-						   1,    /* index jobs */
-						   0,   /* skip threshold */
-						   "",  /* skip threshold pretty printed */
-						   DATA_SECTION_NONE,
-						   restoreDBoptions.snapshot,
-						   restoreDBoptions.restoreOptions,
-						   false, /* roles */
-						   false, /* skipLargeObjects */
-						   restoreDBoptions.skipExtensions,
-						   restoreDBoptions.skipCollations,
-						   false, /* noRolesPasswords */
-						   false, /* failFast */
-						   restoreDBoptions.restart,
-						   restoreDBoptions.resume,
-						   !restoreDBoptions.notConsistent))
+	if (!copydb_init_specs(copySpecs, &restoreDBoptions, DATA_SECTION_NONE))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);

--- a/src/bin/pgcopydb/cli_sentinel.c
+++ b/src/bin/pgcopydb/cli_sentinel.c
@@ -336,27 +336,7 @@ cli_sentinel_create(int argc, char **argv)
 
 	(void) find_pg_commands(&(copySpecs.pgPaths));
 
-	RestoreOptions restoreOptions = { 0 };
-
-	if (!copydb_init_specs(&copySpecs,
-						   sentinelDBoptions.source_pguri,
-						   sentinelDBoptions.target_pguri,
-						   1,   /* tableJobs */
-						   1,   /* indexJobs */
-						   0,   /* skip threshold */
-						   "",  /* skip threshold pretty printed */
-						   DATA_SECTION_ALL,
-						   sentinelDBoptions.snapshot,
-						   restoreOptions,
-						   false, /* roles */
-						   false, /* skipLargeObjects */
-						   false, /* skipExtensions */
-						   false, /* skipCollations */
-						   false, /* noRolesPasswords */
-						   false, /* failFast */
-						   sentinelDBoptions.restart,
-						   sentinelDBoptions.resume,
-						   !sentinelDBoptions.notConsistent))
+	if (!copydb_init_specs(&copySpecs, &sentinelDBoptions, DATA_SECTION_ALL))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);

--- a/src/bin/pgcopydb/cli_stream.c
+++ b/src/bin/pgcopydb/cli_stream.c
@@ -558,27 +558,7 @@ cli_stream_setup(int argc, char **argv)
 		exit(EXIT_CODE_INTERNAL_ERROR);
 	}
 
-	RestoreOptions restoreOptions = { 0 };
-
-	if (!copydb_init_specs(&copySpecs,
-						   streamDBoptions.source_pguri,
-						   streamDBoptions.target_pguri,
-						   1,   /* tableJobs */
-						   1,   /* indexJobs */
-						   0,   /* skip threshold */
-						   "",  /* skip threshold pretty printed */
-						   DATA_SECTION_NONE,
-						   streamDBoptions.snapshot,
-						   restoreOptions,
-						   false, /* roles */
-						   false, /* skipLargeObjects */
-						   false, /* skipExtensions */
-						   false, /* skipCollations */
-						   false, /* noRolesPasswords */
-						   false, /* failFast */
-						   streamDBoptions.restart,
-						   streamDBoptions.resume,
-						   !streamDBoptions.notConsistent))
+	if (!copydb_init_specs(&copySpecs, &streamDBoptions, DATA_SECTION_NONE))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);
@@ -612,34 +592,14 @@ cli_stream_cleanup(int argc, char **argv)
 
 	(void) find_pg_commands(&(copySpecs.pgPaths));
 
-	bool resume = true;         /* pretend --resume has been used */
-	bool restart = false;       /* pretend --restart has NOT been used */
-
-	RestoreOptions restoreOptions = { 0 };
-
-	if (!copydb_init_specs(&copySpecs,
-						   streamDBoptions.source_pguri,
-						   streamDBoptions.target_pguri,
-						   1,   /* tableJobs */
-						   1,   /* indexJobs */
-						   0,   /* skip threshold */
-						   "",  /* skip threshold pretty printed */
-						   DATA_SECTION_NONE,
-						   streamDBoptions.snapshot,
-						   restoreOptions,
-						   false, /* roles */
-						   false, /* skipLargeObjects */
-						   false, /* skipExtensions */
-						   false, /* skipCollations */
-						   false, /* noRolesPasswords */
-						   false, /* failFast */
-						   restart,
-						   resume,
-						   !streamDBoptions.notConsistent))
+	if (!copydb_init_specs(&copySpecs, &streamDBoptions, DATA_SECTION_NONE))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);
 	}
+
+	copySpecs.resume = true;    /* pretend --resume has been used */
+	copySpecs.restart = false;  /* pretend --restart has NOT been used */
 
 	if (!stream_cleanup_databases(&copySpecs,
 								  streamDBoptions.slotName,
@@ -688,27 +648,7 @@ cli_stream_catchup(int argc, char **argv)
 		exit(EXIT_CODE_INTERNAL_ERROR);
 	}
 
-	RestoreOptions restoreOptions = { 0 };
-
-	if (!copydb_init_specs(&copySpecs,
-						   streamDBoptions.source_pguri,
-						   streamDBoptions.target_pguri,
-						   1,   /* tableJobs */
-						   1,   /* indexJobs */
-						   0,   /* skip threshold */
-						   "",  /* skip threshold pretty printed */
-						   DATA_SECTION_NONE,
-						   streamDBoptions.snapshot,
-						   restoreOptions,
-						   false, /* roles */
-						   false, /* skipLargeObjects */
-						   false, /* skipExtensions */
-						   false, /* skipCollations */
-						   false, /* noRolesPasswords */
-						   false, /* failFast */
-						   streamDBoptions.restart,
-						   streamDBoptions.resume,
-						   !streamDBoptions.notConsistent))
+	if (!copydb_init_specs(&copySpecs, &streamDBoptions, DATA_SECTION_NONE))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);
@@ -784,27 +724,7 @@ cli_stream_replay(int argc, char **argv)
 		exit(EXIT_CODE_INTERNAL_ERROR);
 	}
 
-	RestoreOptions restoreOptions = { 0 };
-
-	if (!copydb_init_specs(&copySpecs,
-						   streamDBoptions.source_pguri,
-						   streamDBoptions.target_pguri,
-						   1,   /* tableJobs */
-						   1,   /* indexJobs */
-						   0,   /* skip threshold */
-						   "",  /* skip threshold pretty printed */
-						   DATA_SECTION_NONE,
-						   streamDBoptions.snapshot,
-						   restoreOptions,
-						   false, /* roles */
-						   false, /* skipLargeObjects */
-						   false, /* skipExtensions */
-						   false, /* skipCollations */
-						   false, /* noRolesPasswords */
-						   false, /* failFast */
-						   streamDBoptions.restart,
-						   streamDBoptions.resume,
-						   !streamDBoptions.notConsistent))
+	if (!copydb_init_specs(&copySpecs, &streamDBoptions, DATA_SECTION_NONE))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);
@@ -922,27 +842,7 @@ cli_stream_transform(int argc, char **argv)
 		exit(EXIT_CODE_INTERNAL_ERROR);
 	}
 
-	RestoreOptions restoreOptions = { 0 };
-
-	if (!copydb_init_specs(&copySpecs,
-						   streamDBoptions.source_pguri,
-						   streamDBoptions.target_pguri,
-						   1,   /* tableJobs */
-						   1,   /* indexJobs */
-						   0,   /* skip threshold */
-						   "",  /* skip threshold pretty printed */
-						   DATA_SECTION_NONE,
-						   streamDBoptions.snapshot,
-						   restoreOptions,
-						   false, /* roles */
-						   false, /* skipLargeObjects */
-						   false, /* skipExtensions */
-						   false, /* skipCollations */
-						   false, /* noRolesPasswords */
-						   false, /* failFast */
-						   streamDBoptions.restart,
-						   streamDBoptions.resume,
-						   !streamDBoptions.notConsistent))
+	if (!copydb_init_specs(&copySpecs, &streamDBoptions, DATA_SECTION_NONE))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);
@@ -1060,27 +960,7 @@ cli_stream_apply(int argc, char **argv)
 		exit(EXIT_CODE_INTERNAL_ERROR);
 	}
 
-	RestoreOptions restoreOptions = { 0 };
-
-	if (!copydb_init_specs(&copySpecs,
-						   streamDBoptions.source_pguri,
-						   streamDBoptions.target_pguri,
-						   1,   /* tableJobs */
-						   1,   /* indexJobs */
-						   0,   /* skip threshold */
-						   "",  /* skip threshold pretty printed */
-						   DATA_SECTION_NONE,
-						   streamDBoptions.snapshot,
-						   restoreOptions,
-						   false, /* roles */
-						   false, /* skipLargeObjects */
-						   false, /* skipExtensions */
-						   false, /* skipCollations */
-						   false, /* noRolesPasswords */
-						   false, /* failFast */
-						   streamDBoptions.restart,
-						   streamDBoptions.resume,
-						   !streamDBoptions.notConsistent))
+	if (!copydb_init_specs(&copySpecs, &streamDBoptions, DATA_SECTION_NONE))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);
@@ -1181,27 +1061,7 @@ stream_start_in_mode(LogicalStreamMode mode)
 		exit(EXIT_CODE_INTERNAL_ERROR);
 	}
 
-	RestoreOptions restoreOptions = { 0 };
-
-	if (!copydb_init_specs(&copySpecs,
-						   streamDBoptions.source_pguri,
-						   streamDBoptions.target_pguri,
-						   1,   /* tableJobs */
-						   1,   /* indexJobs */
-						   0,   /* skip threshold */
-						   "",  /* skip threshold pretty printed */
-						   DATA_SECTION_NONE,
-						   streamDBoptions.snapshot,
-						   restoreOptions,
-						   false, /* roles */
-						   false, /* skipLargeObjects */
-						   false, /* skipExtensions */
-						   false, /* skipCollations */
-						   false, /* noRolesPasswords */
-						   false, /* failFast */
-						   streamDBoptions.restart,
-						   streamDBoptions.resume,
-						   !streamDBoptions.notConsistent))
+	if (!copydb_init_specs(&copySpecs, &streamDBoptions, DATA_SECTION_NONE))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -6,6 +6,7 @@
 #ifndef COPYDB_H
 #define COPYDB_H
 
+#include "cli_common.h"
 #include "copydb_paths.h"
 #include "filtering.h"
 #include "lock_utils.h"
@@ -301,24 +302,8 @@ bool copydb_rmdir_or_mkdir(const char *dir, bool removeDir);
 bool copydb_prepare_dump_paths(CopyFilePaths *cfPaths, DumpPaths *dumpPaths);
 
 bool copydb_init_specs(CopyDataSpec *specs,
-					   char *source_pguri,
-					   char *target_pguri,
-					   int tableJobs,
-					   int indexJobs,
-					   uint64_t splitTablesLargerThan,
-					   char *splitTablesLargerThanPretty,
-					   CopyDataSection section,
-					   char *snapshot,
-					   RestoreOptions restoreOptions,
-					   bool roles,
-					   bool skipLargeObjects,
-					   bool skipExtensions,
-					   bool skipCollations,
-					   bool noRolesPasswords,
-					   bool failFast,
-					   bool restart,
-					   bool resume,
-					   bool consistent);
+					   CopyDBOptions *options,
+					   CopyDataSection section);
 
 bool copydb_init_table_specs(CopyTableDataSpec *tableSpecs,
 							 CopyDataSpec *specs,


### PR DESCRIPTION
Rather than having to add so many parameters just re-use the options struct as a parameter there.

We still want to have a separate command line option structure rather than use the internal tracking CopyDataSpec structure at command line parsing time, but we can still simplify the code a good deal.

This allows easier adding of new command line options in the future.