### PR TITLE
Use JSON format for work-directory summary files.

### DIFF
--- a/src/bin/pgcopydb/summary.c
+++ b/src/bin/pgcopydb/summary.c
@@ -852,7 +852,6 @@ void
 print_summary_as_json(Summary *summary, const char *filename)
 {
 	log_notice("Storing migration summary in JSON file \"%s\"", filename);
-	log_warn("Storing migration summary in JSON file \"%s\"", filename);
 
 	JSON_Value *js = json_value_init_object();
 	JSON_Object *jsobj = json_value_get_object(js);
@@ -967,8 +966,6 @@ print_summary_as_json(Summary *summary, const char *filename)
 
 	json_object_set_value(jsobj, "steps", jsSteps);
 
-	log_warn("print_summary_as_json: steps");
-
 	SummaryTable *summaryTable = &(summary->table);
 
 	JSON_Value *jsTables = json_value_init_array();
@@ -980,9 +977,6 @@ print_summary_as_json(Summary *summary, const char *filename)
 
 		JSON_Value *jsTable = json_value_init_object();
 		JSON_Object *jsTableObj = json_value_get_object(jsTable);
-
-		log_warn("print_summary_as_json: table %s [%u] %d/%d",
-				 entry->relname, entry->oid, i, summaryTable->count);
 
 		json_object_set_number(jsTableObj, "oid", entry->oid);
 		json_object_set_string(jsTableObj, "schema", entry->nspname);
@@ -1006,8 +1000,6 @@ print_summary_as_json(Summary *summary, const char *filename)
 			JSON_Value *jsIndex = json_value_init_object();
 			JSON_Object *jsIndexObj = json_value_get_object(jsIndex);
 
-			log_warn("print_summary_as_json: index %s", indexEntry->relname);
-
 			json_object_set_number(jsIndexObj, "oid", indexEntry->oid);
 			json_object_set_string(jsIndexObj, "schema", indexEntry->nspname);
 			json_object_set_string(jsIndexObj, "name", indexEntry->relname);
@@ -1030,8 +1022,6 @@ print_summary_as_json(Summary *summary, const char *filename)
 			JSON_Value *jsConstraint = json_value_init_object();
 			JSON_Object *jsConstraintObj = json_value_get_object(jsConstraint);
 
-			log_warn("print_summary_as_json: constraint %s", cEntry->relname);
-
 			json_object_set_number(jsConstraintObj, "oid", cEntry->oid);
 			json_object_set_string(jsConstraintObj, "schema", cEntry->nspname);
 			json_object_set_string(jsConstraintObj, "name", cEntry->relname);
@@ -1046,8 +1036,6 @@ print_summary_as_json(Summary *summary, const char *filename)
 
 		/* append the current table to the table array */
 		json_array_append_value(jsTableArray, jsTable);
-
-		log_warn("print_summary_as_json: %s done", entry->relname);
 	}
 
 	/* add the table array to the main JSON top-level dict */
@@ -1177,8 +1165,6 @@ print_summary(Summary *summary, CopyDataSpec *specs)
 {
 	SummaryTable *summaryTable = &(summary->table);
 
-	log_warn("print_summary");
-
 	summary->tableJobs = specs->tableJobs;
 	summary->indexJobs = specs->indexJobs;
 
@@ -1189,20 +1175,14 @@ print_summary(Summary *summary, CopyDataSpec *specs)
 		return false;
 	}
 
-	log_warn("print_summary json 1");
-
 	/* print the summary.json file */
 	(void) print_summary_as_json(summary, specs->cfPaths.summaryfile);
-
-	log_warn("print_summary json 2");
 
 	/* then we can prepare the headers and print the table */
 	if (specs->section == DATA_SECTION_TABLE_DATA ||
 		specs->section == DATA_SECTION_ALL)
 	{
-		log_warn("prepare_summary_table_headers");
 		(void) prepare_summary_table_headers(summaryTable);
-		log_warn("print_summary_table");
 		(void) print_summary_table(summaryTable);
 	}
 

