### PR TITLE
Use dynamic memory for variable length schema parts.

### DIFF
--- a/src/bin/pgcopydb/cli_list.c
+++ b/src/bin/pgcopydb/cli_list.c
@@ -1116,8 +1116,8 @@ cli_list_indexes(int argc, char **argv)
 						index->indexNamespace,
 						index->indexRelname,
 						index->constraintName,
-						index->constraintDef,
-						index->indexDef);
+						NULL_AS_EMPTY_STRING(index->constraintDef),
+						NULL_AS_EMPTY_STRING(index->indexDef));
 			}
 			else
 			{
@@ -1131,7 +1131,7 @@ cli_list_indexes(int argc, char **argv)
 						index->indexNamespace,
 						"",
 						index->constraintName,
-						index->constraintDef,
+						NULL_AS_EMPTY_STRING(index->constraintDef),
 						"");
 			}
 		}
@@ -1143,8 +1143,8 @@ cli_list_indexes(int argc, char **argv)
 					index->indexNamespace,
 					index->indexRelname,
 					index->constraintName,
-					index->constraintDef,
-					index->indexDef);
+					NULL_AS_EMPTY_STRING(index->constraintDef),
+					NULL_AS_EMPTY_STRING(index->indexDef));
 		}
 	}
 

--- a/src/bin/pgcopydb/progress.c
+++ b/src/bin/pgcopydb/progress.c
@@ -610,8 +610,30 @@ copydb_parse_schema_json_file(CopyDataSpec *copySpecs)
 
 		strlcpy(index->indexNamespace, schema, sizeof(index->indexNamespace));
 		strlcpy(index->indexRelname, name, sizeof(index->indexRelname));
-		strlcpy(index->indexColumns, cols, sizeof(index->indexColumns));
-		strlcpy(index->indexDef, def, sizeof(index->indexDef));
+
+		int lenCols = strlen(cols) + 1;
+
+		index->indexColumns = (char *) calloc(lenCols, sizeof(char));
+
+		if (index->indexColumns == NULL)
+		{
+			log_fatal(ALLOCATION_FAILED_ERROR);
+			return false;
+		}
+
+		strlcpy(index->indexColumns, cols, lenCols);
+
+		int lenDef = strlen(def) + 1;
+
+		index->indexDef = (char *) calloc(lenDef, sizeof(char));
+
+		if (index->indexDef == NULL)
+		{
+			log_fatal(ALLOCATION_FAILED_ERROR);
+			return false;
+		}
+
+		strlcpy(index->indexDef, def, lenDef);
 
 		strlcpy(index->indexRestoreListName,
 				listName,
@@ -641,7 +663,17 @@ copydb_parse_schema_json_file(CopyDataSpec *copySpecs)
 												"constraint.restore-list-name");
 
 			strlcpy(index->constraintName, name, sizeof(index->constraintName));
