### PR TITLE
Refactor code to prepare for test_decoding improvements.

### DIFF
--- a/src/bin/pgcopydb/cli_clone_follow.c
+++ b/src/bin/pgcopydb/cli_clone_follow.c
@@ -203,6 +203,7 @@ clone_and_follow(CopyDataSpec *copySpecs)
 						   copyDBoptions.origin,
 						   copyDBoptions.endpos,
 						   STREAM_MODE_CATCHUP,
+						   &(copySpecs->catalog),
 						   copyDBoptions.stdIn,
 						   copyDBoptions.stdOut,
 						   logSQL))
@@ -343,6 +344,7 @@ cli_follow(int argc, char **argv)
 						   copyDBoptions.origin,
 						   copyDBoptions.endpos,
 						   STREAM_MODE_CATCHUP,
+						   &(copySpecs.catalog),
 						   copyDBoptions.stdIn,
 						   copyDBoptions.stdOut,
 						   logSQL))

--- a/src/bin/pgcopydb/cli_list.c
+++ b/src/bin/pgcopydb/cli_list.c
@@ -26,7 +26,7 @@
 ListDBOptions listDBoptions = { 0 };
 
 static int cli_list_db_getopts(int argc, char **argv);
-static void cli_list_catalogs(int argc, char **argv);
+static void cli_list_databases(int argc, char **argv);
 static void cli_list_extensions(int argc, char **argv);
 static void cli_list_collations(int argc, char **argv);
 static void cli_list_tables(int argc, char **argv);
@@ -47,7 +47,7 @@ static CommandLine list_catalogs_command =
 		" --source ... ",
 		"  --source            Postgres URI to the source database\n",
 		cli_list_db_getopts,
-		cli_list_catalogs);
+		cli_list_databases);
 
 static CommandLine list_extensions_command =
 	make_command(
@@ -473,13 +473,13 @@ cli_list_db_getopts(int argc, char **argv)
 
 
 /*
- * cli_list_catalogs implements the command: pgcopydb list catalogs
+ * cli_list_databases implements the command: pgcopydb list databases
  */
 static void
-cli_list_catalogs(int argc, char **argv)
+cli_list_databases(int argc, char **argv)
 {
 	PGSQL pgsql = { 0 };
-	SourceCatalogArray catalogArray = { 0, NULL };
+	SourceDatabaseArray databaseArray = { 0, NULL };
 
 	if (!pgsql_init(&pgsql, listDBoptions.source_pguri, PGSQL_CONN_SOURCE))
 	{
@@ -487,13 +487,13 @@ cli_list_catalogs(int argc, char **argv)
 		exit(EXIT_CODE_SOURCE);
 	}
 
-	if (!schema_list_catalogs(&pgsql, &catalogArray))
+	if (!schema_list_databases(&pgsql, &databaseArray))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);
 	}
 
-	log_info("Fetched information for %d catalogs", catalogArray.count);
+	log_info("Fetched information for %d databases", databaseArray.count);
 
 	fformat(stdout, "%10s | %20s | %20s\n",
 			"OID",
@@ -505,9 +505,9 @@ cli_list_catalogs(int argc, char **argv)
 			"--------------------",
 			"--------------------");
 
-	for (int i = 0; i < catalogArray.count; i++)
+	for (int i = 0; i < databaseArray.count; i++)
 	{
-		SourceCatalog *cat = &(catalogArray.array[i]);
+		SourceDatabase *cat = &(databaseArray.array[i]);
 
 		fformat(stdout, "%10u | %20s | %20s\n",
 				cat->oid,

--- a/src/bin/pgcopydb/cli_snapshot.c
+++ b/src/bin/pgcopydb/cli_snapshot.c
@@ -291,6 +291,7 @@ cli_create_snapshot(int argc, char **argv)
 							   createSNoptions.origin,
 							   createSNoptions.endpos,
 							   STREAM_MODE_CATCHUP,
+							   &(copySpecs.catalog),
 							   createSNoptions.stdIn,
 							   createSNoptions.stdOut,
 							   logSQL))

--- a/src/bin/pgcopydb/cli_stream.c
+++ b/src/bin/pgcopydb/cli_stream.c
@@ -555,6 +555,7 @@ cli_stream_setup(int argc, char **argv)
 						   streamDBoptions.origin,
 						   streamDBoptions.endpos,
 						   STREAM_MODE_CATCHUP,
+						   &(copySpecs.catalog),
 						   streamDBoptions.stdIn,
 						   streamDBoptions.stdOut,
 						   logSQL))
@@ -667,6 +668,7 @@ cli_stream_catchup(int argc, char **argv)
 						   streamDBoptions.origin,
 						   streamDBoptions.endpos,
 						   STREAM_MODE_CATCHUP,
+						   &(copySpecs.catalog),
 						   streamDBoptions.stdIn,
 						   streamDBoptions.stdOut,
 						   logSQL))
@@ -750,6 +752,7 @@ cli_stream_replay(int argc, char **argv)
 						   streamDBoptions.origin,
 						   streamDBoptions.endpos,
 						   STREAM_MODE_REPLAY,
+						   &(copySpecs.catalog),
 						   true,  /* stdin */
 						   true, /* stdout */
 						   logSQL))
@@ -875,6 +878,7 @@ cli_stream_transform(int argc, char **argv)
 						   streamDBoptions.origin,
 						   streamDBoptions.endpos,
 						   STREAM_MODE_CATCHUP,