--- a/src/bin/pgcopydb/summary.c
+++ b/src/bin/pgcopydb/summary.c
@@ -31,35 +31,32 @@ static void prepareLineSeparator(char dashes[], int size);
 bool
 write_table_summary(CopyTableSummary *summary, char *filename)
 {
-	PQExpBuffer contents = createPQExpBuffer();
+	JSON_Value *js = json_value_init_object();
+	JSON_Object *jsObj = json_value_get_object(js);
 
-	appendPQExpBuffer(contents,
-					  "%d\n%u\n%s\n%s\n%lld\n%lld\n%lld\n%s\n",
-					  summary->pid,
-					  summary->table->oid,
-					  summary->table->nspname,
-					  summary->table->relname,
-					  (long long) summary->startTime,
-					  (long long) summary->doneTime,
-					  (long long) summary->durationMs,
-					  summary->command);
+	json_object_set_number(jsObj, "pid", summary->pid);
+	json_object_dotset_number(jsObj, "table.oid", summary->table->oid);
+	json_object_dotset_string(jsObj, "table.nspname", summary->table->nspname);
+	json_object_dotset_string(jsObj, "table.relname", summary->table->relname);
+	json_object_set_number(jsObj, "start-time-epoch", summary->startTime);
+	json_object_set_number(jsObj, "done-time-epoch", summary->doneTime);
+	json_object_set_number(jsObj, "duration", summary->durationMs);
+	json_object_set_string(jsObj, "command", summary->command);
 
-	if (PQExpBufferBroken(contents))
-	{
-		log_error("Failed to create file \"%s\": out of memory", filename);
-		destroyPQExpBuffer(contents);
-		return false;
-	}
+	char *serialized_string = json_serialize_to_string_pretty(js);
+	size_t len = strlen(serialized_string);
 
 	/* write the summary to the doneFile */
-	if (!write_file(contents->data, contents->len, filename))
+	bool success = write_file(serialized_string, len, filename);
+
+	json_free_serialized_string(serialized_string);
+	json_value_free(js);
+
+	if (!success)
 	{
 		log_error("Failed to write table summary file \"%s\"", filename);
-		destroyPQExpBuffer(contents);
 		return false;
 	}
-
-	destroyPQExpBuffer(contents);
 
 	return true;
 }
