### PR TITLE
When applying CDC (logical replication), set role to replica.

### DIFF
--- a/src/bin/pgcopydb/copydb.c
+++ b/src/bin/pgcopydb/copydb.c
@@ -23,20 +23,16 @@
 #include "string_utils.h"
 #include "summary.h"
 
-#define COMMON_GUC_SETTINGS \
-	{ "client_encoding", "'UTF-8'" }, \
-	{ "tcp_keepalives_idle", "'60s'" },
-
 
 /* Postgres 9.5 does not have idle_in_transaction_session_timeout */
 GUC srcSettings95[] = {
-	COMMON_GUC_SETTINGS
+	COMMON_GUC_SETTINGS,
 	{ NULL, NULL },
 };
 
 
 GUC srcSettings[] = {
-	COMMON_GUC_SETTINGS
+	COMMON_GUC_SETTINGS,
 	{ "extra_float_digits", "3" },
 	{ "idle_in_transaction_session_timeout", "0" },
 	{ NULL, NULL },
@@ -44,7 +40,7 @@ GUC srcSettings[] = {
 
 
 GUC dstSettings[] = {
-	COMMON_GUC_SETTINGS
+	COMMON_GUC_SETTINGS,
 	{ "maintenance_work_mem", "'1 GB'" },
 	{ "synchronous_commit", "'off'" },
 	{ NULL, NULL },

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -17,6 +17,10 @@
 #include "summary.h"
 
 
+#define COMMON_GUC_SETTINGS \
+	{ "client_encoding", "'UTF-8'" }, \
+	{ "tcp_keepalives_idle", "'60s'" }
+
 /*
  * pgcopydb creates System V OS level objects such as message queues and
  * semaphores, and those have to be cleaned-up "manually".

--- a/src/bin/pgcopydb/ld_apply.c
+++ b/src/bin/pgcopydb/ld_apply.c
@@ -32,6 +32,12 @@
 #include "summary.h"
 
 
+GUC applySettings[] = {
+	COMMON_GUC_SETTINGS,
+	{ "session_replication_role", "'replica'" },
+	{ NULL, NULL },
+};
+
 /*
  * stream_apply_catchup catches up with SQL files that have been prepared by
  * either the `pgcopydb stream prefetch` command.
@@ -582,6 +588,13 @@ stream_apply_sql(StreamApplyContext *context,
 			if (!pgsql_begin(pgsql))
 			{
 				/* errors have already been logged */
+				return false;
+			}
+
+			if (!pgsql_set_gucs(pgsql, applySettings))
+			{
+				log_error("Failed to set the apply GUC settings, "
+						  "see above for details");
 				return false;
 			}
 


### PR DESCRIPTION
Postgres GUC session_replication_role should be used and set to 'replica' when applying changes from the source database system, to avoid triggers firing again.

Fixes #288.