+						   &(copySpecs.catalog),
 						   streamDBoptions.stdIn,
 						   streamDBoptions.stdOut,
 						   logSQL))
@@ -920,7 +924,7 @@ cli_stream_transform(int argc, char **argv)
 			exit(EXIT_CODE_INTERNAL_ERROR);
 		}
 	}
-	else if (!stream_transform_file(jsonfilename, sqlfilename, specs.paths.dir))
+	else if (!stream_transform_file(&specs, jsonfilename, sqlfilename))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);
@@ -1010,6 +1014,7 @@ cli_stream_apply(int argc, char **argv)
 							   streamDBoptions.origin,
 							   streamDBoptions.endpos,
 							   STREAM_MODE_CATCHUP,
+							   &(copySpecs.catalog),
 							   true, /* streamDBoptions.stdIn */
 							   false, /* streamDBoptions.stdOut */
 							   logSQL))
@@ -1109,6 +1114,7 @@ stream_start_in_mode(LogicalStreamMode mode)
 						   streamDBoptions.origin,
 						   streamDBoptions.endpos,
 						   mode,
+						   &(copySpecs.catalog),
 						   streamDBoptions.stdIn,
 						   streamDBoptions.stdOut,
 						   logSQL))

--- a/src/bin/pgcopydb/copydb.c
+++ b/src/bin/pgcopydb/copydb.c
@@ -667,7 +667,8 @@ copydb_init_specs(CopyDataSpec *specs,
 		.vacuumQueue = { 0 },
 		.indexQueue = { 0 },
 
-		.catalog = { 0 }
+		.catalog = { 0 },
+		.tableSpecsArray = { 0, NULL }
 	};
 
 	/* initialize the connection strings */

--- a/src/bin/pgcopydb/copydb.c
+++ b/src/bin/pgcopydb/copydb.c
@@ -667,13 +667,7 @@ copydb_init_specs(CopyDataSpec *specs,
 		.vacuumQueue = { 0 },
 		.indexQueue = { 0 },
 
-		.extensionArray = { 0, NULL },
-		.sourceTableArray = { 0, NULL },
-		.sourceIndexArray = { 0, NULL },
-		.sequenceArray = { 0, NULL },
-		.tableSpecsArray = { 0, NULL },
-
-		.sourceTableHashByOid = NULL
+		.catalog = { 0 }
 	};
 
 	/* initialize the connection strings */

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -261,15 +261,8 @@ typedef struct CopyDataSpec
 	bool hasDBCreatePrivilege;
 	bool hasDBTempPrivilege;
 
-	SourceExtensionArray extensionArray;
-	SourceCollationArray collationArray;
-	SourceTableArray sourceTableArray;
-	SourceIndexArray sourceIndexArray;
+	SourceCatalog catalog;
 	CopyTableDataSpecsArray tableSpecsArray;
-	SourceSequenceArray sequenceArray;
-
-	SourceTable *sourceTableHashByOid;
-	SourceIndex *sourceIndexHashByOid;
 } CopyDataSpec;
 
 

