### PR TITLE
Fix Postgres catalog queries that implement sequences filtering.

### DIFF
--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -164,6 +164,11 @@ typedef struct CopyTableDataSpecsArray
  * the following pg_restore --list example output:
  *
  *   3310; 0 0 INDEX ATTACH public payment_p2020_06_customer_id_idx postgres
+ *
+ * The OBJECT_KIND_DEFAULT goes with the pg_attribute catalog OID where
+ * Postgres keeps a sequence default value call to nextval():
+ *
+ *   3291; 2604 497539 DEFAULT bar id dim
  */
 typedef enum
 {
@@ -174,7 +179,8 @@ typedef enum
 	OBJECT_KIND_TABLE,
 	OBJECT_KIND_INDEX,
 	OBJECT_KIND_CONSTRAINT,
-	OBJECT_KIND_SEQUENCE
+	OBJECT_KIND_SEQUENCE,
+	OBJECT_KIND_DEFAULT
 } ObjectKind;
 
 

--- a/src/bin/pgcopydb/schema.h
+++ b/src/bin/pgcopydb/schema.h
@@ -143,6 +143,7 @@ typedef struct SourceTableArray
 typedef struct SourceSequence
 {
 	uint32_t oid;
+	uint32_t attroid;           /* pg_attrdef default value OID */
 	char nspname[NAMEDATALEN];
 	char relname[NAMEDATALEN];
 	int64_t lastValue;


### PR DESCRIPTION
We need to find sequences that are associated with table columns either as default values (through pg_depend entry between the sequence and pg_attrdef) or as an identity column (through a pg_depend entry between the sequence and the table column directly).

Also, when a sequence is filtered-out from our pg_restore activity, then we need to also filter-out the archive TOC entry for the default value that uses the sequence, in addition to filtering out the table and the sequence themselves.

  ALTER TABLE ONLY public.bar ALTER COLUMN id SET DEFAULT nextval(...)

Otherwise we get ERROR: relation does not exist in pg_restore.