### PR TITLE
Fix apply when file starts with non-begin/keepalive statements.

### DIFF
--- a/src/bin/pgcopydb/ld_apply.c
+++ b/src/bin/pgcopydb/ld_apply.c
@@ -414,8 +414,6 @@ stream_apply_file(StreamApplyContext *context)
 			  content.count,
 			  content.filename);
 
-	context->reachedStartPos = false;
-
 	/* replay the SQL commands from the SQL file */
 	for (int i = 0; i < content.count && !context->reachedEndPos; i++)
 	{
@@ -806,6 +804,9 @@ setupReplicationOrigin(StreamApplyContext *context,
 
 	context->paths = *paths;
 	context->apply = apply;
+
+	context->reachedStartPos = false;
+
 	strlcpy(context->source_pguri, source_pguri, sizeof(context->source_pguri));
 	strlcpy(context->target_pguri, target_pguri, sizeof(context->target_pguri));
 	strlcpy(context->origin, origin, sizeof(context->origin));


### PR DESCRIPTION
This fixes the issues where if a txn continues to next file and first statement of that file is not a BEGIN or KEEPALIVE statement then we skip applying COMMIT as well as I/U/T/D leading to the warning "there is already a transaction in progress".

This happens because `reachedStartPos` is set to `false` everytime a new file is processed. Since `reachedStartPos` is never set to true and apply doesn't starts until `BEGIN` or `KEEPALIVE` is found.