### PR TITLE
apply: Remove unnecessary reading for txnCommitLSN after reaching startpos.

### DIFF
--- a/src/bin/pgcopydb/ld_apply.c
+++ b/src/bin/pgcopydb/ld_apply.c
@@ -501,34 +501,6 @@ stream_apply_sql(StreamApplyContext *context,
 				return false;
 			}
 
-			/* if txnCommitLSN is invalid, then fetch it from txn metadata file */
-			if (metadata->txnCommitLSN == InvalidXLogRecPtr)
-			{
-				char txnfilename[MAXPGPATH] = { 0 };
-
-				if (!computeTxnMetadataFilename(metadata->xid,
-												context->paths.dir,
-												txnfilename))
-				{
-					/* errors have already been logged */
-					return false;
-				}
-
-				log_debug("stream_apply_sql: BEGIN message without a commit LSN, "
-						  "fetching commit LSN from transaction metadata file \"%s\"",
-						  txnfilename);
-
-				LogicalMessageMetadata txnMetadata = { .xid = metadata->xid };
-
-				if (!parseTxnMetadataFile(txnfilename, &txnMetadata))
-				{
-					/* errors have already been logged */
-					return false;
-				}
-
-				metadata->txnCommitLSN = txnMetadata.txnCommitLSN;
-			}
-
 			/* did we reach the starting LSN positions now? */
 			if (!context->reachedStartPos)
 			{
@@ -546,6 +518,12 @@ stream_apply_sql(StreamApplyContext *context,
 				 * transaction's COMMIT LSN or the LSN of non-transaction
 				 * action. Therefore, this condition will still hold true.
 				 */
+
+				if (!readTxnCommitLSN(context, metadata))
+				{
+					/* errors have already been logged */
+					return false;
+				}
 
 				context->reachedStartPos =
 					context->previousLSN < metadata->txnCommitLSN;
@@ -1015,6 +993,48 @@ parseSQLAction(const char *query, LogicalMessageMetadata *metadata)
 		log_error("Failed to parse action from query: %s", query);
 		return false;
 	}
+
+	return true;
+}
+
+
+/*
+ * readTxnCommitLSN ensures metadata has transaction COMMIT LSN by fetching it
+ * from metadata file if it is not present
+ */
+bool
+readTxnCommitLSN(StreamApplyContext *context,
+				 LogicalMessageMetadata *metadata)
+{
+	/* if txnCommitLSN is invalid, then fetch it from txn metadata file */
+	if (metadata->txnCommitLSN != InvalidXLogRecPtr)
+	{
+		return true;
+	}
+
+	char txnfilename[MAXPGPATH] = { 0 };
+
+	if (!computeTxnMetadataFilename(metadata->xid,
+									context->paths.dir,
+									txnfilename))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	log_debug("stream_apply_sql: BEGIN message without a commit LSN, "
+			  "fetching commit LSN from transaction metadata file \"%s\"",
+			  txnfilename);
+
+	LogicalMessageMetadata txnMetadata = { .xid = metadata->xid };
+
+	if (!parseTxnMetadataFile(txnfilename, &txnMetadata))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	metadata->txnCommitLSN = txnMetadata.txnCommitLSN;
 
 	return true;
 }

--- a/src/bin/pgcopydb/ld_stream.h
+++ b/src/bin/pgcopydb/ld_stream.h
@@ -563,7 +563,8 @@ bool setupReplicationOrigin(StreamApplyContext *context,
 bool computeSQLFileName(StreamApplyContext *context);
 
 bool parseSQLAction(const char *query, LogicalMessageMetadata *metadata);
-
+bool readTxnCommitLSN(StreamApplyContext *context,
+					  LogicalMessageMetadata *metadata);
 bool parseTxnMetadataFile(const char *filename, LogicalMessageMetadata *metadata);
 
 /* ld_replay */


### PR DESCRIPTION
Currently, we use txnCommitLSN to determine if we have reached the startpos. If the txnCommitLSN is invalid, we read the transaction metadata file from disk or wait until it exists. However, there is a bug that we continue to check the validity of txnCommitLSN and read metadata file even after reaching startpos. This additional work is unnecessary.

Furthermore, this commit partially address an issue where a transaction is split by KEEPALIVE message during the replay phase. Previously, we would wait for transaction metadata file to be created, which would never happen and eventually lead to migration failure.