--- a/src/bin/pgcopydb/dump_restore.c
+++ b/src/bin/pgcopydb/dump_restore.c
@@ -188,7 +188,7 @@ copydb_target_drop_tables(CopyDataSpec *specs)
 {
 	log_info("Drop tables on the target database, per --drop-if-exists");
 
-	SourceTableArray *tableArray = &(specs->sourceTableArray);
+	SourceTableArray *tableArray = &(specs->catalog.sourceTableArray);
 
 	if (tableArray->count == 0)
 	{

--- a/src/bin/pgcopydb/extensions.c
+++ b/src/bin/pgcopydb/extensions.c
@@ -81,7 +81,7 @@ copydb_copy_extensions(CopyDataSpec *copySpecs, bool createExtensions)
 	int errors = 0;
 	PGSQL dst = { 0 };
 
-	SourceExtensionArray *extensionArray = &(copySpecs->extensionArray);
+	SourceExtensionArray *extensionArray = &(copySpecs->catalog.extensionArray);
 
 	if (!pgsql_init(&dst, copySpecs->target_pguri, PGSQL_CONN_TARGET))
 	{

--- a/src/bin/pgcopydb/indexes.c
+++ b/src/bin/pgcopydb/indexes.c
@@ -169,7 +169,7 @@ copydb_create_index_by_oid(CopyDataSpec *specs, uint32_t indexOid)
 
 	log_trace("copydb_create_index_by_oid: %u", indexOid);
 
-	HASH_FIND(hh, specs->sourceIndexHashByOid, &oid, sizeof(oid), index);
+	HASH_FIND(hh, specs->catalog.sourceIndexHashByOid, &oid, sizeof(oid), index);
 
 	if (index == NULL)
 	{
@@ -186,7 +186,7 @@ copydb_create_index_by_oid(CopyDataSpec *specs, uint32_t indexOid)
 	}
 
 	oid = index->tableOid;
-	HASH_FIND(hh, specs->sourceTableHashByOid, &oid, sizeof(oid), table);
+	HASH_FIND(hh, specs->catalog.sourceTableHashByOid, &oid, sizeof(oid), table);
 
 	if (table == NULL)
 	{
@@ -511,7 +511,7 @@ copydb_copy_all_indexes(CopyDataSpec *specs)
 		return true;
 	}
 
-	SourceIndexArray *indexArray = &(specs->sourceIndexArray);
+	SourceIndexArray *indexArray = &(specs->catalog.sourceIndexArray);
 	IndexFilePathsArray indexPathsArray = { 0, NULL };
 
 	/* build the index file paths we need for the upcoming operations */

--- a/src/bin/pgcopydb/ld_stream.c
+++ b/src/bin/pgcopydb/ld_stream.c
@@ -49,6 +49,7 @@ stream_init_specs(StreamSpecs *specs,
 				  char *origin,
 				  uint64_t endpos,
 				  LogicalStreamMode mode,
+				  SourceCatalog *catalog,
 				  bool stdin,
 				  bool stdout,
 				  bool logSQL)
@@ -61,6 +62,8 @@ stream_init_specs(StreamSpecs *specs,
 
 	specs->paths = *paths;
 	specs->endpos = endpos;
+
+	specs->catalog = catalog;
 
 	/*
 	 * Copy the given ReplicationSlot: it comes from command line parsing, or
@@ -332,6 +335,9 @@ stream_init_context(StreamContext *privateContext, StreamSpecs *specs)
 	 * of startpos.
 	 */
 	privateContext->maxWrittenLSN = specs->startpos;
+
+	/* transform needs some catalog lookups (pkey, type oid) */
+	privateContext->catalog = specs->catalog;
 
 	return true;
 }

--- a/src/bin/pgcopydb/ld_test_decoding.c
+++ b/src/bin/pgcopydb/ld_test_decoding.c
@@ -200,11 +200,15 @@ parseTestDecodingMessageActionAndXid(LogicalStreamContext *context)
  * OUTPUT: pgcopydb LogicalTransactionStatement structure
  */
 bool
-parseTestDecodingMessage(LogicalTransactionStatement *stmt,
-						 LogicalMessageMetadata *metadata,
+parseTestDecodingMessage(StreamContext *privateContext,
 						 char *message,
 						 JSON_Value *json)
 {
+	LogicalTransactionStatement *stmt = privateContext->stmt;
+	LogicalMessageMetadata *metadata = &(privateContext->metadata);
+
+	/* SourceCatalog *catalog = privateContext->catalog; */
+
 	JSON_Object *jsobj = json_value_get_object(json);
 	TestDecodingHeader header = { 0 };
 

--- a/src/bin/pgcopydb/ld_transform.c
+++ b/src/bin/pgcopydb/ld_transform.c
@@ -38,8 +38,6 @@ typedef struct TransformStreamCtx
 {
 	StreamContext *context;
 	uint64_t currentMsgIndex;
-	LogicalMessage currentMsg;
-	LogicalMessageMetadata metadata;
 } TransformStreamCtx;
 
 
@@ -53,6 +51,12 @@ stream_transform_stream(StreamSpecs *specs)
 {
 	StreamContext *privateContext =
 		(StreamContext *) calloc(1, sizeof(StreamContext));
+
+	if (privateContext == NULL)
+	{
+		log_error(ALLOCATION_FAILED_ERROR);
+		return false;
+	}
 
 	if (!stream_init_context(privateContext, specs))
 	{
@@ -81,9 +85,7 @@ stream_transform_stream(StreamSpecs *specs)
 
 	TransformStreamCtx ctx = {
 		.context = privateContext,
-		.currentMsgIndex = 0,
-		.currentMsg = { 0 },
-		.metadata = { 0 }
+		.currentMsgIndex = 0
 	};
 
 	ReadFromStreamContext context = {
@@ -139,8 +141,7 @@ stream_transform_line(void *ctx, const char *line, bool *stop)
 {
 	TransformStreamCtx *transformCtx = (TransformStreamCtx *) ctx;
 	StreamContext *privateContext = transformCtx->context;
-	LogicalMessage *currentMsg = &(transformCtx->currentMsg);
-	LogicalMessageMetadata *metadata = &(transformCtx->metadata);
+	LogicalMessageMetadata *metadata = &(privateContext->metadata);
 
 	static uint64_t lineno = 0;
 
@@ -150,7 +151,7 @@ stream_transform_line(void *ctx, const char *line, bool *stop)
 	LogicalMessageMetadata empty = { 0 };
 	*metadata = empty;
 
-	if (!stream_transform_message((char *) line, metadata, currentMsg))
+	if (!stream_transform_message(privateContext, (char *) line))
 	{
 		/* errors have already been logged */
 		return false;
@@ -158,12 +159,58 @@ stream_transform_line(void *ctx, const char *line, bool *stop)
 
 	if (privateContext->sqlFile == NULL)
 	{
-		if (!stream_transform_rotate(privateContext, metadata))
+		if (!stream_transform_rotate(privateContext))
 		{
 			/* errors have already been logged */
 			return false;
 		}
 	}
+
+	/*
+	 * Is it time to close the current message and prepare a new one?
+	 */
+	if (!stream_transform_write_message(privateContext,
+										&(transformCtx->currentMsgIndex)))
+	{
+		log_error("Failed to transform and flush the current message, "
+				  "see above for details");
+		return false;
+	}
+
+	/* rotate the SQL file when receiving a SWITCH WAL message */
+	if (metadata->action == STREAM_ACTION_SWITCH)
+	{
+		if (!stream_transform_rotate(privateContext))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+	}
+
+	if (privateContext->endpos != InvalidXLogRecPtr &&
+		privateContext->endpos <= metadata->lsn)
+	{
+		*stop = true;
+
+		log_info("Transform reached end position %X/%X at %X/%X",
+				 LSN_FORMAT_ARGS(privateContext->endpos),
+				 LSN_FORMAT_ARGS(metadata->lsn));
+	}
+
+	return true;
+}
+
+
+/*
+ * stream_transform_write_message checks if we need to flush-out the current
+ * message down to file, and maybe also stdout (Unix PIPE).
+ */
+bool
+stream_transform_write_message(StreamContext *privateContext,
+							   uint64_t *currentMsgIndex)
+{
+	LogicalMessage *currentMsg = &(privateContext->currentMsg);
+	LogicalMessageMetadata *metadata = &(privateContext->metadata);
 
 	/*
 	 * Is it time to close the current message and prepare a new one?
@@ -181,10 +228,13 @@ stream_transform_line(void *ctx, const char *line, bool *stop)
 		}
 
 		/* now write the transaction out */
-		if (!stream_write_message(privateContext->out, currentMsg))
+		if (privateContext->out != NULL)
 		{
-			/* errors have already been logged */
-			return false;
+			if (!stream_write_message(privateContext->out, currentMsg))
+			{
+				/* errors have already been logged */
+				return false;
+			}
 		}
 
 		/* now write the transaction out also to file on-disk */
@@ -214,7 +264,7 @@ stream_transform_line(void *ctx, const char *line, bool *stop)
 			LogicalMessage empty = { 0 };
 
 			*currentMsg = empty;
-			++(transformCtx->currentMsgIndex);
+			++(*currentMsgIndex);
 		}
 		else if (currentMsg->isTransaction)
 		{
@@ -247,26 +297,6 @@ stream_transform_line(void *ctx, const char *line, bool *stop)
 		}
 	}
 
-	/* rotate the SQL file when receiving a SWITCH WAL message */
-	if (metadata->action == STREAM_ACTION_SWITCH)
-	{
-		if (!stream_transform_rotate(privateContext, metadata))
-		{
-			/* errors have already been logged */
-			return false;
-		}
-	}
-
-	if (privateContext->endpos != InvalidXLogRecPtr &&
-		privateContext->endpos <= metadata->lsn)
-	{
-		*stop = true;
-
-		log_info("Transform reached end position %X/%X at %X/%X",
-				 LSN_FORMAT_ARGS(privateContext->endpos),
-				 LSN_FORMAT_ARGS(metadata->lsn));
-	}
-
 	return true;
 }
 
@@ -276,10 +306,10 @@ stream_transform_line(void *ctx, const char *line, bool *stop)
  * output into a SQL statement, and appends it to the given opened transaction.
  */
 bool
-stream_transform_message(char *message,
-						 LogicalMessageMetadata *metadata,
-						 LogicalMessage *currentMsg)
+stream_transform_message(StreamContext *privateContext, char *message)
 {
+	LogicalMessageMetadata *metadata = &(privateContext->metadata);
+
 	JSON_Value *json = json_parse_string(message);
 
 	if (!parseMessageMetadata(metadata, message, json, false))
@@ -289,7 +319,7 @@ stream_transform_message(char *message,
 		return false;
 	}
 
-	if (!parseMessage(currentMsg, metadata, message, json))
+	if (!parseMessage(privateContext, message, json))
 	{
 		log_error("Failed to parse JSON message: %s", message);
 		json_value_free(json);
@@ -307,9 +337,10 @@ stream_transform_message(char *message,
  * commands on-disk, which is important for restartability of the process.
  */
 bool
-stream_transform_rotate(StreamContext *privateContext,
-						LogicalMessageMetadata *metadata)
+stream_transform_rotate(StreamContext *privateContext)
 {
+	LogicalMessageMetadata *metadata = &(privateContext->metadata);
+
 	/*
 	 * When streaming from stdin to stdout (or other streams), we also maintain
 	 * our SQL file on-disk using the WAL file naming strategy from Postgres,
@@ -519,7 +550,7 @@ stream_transform_file_at_lsn(StreamSpecs *specs, uint64_t lsn)
 		return false;
 	}
 
-	if (!stream_transform_file(walFileName, sqlFileName, specs->paths.dir))
+	if (!stream_transform_file(specs, walFileName, sqlFileName))
 	{
 		/* errors have already been logged */
 		return false;
@@ -610,7 +641,7 @@ stream_transform_send_stop(Queue *queue)
  * target database.
  */
 bool
-stream_transform_file(char *jsonfilename, char *sqlfilename, char *dir)
+stream_transform_file(StreamSpecs *specs, char *jsonfilename, char *sqlfilename)
 {
 	StreamContent content = { 0 };
 	long size = 0L;
@@ -641,54 +672,58 @@ stream_transform_file(char *jsonfilename, char *sqlfilename, char *dir)
 			  content.count,
 			  content.filename);
 
-	content.messages =
-		(LogicalMessageMetadata *) calloc(content.count,
-										  sizeof(LogicalMessageMetadata));
-
-	if (content.messages == NULL)
-	{
-		log_error(ALLOCATION_FAILED_ERROR);
-		return false;
-	}
-
-	/*
-	 * Message are like:
-	 *
-	 * {action: B} {action: C} {action: K} {action: X}
-	 *
-	 * And when we read a COMMIT message (or KEEPALIVE or SWITCH) we prepare
-	 * for the next message already, which means we need one more entry in the
-	 * array than the number of lines read in the JSON file.
-	 */
-	int maxMesgCount = content.count + 1;
-	LogicalMessageArray mesgs = { 0 };
-
-	/* the actual count is maintained in the for loop below */
-	mesgs.count = 0;
-	mesgs.array =
-		(LogicalMessage *) calloc(maxMesgCount, sizeof(LogicalMessage));
-
-	if (mesgs.array == NULL)
-	{
-		log_error(ALLOCATION_FAILED_ERROR);
-		return false;
-	}
-
 	/*
 	 * Read the JSON-lines file that we received from streaming logical
 	 * decoding messages, and parse the JSON messages into our internal
 	 * representation structure.
 	 */
-	int currentMsgIndex = 0;
-	LogicalMessage *currentMsg = &(mesgs.array[currentMsgIndex]);
+	StreamContext *privateContext =
+		(StreamContext *) calloc(1, sizeof(StreamContext));
+
+	if (privateContext == NULL)
+	{
+		log_error(ALLOCATION_FAILED_ERROR);
+		return false;
+	}
+
+	if (!stream_init_context(privateContext, specs))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/*
+	 * The output is written to a temp/partial file which is renamed after
+	 * close, so that another tool that would want to read the file won't read
+	 * partial JSON messages in there.
+	 */
+	char tempfilename[MAXPGPATH] = { 0 };
+
+	sformat(tempfilename, sizeof(tempfilename), "%s.partial", sqlfilename);
+
+	privateContext->sqlFile =
+		fopen_with_umask(tempfilename, "w", FOPEN_FLAGS_W, 0644);
+
+	if (privateContext->sqlFile == NULL)
+	{
+		log_error("Failed to create and open file \"%s\"", tempfilename);
+		return false;
+	}
+
+	log_debug("stream_transform_file writing to \"%s\"", tempfilename);
+
+	uint64_t currentMsgIndex = 0;
 
 	/* we might need to access to the last message metadata after the loop */
-	LogicalMessageMetadata *metadata = NULL;
+	LogicalMessage *currentMsg = &(privateContext->currentMsg);
+	LogicalMessageMetadata *metadata = &(privateContext->metadata);
 
 	for (int i = 0; i < content.count; i++)
 	{
 		char *message = content.lines[i];
-		metadata = &(content.messages[i]);
+
+		LogicalMessageMetadata empty = { 0 };
+		*metadata = empty;
 
 		log_trace("stream_transform_file[%2d]: %s", i, message);
 
@@ -725,7 +760,7 @@ stream_transform_file(char *jsonfilename, char *sqlfilename, char *dir)
 			*currentMsg = new;
 		}
 
-		if (!parseMessage(currentMsg, metadata, message, json))
+		if (!parseMessage(privateContext, message, json))
 		{
 			log_error("Failed to parse JSON message: %s", message);
 			json_value_free(json);
@@ -740,100 +775,17 @@ stream_transform_file(char *jsonfilename, char *sqlfilename, char *dir)
 		 * non-transactional message (such as a KEEPALIVE or a SWITCH WAL or an
 		 * ENDPOS message).
 		 */
-		if (!currentMsg->isTransaction ||
-			metadata->action == STREAM_ACTION_COMMIT)
+		if (!stream_transform_write_message(privateContext, &currentMsgIndex))
 		{
-			++mesgs.count;
-			++currentMsgIndex;
-
-			if ((maxMesgCount - 1) < currentMsgIndex)
-			{
-				log_error("Parsing message %d, which is more than the "
-						  "maximum allocated message count %d",
-						  currentMsgIndex + 1,
-						  maxMesgCount);
-				return false;
-			}
-
-			currentMsg = &(mesgs.array[currentMsgIndex]);
-		}
-	}
-
-	/*
-	 * We might have a last pending transaction with a COMMIT message to be
-	 * found in a a later file, or a last transaction that's cut by reaching an
-	 * endpos LSN that's between the BEGIN and the COMMIT lsn positions.
-	 *
-	 * In any case if we have a partial transaction pending we have to
-	 * transform it too.
-	 */
-	if (currentMsg->isTransaction && currentMsg->command.tx.count > 0)
-	{
-		++mesgs.count;
-	}
-
-	/* free dynamic memory that's not needed anymore */
-	free(content.lines);
-	free(content.messages);
-
-	log_debug("stream_transform_file read %d messages", mesgs.count);
-
-	/*
-	 * Now that we have read and parsed the JSON file into our internal
-	 * structure that represents SQL transactions with statements, output the
-	 * content in the SQL format.
-	 *
-	 * The output is written to a temp/partial file which is renamed after
-	 * close, so that another tool that would want to read the file won't read
-	 * partial JSON messages in there.
-	 */
-	char tempfilename[MAXPGPATH] = { 0 };
-
-	sformat(tempfilename, sizeof(tempfilename), "%s.partial", sqlfilename);
-
-	FILE *sql = fopen_with_umask(tempfilename, "w", FOPEN_FLAGS_W, 0644);
-
-	if (sql == NULL)
-	{
-		log_error("Failed to create and open file \"%s\"", sqlfilename);
-		return false;
-	}
-
-	log_debug("stream_transform_file writing to \"%s\"", tempfilename);
-
-	for (int i = 0; i < mesgs.count; i++)
-	{
-		LogicalMessage *currentMsg = &(mesgs.array[i]);
-
-		if (!stream_write_message(sql, currentMsg))
-		{
-			/* errors have already been logged */
+			log_error("Failed to transform and flush the current message, "
+					  "see above for details");
 			return false;
 		}
-
-		LogicalTransaction *txn = &(currentMsg->command.tx);
-
-		/*
-		 * If we're in a continued transaction, it means that the earlier write
-		 * of this txn's BEGIN statement didn't have the COMMIT LSN. Therefore,
-		 * we need to maintain that LSN as a separate metadata file. This is
-		 * necessary because the COMMIT LSN is required later in the apply
-		 * process.
-		 */
-		if (txn->continued && txn->commit)
-		{
-			writeTxnMetadataFile(txn, dir);
-		}
-
-		(void) FreeLogicalMessage(currentMsg);
 	}
 
-	/* free the LogicalMessage array memory area */
-	free(mesgs.array);
-
-	if (fclose(sql) == EOF)
+	if (fclose(privateContext->sqlFile) == EOF)
 	{
-		log_error("Failed to write file \"%s\"", sqlfilename);
+		log_error("Failed to write file \"%s\"", tempfilename);
 		return false;
 	}
 
@@ -862,11 +814,11 @@ stream_transform_file(char *jsonfilename, char *sqlfilename, char *dir)
  * representation, that can be later output as SQL text.
  */
 bool
-parseMessage(LogicalMessage *mesg,
-			 LogicalMessageMetadata *metadata,
-			 char *message,
-			 JSON_Value *json)
+parseMessage(StreamContext *privateContext, char *message, JSON_Value *json)
 {
+	LogicalMessage *mesg = &(privateContext->currentMsg);
+	LogicalMessageMetadata *metadata = &(privateContext->metadata);
+
 	if (mesg == NULL)
 	{
 		log_error("BUG: parseMessage called with a NULL LogicalMessage");
@@ -948,6 +900,9 @@ parseMessage(LogicalMessage *mesg,
 		}
 
 		stmt->action = metadata->action;
+
+		/* publish the statement in the privateContext */
+		privateContext->stmt = stmt;
 	}
 
 	switch (metadata->action)
@@ -971,8 +926,8 @@ parseMessage(LogicalMessage *mesg,
 			txn->beginLSN = metadata->lsn;
 
 			/*
-			 * This should be overwritten in COMMIT action as that's what we
-			 * need for replication origin tracking.
+			 * The timestamp is overwritten at COMMIT as that's what we need
+			 * for replication origin tracking.
 			 */
 			strlcpy(txn->timestamp, metadata->timestamp, sizeof(txn->timestamp));
 			txn->first = NULL;
@@ -1093,7 +1048,7 @@ parseMessage(LogicalMessage *mesg,
 			{
 				case JSONString:
 				{
-					if (!parseTestDecodingMessage(stmt, metadata, message, json))
+					if (!parseTestDecodingMessage(privateContext, message, json))
 					{
 						log_error("Failed to parse test_decoding message, "
 								  "see above for details");
@@ -1105,7 +1060,7 @@ parseMessage(LogicalMessage *mesg,
 
 				case JSONObject:
 				{
-					if (!parseWal2jsonMessage(stmt, metadata, message, json))
+					if (!parseWal2jsonMessage(privateContext, message, json))
 					{
 						log_error("Failed to parse wal2json message, "
 								  "see above for details");

--- a/src/bin/pgcopydb/ld_transform.c
+++ b/src/bin/pgcopydb/ld_transform.c
@@ -781,6 +781,15 @@ stream_transform_file(StreamSpecs *specs, char *jsonfilename, char *sqlfilename)
 					  "see above for details");
 			return false;
 		}
+
+		if (privateContext->endpos != InvalidXLogRecPtr &&
+			privateContext->endpos <= metadata->lsn)
+		{
+			log_info("Transform reached end position %X/%X at %X/%X",
+					 LSN_FORMAT_ARGS(privateContext->endpos),
+					 LSN_FORMAT_ARGS(metadata->lsn));
+			break;
+		}
 	}
 
 	if (fclose(privateContext->sqlFile) == EOF)

--- a/src/bin/pgcopydb/ld_wal2json.c
+++ b/src/bin/pgcopydb/ld_wal2json.c
@@ -110,11 +110,13 @@ parseWal2jsonMessageActionAndXid(LogicalStreamContext *context)
  * OUTPUT: pgcopydb LogicalTransactionStatement structure
  */
 bool
-parseWal2jsonMessage(LogicalTransactionStatement *stmt,
-					 LogicalMessageMetadata *metadata,
+parseWal2jsonMessage(StreamContext *privateContext,
 					 char *message,
 					 JSON_Value *json)
 {
+	LogicalTransactionStatement *stmt = privateContext->stmt;
+	LogicalMessageMetadata *metadata = &(privateContext->metadata);
+
 	/* most actions share a need for "schema" and "table" properties */
 	JSON_Object *jsobj = json_value_get_object(json);
 

--- a/src/bin/pgcopydb/progress.c
+++ b/src/bin/pgcopydb/progress.c
@@ -70,7 +70,7 @@ copydb_prepare_schema_json_file(CopyDataSpec *copySpecs)
 	}
 
 	/* array of tables */
-	SourceTableArray *tableArray = &(copySpecs->sourceTableArray);
+	SourceTableArray *tableArray = &(copySpecs->catalog.sourceTableArray);
 
 	log_trace("copydb_prepare_schema_json_file: %d tables", tableArray->count);
 
@@ -81,7 +81,7 @@ copydb_prepare_schema_json_file(CopyDataSpec *copySpecs)
 	}
 
 	/* array of indexes */
-	SourceIndexArray *indexArray = &(copySpecs->sourceIndexArray);
+	SourceIndexArray *indexArray = &(copySpecs->catalog.sourceIndexArray);
 
 	log_trace("copydb_prepare_schema_json_file: %d indexes", indexArray->count);
 
@@ -92,7 +92,7 @@ copydb_prepare_schema_json_file(CopyDataSpec *copySpecs)
 	}
 
 	/* array of sequences */
-	SourceSequenceArray *sequenceArray = &(copySpecs->sequenceArray);
+	SourceSequenceArray *sequenceArray = &(copySpecs->catalog.sequenceArray);
 
 	log_trace("copydb_prepare_schema_json_file: %d sequences",
 			  sequenceArray->count);
@@ -124,7 +124,7 @@ copydb_prepare_schema_json_file(CopyDataSpec *copySpecs)
 
 
 /*
- * copydb_filtering_as_json prepares the filtering setup of the CopyDataSpecs
+ * copydb_setup_as_json prepares the filtering setup of the CopyDataSpecs
  * as a JSON object within the given JSON_Value.
  */
 static bool
@@ -530,11 +530,11 @@ copydb_parse_schema_json_file(CopyDataSpec *copySpecs)
 
 	log_debug("copydb_parse_schema_json_file: parsing %d tables", tableCount);
 
-	copySpecs->sourceTableArray.count = tableCount;
-	copySpecs->sourceTableArray.array =
+	copySpecs->catalog.sourceTableArray.count = tableCount;
+	copySpecs->catalog.sourceTableArray.array =
 		(SourceTable *) calloc(tableCount, sizeof(SourceTable));
 
-	if (copySpecs->sourceTableArray.array == NULL)
+	if (copySpecs->catalog.sourceTableArray.array == NULL)
 	{
 		log_fatal(ALLOCATION_FAILED_ERROR);
 		return false;
@@ -542,7 +542,7 @@ copydb_parse_schema_json_file(CopyDataSpec *copySpecs)
 
 	for (int tableIndex = 0; tableIndex < tableCount; tableIndex++)
 	{
-		SourceTable *table = &(copySpecs->sourceTableArray.array[tableIndex]);
+		SourceTable *table = &(copySpecs->catalog.sourceTableArray.array[tableIndex]);
 		JSON_Object *jsTable = json_array_get_object(jsTableArray, tableIndex);
 
 		table->oid = json_object_get_number(jsTable, "oid");
@@ -646,11 +646,11 @@ copydb_parse_schema_json_file(CopyDataSpec *copySpecs)
 
 	log_debug("copydb_parse_schema_json_file: parsing %d indexes", indexCount);
 
-	copySpecs->sourceIndexArray.count = indexCount;
-	copySpecs->sourceIndexArray.array =
+	copySpecs->catalog.sourceIndexArray.count = indexCount;
+	copySpecs->catalog.sourceIndexArray.array =
 		(SourceIndex *) calloc(indexCount, sizeof(SourceIndex));
 
-	if (copySpecs->sourceIndexArray.array == NULL)
+	if (copySpecs->catalog.sourceIndexArray.array == NULL)
 	{
 		log_fatal(ALLOCATION_FAILED_ERROR);
 		return false;
@@ -658,7 +658,7 @@ copydb_parse_schema_json_file(CopyDataSpec *copySpecs)
 
 	for (int i = 0; i < indexCount; i++)
 	{
-		SourceIndex *index = &(copySpecs->sourceIndexArray.array[i]);
+		SourceIndex *index = &(copySpecs->catalog.sourceIndexArray.array[i]);
 		JSON_Object *jsIndex = json_array_get_object(jsIndexArray, i);
 
 		index->indexOid = json_object_get_number(jsIndex, "oid");
@@ -761,8 +761,8 @@ copydb_parse_schema_json_file(CopyDataSpec *copySpecs)
 bool
 copydb_update_progress(CopyDataSpec *copySpecs, CopyProgress *progress)
 {
-	SourceTableArray *tableArray = &(copySpecs->sourceTableArray);
-	SourceIndexArray *indexArray = &(copySpecs->sourceIndexArray);
+	SourceTableArray *tableArray = &(copySpecs->catalog.sourceTableArray);
+	SourceIndexArray *indexArray = &(copySpecs->catalog.sourceIndexArray);
 
 	progress->tableCount = tableArray->count;
 	progress->indexCount = indexArray->count;

--- a/src/bin/pgcopydb/schema.h
+++ b/src/bin/pgcopydb/schema.h
@@ -273,7 +273,6 @@ typedef struct SourceCatalog
 	SourceIndexArray sourceIndexArray;
 	SourceSequenceArray sequenceArray;
 
-
 	SourceTable *sourceTableHashByOid;
 	SourceIndex *sourceIndexHashByOid;
 } SourceCatalog;

--- a/src/bin/pgcopydb/schema.h
+++ b/src/bin/pgcopydb/schema.h
@@ -20,20 +20,20 @@
  * In the SQL standard we have "catalogs", which are then Postgres databases.
  * Much the same confusion as with namespace vs schema.
  */
-typedef struct SourceCatalog
+typedef struct SourceDatabase
 {
 	uint32_t oid;
 	char datname[NAMEDATALEN];
 	int64_t bytes;
 	char bytesPretty[NAMEDATALEN]; /* pg_size_pretty */
 }
-SourceCatalog;
+SourceDatabase;
 
-typedef struct SourceCatalogArray
+typedef struct SourceDatabaseArray
 {
 	int count;
-	SourceCatalog *array;
-} SourceCatalogArray;
+	SourceDatabase *array;
+} SourceDatabaseArray;
 
 
 typedef struct SourceSchema
@@ -261,12 +261,29 @@ typedef struct SourceDependArray
 	SourceDepend *array;         /* malloc'ed area */
 } SourceDependArray;
 
+/*
+ * SourceCatalog regroups all the information we fetch from a Postgres
+ * instance.
+ */
+typedef struct SourceCatalog
+{
+	SourceExtensionArray extensionArray;
+	SourceCollationArray collationArray;
+	SourceTableArray sourceTableArray;
+	SourceIndexArray sourceIndexArray;
+	SourceSequenceArray sequenceArray;
+
+
+	SourceTable *sourceTableHashByOid;
+	SourceIndex *sourceIndexHashByOid;
+} SourceCatalog;
+
 
 bool schema_query_privileges(PGSQL *pgsql,
 							 bool *hasDBCreatePrivilage,
 							 bool *hasDBTempPrivilege);
 
-bool schema_list_catalogs(PGSQL *pgsql, SourceCatalogArray *catArray);
+bool schema_list_databases(PGSQL *pgsql, SourceDatabaseArray *catArray);
 
 bool schema_list_ext_schemas(PGSQL *pgsql, SourceSchemaArray *array);
 

--- a/src/bin/pgcopydb/sequences.c
+++ b/src/bin/pgcopydb/sequences.c
@@ -28,7 +28,7 @@
 bool
 copydb_prepare_sequence_specs(CopyDataSpec *specs, PGSQL *pgsql)
 {
-	SourceSequenceArray *sequenceArray = &(specs->sequenceArray);
+	SourceSequenceArray *sequenceArray = &(specs->catalog.sequenceArray);
 
 	if (!schema_list_sequences(pgsql, &(specs->filters), sequenceArray))
 	{
@@ -188,7 +188,7 @@ copydb_copy_all_sequences(CopyDataSpec *specs)
 
 	int errors = 0;
 
-	SourceSequenceArray *sequenceArray = &(specs->sequenceArray);
+	SourceSequenceArray *sequenceArray = &(specs->catalog.sequenceArray);
 
 	for (int seqIndex = 0; seqIndex < sequenceArray->count; seqIndex++)
 	{

--- a/src/bin/pgcopydb/table-data.c
+++ b/src/bin/pgcopydb/table-data.c
@@ -485,7 +485,7 @@ copydb_copy_data_by_oid(CopyDataSpec *specs, uint32_t oid, uint32_t part)
 	log_trace("copydb_copy_data_by_oid: %u [%d]", oid, part);
 
 	uint32_t toid = oid;
-	HASH_FIND(hh, specs->sourceTableHashByOid, &toid, sizeof(toid), table);
+	HASH_FIND(hh, specs->catalog.sourceTableHashByOid, &toid, sizeof(toid), table);
 
 	if (table == NULL)
 	{

--- a/tests/cdc-endpos-between-transaction/copydb.sh
+++ b/tests/cdc-endpos-between-transaction/copydb.sh
@@ -53,7 +53,7 @@ psql -t -d ${PGCOPYDB_SOURCE_PGURI} \
 lsn=`jq -r 'select((.columns // empty) | .[] | ((.name == "category_id") and (.value == 1008))) | .lsn' ${SLOT_PEEK_FILE}`
 
 # and prefetch the changes captured in our replication slot
-pgcopydb stream prefetch --resume --endpos "${lsn}" -vv
+pgcopydb stream prefetch --resume --endpos "${lsn}" --notice
 
 SHAREDIR=/var/lib/postgres/.local/share/pgcopydb
 WALFILE=000000010000000000000002.json
@@ -74,12 +74,12 @@ diff ${expected} ${result} || cat ${SHAREDIR}/${WALFILE}
 diff ${expected} ${result}
 
 # now prefetch the changes again, which should be a noop
-pgcopydb stream prefetch --resume --endpos "${lsn}" -vv
+pgcopydb stream prefetch --resume --endpos "${lsn}" --trace
 
 # now transform the JSON file into SQL
 SQLFILENAME=`basename ${WALFILE} .json`.sql
 
-pgcopydb stream transform -vv ${SHAREDIR}/${WALFILE} /tmp/${SQLFILENAME}
+pgcopydb stream transform --trace ${SHAREDIR}/${WALFILE} /tmp/${SQLFILENAME}
 
 # we should get the same result as `pgcopydb stream prefetch`
 diff ${SHAREDIR}/${SQLFILE} /tmp/${SQLFILENAME}


### PR DESCRIPTION
To finish implementing test_decoding support, we need to be able to look-up attribute names for them being part of a primary-key definition, in order to process UPDATE statements without the old-key: and new-key: parts.

In order to do that we prepare internal data structures to make it easy to provide our internal catalogs representation to the transform sub-processes, both when using the catchup mode API (from disk) or the replay mode API (from a stream).

In passing, share more code in the ld_transform.c module in order to simplify maintenance. It also looks like we're going to use much less memory to implement the same job, that's a nice side effect of this refactoring.