### PR TITLE
At follow mode switch, skip empty transform queues.

### DIFF
--- a/src/bin/pgcopydb/ld_stream.h
+++ b/src/bin/pgcopydb/ld_stream.h
@@ -55,7 +55,7 @@ typedef struct LogicalMessageMetadata
 	StreamAction action;
 	uint32_t xid;
 	uint64_t lsn;
-	uint64_t txnCommitLSN;		/* COMMIT LSN of the transaction */
+	uint64_t txnCommitLSN;      /* COMMIT LSN of the transaction */
 	char timestamp[PG_MAX_TIMESTAMP];
 
 	/* our own internal decision making */
@@ -574,7 +574,9 @@ bool follow_main_loop(CopyDataSpec *copySpecs, StreamSpecs *streamSpecs);
 bool followDB(CopyDataSpec *copySpecs, StreamSpecs *streamSpecs);
 
 bool follow_reached_endpos(StreamSpecs *streamSpecs, bool *done);
-bool follow_prepare_mode_switch(StreamSpecs *streamSpecs, LogicalStreamMode previousMode);
+bool follow_prepare_mode_switch(StreamSpecs *streamSpecs,
+								LogicalStreamMode previousMode,
+								LogicalStreamMode currentMode);
 
 bool follow_start_subprocess(StreamSpecs *specs, FollowSubProcess *subprocess);
 

--- a/src/bin/pgcopydb/queue_utils.c
+++ b/src/bin/pgcopydb/queue_utils.c
@@ -150,3 +150,28 @@ queue_receive(Queue *queue, QMessage *msg)
 
 	return true;
 }
+
+
+/*
+ * queue_stats retrieves statistics from the queue.
+ */
+bool
+queue_stats(Queue *queue, QueueStats *stats)
+{
+	struct msqid_ds ds = { 0 };
+
+	if (msgctl(queue->qId, IPC_STAT, &ds) != 0)
+	{
+		log_error("Failed to get stats for %s message queue %d: %m",
+				  queue->name,
+				  queue->qId);
+		return false;
+	}
+
+	stats->msg_cbytes = ds.msg_cbytes;
+	stats->msg_qnum = ds.msg_qnum;
+	stats->msg_lspid = ds.msg_lspid;
+	stats->msg_lrpid = ds.msg_lrpid;
+
+	return true;
+}

--- a/src/bin/pgcopydb/queue_utils.h
+++ b/src/bin/pgcopydb/queue_utils.h
@@ -52,4 +52,15 @@ bool queue_unlink(Queue *queue);
 bool queue_send(Queue *queue, QMessage *msg);
 bool queue_receive(Queue *queue, QMessage *msg);
 
+/* see struct msqid_ds in msgctl(2) */
+typedef struct QueueStats
+{
+	uint64_t msg_cbytes;    /* number of bytes in use on the queue */
+	uint64_t msg_qnum;      /* number of msgs in the queue */
+	pid_t msg_lspid;        /* pid of last msgsnd() */
+	pid_t msg_lrpid;        /* pid of last msgrcv() */
+} QueueStats;
+
+bool queue_stats(Queue *queue, QueueStats *stats);
+
 #endif /* QUEUE_UTILS_H */


### PR DESCRIPTION
Check the number of messages in the queue before entering a message receive loop that won't exit before reading in the STOP message. When the queue is empty, this turns into an infinite loop.