### PR TITLE
Avoid testing with postgis_topology.

### DIFF
--- a/tests/extensions/copydb.sh
+++ b/tests/extensions/copydb.sh
@@ -30,7 +30,6 @@ EOF
 # create extensions on the source pagila database (needs superuser)
 psql -a -1 ${PGCOPYDB_SOURCE_PGURI_SU} <<EOF
 create extension postgis cascade;
-create extension postgis_topology cascade;
 EOF
 
 # the partman extension needs to be installed as the pagila role
@@ -51,6 +50,8 @@ coproc ( pgcopydb snapshot --debug )
 sleep 1
 
 # copy the extensions separately, needs superuser (both on source and target)
+pgcopydb list extensions
+
 pgcopydb copy extensions \
          --source ${PGCOPYDB_SOURCE_PGURI_SU} \
          --target ${PGCOPYDB_TARGET_PGURI_SU}


### PR DESCRIPTION
This is currently a moving target. Version 3.3.3 adds topology_id_seq as an Extension Configuration Table, and pgcopydb is not ready to handle a sequence there.