-			strlcpy(index->constraintDef, def, sizeof(index->constraintDef));
+
+			int len = strlen(def) + 1;
+			index->constraintDef = (char *) calloc(len, sizeof(char));
+
+			if (index->constraintDef == NULL)
+			{
+				log_fatal(ALLOCATION_FAILED_ERROR);
+				return false;
+			}
+
+			strlcpy(index->constraintDef, def, len);
 
 			if (listName != NULL)
 			{

--- a/src/bin/pgcopydb/schema.c
+++ b/src/bin/pgcopydb/schema.c
@@ -3449,15 +3449,16 @@ getCollationList(void *ctx, PGresult *result)
 
 		/* 3. desc */
 		value = PQgetvalue(result, rowNumber, 2);
-		length = strlcpy(collation->desc, value, BUFSIZE);
+		length = strlen(value) + 1;
+		collation->desc = (char *) calloc(length, sizeof(char));
 
-		if (length >= BUFSIZE)
+		if (collation->desc == NULL)
 		{
-			log_error("Collation desc \"%s\" is %d bytes long, "
-					  "the maximum expected is %d (BUFSIZE - 1)",
-					  value, length, BUFSIZE - 1);
-			++errors;
+			log_fatal(ALLOCATION_FAILED_ERROR);
+			return;
 		}
+
+		strlcpy(collation->desc, value, length);
 
 		/* 4. restoreListName */
 		value = PQgetvalue(result, rowNumber, 3);
@@ -3969,27 +3970,29 @@ parseCurrentSourceIndex(PGresult *result, int rowNumber, SourceIndex *index)
 
 	/* 9. cols */
 	value = PQgetvalue(result, rowNumber, 8);
-	length = strlcpy(index->indexColumns, value, BUFSIZE);
+	length = strlen(value) + 1;
+	index->indexColumns = (char *) calloc(length, sizeof(char));
 
-	if (length >= BUFSIZE)
+	if (index->indexColumns == NULL)
 	{
-		log_error("Index name \"%s\" is %d bytes long, "
-				  "the maximum expected is %d (BUFSIZE - 1)",
-				  value, length, BUFSIZE - 1);
-		++errors;
+		log_fatal(ALLOCATION_FAILED_ERROR);
+		return false;
 	}
+
+	strlcpy(index->indexColumns, value, length);
 
 	/* 10. pg_get_indexdef() */
 	value = PQgetvalue(result, rowNumber, 9);
-	length = strlcpy(index->indexDef, value, BUFSIZE);
+	length = strlen(value) + 1;
+	index->indexDef = (char *) calloc(length, sizeof(char));
 
-	if (length >= BUFSIZE)
+	if (index->indexDef == NULL)
 	{
-		log_error("Index name \"%s\" is %d bytes long, "
-				  "the maximum expected is %d (BUFSIZE - 1)",
-				  value, length, BUFSIZE - 1);
-		++errors;
+		log_fatal(ALLOCATION_FAILED_ERROR);
+		return false;
 	}
+
+	strlcpy(index->indexDef, value, length);
 
 	/* 11. c.oid */
 	if (PQgetisnull(result, rowNumber, 10))
@@ -4027,15 +4030,16 @@ parseCurrentSourceIndex(PGresult *result, int rowNumber, SourceIndex *index)
 	if (!PQgetisnull(result, rowNumber, 12))
 	{
 		value = PQgetvalue(result, rowNumber, 12);
-		length = strlcpy(index->constraintDef, value, BUFSIZE);
+		length = strlen(value) + 1;
+		index->constraintDef = (char *) calloc(length, sizeof(char));
 
-		if (length >= BUFSIZE)
+		if (index->constraintDef == NULL)
 		{
-			log_error("Index name \"%s\" is %d bytes long, "
-					  "the maximum expected is %d (BUFSIZE - 1)",
-					  value, length, BUFSIZE - 1);
-			++errors;
+			log_fatal(ALLOCATION_FAILED_ERROR);
+			return false;
 		}
+
+		strlcpy(index->constraintDef, value, length);
 	}
 
 	/* 14. indexRestoreListName */

--- a/src/bin/pgcopydb/schema.h
+++ b/src/bin/pgcopydb/schema.h
@@ -71,7 +71,7 @@ typedef struct SourceCollation
 {
 	uint32_t oid;
 	char collname[NAMEDATALEN];
-	char desc[BUFSIZE];
+	char *desc;                 /* malloc'ed area */
 	char restoreListName[RESTORE_LIST_NAMEDATALEN];
 } SourceCollation;
 
@@ -173,11 +173,11 @@ typedef struct SourceIndex
 	char tableRelname[NAMEDATALEN];
 	bool isPrimary;
 	bool isUnique;
-	char indexColumns[BUFSIZE];
-	char indexDef[BUFSIZE];
+	char *indexColumns;         /* malloc'ed area */
+	char *indexDef;             /* malloc'ed area */
 	uint32_t constraintOid;
 	char constraintName[NAMEDATALEN];
-	char constraintDef[BUFSIZE];
+	char *constraintDef;        /* malloc'ed area */
 	char indexRestoreListName[RESTORE_LIST_NAMEDATALEN];
 	char constraintRestoreListName[RESTORE_LIST_NAMEDATALEN];
 

--- a/src/bin/pgcopydb/string_utils.h
+++ b/src/bin/pgcopydb/string_utils.h
@@ -9,6 +9,8 @@
 
 #define IS_EMPTY_STRING_BUFFER(strbuf) (strbuf[0] == '\0')
 
+#define NULL_AS_EMPTY_STRING(str) (str == NULL ? "" : str)
+
 #define streq(a, b) (a != NULL && b != NULL && strcmp(a, b) == 0)
 
 #define strneq(x, y) \


### PR DESCRIPTION
Rather than using a static BUFSIZE string buffer we call calloc() to allocate memory dynamically for index columns, index definitions, constraint definition, and collation descriptions.

The allocated memory is used throughout the pgcopydb program execution, and at the moment the memory is not de-allocated by a call to free(). Instead, we rely on the OS to take care of that for us when exiting pgcopydb.

Fixes #245.