### PR TITLE
Review and fix connection management for sentinel async updates.

### DIFF
--- a/src/bin/pgcopydb/ld_stream.c
+++ b/src/bin/pgcopydb/ld_stream.c
@@ -410,9 +410,9 @@ startLogicalStreaming(StreamSpecs *specs)
 
 		if (cleanExit)
 		{
-			log_info("Streaming is now finished after processing %lld message%s",
-					 (long long) privateContext.counters.total,
-					 privateContext.counters.total > 0 ? "s" : "");
+			log_info("Streamed up to write_lsn %X/%X, flush_lsn %X/%X, stopping",
+					 LSN_FORMAT_ARGS(context.tracking->written_lsn),
+					 LSN_FORMAT_ARGS(context.tracking->flushed_lsn));
 		}
 		else if (!(asked_to_stop || asked_to_stop_fast || asked_to_quit))
 		{


### PR DESCRIPTION
Manage the connection internally in the stream_apply_send_sync_sentinel and stream_apply_fetch_sync_sentinel functions, closing the connection each time we have received the result.

Fixes #272 