### PR TITLE
Switch from semaphores to message queue to share workload.

### DIFF
--- a/src/bin/pgcopydb/cli_clone_follow.c
+++ b/src/bin/pgcopydb/cli_clone_follow.c
@@ -543,10 +543,7 @@ cloneDB(CopyDataSpec *copySpecs)
 
 	(void) summary_set_current_time(timings, TIMING_STEP_AFTER_PREPARE_SCHEMA);
 
-	log_info("STEP 4: copy data from source to target in %d sub-processes",
-			 copySpecs->tableJobs);
-
-	/* STEPs 5, 6, 7, 8, and 9 are printed when starting the sub-processes */
+	/* STEPs 4, 5, 6, 7, 8, and 9 are printed when starting the sub-processes */
 
 	if (!copydb_copy_all_table_data(copySpecs))
 	{

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -247,8 +247,9 @@ typedef struct CopyDataSpec
 	Semaphore tableSemaphore;
 	Semaphore indexSemaphore;
 
-	Queue vacuumQueue;
+	Queue copyQueue;
 	Queue indexQueue;
+	Queue vacuumQueue;
 
 	DumpPaths dumpPaths;
 
@@ -353,6 +354,7 @@ bool snapshot_write_slot(const char *filename, ReplicationSlot *slot);
 bool snapshot_read_slot(const char *filename, ReplicationSlot *slot);
 
 /* extensions.c */
+bool copydb_start_extension_data_process(CopyDataSpec *specs);
 bool copydb_copy_extensions(CopyDataSpec *copySpecs, bool createExtensions);
 
 /* indexes.c */
@@ -453,18 +455,26 @@ char * copydb_ObjectKindToString(ObjectKind kind);
 
 /* table-data.c */
 bool copydb_copy_all_table_data(CopyDataSpec *specs);
-
 bool copydb_process_table_data(CopyDataSpec *specs);
+
+bool copydb_start_copy_supervisor(CopyDataSpec *specs);
+bool copydb_copy_supervisor(CopyDataSpec *specs);
+bool copydb_start_table_data_workers(CopyDataSpec *specs);
+bool copydb_table_data_worker(CopyDataSpec *specs);
+
+bool copydb_add_copy(CopyDataSpec *specs, uint32_t oid, uint32_t part);
+bool copydb_copy_data_by_oid(CopyDataSpec *specs, uint32_t oid, uint32_t part);
+
 bool copydb_process_table_data_worker(CopyDataSpec *specs);
 
 bool copydb_process_table_data_with_workers(CopyDataSpec *specs);
 
 bool copydb_copy_table(CopyDataSpec *specs, CopyTableDataSpec *tableSpecs);
 
-bool copydb_table_is_being_processed(CopyDataSpec *specs,
-									 CopyTableDataSpec *tableSpecs,
-									 bool *isDone,
-									 bool *isBeingProcessed);
+
+bool copydb_table_create_lockfile(CopyDataSpec *specs,
+								  CopyTableDataSpec *tableSpecs,
+								  bool *isDone);
 
 bool copydb_mark_table_as_done(CopyDataSpec *specs,
 							   CopyTableDataSpec *tableSpecs);

--- a/src/bin/pgcopydb/copydb_schema.c
+++ b/src/bin/pgcopydb/copydb_schema.c
@@ -434,7 +434,7 @@ copydb_prepare_index_specs(CopyDataSpec *specs, PGSQL *pgsql)
 		{
 			SourceIndex *index = &(indexArray->array[i]);
 
-			/* add the current table to the index Hash-by-OID */
+			/* add the current index to the index Hash-by-OID */
 			HASH_ADD(hh, sourceIndexHashByOid, indexOid, sizeof(uint32_t), index);
 
 			/* find the index table, update its index list */

--- a/src/bin/pgcopydb/queue_utils.c
+++ b/src/bin/pgcopydb/queue_utils.c
@@ -42,8 +42,9 @@ queue_create(Queue *queue, char *name)
 		return false;
 	}
 
-	log_debug("Created message %s queue %d (cleanup with ipcrm -q)",
+	log_debug("Created message %s queue %d (cleanup with `ipcrm -q %d`)",
 			  queue->name,
+			  queue->qId,
 			  queue->qId);
 
 	return true;

--- a/src/bin/pgcopydb/queue_utils.h
+++ b/src/bin/pgcopydb/queue_utils.h
@@ -30,9 +30,10 @@ typedef struct Queue
 typedef enum
 {
 	QMSG_TYPE_UNKNOWN = 0,
-	QMSG_TYPE_TABLEOID,
-	QMSG_TYPE_INDEXOID,
-	QMSG_TYPE_STREAM_TRANSFORM,
+	QMSG_TYPE_TABLEOID,         /* table oid */
+	QMSG_TYPE_TABLEPOID,        /* table oid, table partition number */
+	QMSG_TYPE_INDEXOID,         /* index oid */
+	QMSG_TYPE_STREAM_TRANSFORM, /* lsn position for transform process */
 	QMSG_TYPE_STOP
 } QMessageType;
 
@@ -43,6 +44,13 @@ typedef struct QMessage
 	{
 		uint32_t oid;
 		uint64_t lsn;
+
+		/* table parts (support for COPY partitionning) */
+		struct tp
+		{
+			uint32_t oid;
+			uint32_t part;
+		} tp;
 	} data;
 } QMessage;
 


### PR DESCRIPTION
Using semaphores for work-sharing isn't ideal and brings some complexity and inefficiencies (each worker process loops over the whole table array). Now that we have introduced Sys V queues, use that mechanism instead to share the workload between table-data COPY workers.

We still need to use a semaphore to create the lockfile and donefile so that we can track progress, resume from interrupted operations, and discover if all the partitions of a single table have been processed already. That said, we don't have to deal with same-table concurrency using the semaphore and files, the queue solves that for us.