### PR TITLE
Fix the transition between replay operating modes.

### DIFF
--- a/src/bin/pgcopydb/cli_common.c
+++ b/src/bin/pgcopydb/cli_common.c
@@ -894,6 +894,13 @@ cli_copy_db_getopts(int argc, char **argv)
 				exit(EXIT_CODE_QUIT);
 				break;
 			}
+
+			case '?':
+			{
+				commandline_help(stderr);
+				exit(EXIT_CODE_BAD_ARGS);
+				break;
+			}
 		}
 	}
 

--- a/src/bin/pgcopydb/ld_apply.c
+++ b/src/bin/pgcopydb/ld_apply.c
@@ -48,14 +48,20 @@ stream_apply_catchup(StreamSpecs *specs)
 		return false;
 	}
 
-	if (!stream_read_context(&(specs->paths),
-							 &(context.system),
-							 &(context.WalSegSz)))
+	if (specs->system.timeline == 0)
 	{
-		log_error("Failed to read the streaming context information "
-				  "from the source database, see above for details");
-		return false;
+		if (!stream_read_context(&(specs->paths),
+								 &(specs->system),
+								 &(specs->WalSegSz)))
+		{
+			log_error("Failed to read the streaming context information "
+					  "from the source database, see above for details");
+			return false;
+		}
 	}
+
+	context.system = specs->system;
+	context.WalSegSz = specs->WalSegSz;
 
 	log_debug("Source database wal_segment_size is %u", context.WalSegSz);
 	log_debug("Source database timeline is %d", context.system.timeline);

--- a/src/bin/pgcopydb/ld_replay.c
+++ b/src/bin/pgcopydb/ld_replay.c
@@ -57,14 +57,20 @@ stream_apply_replay(StreamSpecs *specs)
 		return false;
 	}
 
-	if (!stream_read_context(&(specs->paths),
-							 &(context->system),
-							 &(context->WalSegSz)))
+	if (specs->system.timeline == 0)
 	{
-		log_error("Failed to read the streaming context information "
-				  "from the source database, see above for details");
-		return false;
+		if (!stream_read_context(&(specs->paths),
+								 &(specs->system),
+								 &(specs->WalSegSz)))
+		{
+			log_error("Failed to read the streaming context information "
+					  "from the source database, see above for details");
+			return false;
+		}
 	}
+
+	context->system = specs->system;
+	context->WalSegSz = specs->WalSegSz;
 
 	log_debug("Source database wal_segment_size is %u", context->WalSegSz);
 	log_debug("Source database timeline is %d", context->system.timeline);

--- a/src/bin/pgcopydb/ld_stream.h
+++ b/src/bin/pgcopydb/ld_stream.h
@@ -338,6 +338,9 @@ struct StreamSpecs
 	char logrep_pguri[MAXCONNINFO];
 	char target_pguri[MAXCONNINFO];
 
+	uint32_t WalSegSz;
+	IdentifySystem system;
+
 	StreamOutputPlugin plugin;
 	KeyVal pluginOptions;
 
@@ -466,6 +469,7 @@ StreamAction StreamActionFromChar(char action);
 
 /* ld_transform.c */
 bool stream_transform_worker(StreamSpecs *specs);
+bool stream_transform_from_queue(StreamSpecs *specs);
 bool stream_transform_add_file(Queue *queue, uint64_t firstLSN);
 bool stream_transform_send_stop(Queue *queue);
 
@@ -487,6 +491,8 @@ bool stream_transform_rotate(StreamContext *privateContext,
 							 LogicalMessageMetadata *metadata);
 
 bool stream_transform_file(char *jsonfilename, char *sqlfilename);
+bool stream_transform_file_at_lsn(StreamSpecs *specs, uint64_t lsn);
+
 bool stream_write_message(FILE *out, LogicalMessage *msg);
 bool stream_write_transaction(FILE *out, LogicalTransaction *tx);
 bool stream_write_begin(FILE *out, LogicalTransaction *tx);
@@ -575,6 +581,9 @@ bool follow_get_sentinel(StreamSpecs *specs, CopyDBSentinel *sentinel);
 bool follow_main_loop(CopyDataSpec *copySpecs, StreamSpecs *streamSpecs);
 
 bool followDB(CopyDataSpec *copySpecs, StreamSpecs *streamSpecs);
+
+bool follow_reached_endpos(StreamSpecs *streamSpecs, bool *done);
+bool follow_prepare_mode_switch(StreamSpecs *streamSpecs);
 
 bool follow_start_subprocess(StreamSpecs *specs, FollowSubProcess *subprocess);
 

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -4204,6 +4204,9 @@ pgsql_stream_logical(LogicalStreamClient *client, LogicalStreamContext *context)
 	clear_results(pgsql);
 	pgsql_finish(pgsql);
 
+	/* unset the signals which have been processed correctly now */
+	(void) unset_signal_flags();
+
 	/* call the closeFunction callback now */
 	if (!(*client->closeFunction)(context))
 	{

--- a/src/bin/pgcopydb/signals.c
+++ b/src/bin/pgcopydb/signals.c
@@ -195,6 +195,20 @@ get_current_signal(int defaultSignal)
 
 
 /*
+ * unset_signal_flags assigns 0 to all our control flags. Use to avoid
+ * re-processing an exit flag that is currently being processed already.
+ */
+void
+unset_signal_flags()
+{
+	asked_to_stop = 0;
+	asked_to_stop_fast = 0;
+	asked_to_quit = 0;
+	asked_to_reload = 0;
+}
+
+
+/*
  * pick_stronger_signal returns the "stronger" signal among the two given
  * arguments.
  *

--- a/src/bin/pgcopydb/signals.h
+++ b/src/bin/pgcopydb/signals.h
@@ -26,6 +26,7 @@ void catch_int(int sig);
 void catch_term(int sig);
 void catch_quit(int sig);
 void catch_quit_and_exit(int sig);
+void unset_signal_flags(void);
 
 int get_current_signal(int defaultSignal);
 int pick_stronger_signal(int sig1, int sig2);


### PR DESCRIPTION
When switching replay operating modes we want to replay all the changes that has been streamed locally but have not been caught-up yet. This includes some JSON to SQL transformation work that was missed before.

To be able to receive from the transform queue after having received a signal to stop, we need to also reset the signals control flags, otherwise all we get is an early exit in queue_receive.

Fixes #274 