### PR TITLE
Fix issue with missing data from transactions with BEGIN LSN less than consistent_point.

### DIFF
--- a/src/bin/pgcopydb/ld_stream.c
+++ b/src/bin/pgcopydb/ld_stream.c
@@ -1540,6 +1540,20 @@ parseMessageMetadata(LogicalMessageMetadata *metadata,
 		}
 	}
 
+	if (json_object_has_value(jsobj, "commit_lsn"))
+	{
+		char *txnCommitLSN = (char *) json_object_get_string(jsobj, "commit_lsn");
+
+		if (txnCommitLSN != NULL)
+		{
+			if (!parseLSN(txnCommitLSN, &(metadata->txnCommitLSN)))
+			{
+				log_error("Failed to parse LSN \"%s\"", txnCommitLSN);
+				return false;
+			}
+		}
+	}
+
 	if (!skipAction &&
 		metadata->lsn == InvalidXLogRecPtr &&
 		(metadata->action == STREAM_ACTION_BEGIN ||

--- a/src/bin/pgcopydb/ld_stream.h
+++ b/src/bin/pgcopydb/ld_stream.h
@@ -55,6 +55,7 @@ typedef struct LogicalMessageMetadata
 	StreamAction action;
 	uint32_t xid;
 	uint64_t lsn;
+	uint64_t txnCommitLSN;		/* COMMIT LSN of the transaction */
 	char timestamp[PG_MAX_TIMESTAMP];
 
 	/* our own internal decision making */

--- a/src/bin/pgcopydb/ld_transform.c
+++ b/src/bin/pgcopydb/ld_transform.c
@@ -1521,19 +1521,19 @@ stream_write_transaction(FILE *out, LogicalTransaction *txn)
 
 
 /*
- * stream_write_switchwal writes a SWITCH statement to the already open out
- * stream.
+ * stream_write_begin writes a BEGIN statement to the already open out stream.
  */
 bool
 stream_write_begin(FILE *out, LogicalTransaction *txn)
 {
 	int ret =
 		fformat(out,
-				"%s{\"xid\":%lld,\"lsn\":\"%X/%X\",\"timestamp\":\"%s\"}\n",
+				"%s{\"xid\":%lld,\"lsn\":\"%X/%X\",\"timestamp\":\"%s\",\"commit_lsn\":\"%X/%X\"}\n",
 				OUTPUT_BEGIN,
 				(long long) txn->xid,
 				LSN_FORMAT_ARGS(txn->beginLSN),
-				txn->timestamp);
+				txn->timestamp,
+				LSN_FORMAT_ARGS(txn->commitLSN));
 
 	return ret != -1;
 }

--- a/tests/follow-data-only/Dockerfile
+++ b/tests/follow-data-only/Dockerfile
@@ -2,6 +2,7 @@ FROM pagila
 
 WORKDIR /usr/src/pgcopydb
 COPY ./copydb.sh copydb.sh
+COPY ./run-background-traffic.sh run-background-traffic.sh
 COPY ./dml.sql dml.sql
 COPY ./ddl.sql ddl.sql
 

--- a/tests/follow-data-only/run-background-traffic.sh
+++ b/tests/follow-data-only/run-background-traffic.sh
@@ -1,0 +1,14 @@
+#! /bin/bash
+
+set -e
+
+# Run transactions that insert a variable number of rows at a time. The number
+# of rows inserted varies between 1 and 100. Each insert will occur in the
+# background and finish quickly which avoids excessive connections.
+while true; do
+    psql -d ${PGCOPYDB_SOURCE_PGURI} \
+         -c "INSERT INTO table_a(some_field) SELECT generate_series(1,(random() * 100 + 1)::int);" &
+    # To control the rate, we include a sleep of 0.1 seconds between each insert
+    # operation.
+    sleep 0.1
+done


### PR DESCRIPTION
Currently we skip applying SQL statements whose source/origin LSN is less than `previousLSN`. When using `pgcopydb clone --follow`, the initial `previousLSN` matches the`consistent_point` obtained during the snapshot.

Comparing LSN of each SQL statement creates a problem when parallel transactions are running during the snapshot capture. These transactions could have statements whose LSN is less than the `previousLSN`. Consequently, the initial portion of some transactions, containing statements with LSN less than the `consistent_point`, are inadvertently omitted.

The fix here is to compare the COMMIT LSN instead of each statement's LSN as it is guaranteed that the COMMIT LSN of every streamed message will be greater than `consistent_point`.

Fixes: #282