@@ -124,86 +121,38 @@ prepare_table_summary_as_json(CopyTableSummary *summary,
 bool
 read_table_summary(CopyTableSummary *summary, const char *filename)
 {
-	char *fileContents = NULL;
-	long fileSize = 0L;
+	JSON_Value *json = json_parse_file(filename);
 
-	if (!read_file(filename, &fileContents, &fileSize))
+	if (json == NULL)
 	{
-		/* errors have already been logged */
+		log_error("Failed to parse summary file \"%s\"", filename);
 		return false;
 	}
 
-	char *fileLines[BUFSIZE] = { 0 };
-	int lineCount = splitLines(fileContents, fileLines, BUFSIZE);
+	JSON_Object *jsObj = json_value_get_object(json);
 
-	if (lineCount < COPY_TABLE_SUMMARY_LINES)
-	{
-		log_error("Failed to parse summary file \"%s\" which contains only "
-				  "%d lines, at least %d lines are expected",
-				  filename,
-				  lineCount,
-				  COPY_TABLE_SUMMARY_LINES);
+	summary->pid = json_object_get_number(jsObj, "pid");
 
-		free(fileContents);
+	summary->table->oid = json_object_dotget_number(jsObj, "table.oid");
 
-		return false;
-	}
+	char *schema = (char *) json_object_dotget_string(jsObj, "table.nspname");
+	char *name = (char *) json_object_dotget_string(jsObj, "table.relname");
 
-	if (!stringToInt(fileLines[0], &(summary->pid)))
-	{
-		/* errors have already been logged */
-		return false;
-	}
+	strlcpy(summary->table->nspname, schema, sizeof(summary->table->nspname));
+	strlcpy(summary->table->relname, name, sizeof(summary->table->relname));
 
-	/* better not point to NULL */
-	SourceTable *table = summary->table;
+	summary->startTime = json_object_get_number(jsObj, "start-time-epoch");
+	summary->doneTime = json_object_get_number(jsObj, "done-time-epoch");
+	summary->durationMs = json_object_get_number(jsObj, "duration");
 
-	if (table == NULL)
-	{
-		log_error("BUG: read_table_summary summary->table is NULL");
-		return false;
-	}
-
-	if (!stringToUInt32(fileLines[1], &(table->oid)))
-	{
-		/* errors have already been logged */
-		return false;
-	}
-
-	strlcpy(table->nspname, fileLines[2], sizeof(table->nspname));
-	strlcpy(table->relname, fileLines[3], sizeof(table->relname));
-
-	if (!stringToUInt64(fileLines[4], &(summary->startTime)))
-	{
-		/* errors have already been logged */
-		return false;
-	}
-
-	if (!stringToUInt64(fileLines[5], &(summary->doneTime)))
-	{
-		/* errors have already been logged */
-		return false;
-	}
-
-	if (!stringToUInt64(fileLines[6], &(summary->durationMs)))
-	{
-		/* errors have already been logged */
-		return false;
-	}
-
-	/* last summary line in the file is the SQL command */
-	char *sql = fileLines[7];
-	int len = strlen(sql) + 1;
-
-	summary->command = (char *) calloc(len, sizeof(char));
+	summary->command = strdup(json_object_get_string(jsObj, "command"));
 
 	if (summary->command == NULL)
 	{
 		log_error(ALLOCATION_FAILED_ERROR);
+		json_value_free(json);
 		return false;
 	}
-
-	strlcpy(summary->command, sql, len);
 
 	/* we can't provide instr_time readers */
 	summary->startTimeInstr = (instr_time) {
@@ -213,6 +162,7 @@ read_table_summary(CopyTableSummary *summary, const char *filename)
 		0
 	};
 
+	json_value_free(json);
 	return true;
 }
 
@@ -374,7 +324,8 @@ read_table_index_file(SourceIndexArray *indexArray, char *filename)
 bool
 write_index_summary(CopyIndexSummary *summary, char *filename, bool constraint)
 {
-	PQExpBuffer contents = createPQExpBuffer();
+	JSON_Value *js = json_value_init_object();
+	JSON_Object *jsObj = json_value_get_object(js);
 
 	uint32_t oid =
 		constraint
@@ -386,30 +337,30 @@ write_index_summary(CopyIndexSummary *summary, char *filename, bool constraint)
 		? summary->index->constraintName
 		: summary->index->indexRelname;
 
-	appendPQExpBuffer(contents,
-					  "%d\n%u\n%s\n%s\n%lld\n%lld\n%lld\n%s\n",
-					  summary->pid,
-					  oid,
-					  summary->index->indexNamespace,
-					  name,
-					  (long long) summary->startTime,
-					  (long long) summary->doneTime,
-					  (long long) summary->durationMs,
-					  summary->command);
+	json_object_set_number(jsObj, "pid", summary->pid);
 
-	/* memory allocation could have failed while building string */
-	if (PQExpBufferBroken(contents))
-	{
-		log_error("Failed to create file \"%s\": out of memory", filename);
-		destroyPQExpBuffer(contents);
-		return false;
-	}
+	json_object_dotset_number(jsObj, "index.oid", oid);
+	json_object_dotset_string(jsObj, "index.nspname",
+							  summary->index->indexNamespace);
+	json_object_dotset_string(jsObj, "index.relname", name);
+
+	json_object_set_number(jsObj, "start-time-epoch", summary->startTime);
+	json_object_set_number(jsObj, "done-time-epoch", summary->doneTime);
+	json_object_set_number(jsObj, "duration", summary->durationMs);
+	json_object_set_string(jsObj, "command", summary->command);
+
+	char *serialized_string = json_serialize_to_string_pretty(js);
+	size_t len = strlen(serialized_string);
 
 	/* write the summary to the doneFile */
-	if (!write_file(contents->data, contents->len, filename))
+	bool success = write_file(serialized_string, len, filename);
+
+	json_free_serialized_string(serialized_string);
+	json_value_free(js);
+
+	if (!success)
 	{
-		log_error("Failed to write file \"%s\"", filename);
-		destroyPQExpBuffer(contents);
+		log_error("Failed to write table summary file \"%s\"", filename);
 		return false;
 	}
 
@@ -423,82 +374,41 @@ write_index_summary(CopyIndexSummary *summary, char *filename, bool constraint)
 bool
 read_index_summary(CopyIndexSummary *summary, const char *filename)
 {
-	char *fileContents = NULL;
-	long fileSize = 0L;
+	JSON_Value *json = json_parse_file(filename);
 
-	if (!read_file(filename, &fileContents, &fileSize))
+	if (json == NULL)
 	{
-		/* errors have already been logged */
+		log_error("Failed to parse summary file \"%s\"", filename);
 		return false;
 	}
 
-	char *fileLines[BUFSIZE] = { 0 };
-	int lineCount = splitLines(fileContents, fileLines, BUFSIZE);
+	JSON_Object *jsObj = json_value_get_object(json);
 
-	if (lineCount < COPY_TABLE_SUMMARY_LINES)
-	{
-		log_error("Failed to parse summary file \"%s\" which contains only "
-				  "%d lines, at least %d lines are expected",
-				  filename,
-				  lineCount,
-				  COPY_TABLE_SUMMARY_LINES);
+	summary->pid = json_object_get_number(jsObj, "pid");
 
-		free(fileContents);
+	summary->index->indexOid = json_object_dotget_number(jsObj, "index.oid");
 
-		return false;
-	}
+	char *schema = (char *) json_object_dotget_string(jsObj, "index.nspname");
+	char *name = (char *) json_object_dotget_string(jsObj, "index.relname");
 
-	if (!stringToInt(fileLines[0], &(summary->pid)))
-	{
-		/* errors have already been logged */
-		return false;
-	}
+	strlcpy(summary->index->indexNamespace,
+			schema,
+			sizeof(summary->index->indexNamespace));
 
-	/* better not point to NULL */
-	SourceIndex *index = summary->index;
+	strlcpy(summary->index->indexRelname,
+			name,
+			sizeof(summary->index->indexRelname));
 
-	if (index == NULL)
-	{
-		log_error("BUG: read_index_summary summary->index is NULL");
-		return false;
-	}
+	summary->startTime = json_object_get_number(jsObj, "start-time-epoch");
+	summary->doneTime = json_object_get_number(jsObj, "done-time-epoch");
+	summary->durationMs = json_object_get_number(jsObj, "duration");
 
-	if (!stringToUInt32(fileLines[1], &(index->indexOid)))
-	{
-		/* errors have already been logged */
-		return false;
-	}
-
-	strlcpy(index->indexNamespace, fileLines[2], sizeof(index->indexNamespace));
-	strlcpy(index->indexRelname, fileLines[3], sizeof(index->indexRelname));
-
-	if (!stringToUInt64(fileLines[4], &(summary->startTime)))
-	{
-		/* errors have already been logged */
-		return false;
-	}
-
-	if (!stringToUInt64(fileLines[5], &(summary->doneTime)))
-	{
-		/* errors have already been logged */
-		return false;
-	}
-
-	if (!stringToUInt64(fileLines[6], &(summary->durationMs)))
-	{
-		/* errors have already been logged */
-		return false;
-	}
-
-	/* last summary line in the file is the SQL command */
-	char *sql = fileLines[7];
-	int len = strlen(sql) + 1;
-
-	summary->command = (char *) calloc(len, sizeof(char));
+	summary->command = strdup(json_object_get_string(jsObj, "command"));
 
 	if (summary->command == NULL)
 	{
 		log_error(ALLOCATION_FAILED_ERROR);
+		json_value_free(json);
 		return false;
 	}
 
@@ -510,6 +420,7 @@ read_index_summary(CopyIndexSummary *summary, const char *filename)
 		0
 	};
 
+	json_value_free(json);
 	return true;
 }
 
@@ -940,6 +851,9 @@ print_summary_table(SummaryTable *summary)
 void
 print_summary_as_json(Summary *summary, const char *filename)
 {
+	log_notice("Storing migration summary in JSON file \"%s\"", filename);
+	log_warn("Storing migration summary in JSON file \"%s\"", filename);
+
 	JSON_Value *js = json_value_init_object();
 	JSON_Object *jsobj = json_value_get_object(js);
 
@@ -1053,6 +967,8 @@ print_summary_as_json(Summary *summary, const char *filename)
 
 	json_object_set_value(jsobj, "steps", jsSteps);
 
+	log_warn("print_summary_as_json: steps");
+
 	SummaryTable *summaryTable = &(summary->table);
 
 	JSON_Value *jsTables = json_value_init_array();
@@ -1064,6 +980,9 @@ print_summary_as_json(Summary *summary, const char *filename)
 
 		JSON_Value *jsTable = json_value_init_object();
 		JSON_Object *jsTableObj = json_value_get_object(jsTable);
+
+		log_warn("print_summary_as_json: table %s [%u] %d/%d",
+				 entry->relname, entry->oid, i, summaryTable->count);
 
 		json_object_set_number(jsTableObj, "oid", entry->oid);
 		json_object_set_string(jsTableObj, "schema", entry->nspname);
@@ -1087,6 +1006,8 @@ print_summary_as_json(Summary *summary, const char *filename)
 			JSON_Value *jsIndex = json_value_init_object();
 			JSON_Object *jsIndexObj = json_value_get_object(jsIndex);
 
+			log_warn("print_summary_as_json: index %s", indexEntry->relname);
+
 			json_object_set_number(jsIndexObj, "oid", indexEntry->oid);
 			json_object_set_string(jsIndexObj, "schema", indexEntry->nspname);
 			json_object_set_string(jsIndexObj, "name", indexEntry->relname);
@@ -1109,6 +1030,8 @@ print_summary_as_json(Summary *summary, const char *filename)
 			JSON_Value *jsConstraint = json_value_init_object();
 			JSON_Object *jsConstraintObj = json_value_get_object(jsConstraint);
 
+			log_warn("print_summary_as_json: constraint %s", cEntry->relname);
+
 			json_object_set_number(jsConstraintObj, "oid", cEntry->oid);
 			json_object_set_string(jsConstraintObj, "schema", cEntry->nspname);
 			json_object_set_string(jsConstraintObj, "name", cEntry->relname);
@@ -1123,6 +1046,8 @@ print_summary_as_json(Summary *summary, const char *filename)
 
 		/* append the current table to the table array */
 		json_array_append_value(jsTableArray, jsTable);
+
+		log_warn("print_summary_as_json: %s done", entry->relname);
 	}
 
 	/* add the table array to the main JSON top-level dict */
@@ -1130,8 +1055,6 @@ print_summary_as_json(Summary *summary, const char *filename)
 
 	char *serialized_string = json_serialize_to_string_pretty(js);
 	size_t len = strlen(serialized_string);
-
-	log_notice("Storing migration summary in JSON file \"%s\"", filename);
 
 	if (!write_file(serialized_string, len, filename))
 	{
@@ -1254,6 +1177,8 @@ print_summary(Summary *summary, CopyDataSpec *specs)
 {
 	SummaryTable *summaryTable = &(summary->table);
 
+	log_warn("print_summary");
+
 	summary->tableJobs = specs->tableJobs;
 	summary->indexJobs = specs->indexJobs;
 
@@ -1264,14 +1189,20 @@ print_summary(Summary *summary, CopyDataSpec *specs)
 		return false;
 	}
 
+	log_warn("print_summary json 1");
+
 	/* print the summary.json file */
 	(void) print_summary_as_json(summary, specs->cfPaths.summaryfile);
+
+	log_warn("print_summary json 2");
 
 	/* then we can prepare the headers and print the table */
 	if (specs->section == DATA_SECTION_TABLE_DATA ||
 		specs->section == DATA_SECTION_ALL)
 	{
+		log_warn("prepare_summary_table_headers");
 		(void) prepare_summary_table_headers(summaryTable);
+		log_warn("print_summary_table");
 		(void) print_summary_table(summaryTable);
 	}
 
@@ -1326,7 +1257,8 @@ prepare_summary_table(Summary *summary, CopyDataSpec *specs)
 
 		if (!read_table_summary(&tableSummary, tableSpecs->tablePaths.doneFile))
 		{
-			/* errors have already been logged */
+			log_error("Failed to read table summary \"%s\"",
+					  tableSpecs->tablePaths.doneFile);
 			return false;
 		}
 
@@ -1352,7 +1284,8 @@ prepare_summary_table(Summary *summary, CopyDataSpec *specs)
 			if (!read_table_index_file(&indexArray,
 									   tableSpecs->tablePaths.idxListFile))
 			{
-				/* errors have already been logged */
+				log_error("Failed to read table index file \"%s\"",
+						  tableSpecs->tablePaths.idxListFile);
 				return false;
 			}
 
@@ -1392,7 +1325,8 @@ prepare_summary_table(Summary *summary, CopyDataSpec *specs)
 													 false, /* constraint */
 													 indexEntry))
 					{
-						/* errors have already been logged */
+						log_error("Failed to read index done file \"%s\"",
+								  indexPaths.doneFile);
 						return false;
 					}
 
