### PR TITLE
Fix exclude-schema filtering to apply to pg_dump and pg_restore.

### DIFF
--- a/src/bin/pgcopydb/dump_restore.c
+++ b/src/bin/pgcopydb/dump_restore.c
@@ -61,6 +61,7 @@ copydb_dump_source_schema(CopyDataSpec *specs,
 							 specs->source_pguri,
 							 snapshot,
 							 "pre-data",
+							 &(specs->filters),
 							 specs->dumpPaths.preFilename))
 		{
 			/* errors have already been logged */
@@ -90,6 +91,7 @@ copydb_dump_source_schema(CopyDataSpec *specs,
 							 specs->source_pguri,
 							 snapshot,
 							 "post-data",
+							 &(specs->filters),
 							 specs->dumpPaths.postFilename))
 		{
 			/* errors have already been logged */
@@ -155,6 +157,7 @@ copydb_target_prepare_schema(CopyDataSpec *specs)
 
 	if (!pg_restore_db(&(specs->pgPaths),
 					   specs->target_pguri,
+					   &(specs->filters),
 					   specs->dumpPaths.preFilename,
 					   specs->dumpPaths.preListFilename,
 					   specs->restoreOptions))
@@ -268,6 +271,7 @@ copydb_target_finalize_schema(CopyDataSpec *specs)
 
 	if (!pg_restore_db(&(specs->pgPaths),
 					   specs->target_pguri,
+					   &(specs->filters),
 					   specs->dumpPaths.postFilename,
 					   specs->dumpPaths.postListFilename,
 					   specs->restoreOptions))

--- a/src/bin/pgcopydb/pgcmd.h
+++ b/src/bin/pgcopydb/pgcmd.h
@@ -15,6 +15,7 @@
 
 #include "defaults.h"
 #include "file_utils.h"
+#include "filtering.h"
 #include "pgsql.h"
 
 #define PG_VERSION_STRING_MAX 12
@@ -84,6 +85,7 @@ bool pg_dump_db(PostgresPaths *pgPaths,
 				const char *pguri,
 				const char *snapshot,
 				const char *section,
+				SourceFilters *filters,
 				const char *filename);
 
 bool pg_dumpall_roles(PostgresPaths *pgPaths,
@@ -103,6 +105,7 @@ bool pg_copy_roles(PostgresPaths *pgPaths,
 
 bool pg_restore_db(PostgresPaths *pgPaths,
 				   const char *pguri,
+				   SourceFilters *filters,
 				   const char *dumpFilename,
 				   const char *listFilename,
 				   RestoreOptions options);


### PR DESCRIPTION
It could be that the role used to connect to the source and target databases lacks privileges to access some Postgres schema and/or objects within that schema, which means using --exclude-schema on the command line is the right approach.

Fixes #236.