### PR TITLE
Fix double precision out of range during COPY.

### DIFF
--- a/src/bin/pgcopydb/copydb.c
+++ b/src/bin/pgcopydb/copydb.c
@@ -37,8 +37,8 @@ GUC srcSettings95[] = {
 
 GUC srcSettings[] = {
 	COMMON_GUC_SETTINGS
-	{ "idle_in_transaction_session_timeout", "0" },
 	{ "extra_float_digits", "3" },
+	{ "idle_in_transaction_session_timeout", "0" },
 	{ NULL, NULL },
 };
 

--- a/src/bin/pgcopydb/copydb.c
+++ b/src/bin/pgcopydb/copydb.c
@@ -38,6 +38,7 @@ GUC srcSettings95[] = {
 GUC srcSettings[] = {
 	COMMON_GUC_SETTINGS
 	{ "idle_in_transaction_session_timeout", "0" },
+	{ "extra_float_digits", "3" },
 	{ NULL, NULL },
 };
 


### PR DESCRIPTION
We have identified the root cause of the issue where double precision values were going out of range during the COPY operation. It turns out that we were missing the extra_float_digits GUC (grand unified configuration) while copying the float8 data. As a result, when extreme values like '1.7976931348623157E+308' were copied from the source, an overflow occurred leading to the following error:

```log
2023-05-08 14:17:00 16666 ERROR  pgsql.c:2555              TARGET [22003] ERROR:  "1.79769313486232e+308" is out of range for type double precision
2023-05-08 14:17:00 16666 ERROR  pgsql.c:2559              TARGET CONTEXT:  COPY t_numeric_types, line 46650, column c_double_precision: "1.79769313486232e+308"
2023-05-08 14:17:00 16666 ERROR  pgsql.c:2563              TARGET Context: Failed to copy data to target
```

Value of `3` is inspired from `pg_dump` https://github.com/postgres/postgres/blob/ff4213cdc2e2bef7fadba6db2fc97057fd03be74/src/bin/pg_dump/pg_dump.c#L1176