@@ -1414,7 +1348,8 @@ prepare_summary_table(Summary *summary, CopyDataSpec *specs)
 													 true, /* constraint */
 													 indexEntry))
 					{
-						/* errors have already been logged */
+						log_error("Failed to read index done file \"%s\"",
+								  indexPaths.constraintDoneFile);
 						return false;
 					}
 
@@ -1447,7 +1382,8 @@ prepare_summary_table(Summary *summary, CopyDataSpec *specs)
 
 		if (!read_blobs_summary(&blobsSummary, specs->cfPaths.done.blobs))
 		{
-			/* errors have already been logged */
+			log_error("Failed to read blog summary file \"%s\"",
+					  specs->cfPaths.done.blobs);
 			return false;
 		}
 

--- a/src/bin/pgcopydb/summary.h
+++ b/src/bin/pgcopydb/summary.h
@@ -184,7 +184,6 @@ typedef struct Summary
 	int indexJobs;
 } Summary;
 
-
 bool write_table_summary(CopyTableSummary *summary, char *filename);
 bool read_table_summary(CopyTableSummary *summary, const char *filename);
 bool open_table_summary(CopyTableSummary *summary, char *filename);

--- a/src/bin/pgcopydb/table-data.c
+++ b/src/bin/pgcopydb/table-data.c
@@ -267,8 +267,6 @@ copydb_copy_supervisor(CopyDataSpec *specs)
 	{
 		QMessage stop = { .type = QMSG_TYPE_STOP };
 
-		log_warn("Send STOP message to COPY queue %d", specs->copyQueue.qId);
-
 		if (!queue_send(&(specs->copyQueue), &stop))
 		{
 			/* errors have already been logged */
@@ -279,16 +277,12 @@ copydb_copy_supervisor(CopyDataSpec *specs)
 	/*
 	 * Now just wait for the table-data COPY processes to be done.
 	 */
-	log_warn("COPY supervisor waits for children");
-
 	if (!copydb_wait_for_subprocesses(specs->failFast))
 	{
 		log_error("Some COPY worker process(es) have exited with error, "
 				  "see above for details");
 		return false;
 	}
-
-	log_warn("COPY supervisor children have now all exited");
 
 	/* write that we successfully finished copying all tables */
 	if (!write_file("", 0, specs->cfPaths.done.tables))
@@ -475,8 +469,6 @@ copydb_table_data_worker(CopyDataSpec *specs)
 				  pid,
 				  errors);
 	}
