### PR TITLE
Fix incorrect xid and timestamp for continued txn COMMIT SQL.

### DIFF
--- a/src/bin/pgcopydb/ld_transform.c
+++ b/src/bin/pgcopydb/ld_transform.c
@@ -219,20 +219,6 @@ stream_transform_line(void *ctx, const char *line, bool *stop)
 			new.isTransaction = true;
 			new.action = STREAM_ACTION_BEGIN;
 
-			LogicalTransactionStatement *stmt = NULL;
-
-			stmt = (LogicalTransactionStatement *)
-				   calloc(1,
-						  sizeof(LogicalTransactionStatement));
-
-			if (stmt == NULL)
-			{
-				log_error(ALLOCATION_FAILED_ERROR);
-				return false;
-			}
-
-			stmt->action = STREAM_ACTION_BEGIN;
-
 			LogicalTransaction *old = &(currentMsg->command.tx);
 			LogicalTransaction *txn = &(new.command.tx);
 
@@ -718,22 +704,9 @@ stream_transform_file(char *jsonfilename, char *sqlfilename)
 			new.isTransaction = true;
 			new.action = STREAM_ACTION_BEGIN;
 
-			LogicalTransactionStatement *stmt = NULL;
-
-			stmt = (LogicalTransactionStatement *)
-				   calloc(1,
-						  sizeof(LogicalTransactionStatement));
-
-			if (stmt == NULL)
-			{
-				log_error(ALLOCATION_FAILED_ERROR);
-				return false;
-			}
-
-			stmt->action = STREAM_ACTION_BEGIN;
-
 			LogicalTransaction *txn = &(new.command.tx);
 			txn->continued = true;
+			txn->xid = metadata->xid;
 			txn->first = NULL;
 
 			*currentMsg = new;
@@ -1000,6 +973,8 @@ parseMessage(LogicalMessage *mesg,
 
 			txn->xid = metadata->xid;
 			txn->beginLSN = metadata->lsn;
+
+			/* this should be overwritten in COMMIT action as that's what we need for origin */
 			strlcpy(txn->timestamp, metadata->timestamp, sizeof(txn->timestamp));
 			txn->first = NULL;
 
@@ -1022,6 +997,8 @@ parseMessage(LogicalMessage *mesg,
 				return false;
 			}
 
+			/* update the timestamp for tracking in replication origin */
+			strlcpy(txn->timestamp, metadata->timestamp, sizeof(txn->timestamp));
 			txn->commitLSN = metadata->lsn;
 			txn->commit = true;
 


### PR DESCRIPTION
This fixes the missing `xid` and `timestamp` for continued transactions,
```sql
COMMIT; -- {"xid":0,"lsn":"6/A50001C8","timestamp":""}
```

This timestamp is used in `pgsql_replication_origin_xact_setup` which we
update along with `COMMIT;` statement. So it makes more sense to put
COMMIT's `timestamp` as origin timestamp.

Retaining the current update with `BEGIN` action as well. This avoids
`timestamp` being empty for `BEGIN` SQL statement in the file when COMMIT
spills to next SQL file.