### PR TITLE
Fix schema queries for exclusion filters.

### DIFF
--- a/src/bin/pgcopydb/cli_list.c
+++ b/src/bin/pgcopydb/cli_list.c
@@ -1028,20 +1028,22 @@ cli_list_sequences(int argc, char **argv)
 
 	log_info("Fetched information for %d sequences", sequenceArray.count);
 
-	fformat(stdout, "%8s | %20s | %30s\n",
-			"OID", "Schema Name", "Sequence Name");
+	fformat(stdout, "%8s | %20s | %30s | %10s \n",
+			"OID", "Schema Name", "Sequence Name", "attroid");
 
-	fformat(stdout, "%8s-+-%20s-+-%30s\n",
+	fformat(stdout, "%8s-+-%20s-+-%30s-+-%10s\n",
 			"--------",
 			"--------------------",
-			"------------------------------");
+			"------------------------------",
+			"----------");
 
 	for (int i = 0; i < sequenceArray.count; i++)
 	{
-		fformat(stdout, "%8d | %20s | %30s\n",
+		fformat(stdout, "%8d | %20s | %30s | %10d\n",
 				sequenceArray.array[i].oid,
 				sequenceArray.array[i].nspname,
-				sequenceArray.array[i].relname);
+				sequenceArray.array[i].relname,
+				sequenceArray.array[i].attroid);
 	}
 
 	fformat(stdout, "\n");
