### PR TITLE
Assorted set of small fixes.

### DIFF
--- a/src/bin/pgcopydb/cli_clone_follow.c
+++ b/src/bin/pgcopydb/cli_clone_follow.c
@@ -544,7 +544,6 @@ cloneDB(CopyDataSpec *copySpecs)
 	(void) summary_set_current_time(timings, TIMING_STEP_AFTER_PREPARE_SCHEMA);
 
 	/* STEPs 4, 5, 6, 7, 8, and 9 are printed when starting the sub-processes */
-
 	if (!copydb_copy_all_table_data(copySpecs))
 	{
 		/* errors have already been logged */


### PR DESCRIPTION
  - When the filtering results in an empty list of selected tables, make sure we don't enter infinite loop waiting for events that won't happen.

  - Make sure to prepare the pgcopydb_table_size (temporary) table when doing the pgcopydb copy ... commands that need it.

  - Ensure proper memory allocation and calloc() error detection when printing the summary tables.

  - Work around what looks like a compiler bug when int errors = 0; actually sets the errors counter to 32759 on macOs. For that the COPY workers are now always in "fail-fast" mode, we can't count the errors anymore.