-
-	log_warn("Exiting table data COPY worker %d: %s", pid, success ? "ok" : "ko");
 
 	return success;
 }

--- a/src/bin/pgcopydb/vacuum.c
+++ b/src/bin/pgcopydb/vacuum.c
@@ -169,8 +169,6 @@ vacuum_analyze_table_by_oid(CopyDataSpec *specs, uint32_t oid)
 	CopyFilePaths *cfPaths = &(specs->cfPaths);
 	TableFilePaths tablePaths = { 0 };
 
-	log_trace("vacuum_analyze_table_by_oid: \"%s\"", specs->cfPaths.tbldir);
-
 	if (!copydb_init_tablepaths(cfPaths, &tablePaths, oid))
 	{
 		log_error("Failed to prepare pathnames for table %u", oid);
@@ -196,7 +194,8 @@ vacuum_analyze_table_by_oid(CopyDataSpec *specs, uint32_t oid)
 
 	if (!read_table_summary(&tableSummary, tablePaths.doneFile))
 	{
-		/* errors have already been logged */
+		log_error("Failed to read table summary file: \"%s\"",
+				  tablePaths.doneFile);
 		return false;
 	}
 
@@ -242,6 +241,8 @@ vacuum_add_table(CopyDataSpec *specs, uint32_t oid)
 		.type = QMSG_TYPE_TABLEOID,
 		.data.oid = oid
 	};