@@ -1243,7 +1245,7 @@ cli_list_depends(int argc, char **argv)
 
 			if (filters.type == SOURCE_FILTER_TYPE_NONE)
 			{
-				log_error("BUG: can't list skipped sequences "
+				log_error("BUG: can't list skipped dependencies "
 						  " from filtering type %d",
 						  filters.type);
 				exit(EXIT_CODE_INTERNAL_ERROR);

--- a/src/bin/pgcopydb/filtering.c
+++ b/src/bin/pgcopydb/filtering.c
@@ -260,10 +260,13 @@ parse_filters(const char *filename, SourceFilters *filters)
 	 * and any other filtering rule, which are exclusion rules. Otherwise it's
 	 * unclear what to do with tables that are not excluded and not included
 	 * either.
+	 *
+	 * Using both exclude-schema and include-only-table sections is allowed,
+	 * the user needs to pay attention not to exclude schemas of tables that
+	 * are then to be included only.
 	 */
 	if (filters->includeOnlyTableList.count > 0 &&
-		(filters->excludeTableList.count > 0 ||
-		 filters->excludeSchemaList.count > 0))
+		filters->excludeTableList.count > 0)
 	{
 		log_error("Filtering setup in \"%s\" contains "
 				  "%d entries in \"%s\" section and %d entries in \"%s\" "
@@ -274,6 +277,20 @@ parse_filters(const char *filename, SourceFilters *filters)
 				  filters->excludeTableList.count,
 				  "exclude-table");
 		return false;
+	}
+
+	if (filters->includeOnlyTableList.count > 0 &&
+		filters->excludeSchemaList.count > 0)
+	{
+		log_warn("Filtering setup in \"%s\" contains %d entries "
+				 "in \"%s\" section and %d entries in \"%s\" section, "
+				 "please make sure not to filter-out schema of "
+				 "tables you want to include",
+				 filename,
+				 filters->includeOnlyTableList.count,
+				 "include-only-table",
+				 filters->excludeSchemaList.count,
+				 "exclude-schema");
 	}
 
 	/*

--- a/tests/filtering/Dockerfile
+++ b/tests/filtering/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /usr/src/pgcopydb
 COPY ./copydb.sh copydb.sh
 COPY ./include.ini include.ini
 COPY ./exclude.ini exclude.ini
+COPY ./extra.sql extra.sql
 
 # unit tests
 COPY ./sql ./test/sql

--- a/tests/filtering/copydb.sh
+++ b/tests/filtering/copydb.sh
@@ -45,7 +45,7 @@ find .
 
 pgopts="--single-transaction --no-psqlrc --expanded"
 
-for f in ./sql/3-*.sql
+for f in ./sql/*.sql
 do
     t=`basename $f .sql`
     r=/tmp/results/${t}.out

--- a/tests/filtering/copydb.sh
+++ b/tests/filtering/copydb.sh
@@ -15,9 +15,27 @@ pgcopydb ping
 
 psql -o /tmp/s.out -d ${PGCOPYDB_SOURCE_PGURI} -1 -f /usr/src/pagila/pagila-schema.sql
 psql -o /tmp/d.out -d ${PGCOPYDB_SOURCE_PGURI} -1 -f /usr/src/pagila/pagila-data.sql
+psql -o /tmp/e.out -d ${PGCOPYDB_SOURCE_PGURI} -1 -f /usr/src/pgcopydb/extra.sql
 
-# pgcopydb clone uses the environment variables
-pgcopydb clone --filters /usr/src/pgcopydb/include.ini
+# list the exclude filters now, and the computed dependencies
+cat /usr/src/pgcopydb/exclude.ini
+
+# list the dependencies of objects that are selected by the filters
+pgcopydb list depends --filters /usr/src/pgcopydb/exclude.ini
+
+# list the dependencies of objects that are NOT selected by the filters
+pgcopydb list depends --filters /usr/src/pgcopydb/exclude.ini --list-skipped
+
+# list the sequences that are selected
+pgcopydb list sequences --filters /usr/src/pgcopydb/exclude.ini
+
+# list the sequences that are NOT selected
+pgcopydb list sequences --filters /usr/src/pgcopydb/exclude.ini --list-skipped
+
+pgcopydb clone --filters /usr/src/pgcopydb/exclude.ini
+
+# now another migration with the "include-only" parts of the data
+pgcopydb clone --filters /usr/src/pgcopydb/include.ini --restart
 
 # now compare the output of running the SQL command with what's expected
 # as we're not root when running tests, can't write in /usr/src
@@ -27,7 +45,7 @@ find .
 
 pgopts="--single-transaction --no-psqlrc --expanded"
 
-for f in ./sql/*.sql
+for f in ./sql/3-*.sql
 do
     t=`basename $f .sql`
     r=/tmp/results/${t}.out

--- a/tests/filtering/exclude.ini
+++ b/tests/filtering/exclude.ini
@@ -1,17 +1,13 @@
 [exclude-schema]
-foo
+public
 bar
-expected
 
 [exclude-table]
-"schema"."name"
-schema.othername
-err.errors
-public.serial
-
-[exclude-index]
-schema.indexname
-
-[exclude-table-data]
-public.bar
-nsitra.test1
+# public.actor
+# public.category
+# public.film
+# public.film_actor
+# public.film_category
+# public.language
+# public.rental
+foo.test_tbl_2

--- a/tests/filtering/expected/3-schema-bar-does-not-exists.out
+++ b/tests/filtering/expected/3-schema-bar-does-not-exists.out
@@ -1,0 +1,5 @@
+-[ RECORD 1 ]---
+nspname | public
+-[ RECORD 2 ]---
+nspname | foo
+

--- a/tests/filtering/extra.sql
+++ b/tests/filtering/extra.sql
@@ -1,0 +1,43 @@
+--
+-- See https://github.com/dimitri/pgcopydb/issues/280
+--
+create schema foo;
+
+-- create status dictionary table
+create table foo.tbl_status (
+    id bigserial not null primary key,
+    name varchar(32) not null unique check (name != '')
+);
+
+insert into foo.tbl_status (id, name)
+     values (1, 'draft'),
+            (2, 'active'),
+            (3, 'closed');
+
+-- fix id sequence value the manual way
+SELECT setval(pg_get_serial_sequence('foo.tbl_status', 'id'),
+              (SELECT COALESCE(MAX(id) + 1, 1) FROM foo.tbl_status),
+              false);
+
+-- create first table
+create table foo.tbl1 (
+    id bigserial not null primary key,
+    status_id bigint not null default 1 references foo.tbl_status(id),
+    desc_text varchar(32)
+);
+
+create index if not exists tbl1_status_id_idx on foo.tbl1(status_id);
+
+-- create second table
+create table foo.tbl2 (
+    id bigserial not null primary key,
+    tbl1_id bigint not null references foo.tbl1(id),
+    desc_text varchar(32)
+);
+
+create index if not exists tbl2_tbl1_id_idx on foo.tbl2(tbl1_id);
+
+--
+-- And another schema that we exclude wholesale.
+--
+create schema bar;

--- a/tests/filtering/include.ini
+++ b/tests/filtering/include.ini
@@ -1,3 +1,7 @@
+[exclude-schema]
+foo
+bar
+
 [include-only-table]
 public.actor
 public.category

--- a/tests/filtering/sql/3-schema-bar-does-not-exists.sql
+++ b/tests/filtering/sql/3-schema-bar-does-not-exists.sql
@@ -1,0 +1,3 @@
+select nspname
+  from pg_namespace
+ where nspname !~ '^pg_' and nspname <> 'information_schema';


### PR DESCRIPTION
Schema queries for dependencies and sequences for exclusion filters where both having bugs, impacting the selection of the objects to be filtered-out when using exclusion filters.

Fixes #280.