### PR TITLE
transform: Fix transformation to empty txn when first line is COMMIT.

### DIFF
--- a/src/bin/pgcopydb/ld_transform.c
+++ b/src/bin/pgcopydb/ld_transform.c
@@ -1355,7 +1355,7 @@ stream_write_transaction(FILE *out, LogicalTransaction *txn)
 	 * other databases or background activity in the source Postgres instance
 	 * where the LSN is moving forward. We want to replay them.
 	 */
-	if (txn->count == 0)
+	if (!txn->continued && txn->count == 0)
 	{
 		if (!stream_write_begin(out, txn))
 		{


### PR DESCRIPTION
During prefetching, when a transaction continues to the next file and the first line of the next file (which is also the only remaining statement of the transaction) is a COMMIT message, it is incorrectly interpreted as an empty transaction. This fix addresses that issue.