### PR TITLE
Fix follow_prepare_mode_switch not finishing when previous mode is REPLAY.

### DIFF
--- a/src/bin/pgcopydb/ld_stream.h
+++ b/src/bin/pgcopydb/ld_stream.h
@@ -573,7 +573,7 @@ bool follow_main_loop(CopyDataSpec *copySpecs, StreamSpecs *streamSpecs);
 bool followDB(CopyDataSpec *copySpecs, StreamSpecs *streamSpecs);
 
 bool follow_reached_endpos(StreamSpecs *streamSpecs, bool *done);
-bool follow_prepare_mode_switch(StreamSpecs *streamSpecs);
+bool follow_prepare_mode_switch(StreamSpecs *streamSpecs, LogicalStreamMode previousMode);
 
 bool follow_start_subprocess(StreamSpecs *specs, FollowSubProcess *subprocess);
 


### PR DESCRIPTION
When the previous streaming mode was REPLAY and we attempt to empty the transform queue using `stream_transform_from_queue`, the function waits indefinitely for `QMSG_TYPE_STOP` (or any message) because the queue has already been emptied.