+
+	log_debug("vacuum_add_table: %u", oid);
 
 	if (!queue_send(&(specs->vacuumQueue), &mesg))
 	{

--- a/tests/pagila/copydb.sh
+++ b/tests/pagila/copydb.sh
@@ -36,5 +36,3 @@ psql -o /tmp/s.out -d ${PAGILA_SOURCE_PGURI} -1 -f /tmp/pagila-schema.sql
 psql -o /tmp/d.out -d ${PAGILA_SOURCE_PGURI} -1 -f /usr/src/pagila/pagila-data.sql
 
 pgcopydb clone --source ${PAGILA_SOURCE_PGURI} --target ${PAGILA_TARGET_PGURI}
-
-echo $?

--- a/tests/pagila/copydb.sh
+++ b/tests/pagila/copydb.sh
@@ -36,3 +36,5 @@ psql -o /tmp/s.out -d ${PAGILA_SOURCE_PGURI} -1 -f /tmp/pagila-schema.sql
 psql -o /tmp/d.out -d ${PAGILA_SOURCE_PGURI} -1 -f /usr/src/pagila/pagila-data.sql
 
 pgcopydb clone --source ${PAGILA_SOURCE_PGURI} --target ${PAGILA_TARGET_PGURI}
+
+echo $?

--- a/tests/unit/copydb.sh
+++ b/tests/unit/copydb.sh
@@ -25,7 +25,7 @@ create collation if not exists mycol
 EOF
 
 # pgcopydb fork uses the environment variables
-pgcopydb fork --skip-collations --debug
+pgcopydb fork --skip-collations --fail-fast --notice
 
 # now compare the output of running the SQL command with what's expected
 # as we're not root when running tests, can't write in /usr/src

--- a/tests/unit/setup/6-multiline-table-name.sql
+++ b/tests/unit/setup/6-multiline-table-name.sql
@@ -1,0 +1,7 @@
+CREATE TABLE public."with MyTableName
+
+     AS (SELECT row_id
+
+  " (
+    row_id uuid NOT NULL
+);

--- a/tests/unit/setup/setup.sql
+++ b/tests/unit/setup/setup.sql
@@ -3,3 +3,4 @@
 \ir 3-collations.sql
 \ir 4-list-table-split.sql
 \ir 5-long-index-def.sql
+\ir 6-multiline-table-name.sql


### PR DESCRIPTION
This ensures that Postgres object names are properly handled even when they may contain multiple lines, which is accepted, possible... and then found in the field.

In passing, ensure that we VACUUM ANALYZE tables without indexes. It's almost relevant to that patch because the failure mode of multiple-lines table names would break our vacuum module.

Fixes #297.