### PR TITLE
Use dynamic memory for connection strings handling.

### DIFF
--- a/src/bin/pgcopydb/blobs.c
+++ b/src/bin/pgcopydb/blobs.c
@@ -129,7 +129,7 @@ copydb_copy_blobs(CopyDataSpec *specs)
 		 * established snapshot to set nor a connection to piggyback onto, so
 		 * we have to initialize our client connection now.
 		 */
-		if (!pgsql_init(&pgsql, specs->source_pguri, PGSQL_CONN_SOURCE))
+		if (!pgsql_init(&pgsql, specs->connStrings.source_pguri, PGSQL_CONN_SOURCE))
 		{
 			/* errors have already been logged */
 			return false;
@@ -144,7 +144,7 @@ copydb_copy_blobs(CopyDataSpec *specs)
 		}
 	}
 
-	if (!pgsql_init(&dst, specs->target_pguri, PGSQL_CONN_TARGET))
+	if (!pgsql_init(&dst, specs->connStrings.target_pguri, PGSQL_CONN_TARGET))
 	{
 		/* errors have already been logged */
 		return false;

--- a/src/bin/pgcopydb/cli_clone_follow.c
+++ b/src/bin/pgcopydb/cli_clone_follow.c
@@ -197,8 +197,7 @@ clone_and_follow(CopyDataSpec *copySpecs)
 
 	if (!stream_init_specs(&streamSpecs,
 						   &(copySpecs->cfPaths.cdc),
-						   copySpecs->source_pguri,
-						   copySpecs->target_pguri,
+						   &(copySpecs->connStrings),
 						   &(copyDBoptions.slot),
 						   copyDBoptions.origin,
 						   copyDBoptions.endpos,
@@ -338,8 +337,7 @@ cli_follow(int argc, char **argv)
 
 	if (!stream_init_specs(&specs,
 						   &(copySpecs.cfPaths.cdc),
-						   copySpecs.source_pguri,
-						   copySpecs.target_pguri,
+						   &(copySpecs.connStrings),
 						   &(copyDBoptions.slot),
 						   copyDBoptions.origin,
 						   copyDBoptions.endpos,
@@ -474,8 +472,7 @@ cloneDB(CopyDataSpec *copySpecs)
 		log_info("STEP 0: copy the source database roles");
 
 		if (!pg_copy_roles(&(copySpecs->pgPaths),
-						   copySpecs->source_pguri,
-						   copySpecs->target_pguri,
+						   &(copySpecs->connStrings),
 						   copySpecs->dumpPaths.rolesFilename,
 						   copySpecs->noRolesPasswords))
 		{
@@ -575,7 +572,9 @@ cloneDB(CopyDataSpec *copySpecs)
 
 		log_info("Updating the pgcopydb.sentinel to enable applying changes");
 
-		if (!pgsql_init(&pgsql, copySpecs->source_pguri, PGSQL_CONN_SOURCE))
+		if (!pgsql_init(&pgsql,
+						copySpecs->connStrings.source_pguri,
+						PGSQL_CONN_SOURCE))
 		{
 			/* errors have already been logged */
 			return false;

--- a/src/bin/pgcopydb/cli_common.c
+++ b/src/bin/pgcopydb/cli_common.c
@@ -172,8 +172,8 @@ cli_copydb_getenv(CopyDBOptions *options)
 	if (env_exists(PGCOPYDB_SOURCE_PGURI))
 	{
 		if (!get_env_dup(PGCOPYDB_SOURCE_PGURI,
-						  &(options->source_pguri),
-						  NULL))
+						 &(options->source_pguri),
+						 NULL))
 		{
 			/* errors have already been logged */
 			++errors;
@@ -183,8 +183,8 @@ cli_copydb_getenv(CopyDBOptions *options)
 	if (env_exists(PGCOPYDB_TARGET_PGURI))
 	{
 		if (!get_env_dup(PGCOPYDB_TARGET_PGURI,
-						  &(options->target_pguri),
-						  NULL))
+						 &(options->target_pguri),
+						 NULL))
 		{
 			/* errors have already been logged */
 			++errors;

--- a/src/bin/pgcopydb/cli_common.c
+++ b/src/bin/pgcopydb/cli_common.c
@@ -171,9 +171,9 @@ cli_copydb_getenv(CopyDBOptions *options)
 	/* now some of the options can be also set from the environment */
 	if (env_exists(PGCOPYDB_SOURCE_PGURI))
 	{
-		if (!get_env_copy(PGCOPYDB_SOURCE_PGURI,
-						  options->source_pguri,
-						  sizeof(options->source_pguri)))
+		if (!get_env_copy_dynamic(PGCOPYDB_SOURCE_PGURI,
+						  &(options->source_pguri),
+						  NULL))
 		{
 			/* errors have already been logged */
 			++errors;
@@ -182,9 +182,9 @@ cli_copydb_getenv(CopyDBOptions *options)
 
 	if (env_exists(PGCOPYDB_TARGET_PGURI))
 	{
-		if (!get_env_copy(PGCOPYDB_TARGET_PGURI,
-						  options->target_pguri,
-						  sizeof(options->target_pguri)))
+		if (!get_env_copy_dynamic(PGCOPYDB_TARGET_PGURI,
+						  &(options->target_pguri),
+						  NULL))
 		{
 			/* errors have already been logged */
 			++errors;
@@ -717,7 +717,13 @@ cli_copy_db_getopts(int argc, char **argv)
 							  "see above for details.");
 					++errors;
 				}
-				strlcpy(options.source_pguri, optarg, MAXCONNINFO);
+				size_t len = strlen(optarg) + 1;
+				options.source_pguri = (char *) calloc(len, sizeof(char));
+				if (options.source_pguri  == NULL) {
+					log_error(ALLOCATION_FAILED_ERROR);
+					break;
+				}
+				strlcpy(options.source_pguri, optarg, len);
 				log_trace("--source %s", options.source_pguri);
 				break;
 			}
@@ -730,7 +736,13 @@ cli_copy_db_getopts(int argc, char **argv)
 							  "see above for details.");
 					++errors;
 				}
-				strlcpy(options.target_pguri, optarg, MAXCONNINFO);
+				size_t len = strlen(optarg) + 1;
+				options.target_pguri = (char *) calloc(len, sizeof(char));
+				if (options.target_pguri  == NULL) {
+					log_error(ALLOCATION_FAILED_ERROR);
+					break;
+				}
+				strlcpy(options.target_pguri, optarg, len);
 				log_trace("--target %s", options.target_pguri);
 				break;
 			}

--- a/src/bin/pgcopydb/cli_common.c
+++ b/src/bin/pgcopydb/cli_common.c
@@ -171,7 +171,7 @@ cli_copydb_getenv(CopyDBOptions *options)
 	/* now some of the options can be also set from the environment */
 	if (env_exists(PGCOPYDB_SOURCE_PGURI))
 	{
-		if (!get_env_copy_dynamic(PGCOPYDB_SOURCE_PGURI,
+		if (!get_env_dup(PGCOPYDB_SOURCE_PGURI,
 						  &(options->source_pguri),
 						  NULL))
 		{
@@ -182,7 +182,7 @@ cli_copydb_getenv(CopyDBOptions *options)
 
 	if (env_exists(PGCOPYDB_TARGET_PGURI))
 	{
-		if (!get_env_copy_dynamic(PGCOPYDB_TARGET_PGURI,
+		if (!get_env_dup(PGCOPYDB_TARGET_PGURI,
 						  &(options->target_pguri),
 						  NULL))
 		{
@@ -717,13 +717,7 @@ cli_copy_db_getopts(int argc, char **argv)
 							  "see above for details.");
 					++errors;
 				}
-				size_t len = strlen(optarg) + 1;
-				options.source_pguri = (char *) calloc(len, sizeof(char));
-				if (options.source_pguri  == NULL) {
-					log_error(ALLOCATION_FAILED_ERROR);
-					break;
-				}
-				strlcpy(options.source_pguri, optarg, len);
+				options.source_pguri = strdup(optarg);
 				log_trace("--source %s", options.source_pguri);
 				break;
 			}
@@ -736,13 +730,7 @@ cli_copy_db_getopts(int argc, char **argv)
 							  "see above for details.");
 					++errors;
 				}
-				size_t len = strlen(optarg) + 1;
-				options.target_pguri = (char *) calloc(len, sizeof(char));
-				if (options.target_pguri  == NULL) {
-					log_error(ALLOCATION_FAILED_ERROR);
-					break;
-				}
-				strlcpy(options.target_pguri, optarg, len);
+				options.target_pguri = strdup(optarg);
 				log_trace("--target %s", options.target_pguri);
 				break;
 			}

--- a/src/bin/pgcopydb/cli_common.c
+++ b/src/bin/pgcopydb/cli_common.c
@@ -172,8 +172,7 @@ cli_copydb_getenv(CopyDBOptions *options)
 	if (env_exists(PGCOPYDB_SOURCE_PGURI))
 	{
 		if (!get_env_dup(PGCOPYDB_SOURCE_PGURI,
-						 &(options->source_pguri),
-						 NULL))
+						 &(options->source_pguri)))
 		{
 			/* errors have already been logged */
 			++errors;
@@ -183,8 +182,7 @@ cli_copydb_getenv(CopyDBOptions *options)
 	if (env_exists(PGCOPYDB_TARGET_PGURI))
 	{
 		if (!get_env_dup(PGCOPYDB_TARGET_PGURI,
-						 &(options->target_pguri),
-						 NULL))
+						 &(options->target_pguri)))
 		{
 			/* errors have already been logged */
 			++errors;
@@ -717,7 +715,7 @@ cli_copy_db_getopts(int argc, char **argv)
 							  "see above for details.");
 					++errors;
 				}
-				options.source_pguri = strdup(optarg);
+				options.source_pguri = pg_strdup(optarg);
 				log_trace("--source %s", options.source_pguri);
 				break;
 			}
@@ -730,7 +728,7 @@ cli_copy_db_getopts(int argc, char **argv)
 							  "see above for details.");
 					++errors;
 				}
-				options.target_pguri = strdup(optarg);
+				options.target_pguri = pg_strdup(optarg);
 				log_trace("--target %s", options.target_pguri);
 				break;
 			}

--- a/src/bin/pgcopydb/cli_common.h
+++ b/src/bin/pgcopydb/cli_common.h
@@ -17,6 +17,7 @@
 #include "copydb_paths.h"
 #include "defaults.h"
 #include "parson.h"
+#include "parsing_utils.h"
 #include "pgcmd.h"
 #include "pgsql.h"
 
@@ -31,8 +32,7 @@ typedef struct CopyDBOptions
 {
 	char dir[MAXPGPATH];
 
-	char *source_pguri;     /* malloc'ed area */
-	char *target_pguri;     /* malloc'ed area */
+	ConnStrings connStrings;
 
 	int tableJobs;
 	int indexJobs;
@@ -80,7 +80,7 @@ void cli_print_version(int argc, char **argv);
 void cli_pprint_json(JSON_Value *js);
 char * logLevelToString(int logLevel);
 
-bool cli_copydb_getenv_source_pguri(char *pguri);
+bool cli_copydb_getenv_source_pguri(char **pguri);
 bool cli_copydb_getenv_split(SplitTableLargerThan *splitTablesLargerThan);
 
 bool cli_copydb_getenv(CopyDBOptions *options);
@@ -98,5 +98,7 @@ bool cli_parse_bytes_pretty(const char *byteString,
 							uint64_t *bytes,
 							char *bytesPretty,
 							size_t bytesPrettySize);
+
+bool cli_prepare_pguris(ConnStrings *connStrings);
 
 #endif  /* CLI_COMMON_H */

--- a/src/bin/pgcopydb/cli_common.h
+++ b/src/bin/pgcopydb/cli_common.h
@@ -20,6 +20,13 @@
 #include "pgcmd.h"
 #include "pgsql.h"
 
+typedef struct SplitTableLargerThan
+{
+	uint64_t bytes;
+	char bytesPretty[NAMEDATALEN];
+} SplitTableLargerThan;
+
+
 typedef struct CopyDBOptions
 {
 	char dir[MAXPGPATH];
@@ -29,8 +36,8 @@ typedef struct CopyDBOptions
 
 	int tableJobs;
 	int indexJobs;
-	uint64_t splitTablesLargerThan;
-	char splitTablesLargerThanPretty[NAMEDATALEN];
+
+	SplitTableLargerThan splitTablesLargerThan;
 
 	RestoreOptions restoreOptions;
 
@@ -72,6 +79,9 @@ void cli_print_version(int argc, char **argv);
 
 void cli_pprint_json(JSON_Value *js);
 char * logLevelToString(int logLevel);
+
+bool cli_copydb_getenv_source_pguri(char *pguri);
+bool cli_copydb_getenv_split(SplitTableLargerThan *splitTablesLargerThan);
 
 bool cli_copydb_getenv(CopyDBOptions *options);
 bool cli_copydb_is_consistent(CopyDBOptions *options);

--- a/src/bin/pgcopydb/cli_common.h
+++ b/src/bin/pgcopydb/cli_common.h
@@ -24,8 +24,8 @@ typedef struct CopyDBOptions
 {
 	char dir[MAXPGPATH];
 
-	char source_pguri[MAXCONNINFO];
-	char target_pguri[MAXCONNINFO];
+	char *source_pguri;
+	char *target_pguri;
 
 	int tableJobs;
 	int indexJobs;

--- a/src/bin/pgcopydb/cli_common.h
+++ b/src/bin/pgcopydb/cli_common.h
@@ -24,7 +24,7 @@ typedef struct CopyDBOptions
 {
 	char dir[MAXPGPATH];
 
-	char *source_pguri;		/* malloc'ed area */
+	char *source_pguri;     /* malloc'ed area */
 	char *target_pguri;     /* malloc'ed area */
 
 	int tableJobs;

--- a/src/bin/pgcopydb/cli_common.h
+++ b/src/bin/pgcopydb/cli_common.h
@@ -24,8 +24,8 @@ typedef struct CopyDBOptions
 {
 	char dir[MAXPGPATH];
 
-	char *source_pguri;
-	char *target_pguri;
+	char *source_pguri;		/* malloc'ed area */
+	char *target_pguri;     /* malloc'ed area */
 
 	int tableJobs;
 	int indexJobs;

--- a/src/bin/pgcopydb/cli_copy.c
+++ b/src/bin/pgcopydb/cli_copy.c
@@ -637,8 +637,7 @@ cli_copy_roles(int argc, char **argv)
 	(void) cli_copy_prepare_specs(&copySpecs, DATA_SECTION_SCHEMA);
 
 	if (!pg_copy_roles(&(copySpecs.pgPaths),
-					   copySpecs.source_pguri,
-					   copySpecs.target_pguri,
+					   &(copySpecs.connStrings),
 					   copySpecs.dumpPaths.rolesFilename,
 					   copySpecs.noRolesPasswords))
 	{

--- a/src/bin/pgcopydb/cli_dump.c
+++ b/src/bin/pgcopydb/cli_dump.c
@@ -143,8 +143,8 @@ cli_dump_schema_getopts(int argc, char **argv)
 							  "see above for details.");
 					exit(EXIT_CODE_BAD_ARGS);
 				}
-				options.source_pguri = pg_strdup(optarg);
-				log_trace("--source %s", options.source_pguri);
+				options.connStrings.source_pguri = pg_strdup(optarg);
+				log_trace("--source %s", options.connStrings.source_pguri);
 				break;
 			}
 
@@ -156,8 +156,8 @@ cli_dump_schema_getopts(int argc, char **argv)
 							  "see above for details.");
 					exit(EXIT_CODE_BAD_ARGS);
 				}
-				options.target_pguri = pg_strdup(optarg);
-				log_trace("--target %s", options.target_pguri);
+				options.connStrings.target_pguri = pg_strdup(optarg);
+				log_trace("--target %s", options.connStrings.target_pguri);
 				break;
 			}
 
@@ -272,7 +272,7 @@ cli_dump_schema_getopts(int argc, char **argv)
 		}
 	}
 
-	if (IS_EMPTY_STRING_BUFFER(options.source_pguri))
+	if (options.connStrings.source_pguri == NULL)
 	{
 		log_fatal("Option --source is mandatory");
 		++errors;
@@ -376,12 +376,15 @@ cli_dump_schema_section(CopyDBOptions *dumpDBoptions,
 		exit(EXIT_CODE_INTERNAL_ERROR);
 	}
 
-	char scrubbedSourceURI[MAXCONNINFO] = { 0 };
+	ConnStrings *dsn = &(copySpecs.connStrings);
 
-	(void) parse_and_scrub_connection_string(copySpecs.source_pguri,
-											 scrubbedSourceURI);
+	if (!cli_prepare_pguris(dsn))
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
 
-	log_info("Dumping database from \"%s\"", scrubbedSourceURI);
+	log_info("Dumping database from \"%s\"", dsn->safeSourcePGURI.pguri);
 	log_info("Dumping database into directory \"%s\"", cfPaths->topdir);
 
 	if (section == PG_DUMP_SECTION_ROLES)
@@ -411,7 +414,7 @@ cli_dump_schema_section(CopyDBOptions *dumpDBoptions,
 	if (section == PG_DUMP_SECTION_ROLES)
 	{
 		if (!pg_dumpall_roles(&(copySpecs.pgPaths),
-							  copySpecs.source_pguri,
+							  &(copySpecs.connStrings),
 							  copySpecs.dumpPaths.rolesFilename,
 							  copySpecs.noRolesPasswords))
 		{

--- a/src/bin/pgcopydb/cli_dump.c
+++ b/src/bin/pgcopydb/cli_dump.c
@@ -143,7 +143,13 @@ cli_dump_schema_getopts(int argc, char **argv)
 							  "see above for details.");
 					exit(EXIT_CODE_BAD_ARGS);
 				}
-				strlcpy(options.source_pguri, optarg, MAXCONNINFO);
+				size_t len = strlen(optarg) + 1;
+				options.source_pguri = (char *) calloc(len, sizeof(char));
+				if (options.source_pguri  == NULL) {
+					log_error(ALLOCATION_FAILED_ERROR);
+					break;
+				}
+				strlcpy(options.source_pguri, optarg, len);
 				log_trace("--source %s", options.source_pguri);
 				break;
 			}
@@ -156,7 +162,13 @@ cli_dump_schema_getopts(int argc, char **argv)
 							  "see above for details.");
 					exit(EXIT_CODE_BAD_ARGS);
 				}
-				strlcpy(options.target_pguri, optarg, MAXCONNINFO);
+				size_t len = strlen(optarg) + 1;
+				options.target_pguri = (char *) calloc(len, sizeof(char));
+				if (options.source_pguri  == NULL) {
+					log_error(ALLOCATION_FAILED_ERROR);
+					break;
+				}
+				strlcpy(options.source_pguri, optarg, len);
 				log_trace("--target %s", options.target_pguri);
 				break;
 			}

--- a/src/bin/pgcopydb/cli_dump.c
+++ b/src/bin/pgcopydb/cli_dump.c
@@ -143,13 +143,7 @@ cli_dump_schema_getopts(int argc, char **argv)
 							  "see above for details.");
 					exit(EXIT_CODE_BAD_ARGS);
 				}
-				size_t len = strlen(optarg) + 1;
-				options.source_pguri = (char *) calloc(len, sizeof(char));
-				if (options.source_pguri  == NULL) {
-					log_error(ALLOCATION_FAILED_ERROR);
-					break;
-				}
-				strlcpy(options.source_pguri, optarg, len);
+				options.source_pguri = strdup(optarg);
 				log_trace("--source %s", options.source_pguri);
 				break;
 			}
@@ -162,13 +156,7 @@ cli_dump_schema_getopts(int argc, char **argv)
 							  "see above for details.");
 					exit(EXIT_CODE_BAD_ARGS);
 				}
-				size_t len = strlen(optarg) + 1;
-				options.target_pguri = (char *) calloc(len, sizeof(char));
-				if (options.source_pguri  == NULL) {
-					log_error(ALLOCATION_FAILED_ERROR);
-					break;
-				}
-				strlcpy(options.source_pguri, optarg, len);
+				options.target_pguri = strdup(optarg);
 				log_trace("--target %s", options.target_pguri);
 				break;
 			}

--- a/src/bin/pgcopydb/cli_dump.c
+++ b/src/bin/pgcopydb/cli_dump.c
@@ -143,7 +143,7 @@ cli_dump_schema_getopts(int argc, char **argv)
 							  "see above for details.");
 					exit(EXIT_CODE_BAD_ARGS);
 				}
-				options.source_pguri = strdup(optarg);
+				options.source_pguri = pg_strdup(optarg);
 				log_trace("--source %s", options.source_pguri);
 				break;
 			}
@@ -156,7 +156,7 @@ cli_dump_schema_getopts(int argc, char **argv)
 							  "see above for details.");
 					exit(EXIT_CODE_BAD_ARGS);
 				}
-				options.target_pguri = strdup(optarg);
+				options.target_pguri = pg_strdup(optarg);
 				log_trace("--target %s", options.target_pguri);
 				break;
 			}

--- a/src/bin/pgcopydb/cli_list.c
+++ b/src/bin/pgcopydb/cli_list.c
@@ -441,7 +441,7 @@ cli_list_db_getopts(int argc, char **argv)
 		}
 	}
 
-	if (IS_EMPTY_STRING_BUFFER(options.connStrings.source_pguri))
+	if (options.connStrings.source_pguri == NULL)
 	{
 		log_fatal("Option --source is mandatory");
 		++errors;

--- a/src/bin/pgcopydb/cli_list.c
+++ b/src/bin/pgcopydb/cli_list.c
@@ -208,6 +208,7 @@ cli_list_db_getopts(int argc, char **argv)
 	};
 
 	optind = 0;
+
 	/* read values from the environment */
 	if (!cli_copydb_getenv(&options))
 	{
@@ -1319,9 +1320,10 @@ cli_list_schema(int argc, char **argv)
 		/* errors have already been logged */
 		exit(EXIT_CODE_BAD_ARGS);
 	}
+
 	/* allocating it to the length of listDBoptions.source_pguri as ListDBOptions does not have target_pguri */
-	options.target_pguri = calloc(strlen(listDBoptions.source_pguri)+1, sizeof(char));
-	if(options.target_pguri == NULL)
+	options.target_pguri = calloc(strlen(listDBoptions.source_pguri) + 1, sizeof(char));
+	if (options.target_pguri == NULL)
 	{
 		log_error(ALLOCATION_FAILED_ERROR);
 		exit(EXIT_CODE_INTERNAL_ERROR);

--- a/src/bin/pgcopydb/cli_list.c
+++ b/src/bin/pgcopydb/cli_list.c
@@ -1321,7 +1321,8 @@ cli_list_schema(int argc, char **argv)
 	}
 	/* allocating it to the length of listDBoptions.source_pguri as ListDBOptions does not have target_pguri */
 	options.target_pguri = calloc(strlen(listDBoptions.source_pguri)+1, sizeof(char));
-	if(options.target_pguri == NULL){
+	if(options.target_pguri == NULL)
+	{
 		log_error(ALLOCATION_FAILED_ERROR);
 		exit(EXIT_CODE_INTERNAL_ERROR);
 	}

--- a/src/bin/pgcopydb/cli_list.c
+++ b/src/bin/pgcopydb/cli_list.c
@@ -228,13 +228,7 @@ cli_list_db_getopts(int argc, char **argv)
 							  "see above for details.");
 					exit(EXIT_CODE_BAD_ARGS);
 				}
-				size_t len = strlen(optarg) + 1;
-				options.source_pguri = (char *) calloc(len, sizeof(char));
-				if (options.source_pguri  == NULL) {
-					log_error(ALLOCATION_FAILED_ERROR);
-					break;
-				}
-				strlcpy(options.source_pguri, optarg, len);
+				options.source_pguri = strdup(optarg);
 				log_trace("--source %s", options.source_pguri);
 				break;
 			}
@@ -1540,13 +1534,7 @@ copydb_init_specs_from_listdboptions(CopyDBOptions *options,
 									 ListDBOptions *listDBoptions)
 {
 	strlcpy(options->dir, listDBoptions->dir, MAXPGPATH);
-	options->source_pguri = calloc(strlen(listDBoptions->source_pguri)+1, sizeof(char));
-	if(options->source_pguri == NULL){
-		log_error(ALLOCATION_FAILED_ERROR);
-		return false;
-	}
-	strlcpy(options->source_pguri, listDBoptions->source_pguri, strlen(listDBoptions->source_pguri)+1);
-
+	options->source_pguri = listDBoptions->source_pguri;
 	options->splitTablesLargerThan = listDBoptions->splitTablesLargerThan;
 
 	strlcpy(options->splitTablesLargerThanPretty,

--- a/src/bin/pgcopydb/cli_list.c
+++ b/src/bin/pgcopydb/cli_list.c
@@ -229,7 +229,7 @@ cli_list_db_getopts(int argc, char **argv)
 							  "see above for details.");
 					exit(EXIT_CODE_BAD_ARGS);
 				}
-				options.source_pguri = strdup(optarg);
+				options.source_pguri = pg_strdup(optarg);
 				log_trace("--source %s", options.source_pguri);
 				break;
 			}
@@ -1319,14 +1319,6 @@ cli_list_schema(int argc, char **argv)
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_BAD_ARGS);
-	}
-
-	/* allocating it to the length of listDBoptions.source_pguri as ListDBOptions does not have target_pguri */
-	options.target_pguri = calloc(strlen(listDBoptions.source_pguri) + 1, sizeof(char));
-	if (options.target_pguri == NULL)
-	{
-		log_error(ALLOCATION_FAILED_ERROR);
-		exit(EXIT_CODE_INTERNAL_ERROR);
 	}
 
 	if (!copydb_init_specs(&copySpecs, &options, DATA_SECTION_ALL))

--- a/src/bin/pgcopydb/cli_list.h
+++ b/src/bin/pgcopydb/cli_list.h
@@ -30,8 +30,7 @@ typedef struct ListDBOptions
 	bool dropCache;
 	bool summary;
 
-	uint64_t splitTablesLargerThan;
-	char splitTablesLargerThanPretty[NAMEDATALEN];
+	SplitTableLargerThan splitTablesLargerThan;
 } ListDBOptions;
 
 

--- a/src/bin/pgcopydb/cli_list.h
+++ b/src/bin/pgcopydb/cli_list.h
@@ -19,7 +19,8 @@ typedef struct ListDBOptions
 {
 	char dir[MAXPGPATH];
 
-	char *source_pguri;     /* malloc'ed area */
+	ConnStrings connStrings;
+
 	char schema_name[NAMEDATALEN];
 	char table_name[NAMEDATALEN];
 	char filterFileName[MAXPGPATH];

--- a/src/bin/pgcopydb/cli_list.h
+++ b/src/bin/pgcopydb/cli_list.h
@@ -19,7 +19,7 @@ typedef struct ListDBOptions
 {
 	char dir[MAXPGPATH];
 
-	char *source_pguri; 	/* malloc'ed area */
+	char *source_pguri;     /* malloc'ed area */
 	char schema_name[NAMEDATALEN];
 	char table_name[NAMEDATALEN];
 	char filterFileName[MAXPGPATH];

--- a/src/bin/pgcopydb/cli_list.h
+++ b/src/bin/pgcopydb/cli_list.h
@@ -19,7 +19,7 @@ typedef struct ListDBOptions
 {
 	char dir[MAXPGPATH];
 
-	char source_pguri[MAXCONNINFO];
+	char *source_pguri;
 	char schema_name[NAMEDATALEN];
 	char table_name[NAMEDATALEN];
 	char filterFileName[MAXPGPATH];

--- a/src/bin/pgcopydb/cli_list.h
+++ b/src/bin/pgcopydb/cli_list.h
@@ -19,7 +19,7 @@ typedef struct ListDBOptions
 {
 	char dir[MAXPGPATH];
 
-	char *source_pguri;
+	char *source_pguri; 	/* malloc'ed area */
 	char schema_name[NAMEDATALEN];
 	char table_name[NAMEDATALEN];
 	char filterFileName[MAXPGPATH];

--- a/src/bin/pgcopydb/cli_ping.c
+++ b/src/bin/pgcopydb/cli_ping.c
@@ -76,7 +76,7 @@ cli_ping_getopts(int argc, char **argv)
 							  "see above for details.");
 					++errors;
 				}
-				options.source_pguri = strdup(optarg);
+				options.source_pguri = pg_strdup(optarg);
 				log_trace("--source %s", options.source_pguri);
 				break;
 			}
@@ -89,7 +89,7 @@ cli_ping_getopts(int argc, char **argv)
 							  "see above for details.");
 					++errors;
 				}
-				options.target_pguri = strdup(optarg);
+				options.target_pguri = pg_strdup(optarg);
 				log_trace("--target %s", options.target_pguri);
 				break;
 			}

--- a/src/bin/pgcopydb/cli_ping.c
+++ b/src/bin/pgcopydb/cli_ping.c
@@ -76,14 +76,7 @@ cli_ping_getopts(int argc, char **argv)
 							  "see above for details.");
 					++errors;
 				}
-
-				size_t len = strlen(optarg) + 1;
-				options.source_pguri = (char *) calloc(len, sizeof(char));
-				if (options.source_pguri  == NULL) {
-					log_error(ALLOCATION_FAILED_ERROR);
-					break;
-				}
-				strlcpy(options.source_pguri, optarg, len);
+				options.source_pguri = strdup(optarg);
 				log_trace("--source %s", options.source_pguri);
 				break;
 			}
@@ -96,13 +89,7 @@ cli_ping_getopts(int argc, char **argv)
 							  "see above for details.");
 					++errors;
 				}
-				size_t len = strlen(optarg) + 1;
-				options.target_pguri = (char *) calloc(len, sizeof(char));
-				if (options.target_pguri  == NULL) {
-					log_error(ALLOCATION_FAILED_ERROR);
-					break;
-				}
-				strlcpy(options.target_pguri, optarg, len);
+				options.target_pguri = strdup(optarg);
 				log_trace("--target %s", options.target_pguri);
 				break;
 			}

--- a/src/bin/pgcopydb/cli_ping.c
+++ b/src/bin/pgcopydb/cli_ping.c
@@ -76,7 +76,14 @@ cli_ping_getopts(int argc, char **argv)
 							  "see above for details.");
 					++errors;
 				}
-				strlcpy(options.source_pguri, optarg, MAXCONNINFO);
+
+				size_t len = strlen(optarg) + 1;
+				options.source_pguri = (char *) calloc(len, sizeof(char));
+				if (options.source_pguri  == NULL) {
+					log_error(ALLOCATION_FAILED_ERROR);
+					break;
+				}
+				strlcpy(options.source_pguri, optarg, len);
 				log_trace("--source %s", options.source_pguri);
 				break;
 			}
@@ -89,7 +96,13 @@ cli_ping_getopts(int argc, char **argv)
 							  "see above for details.");
 					++errors;
 				}
-				strlcpy(options.target_pguri, optarg, MAXCONNINFO);
+				size_t len = strlen(optarg) + 1;
+				options.target_pguri = (char *) calloc(len, sizeof(char));
+				if (options.target_pguri  == NULL) {
+					log_error(ALLOCATION_FAILED_ERROR);
+					break;
+				}
+				strlcpy(options.target_pguri, optarg, len);
 				log_trace("--target %s", options.target_pguri);
 				break;
 			}

--- a/src/bin/pgcopydb/cli_ping.c
+++ b/src/bin/pgcopydb/cli_ping.c
@@ -55,7 +55,6 @@ cli_ping_getopts(int argc, char **argv)
 	};
 	optind = 0;
 
-
 	/* read values from the environment */
 	if (!cli_copydb_getenv(&options))
 	{
@@ -76,8 +75,8 @@ cli_ping_getopts(int argc, char **argv)
 							  "see above for details.");
 					++errors;
 				}
-				options.source_pguri = pg_strdup(optarg);
-				log_trace("--source %s", options.source_pguri);
+				options.connStrings.source_pguri = pg_strdup(optarg);
+				log_trace("--source %s", options.connStrings.source_pguri);
 				break;
 			}
 
@@ -89,8 +88,8 @@ cli_ping_getopts(int argc, char **argv)
 							  "see above for details.");
 					++errors;
 				}
-				options.target_pguri = pg_strdup(optarg);
-				log_trace("--target %s", options.target_pguri);
+				options.connStrings.target_pguri = pg_strdup(optarg);
+				log_trace("--target %s", options.connStrings.target_pguri);
 				break;
 			}
 
@@ -156,11 +155,18 @@ cli_ping_getopts(int argc, char **argv)
 		}
 	}
 
-	if (IS_EMPTY_STRING_BUFFER(options.source_pguri) ||
-		IS_EMPTY_STRING_BUFFER(options.target_pguri))
+	if (options.connStrings.source_pguri == NULL ||
+		options.connStrings.target_pguri == NULL)
 	{
 		log_fatal("Options --source and --target are mandatory");
 		exit(EXIT_CODE_BAD_ARGS);
+	}
+
+	/* prepare safe versions of the connection strings (without password) */
+	if (!cli_prepare_pguris(&(options.connStrings)))
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_INTERNAL_ERROR);
 	}
 
 	/* publish our option parsing in the global variable */
@@ -177,14 +183,11 @@ static void
 cli_ping(int argc, char **argv)
 {
 	int errors = 0;
-	char scrubbedSourceURI[MAXCONNINFO] = { 0 };
-	char scrubbedTargetURI[MAXCONNINFO] = { 0 };
 
-	char *source = copyDBoptions.source_pguri;
-	char *target = copyDBoptions.target_pguri;
+	ConnStrings *dsn = &(copyDBoptions.connStrings);
 
-	(void) parse_and_scrub_connection_string(source, scrubbedSourceURI);
-	(void) parse_and_scrub_connection_string(target, scrubbedTargetURI);
+	char *source = dsn->source_pguri;
+	char *target = dsn->target_pguri;
 
 	/* ping both source and target databases concurrently */
 	pid_t sPid = fork();
@@ -217,8 +220,8 @@ cli_ping(int argc, char **argv)
 				exit(EXIT_CODE_TARGET);
 			}
 
-			log_info("Successfully could connect t source database at \"%s\"",
-					 scrubbedSourceURI);
+			log_info("Successfully could connect to source database at \"%s\"",
+					 dsn->safeSourcePGURI.pguri);
 
 			pgsql_finish(&src);
 
@@ -264,7 +267,7 @@ cli_ping(int argc, char **argv)
 			}
 
 			log_info("Successfully could connect to target database at \"%s\"",
-					 scrubbedTargetURI);
+					 dsn->safeTargetPGURI.pguri);
 
 			pgsql_finish(&dst);
 

--- a/src/bin/pgcopydb/cli_restore.c
+++ b/src/bin/pgcopydb/cli_restore.c
@@ -187,13 +187,7 @@ cli_restore_schema_getopts(int argc, char **argv)
 							  "see above for details.");
 					exit(EXIT_CODE_BAD_ARGS);
 				}
-				size_t len = strlen(optarg) + 1;
-				options.source_pguri = (char *) calloc(len, sizeof(char));
-				if (options.source_pguri  == NULL) {
-					log_error(ALLOCATION_FAILED_ERROR);
-					break;
-				}
-				strlcpy(options.source_pguri, optarg, len);
+				options.source_pguri = strdup(optarg);
 				log_trace("--source %s", options.source_pguri);
 				break;
 			}
@@ -206,13 +200,7 @@ cli_restore_schema_getopts(int argc, char **argv)
 							  "see above for details.");
 					exit(EXIT_CODE_BAD_ARGS);
 				}
-				size_t len = strlen(optarg) + 1;
-				options.target_pguri = (char *) calloc(len, sizeof(char));
-				if (options.target_pguri  == NULL) {
-					log_error(ALLOCATION_FAILED_ERROR);
-					break;
-				}
-				strlcpy(options.target_pguri, optarg, len);
+				options.target_pguri = strdup(optarg);
 				log_trace("--target %s", options.target_pguri);
 				break;
 			}

--- a/src/bin/pgcopydb/cli_restore.c
+++ b/src/bin/pgcopydb/cli_restore.c
@@ -187,7 +187,7 @@ cli_restore_schema_getopts(int argc, char **argv)
 							  "see above for details.");
 					exit(EXIT_CODE_BAD_ARGS);
 				}
-				options.source_pguri = strdup(optarg);
+				options.source_pguri = pg_strdup(optarg);
 				log_trace("--source %s", options.source_pguri);
 				break;
 			}
@@ -200,7 +200,7 @@ cli_restore_schema_getopts(int argc, char **argv)
 							  "see above for details.");
 					exit(EXIT_CODE_BAD_ARGS);
 				}
-				options.target_pguri = strdup(optarg);
+				options.target_pguri = pg_strdup(optarg);
 				log_trace("--target %s", options.target_pguri);
 				break;
 			}

--- a/src/bin/pgcopydb/cli_restore.c
+++ b/src/bin/pgcopydb/cli_restore.c
@@ -187,7 +187,13 @@ cli_restore_schema_getopts(int argc, char **argv)
 							  "see above for details.");
 					exit(EXIT_CODE_BAD_ARGS);
 				}
-				strlcpy(options.source_pguri, optarg, MAXCONNINFO);
+				size_t len = strlen(optarg) + 1;
+				options.source_pguri = (char *) calloc(len, sizeof(char));
+				if (options.source_pguri  == NULL) {
+					log_error(ALLOCATION_FAILED_ERROR);
+					break;
+				}
+				strlcpy(options.source_pguri, optarg, len);
 				log_trace("--source %s", options.source_pguri);
 				break;
 			}
@@ -200,7 +206,13 @@ cli_restore_schema_getopts(int argc, char **argv)
 							  "see above for details.");
 					exit(EXIT_CODE_BAD_ARGS);
 				}
-				strlcpy(options.target_pguri, optarg, MAXCONNINFO);
+				size_t len = strlen(optarg) + 1;
+				options.target_pguri = (char *) calloc(len, sizeof(char));
+				if (options.target_pguri  == NULL) {
+					log_error(ALLOCATION_FAILED_ERROR);
+					break;
+				}
+				strlcpy(options.target_pguri, optarg, len);
 				log_trace("--target %s", options.target_pguri);
 				break;
 			}

--- a/src/bin/pgcopydb/cli_restore.c
+++ b/src/bin/pgcopydb/cli_restore.c
@@ -187,8 +187,8 @@ cli_restore_schema_getopts(int argc, char **argv)
 							  "see above for details.");
 					exit(EXIT_CODE_BAD_ARGS);
 				}
-				options.source_pguri = pg_strdup(optarg);
-				log_trace("--source %s", options.source_pguri);
+				options.connStrings.source_pguri = pg_strdup(optarg);
+				log_trace("--source %s", options.connStrings.source_pguri);
 				break;
 			}
 
@@ -200,8 +200,8 @@ cli_restore_schema_getopts(int argc, char **argv)
 							  "see above for details.");
 					exit(EXIT_CODE_BAD_ARGS);
 				}
-				options.target_pguri = pg_strdup(optarg);
-				log_trace("--target %s", options.target_pguri);
+				options.connStrings.target_pguri = pg_strdup(optarg);
+				log_trace("--target %s", options.connStrings.target_pguri);
 				break;
 			}
 
@@ -357,7 +357,7 @@ cli_restore_schema_getopts(int argc, char **argv)
 		}
 	}
 
-	if (IS_EMPTY_STRING_BUFFER(options.target_pguri))
+	if (options.connStrings.target_pguri == NULL)
 	{
 		log_fatal("Option --target is mandatory");
 		++errors;
@@ -367,6 +367,13 @@ cli_restore_schema_getopts(int argc, char **argv)
 	{
 		log_fatal("Option --resume requires option --not-consistent");
 		exit(EXIT_CODE_BAD_ARGS);
+	}
+
+	/* prepare safe versions of the connection strings (without password) */
+	if (!cli_prepare_pguris(&(options.connStrings)))
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_INTERNAL_ERROR);
 	}
 
 	if (errors > 0)
@@ -452,7 +459,7 @@ cli_restore_roles(int argc, char **argv)
 	(void) cli_restore_prepare_specs(&copySpecs);
 
 	if (!pg_restore_roles(&(copySpecs.pgPaths),
-						  copySpecs.target_pguri,
+						  copySpecs.connStrings.target_pguri,
 						  copySpecs.dumpPaths.rolesFilename))
 	{
 		/* errors have already been logged */
@@ -528,17 +535,12 @@ cli_restore_prepare_specs(CopyDataSpec *copySpecs)
 	CopyFilePaths *cfPaths = &(copySpecs->cfPaths);
 	PostgresPaths *pgPaths = &(copySpecs->pgPaths);
 
-	char scrubbedSourceURI[MAXCONNINFO] = { 0 };
-	char scrubbedTargetURI[MAXCONNINFO] = { 0 };
+	ConnStrings *dsn = &(copySpecs->connStrings);
+	char *source = dsn->safeSourcePGURI.pguri;
+	char *target = dsn->safeTargetPGURI.pguri;
 
-	(void) parse_and_scrub_connection_string(restoreDBoptions.source_pguri,
-											 scrubbedSourceURI);
-
-	(void) parse_and_scrub_connection_string(restoreDBoptions.target_pguri,
-											 scrubbedTargetURI);
-
-	log_info("[SOURCE] Restoring database from \"%s\"", scrubbedSourceURI);
-	log_info("[TARGET] Restoring database into \"%s\"", scrubbedTargetURI);
+	log_info("[SOURCE] Restoring database from \"%s\"", source);
+	log_info("[TARGET] Restoring database into \"%s\"", target);
 
 	(void) find_pg_commands(pgPaths);
 

--- a/src/bin/pgcopydb/cli_snapshot.c
+++ b/src/bin/pgcopydb/cli_snapshot.c
@@ -84,7 +84,7 @@ cli_create_snapshot_getopts(int argc, char **argv)
 							  "see above for details.");
 					exit(EXIT_CODE_BAD_ARGS);
 				}
-				options.source_pguri = strdup(optarg);
+				options.source_pguri = pg_strdup(optarg);
 				log_trace("--source %s", options.source_pguri);
 				break;
 			}

--- a/src/bin/pgcopydb/cli_snapshot.c
+++ b/src/bin/pgcopydb/cli_snapshot.c
@@ -84,7 +84,13 @@ cli_create_snapshot_getopts(int argc, char **argv)
 							  "see above for details.");
 					exit(EXIT_CODE_BAD_ARGS);
 				}
-				strlcpy(options.source_pguri, optarg, MAXCONNINFO);
+				size_t len = strlen(optarg) + 1;
+				options.source_pguri = (char *) calloc(len, sizeof(char));
+				if (options.source_pguri  == NULL) {
+					log_error(ALLOCATION_FAILED_ERROR);
+					break;
+				}
+				strlcpy(options.source_pguri, optarg, len);
 				log_trace("--source %s", options.source_pguri);
 				break;
 			}

--- a/src/bin/pgcopydb/cli_snapshot.c
+++ b/src/bin/pgcopydb/cli_snapshot.c
@@ -84,13 +84,7 @@ cli_create_snapshot_getopts(int argc, char **argv)
 							  "see above for details.");
 					exit(EXIT_CODE_BAD_ARGS);
 				}
-				size_t len = strlen(optarg) + 1;
-				options.source_pguri = (char *) calloc(len, sizeof(char));
-				if (options.source_pguri  == NULL) {
-					log_error(ALLOCATION_FAILED_ERROR);
-					break;
-				}
-				strlcpy(options.source_pguri, optarg, len);
+				options.source_pguri = strdup(optarg);
 				log_trace("--source %s", options.source_pguri);
 				break;
 			}

--- a/src/bin/pgcopydb/cli_snapshot.c
+++ b/src/bin/pgcopydb/cli_snapshot.c
@@ -84,8 +84,8 @@ cli_create_snapshot_getopts(int argc, char **argv)
 							  "see above for details.");
 					exit(EXIT_CODE_BAD_ARGS);
 				}
-				options.source_pguri = pg_strdup(optarg);
-				log_trace("--source %s", options.source_pguri);
+				options.connStrings.source_pguri = pg_strdup(optarg);
+				log_trace("--source %s", options.connStrings.source_pguri);
 				break;
 			}
 
@@ -186,10 +186,17 @@ cli_create_snapshot_getopts(int argc, char **argv)
 		}
 	}
 
-	if (IS_EMPTY_STRING_BUFFER(options.source_pguri))
+	if (options.connStrings.source_pguri == NULL)
 	{
 		log_fatal("Option --source is mandatory");
 		++errors;
+	}
+
+	/* prepare safe versions of the connection strings (without password) */
+	if (!cli_prepare_pguris(&(options.connStrings)))
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_INTERNAL_ERROR);
 	}
 
 	if (!cli_copydb_is_consistent(&options))
@@ -285,8 +292,7 @@ cli_create_snapshot(int argc, char **argv)
 
 		if (!stream_init_specs(&streamSpecs,
 							   &(copySpecs.cfPaths.cdc),
-							   copySpecs.source_pguri,
-							   copySpecs.target_pguri,
+							   &(copySpecs.connStrings),
 							   &(createSNoptions.slot),
 							   createSNoptions.origin,
 							   createSNoptions.endpos,
@@ -300,8 +306,10 @@ cli_create_snapshot(int argc, char **argv)
 			exit(EXIT_CODE_INTERNAL_ERROR);
 		}
 
+		char *logrep_pguri = streamSpecs.connStrings->logrep_pguri;
+
 		if (!copydb_create_logical_replication_slot(&copySpecs,
-													streamSpecs.logrep_pguri,
+													logrep_pguri,
 													&(streamSpecs.slot)))
 		{
 			/* errors have already been logged */

--- a/src/bin/pgcopydb/copydb.c
+++ b/src/bin/pgcopydb/copydb.c
@@ -678,10 +678,6 @@ copydb_init_specs(CopyDataSpec *specs,
 				sizeof(tmpCopySpecs.sourceSnapshot.snapshot));
 	}
 
-	strlcpy(tmpCopySpecs.splitTablesLargerThanPretty,
-			options->splitTablesLargerThanPretty,
-			sizeof(tmpCopySpecs.splitTablesLargerThanPretty));
-
 	/* copy the structure as a whole memory area to the target place */
 	*specs = tmpCopySpecs;
 

--- a/src/bin/pgcopydb/copydb.c
+++ b/src/bin/pgcopydb/copydb.c
@@ -629,12 +629,12 @@ copydb_init_specs(CopyDataSpec *specs,
 		.cfPaths = specs->cfPaths,
 		.pgPaths = specs->pgPaths,
 
-		.source_pguri = { 0 },
-		.target_pguri = { 0 },
+		.source_pguri = (char *) calloc(strlen(options->source_pguri) + 1, sizeof(char)),
+		.target_pguri = (char *) calloc(strlen(options->target_pguri) + 1, sizeof(char)),
 
 		.sourceSnapshot = {
 			.pgsql = { 0 },
-			.pguri = { 0 },
+			.pguri = (char *) calloc(strlen(options->source_pguri) + 1, sizeof(char)),
 			.connectionType = PGSQL_CONN_SOURCE,
 			.snapshot = { 0 }
 		},
@@ -670,22 +670,26 @@ copydb_init_specs(CopyDataSpec *specs,
 		.catalog = { 0 },
 		.tableSpecsArray = { 0, NULL }
 	};
+	if(tmpCopySpecs.source_pguri == NULL || tmpCopySpecs.target_pguri == NULL){
+		log_error(ALLOCATION_FAILED_ERROR);
+		return false;
+	}
 
 	/* initialize the connection strings */
 	if (!IS_EMPTY_STRING_BUFFER(options->source_pguri))
 	{
 		strlcpy(tmpCopySpecs.source_pguri,
 				options->source_pguri,
-				MAXCONNINFO);
+				strlen(options->source_pguri)+1);
 
 		strlcpy(tmpCopySpecs.sourceSnapshot.pguri,
 				options->source_pguri,
-				MAXCONNINFO);
+				strlen(options->source_pguri)+1);
 	}
 
 	if (!IS_EMPTY_STRING_BUFFER(options->target_pguri))
 	{
-		strlcpy(tmpCopySpecs.target_pguri, options->target_pguri, MAXCONNINFO);
+		strlcpy(tmpCopySpecs.target_pguri, options->target_pguri, strlen(options->target_pguri)+1);
 	}
 
 	if (!IS_EMPTY_STRING_BUFFER(options->snapshot))
@@ -778,8 +782,8 @@ copydb_init_table_specs(CopyTableDataSpec *tableSpecs,
 		.cfPaths = &(specs->cfPaths),
 		.pgPaths = &(specs->pgPaths),
 
-		.source_pguri = (char *) &(specs->source_pguri),
-		.target_pguri = (char *) &(specs->target_pguri),
+		.source_pguri = (char *) calloc(strlen(specs->source_pguri) + 1, sizeof(char)),
+		.target_pguri = (char *) calloc(strlen(specs->target_pguri) + 1, sizeof(char)),
 
 		.section = specs->section,
 		.resume = specs->resume,
@@ -794,6 +798,24 @@ copydb_init_table_specs(CopyTableDataSpec *tableSpecs,
 		.indexSemaphore = &(specs->indexSemaphore)
 	};
 
+	if(tmpTableSpecs.source_pguri == NULL || tmpTableSpecs.target_pguri == NULL){
+		log_error(ALLOCATION_FAILED_ERROR);
+		return false;
+	}
+
+	if (!IS_EMPTY_STRING_BUFFER(specs->source_pguri))
+	{
+		strlcpy(tmpTableSpecs.source_pguri,
+				specs->source_pguri,
+				strlen(specs->source_pguri)+1);
+	}
+
+	if (!IS_EMPTY_STRING_BUFFER(specs->target_pguri))
+	{
+		strlcpy(tmpTableSpecs.target_pguri, 
+				specs->target_pguri,
+				strlen(specs->target_pguri)+1);
+	}
 	/* copy the structure as a whole memory area to the target place */
 	*tableSpecs = tmpTableSpecs;
 

--- a/src/bin/pgcopydb/copydb.c
+++ b/src/bin/pgcopydb/copydb.c
@@ -670,13 +670,6 @@ copydb_init_specs(CopyDataSpec *specs,
 		.catalog = { 0 },
 		.tableSpecsArray = { 0, NULL }
 	};
-	if (tmpCopySpecs.source_pguri == NULL || tmpCopySpecs.target_pguri == NULL ||
-		tmpCopySpecs.sourceSnapshot.pguri == NULL)
-	{
-		log_error(ALLOCATION_FAILED_ERROR);
-		return false;
-	}
-
 
 	if (!IS_EMPTY_STRING_BUFFER(options->snapshot))
 	{
@@ -783,12 +776,6 @@ copydb_init_table_specs(CopyTableDataSpec *tableSpecs,
 
 		.indexSemaphore = &(specs->indexSemaphore)
 	};
-
-	if (tmpTableSpecs.source_pguri == NULL || tmpTableSpecs.target_pguri == NULL)
-	{
-		log_error(ALLOCATION_FAILED_ERROR);
-		return false;
-	}
 
 	/* copy the structure as a whole memory area to the target place */
 	*tableSpecs = tmpTableSpecs;

--- a/src/bin/pgcopydb/copydb.c
+++ b/src/bin/pgcopydb/copydb.c
@@ -629,12 +629,12 @@ copydb_init_specs(CopyDataSpec *specs,
 		.cfPaths = specs->cfPaths,
 		.pgPaths = specs->pgPaths,
 
-		.source_pguri = (char *) calloc(strlen(options->source_pguri) + 1, sizeof(char)),
-		.target_pguri = (char *) calloc(strlen(options->target_pguri) + 1, sizeof(char)),
+		.source_pguri = !IS_EMPTY_STRING_BUFFER(options->source_pguri) ? options->source_pguri : NULL,
+		.target_pguri = !IS_EMPTY_STRING_BUFFER(options->target_pguri) ? options->target_pguri : NULL,
 
 		.sourceSnapshot = {
 			.pgsql = { 0 },
-			.pguri = (char *) calloc(strlen(options->source_pguri) + 1, sizeof(char)),
+			.pguri = !IS_EMPTY_STRING_BUFFER(options->source_pguri) ? options->source_pguri : NULL,
 			.connectionType = PGSQL_CONN_SOURCE,
 			.snapshot = { 0 }
 		},
@@ -670,27 +670,11 @@ copydb_init_specs(CopyDataSpec *specs,
 		.catalog = { 0 },
 		.tableSpecsArray = { 0, NULL }
 	};
-	if(tmpCopySpecs.source_pguri == NULL || tmpCopySpecs.target_pguri == NULL){
-		log_error(ALLOCATION_FAILED_ERROR);
+	if(tmpCopySpecs.source_pguri == NULL || tmpCopySpecs.target_pguri == NULL || tmpCopySpecs.sourceSnapshot.pguri == NULL)
+	{
 		return false;
 	}
 
-	/* initialize the connection strings */
-	if (!IS_EMPTY_STRING_BUFFER(options->source_pguri))
-	{
-		strlcpy(tmpCopySpecs.source_pguri,
-				options->source_pguri,
-				strlen(options->source_pguri)+1);
-
-		strlcpy(tmpCopySpecs.sourceSnapshot.pguri,
-				options->source_pguri,
-				strlen(options->source_pguri)+1);
-	}
-
-	if (!IS_EMPTY_STRING_BUFFER(options->target_pguri))
-	{
-		strlcpy(tmpCopySpecs.target_pguri, options->target_pguri, strlen(options->target_pguri)+1);
-	}
 
 	if (!IS_EMPTY_STRING_BUFFER(options->snapshot))
 	{
@@ -782,8 +766,8 @@ copydb_init_table_specs(CopyTableDataSpec *tableSpecs,
 		.cfPaths = &(specs->cfPaths),
 		.pgPaths = &(specs->pgPaths),
 
-		.source_pguri = (char *) calloc(strlen(specs->source_pguri) + 1, sizeof(char)),
-		.target_pguri = (char *) calloc(strlen(specs->target_pguri) + 1, sizeof(char)),
+		.source_pguri = !IS_EMPTY_STRING_BUFFER(specs->source_pguri) ? specs->source_pguri : NULL,
+		.target_pguri = !IS_EMPTY_STRING_BUFFER(specs->target_pguri) ? specs->target_pguri : NULL,
 
 		.section = specs->section,
 		.resume = specs->resume,
@@ -798,24 +782,11 @@ copydb_init_table_specs(CopyTableDataSpec *tableSpecs,
 		.indexSemaphore = &(specs->indexSemaphore)
 	};
 
-	if(tmpTableSpecs.source_pguri == NULL || tmpTableSpecs.target_pguri == NULL){
-		log_error(ALLOCATION_FAILED_ERROR);
+	if(tmpTableSpecs.source_pguri == NULL || tmpTableSpecs.target_pguri == NULL)
+	{
 		return false;
 	}
 
-	if (!IS_EMPTY_STRING_BUFFER(specs->source_pguri))
-	{
-		strlcpy(tmpTableSpecs.source_pguri,
-				specs->source_pguri,
-				strlen(specs->source_pguri)+1);
-	}
-
-	if (!IS_EMPTY_STRING_BUFFER(specs->target_pguri))
-	{
-		strlcpy(tmpTableSpecs.target_pguri, 
-				specs->target_pguri,
-				strlen(specs->target_pguri)+1);
-	}
 	/* copy the structure as a whole memory area to the target place */
 	*tableSpecs = tmpTableSpecs;
 

--- a/src/bin/pgcopydb/copydb.c
+++ b/src/bin/pgcopydb/copydb.c
@@ -629,12 +629,12 @@ copydb_init_specs(CopyDataSpec *specs,
 		.cfPaths = specs->cfPaths,
 		.pgPaths = specs->pgPaths,
 
-		.source_pguri = !IS_EMPTY_STRING_BUFFER(options->source_pguri) ? options->source_pguri : NULL,
-		.target_pguri = !IS_EMPTY_STRING_BUFFER(options->target_pguri) ? options->target_pguri : NULL,
+		.source_pguri = options->source_pguri,
+		.target_pguri = options->target_pguri,
 
 		.sourceSnapshot = {
 			.pgsql = { 0 },
-			.pguri = !IS_EMPTY_STRING_BUFFER(options->source_pguri) ? options->source_pguri : NULL,
+			.pguri = options->source_pguri,
 			.connectionType = PGSQL_CONN_SOURCE,
 			.snapshot = { 0 }
 		},
@@ -670,8 +670,10 @@ copydb_init_specs(CopyDataSpec *specs,
 		.catalog = { 0 },
 		.tableSpecsArray = { 0, NULL }
 	};
-	if(tmpCopySpecs.source_pguri == NULL || tmpCopySpecs.target_pguri == NULL || tmpCopySpecs.sourceSnapshot.pguri == NULL)
+	if (tmpCopySpecs.source_pguri == NULL || tmpCopySpecs.target_pguri == NULL ||
+		tmpCopySpecs.sourceSnapshot.pguri == NULL)
 	{
+		log_error(ALLOCATION_FAILED_ERROR);
 		return false;
 	}
 
@@ -766,8 +768,8 @@ copydb_init_table_specs(CopyTableDataSpec *tableSpecs,
 		.cfPaths = &(specs->cfPaths),
 		.pgPaths = &(specs->pgPaths),
 
-		.source_pguri = !IS_EMPTY_STRING_BUFFER(specs->source_pguri) ? specs->source_pguri : NULL,
-		.target_pguri = !IS_EMPTY_STRING_BUFFER(specs->target_pguri) ? specs->target_pguri : NULL,
+		.source_pguri = specs->source_pguri,
+		.target_pguri = specs->target_pguri,
 
 		.section = specs->section,
 		.resume = specs->resume,
@@ -782,8 +784,9 @@ copydb_init_table_specs(CopyTableDataSpec *tableSpecs,
 		.indexSemaphore = &(specs->indexSemaphore)
 	};
 
-	if(tmpTableSpecs.source_pguri == NULL || tmpTableSpecs.target_pguri == NULL)
+	if (tmpTableSpecs.source_pguri == NULL || tmpTableSpecs.target_pguri == NULL)
 	{
+		log_error(ALLOCATION_FAILED_ERROR);
 		return false;
 	}
 

--- a/src/bin/pgcopydb/copydb.c
+++ b/src/bin/pgcopydb/copydb.c
@@ -629,12 +629,12 @@ copydb_init_specs(CopyDataSpec *specs,
 		.cfPaths = specs->cfPaths,
 		.pgPaths = specs->pgPaths,
 
-		.source_pguri = options->source_pguri,
-		.target_pguri = options->target_pguri,
+		.connStrings = options->connStrings,
 
 		.sourceSnapshot = {
 			.pgsql = { 0 },
-			.pguri = options->source_pguri,
+			.pguri = options->connStrings.source_pguri,
+			.safeURI = options->connStrings.safeSourcePGURI,
 			.connectionType = PGSQL_CONN_SOURCE,
 			.snapshot = { 0 }
 		},
@@ -757,8 +757,7 @@ copydb_init_table_specs(CopyTableDataSpec *tableSpecs,
 		.cfPaths = &(specs->cfPaths),
 		.pgPaths = &(specs->pgPaths),
 
-		.source_pguri = specs->source_pguri,
-		.target_pguri = specs->target_pguri,
+		.connStrings = &(specs->connStrings),
 
 		.section = specs->section,
 		.resume = specs->resume,

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -220,8 +220,8 @@ typedef struct CopyDataSpec
 	SourceFilterItem *hOid;     /* hash table of objects, by Oid */
 	SourceFilterItem *hName;    /* hash table of objects, by pg_restore name */
 
-	char *source_pguri;
-	char *target_pguri;
+	char *source_pguri; 	    /* malloc'ed area */
+	char *target_pguri;         /* malloc'ed area */
 
 	TransactionSnapshot sourceSnapshot;
 

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -81,6 +81,8 @@ typedef struct TransactionSnapshot
 	TransactionSnapshotState state;
 
 	char *pguri;    /* malloc'ed area */
+	SafeURI safeURI;
+
 	PGSQL pgsql;
 
 	bool exportedCreateSlotSnapshot;
@@ -128,8 +130,7 @@ typedef struct CopyTableDataSpec
 	CopyFilePaths *cfPaths;
 	PostgresPaths *pgPaths;
 
-	char *source_pguri;
-	char *target_pguri;
+	ConnStrings *connStrings;
 
 	CopyDataSection section;
 	bool resume;
@@ -220,9 +221,7 @@ typedef struct CopyDataSpec
 	SourceFilterItem *hOid;     /* hash table of objects, by Oid */
 	SourceFilterItem *hName;    /* hash table of objects, by pg_restore name */
 
-	char *source_pguri;
-	char *target_pguri;
-
+	ConnStrings connStrings;
 	TransactionSnapshot sourceSnapshot;
 
 	CopyDataSection section;

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -80,7 +80,7 @@ typedef struct TransactionSnapshot
 	TransactionSnapshotKind kind;
 	TransactionSnapshotState state;
 
-	char pguri[MAXCONNINFO];
+	char *pguri;
 	PGSQL pgsql;
 
 	bool exportedCreateSlotSnapshot;
@@ -220,8 +220,8 @@ typedef struct CopyDataSpec
 	SourceFilterItem *hOid;     /* hash table of objects, by Oid */
 	SourceFilterItem *hName;    /* hash table of objects, by pg_restore name */
 
-	char source_pguri[MAXCONNINFO];
-	char target_pguri[MAXCONNINFO];
+	char *source_pguri;
+	char *target_pguri;
 
 	TransactionSnapshot sourceSnapshot;
 

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -80,7 +80,7 @@ typedef struct TransactionSnapshot
 	TransactionSnapshotKind kind;
 	TransactionSnapshotState state;
 
-	char *pguri;
+	char *pguri;  	/* malloc'ed area */
 	PGSQL pgsql;
 
 	bool exportedCreateSlotSnapshot;

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -80,7 +80,7 @@ typedef struct TransactionSnapshot
 	TransactionSnapshotKind kind;
 	TransactionSnapshotState state;
 
-	char *pguri;  	/* malloc'ed area */
+	char *pguri;    /* malloc'ed area */
 	PGSQL pgsql;
 
 	bool exportedCreateSlotSnapshot;
@@ -220,8 +220,8 @@ typedef struct CopyDataSpec
 	SourceFilterItem *hOid;     /* hash table of objects, by Oid */
 	SourceFilterItem *hName;    /* hash table of objects, by pg_restore name */
 
-	char *source_pguri; 	    /* malloc'ed area */
-	char *target_pguri;         /* malloc'ed area */
+	char *source_pguri;
+	char *target_pguri;
 
 	TransactionSnapshot sourceSnapshot;
 

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -245,8 +245,7 @@ typedef struct CopyDataSpec
 	int indexJobs;
 	int vacuumJobs;
 
-	uint64_t splitTablesLargerThan;
-	char splitTablesLargerThanPretty[NAMEDATALEN];
+	SplitTableLargerThan splitTablesLargerThan;
 
 	Semaphore tableSemaphore;
 	Semaphore indexSemaphore;

--- a/src/bin/pgcopydb/copydb_schema.c
+++ b/src/bin/pgcopydb/copydb_schema.c
@@ -48,7 +48,7 @@ copydb_fetch_schema_and_prepare_specs(CopyDataSpec *specs)
 	else
 	{
 		log_debug("--not-consistent, create a fresh connection");
-		if (!pgsql_init(&pgsql, specs->source_pguri, PGSQL_CONN_SOURCE))
+		if (!pgsql_init(&pgsql, specs->connStrings.source_pguri, PGSQL_CONN_SOURCE))
 		{
 			/* errors have already been logged */
 			return false;

--- a/src/bin/pgcopydb/copydb_schema.c
+++ b/src/bin/pgcopydb/copydb_schema.c
@@ -248,10 +248,10 @@ copydb_prepare_table_specs(CopyDataSpec *specs, PGSQL *pgsql)
 
 	int copySpecsCount = 0;
 
-	if (specs->splitTablesLargerThan > 0)
+	if (specs->splitTablesLargerThan.bytes > 0)
 	{
 		log_info("Splitting source candidate tables larger than %s",
-				 specs->splitTablesLargerThanPretty);
+				 specs->splitTablesLargerThan.bytesPretty);
 	}
 
 	/* prepare a SourceTable hash table, indexed by Oid */
@@ -268,8 +268,8 @@ copydb_prepare_table_specs(CopyDataSpec *specs, PGSQL *pgsql)
 		/* add the current table to the Hash-by-OID */
 		HASH_ADD(hh, sourceTableHashByOid, oid, sizeof(uint32_t), source);
 
-		if (specs->splitTablesLargerThan > 0 &&
-			specs->splitTablesLargerThan <= source->bytes)
+		if (specs->splitTablesLargerThan.bytes > 0 &&
+			specs->splitTablesLargerThan.bytes <= source->bytes)
 		{
 			if (IS_EMPTY_STRING_BUFFER(source->partKey))
 			{
@@ -280,7 +280,7 @@ copydb_prepare_table_specs(CopyDataSpec *specs, PGSQL *pgsql)
 						 source->nspname,
 						 source->relname,
 						 source->bytesPretty,
-						 specs->splitTablesLargerThanPretty);
+						 specs->splitTablesLargerThan.bytesPretty);
 
 				log_warn("Skipping same-table concurrency for table \"%s\".\"%s\"",
 						 source->nspname,
@@ -292,7 +292,7 @@ copydb_prepare_table_specs(CopyDataSpec *specs, PGSQL *pgsql)
 
 			if (!schema_list_partitions(pgsql,
 										source,
-										specs->splitTablesLargerThan))
+										specs->splitTablesLargerThan.bytes))
 			{
 				/* errors have already been logged */
 				return false;

--- a/src/bin/pgcopydb/dump_restore.c
+++ b/src/bin/pgcopydb/dump_restore.c
@@ -58,7 +58,7 @@ copydb_dump_source_schema(CopyDataSpec *specs,
 					 specs->cfPaths.done.preDataDump);
 		}
 		else if (!pg_dump_db(&(specs->pgPaths),
-							 specs->source_pguri,
+							 &(specs->connStrings),
 							 snapshot,
 							 "pre-data",
 							 &(specs->filters),
@@ -88,7 +88,7 @@ copydb_dump_source_schema(CopyDataSpec *specs,
 					 specs->cfPaths.done.postDataDump);
 		}
 		else if (!pg_dump_db(&(specs->pgPaths),
-							 specs->source_pguri,
+							 &(specs->connStrings),
 							 snapshot,
 							 "post-data",
 							 &(specs->filters),
@@ -156,7 +156,7 @@ copydb_target_prepare_schema(CopyDataSpec *specs)
 	}
 
 	if (!pg_restore_db(&(specs->pgPaths),
-					   specs->target_pguri,
+					   &(specs->connStrings),
 					   &(specs->filters),
 					   specs->dumpPaths.preFilename,
 					   specs->dumpPaths.preListFilename,
@@ -222,7 +222,7 @@ copydb_target_drop_tables(CopyDataSpec *specs)
 
 	PGSQL dst = { 0 };
 
-	if (!pgsql_init(&dst, specs->target_pguri, PGSQL_CONN_TARGET))
+	if (!pgsql_init(&dst, specs->connStrings.target_pguri, PGSQL_CONN_TARGET))
 	{
 		/* errors have already been logged */
 		destroyPQExpBuffer(query);
@@ -270,7 +270,7 @@ copydb_target_finalize_schema(CopyDataSpec *specs)
 	}
 
 	if (!pg_restore_db(&(specs->pgPaths),
-					   specs->target_pguri,
+					   &(specs->connStrings),
 					   &(specs->filters),
 					   specs->dumpPaths.postFilename,
 					   specs->dumpPaths.postListFilename,

--- a/src/bin/pgcopydb/env_utils.c
+++ b/src/bin/pgcopydb/env_utils.c
@@ -118,13 +118,13 @@ get_env_copy_with_fallback(const char *name, char *result, int maxLength,
 
 
 /*
- * get_env_dup copies the environment variable with "name" into
+ * get_env_dup_with_fallback copies the environment variable with "name" into
  * the result buffer using strdup. It returns false when it fails. If the environment
  * variable is not set the fallback string will be written in the buffer.
  * Except when fallback is NULL, in that case an error is returned.
  */
 bool
-get_env_dup(const char *name, char **result, const char *fallback)
+get_env_dup_with_fallback(const char *name, char **result, const char *fallback)
 {
 	if (name == NULL || strlen(name) == 0)
 	{
@@ -157,6 +157,18 @@ get_env_dup(const char *name, char **result, const char *fallback)
 	}
 
 	return true;
+}
+
+
+/*
+ * get_env_dup copies the environmennt variable with "name" into the result
+ * buffer using strdup. It returns false when it fails. The environment variable not
+ * existing is also considered a failure.
+ */
+bool
+get_env_dup(const char *name, char **result)
+{
+	return get_env_dup_with_fallback(name, result, NULL);
 }
 
 

--- a/src/bin/pgcopydb/env_utils.c
+++ b/src/bin/pgcopydb/env_utils.c
@@ -117,13 +117,13 @@ get_env_copy_with_fallback(const char *name, char *result, int maxLength,
 }
 
 /*
- * get_env_copy_dynamic copies the environment variable with "name" into
- * the result buffer. It returns false when it fails. If the environment
+ * get_env_dup copies the environment variable with "name" into
+ * the result buffer using strdup. It returns false when it fails. If the environment
  * variable is not set the fallback string will be written in the buffer.
  * Except when fallback is NULL, in that case an error is returned.
  */
 bool
-get_env_copy_dynamic(const char *name, char **result, const char *fallback)
+get_env_dup(const char *name, char **result, const char *fallback)
 {
 	if (name == NULL || strlen(name) == 0)
 	{
@@ -148,16 +148,7 @@ get_env_copy_dynamic(const char *name, char **result, const char *fallback)
 			return false;
 		}
 	}
-
-	size_t len = strlen(envvalue) + 1;
-    *result = (char *) calloc(len, sizeof(char));
-    if (*result == NULL) {
-        // Log or handle the error when memory allocation fails
-		log_error(ALLOCATION_FAILED_ERROR);
-        return false;
-    }
-
-	strlcpy(*result, envvalue, len);
+	*result = strdup(envvalue);
 
 	return true;
 }

--- a/src/bin/pgcopydb/env_utils.c
+++ b/src/bin/pgcopydb/env_utils.c
@@ -116,6 +116,7 @@ get_env_copy_with_fallback(const char *name, char *result, int maxLength,
 	return true;
 }
 
+
 /*
  * get_env_dup copies the environment variable with "name" into
  * the result buffer using strdup. It returns false when it fails. If the environment
@@ -149,10 +150,14 @@ get_env_dup(const char *name, char **result, const char *fallback)
 		}
 	}
 	*result = strdup(envvalue);
+	if (*result == NULL)
+	{
+		log_error(ALLOCATION_FAILED_ERROR);
+		return false;
+	}
 
 	return true;
 }
-
 
 
 /*

--- a/src/bin/pgcopydb/env_utils.h
+++ b/src/bin/pgcopydb/env_utils.h
@@ -13,7 +13,7 @@ bool env_exists(const char *name);
 bool get_env_copy(const char *name, char *outbuffer, int maxLength);
 bool get_env_copy_with_fallback(const char *name, char *result, int maxLength,
 								const char *fallback);
-bool get_env_copy_dynamic(const char *name, char **result, const char *fallback);
+bool get_env_dup(const char *name, char **result, const char *fallback);
 bool get_env_pgdata(char *pgdata);
 void get_env_pgdata_or_exit(char *pgdata);
 #endif /* ENV_UTILS_H */

--- a/src/bin/pgcopydb/env_utils.h
+++ b/src/bin/pgcopydb/env_utils.h
@@ -13,6 +13,7 @@ bool env_exists(const char *name);
 bool get_env_copy(const char *name, char *outbuffer, int maxLength);
 bool get_env_copy_with_fallback(const char *name, char *result, int maxLength,
 								const char *fallback);
+bool get_env_copy_dynamic(const char *name, char **result, const char *fallback);
 bool get_env_pgdata(char *pgdata);
 void get_env_pgdata_or_exit(char *pgdata);
 #endif /* ENV_UTILS_H */

--- a/src/bin/pgcopydb/env_utils.h
+++ b/src/bin/pgcopydb/env_utils.h
@@ -13,7 +13,8 @@ bool env_exists(const char *name);
 bool get_env_copy(const char *name, char *outbuffer, int maxLength);
 bool get_env_copy_with_fallback(const char *name, char *result, int maxLength,
 								const char *fallback);
-bool get_env_dup(const char *name, char **result, const char *fallback);
+bool get_env_dup(const char *name, char **result);
+bool get_env_dup_with_fallback(const char *name, char **result, const char *fallback);
 bool get_env_pgdata(char *pgdata);
 void get_env_pgdata_or_exit(char *pgdata);
 #endif /* ENV_UTILS_H */

--- a/src/bin/pgcopydb/extensions.c
+++ b/src/bin/pgcopydb/extensions.c
@@ -83,7 +83,7 @@ copydb_copy_extensions(CopyDataSpec *copySpecs, bool createExtensions)
 
 	SourceExtensionArray *extensionArray = &(copySpecs->catalog.extensionArray);
 
-	if (!pgsql_init(&dst, copySpecs->target_pguri, PGSQL_CONN_TARGET))
+	if (!pgsql_init(&dst, copySpecs->connStrings.target_pguri, PGSQL_CONN_TARGET))
 	{
 		/* errors have already been logged */
 		return false;

--- a/src/bin/pgcopydb/follow.c
+++ b/src/bin/pgcopydb/follow.c
@@ -29,8 +29,10 @@ follow_export_snapshot(CopyDataSpec *copySpecs, StreamSpecs *streamSpecs)
 	 * When using logical decoding, we need to create our replication slot and
 	 * fetch the snapshot from that logical replication command.
 	 */
+	char *logrep_pguri = streamSpecs->connStrings->logrep_pguri;
+
 	if (!copydb_create_logical_replication_slot(copySpecs,
-												streamSpecs->logrep_pguri,
+												logrep_pguri,
 												&(streamSpecs->slot)))
 	{
 		/* errors have already been logged */
@@ -105,6 +107,8 @@ follow_reset_sequences(CopyDataSpec *copySpecs, StreamSpecs *streamSpecs)
 	/* copy our structure wholesale */
 	seqSpecs = *copySpecs;
 
+	log_info("follow_reset_sequences: %s", seqSpecs.connStrings.source_pguri);
+
 	/* then force some options such as --resume --not-consistent */
 	seqSpecs.restart = false;
 	seqSpecs.resume = true;
@@ -142,7 +146,7 @@ follow_init_sentinel(StreamSpecs *specs, CopyDBSentinel *sentinel)
 {
 	PGSQL pgsql = { 0 };
 
-	if (!pgsql_init(&pgsql, specs->source_pguri, PGSQL_CONN_SOURCE))
+	if (!pgsql_init(&pgsql, specs->connStrings->source_pguri, PGSQL_CONN_SOURCE))
 	{
 		/* errors have already been logged */
 		return false;
@@ -188,7 +192,7 @@ follow_get_sentinel(StreamSpecs *specs, CopyDBSentinel *sentinel)
 {
 	PGSQL pgsql = { 0 };
 
-	if (!pgsql_init(&pgsql, specs->source_pguri, PGSQL_CONN_SOURCE))
+	if (!pgsql_init(&pgsql, specs->connStrings->source_pguri, PGSQL_CONN_SOURCE))
 	{
 		/* errors have already been logged */
 		return false;

--- a/src/bin/pgcopydb/indexes.c
+++ b/src/bin/pgcopydb/indexes.c
@@ -221,7 +221,7 @@ copydb_create_index_by_oid(CopyDataSpec *specs, uint32_t indexOid)
 	bool ifNotExists =
 		specs->resume || specs->section == DATA_SECTION_INDEXES;
 
-	if (!copydb_create_index(specs->target_pguri,
+	if (!copydb_create_index(specs->connStrings.target_pguri,
 							 index,
 							 &indexPaths,
 							 &(specs->indexSemaphore),
@@ -638,7 +638,7 @@ copydb_start_index_process(CopyDataSpec *specs,
 
 		bool ifNotExists = true;
 
-		if (!copydb_create_index(specs->target_pguri,
+		if (!copydb_create_index(specs->connStrings.target_pguri,
 								 index,
 								 indexPaths,
 								 &(specs->indexSemaphore),
@@ -1094,7 +1094,7 @@ copydb_create_constraints(CopyDataSpec *specs, SourceTable *table)
 {
 	int errors = 0;
 
-	const char *pguri = specs->target_pguri;
+	const char *pguri = specs->connStrings.target_pguri;
 	PGSQL dst = { 0 };
 
 	if (!pgsql_init(&dst, (char *) pguri, PGSQL_CONN_TARGET))

--- a/src/bin/pgcopydb/ld_apply.c
+++ b/src/bin/pgcopydb/ld_apply.c
@@ -74,8 +74,7 @@ stream_apply_catchup(StreamSpecs *specs)
 
 	if (!setupReplicationOrigin(&context,
 								&(specs->paths),
-								specs->source_pguri,
-								specs->target_pguri,
+								specs->connStrings,
 								specs->origin,
 								specs->endpos,
 								context.apply,
@@ -216,7 +215,7 @@ stream_apply_wait_for_sentinel(StreamSpecs *specs, StreamApplyContext *context)
 	bool firstLoop = true;
 	CopyDBSentinel sentinel = { 0 };
 
-	if (!pgsql_init(&src, specs->source_pguri, PGSQL_CONN_SOURCE))
+	if (!pgsql_init(&src, specs->connStrings->source_pguri, PGSQL_CONN_SOURCE))
 	{
 		/* errors have already been logged */
 		return false;
@@ -293,7 +292,7 @@ stream_apply_sync_sentinel(StreamApplyContext *context)
 	PGSQL src = { 0 };
 	CopyDBSentinel sentinel = { 0 };
 
-	if (!pgsql_init(&src, context->source_pguri, PGSQL_CONN_SOURCE))
+	if (!pgsql_init(&src, context->connStrings->source_pguri, PGSQL_CONN_SOURCE))
 	{
 		/* errors have already been logged */
 		return false;
@@ -841,8 +840,7 @@ stream_apply_sql(StreamApplyContext *context,
 bool
 setupReplicationOrigin(StreamApplyContext *context,
 					   CDCPaths *paths,
-					   char *source_pguri,
-					   char *target_pguri,
+					   ConnStrings *connStrings,
 					   char *origin,
 					   uint64_t endpos,
 					   bool apply,
@@ -877,11 +875,11 @@ setupReplicationOrigin(StreamApplyContext *context,
 
 	context->reachedStartPos = false;
 
-	strlcpy(context->source_pguri, source_pguri, sizeof(context->source_pguri));
-	strlcpy(context->target_pguri, target_pguri, sizeof(context->target_pguri));
+	context->connStrings = connStrings;
+
 	strlcpy(context->origin, origin, sizeof(context->origin));
 
-	if (!pgsql_init(pgsql, context->target_pguri, PGSQL_CONN_TARGET))
+	if (!pgsql_init(pgsql, context->connStrings->target_pguri, PGSQL_CONN_TARGET))
 	{
 		/* errors have already been logged */
 		return false;

--- a/src/bin/pgcopydb/ld_replay.c
+++ b/src/bin/pgcopydb/ld_replay.c
@@ -77,8 +77,7 @@ stream_apply_replay(StreamSpecs *specs)
 
 	if (!setupReplicationOrigin(context,
 								&(specs->paths),
-								specs->source_pguri,
-								specs->target_pguri,
+								specs->connStrings,
 								specs->origin,
 								specs->endpos,
 								context->apply,
@@ -116,7 +115,7 @@ stream_apply_replay(StreamSpecs *specs)
 	 */
 	PGSQL *src = &(context->src);
 
-	if (!pgsql_init(src, context->source_pguri, PGSQL_CONN_SOURCE))
+	if (!pgsql_init(src, context->connStrings->source_pguri, PGSQL_CONN_SOURCE))
 	{
 		/* errors have already been logged */
 		return false;

--- a/src/bin/pgcopydb/ld_stream.h
+++ b/src/bin/pgcopydb/ld_stream.h
@@ -278,9 +278,7 @@ struct StreamSpecs
 {
 	CDCPaths paths;
 
-	char source_pguri[MAXCONNINFO];
-	char logrep_pguri[MAXCONNINFO];
-	char target_pguri[MAXCONNINFO];
+	ConnStrings *connStrings;
 
 	uint32_t WalSegSz;
 	IdentifySystem system;
@@ -330,7 +328,7 @@ typedef struct StreamContext
 	CDCPaths paths;
 	LogicalStreamMode mode;
 
-	char source_pguri[MAXCONNINFO];
+	ConnStrings *connStrings;
 
 	uint64_t startpos;
 	uint64_t endpos;
@@ -383,8 +381,7 @@ typedef struct StreamApplyContext
 	bool sentinelQueryInProgress;
 	uint64_t sentinelSyncTime;
 
-	char source_pguri[MAXCONNINFO];
-	char target_pguri[MAXCONNINFO];
+	ConnStrings *connStrings;
 	char origin[BUFSIZE];
 
 	IdentifySystem system;      /* information about source database */
@@ -419,8 +416,7 @@ typedef struct StreamContent
 
 bool stream_init_specs(StreamSpecs *specs,
 					   CDCPaths *paths,
-					   char *source_pguri,
-					   char *target_pguri,
+					   ConnStrings *connStrings,
 					   ReplicationSlot *slot,
 					   char *origin,
 					   uint64_t endpos,
@@ -470,7 +466,7 @@ bool stream_read_latest(StreamSpecs *specs, StreamContent *content);
 bool stream_update_latest_symlink(StreamContext *privateContext,
 								  const char *filename);
 
-bool buildReplicationURI(const char *pguri, char *repl_pguri);
+bool buildReplicationURI(const char *pguri, char **repl_pguri);
 
 bool stream_setup_databases(CopyDataSpec *copySpecs, StreamSpecs *streamSpecs);
 
@@ -590,8 +586,7 @@ bool stream_apply_sql(StreamApplyContext *context,
 
 bool setupReplicationOrigin(StreamApplyContext *context,
 							CDCPaths *paths,
-							char *source_pguri,
-							char *target_pguri,
+							ConnStrings *connStrings,
 							char *origin,
 							uint64_t endpos,
 							bool apply,

--- a/src/bin/pgcopydb/parsing_utils.c
+++ b/src/bin/pgcopydb/parsing_utils.c
@@ -940,7 +940,7 @@ extract_connection_string_password(const char *pguri, SafeURI *safeURI)
 		{
 			if (option->val != NULL)
 			{
-				strlcpy(safeURI->password, option->val, MAXCONNINFO);
+				strlcpy(safeURI->password, option->val, strlen(pguri)+1);
 			}
 			continue;
 		}

--- a/src/bin/pgcopydb/parsing_utils.c
+++ b/src/bin/pgcopydb/parsing_utils.c
@@ -940,7 +940,7 @@ extract_connection_string_password(const char *pguri, SafeURI *safeURI)
 		{
 			if (option->val != NULL)
 			{
-				strlcpy(safeURI->password, option->val, strlen(pguri)+1);
+				safeURI->password = strdup(option->val);
 			}
 			continue;
 		}

--- a/src/bin/pgcopydb/parsing_utils.c
+++ b/src/bin/pgcopydb/parsing_utils.c
@@ -586,33 +586,31 @@ parse_pguri_info_key_vals(const char *pguri,
 			strcmp(option->keyword, "hostaddr") == 0)
 		{
 			foundHost = true;
-			strlcpy(uriParameters->hostname, option->val, MAXCONNINFO);
+			uriParameters->hostname = strdup(option->val);
 		}
 		else if (strcmp(option->keyword, "port") == 0)
 		{
 			foundPort = true;
-			strlcpy(uriParameters->port, option->val, MAXCONNINFO);
+			uriParameters->port = strdup(option->val);
 		}
 		else if (strcmp(option->keyword, "user") == 0)
 		{
 			foundUser = true;
-			strlcpy(uriParameters->username, option->val, MAXCONNINFO);
+			uriParameters->username = strdup(option->val);
 		}
 		else if (strcmp(option->keyword, "dbname") == 0)
 		{
 			foundDBName = true;
-			strlcpy(uriParameters->dbname, option->val, MAXCONNINFO);
+			uriParameters->dbname = strdup(option->val);
 		}
 		else if (!IS_EMPTY_STRING_BUFFER(value))
 		{
 			/* make a copy in our key/val arrays */
-			strlcpy(uriParameters->parameters.keywords[paramIndex],
-					option->keyword,
-					MAXCONNINFO);
+			uriParameters->parameters.keywords[paramIndex] =
+				strdup(option->keyword);
 
-			strlcpy(uriParameters->parameters.values[paramIndex],
-					value,
-					MAXCONNINFO);
+			uriParameters->parameters.values[paramIndex] =
+				strdup(value);
 
 			++uriParameters->parameters.count;
 			++paramIndex;
@@ -658,59 +656,66 @@ parse_pguri_info_key_vals(const char *pguri,
 
 /*
  * buildPostgresURIfromPieces builds a Postgres connection string from keywords
- * and values, in a user friendly way. The pguri parameter should point to a
- * memory area that has been allocated by the caller and has at least
- * MAXCONNINFO bytes.
+ * and values, in a user friendly way.
  */
 bool
-buildPostgresURIfromPieces(URIParams *uriParams, char *pguri)
+buildPostgresURIfromPieces(URIParams *uriParams, char **pguri)
 {
+	PQExpBuffer uri = createPQExpBuffer();
+
 	int index = 0;
 
-	char escapedUsername[MAXCONNINFO] = { 0 };
-	char escapedHostname[MAXCONNINFO] = { 0 };
-	char escapedDBName[MAXCONNINFO] = { 0 };
+	/* prepare the mandatory part of the Postgres URI */
+	appendPQExpBufferStr(uri, "postgres://");
 
-	/*
-	 * We want to escape uriParams username, hostname, and dbname, in exactly
-	 * the same way, and also wish to report which URI parameter we failed to
-	 * escape in case of errors, and we also want to avoid copy pasting the
-	 * same code 3 times in a row.
-	 *
-	 * We would rather loop over an array where we would have the parameter
-	 * name (keyword), and a pointer to the value to escape, and a pointer to
-	 * where to store the escaped string bytes then.
-	 */
-	struct namedPair
+	if (uriParams->username)
 	{
-		char *name;
-		char *raw;
-		char *escaped;
-	};
+		char *escaped = NULL;
 
-	struct namedPair args[] = {
-		{ "username", uriParams->username, escapedUsername },
-		{ "hostname", uriParams->hostname, escapedHostname },
-		{ "dbname", uriParams->dbname, escapedDBName },
-		{ NULL, NULL, NULL }
-	};
-
-	for (int i = 0; args[i].name != NULL; i++)
-	{
-		if (!escapeWithPercentEncoding(args[i].raw, args[i].escaped))
+		if (!escapeWithPercentEncoding(uriParams->username, &escaped))
 		{
-			log_error("Failed to percent-escape URI %s", args[i].name);
+			log_error("Failed to percent-escape URI username \"%s\"",
+					  uriParams->username);
 			return false;
 		}
+		appendPQExpBuffer(uri, "%s@", escaped);
+		free(escaped);
 	}
 
-	/* prepare the mandatory part of the Postgres URI */
-	sformat(pguri, MAXCONNINFO,
-			"postgres://%s@%s:%s/%s?",
-			escapedUsername,
-			escapedHostname,
-			uriParams->port,
-			escapedDBName);
+	if (uriParams->hostname)
+	{
+		char *escaped = NULL;
+
+		if (!escapeWithPercentEncoding(uriParams->hostname, &escaped))
+		{
+			log_error("Failed to percent-escape URI hostname \"%s\"",
+					  uriParams->hostname);
+			return false;
+		}
+		appendPQExpBuffer(uri, "%s", escaped);
+		free(escaped);
+	}
+
+	if (uriParams->port)
+	{
+		appendPQExpBuffer(uri, ":%s", uriParams->port);
+	}
+
+	appendPQExpBufferStr(uri, "/");
+
+	if (uriParams->dbname)
+	{
+		char *escaped = NULL;
+
+		if (!escapeWithPercentEncoding(uriParams->dbname, &escaped))
+		{
+			log_error("Failed to percent-escape URI dbname \"%s\"",
+					  uriParams->dbname);
+			return false;
+		}
+		appendPQExpBuffer(uri, "%s", escaped);
+		free(escaped);
+	}
 
 	/* now add optional parameters to the Postgres URI */
 	for (index = 0; index < uriParams->parameters.count; index++)
@@ -718,16 +723,19 @@ buildPostgresURIfromPieces(URIParams *uriParams, char *pguri)
 		char *keyword = uriParams->parameters.keywords[index];
 		char *value = uriParams->parameters.values[index];
 
-		char escapedValue[MAXCONNINFO] = { 0 };
-
 		/* if we have password="****" then just keep that */
 		if (streq(keyword, "password") && streq(value, PASSWORD_MASK))
 		{
-			strlcpy(escapedValue, value, sizeof(escapedValue));
+			appendPQExpBuffer(uri, "%s%s=%s",
+							  index == 0 ? "?" : "&",
+							  keyword,
+							  value);
 		}
-		else
+		else if (value != NULL)
 		{
-			if (!escapeWithPercentEncoding(value, escapedValue))
+			char *escapedValue = NULL;
+
+			if (!escapeWithPercentEncoding(value, &escapedValue))
 			{
 				if (streq(keyword, "password"))
 				{
@@ -742,23 +750,76 @@ buildPostgresURIfromPieces(URIParams *uriParams, char *pguri)
 				}
 				return false;
 			}
-		}
 
-		if (index == 0)
-		{
-			sformat(pguri, MAXCONNINFO,
-					"%s%s=%s",
-					pguri, keyword, escapedValue);
+			appendPQExpBuffer(uri, "%s%s=%s",
+							  index == 0 ? "?" : "&",
+							  keyword,
+							  escapedValue);
+
+			free(escapedValue);
 		}
 		else
 		{
-			sformat(pguri, MAXCONNINFO,
-					"%s&%s=%s",
-					pguri, keyword, escapedValue);
+			log_warn("buildPostgresURIfromPieces: %s is NULL", keyword);
 		}
 	}
 
+	if (PQExpBufferBroken(uri))
+	{
+		log_error("Failed to build Postgres URI: out of memory");
+		destroyPQExpBuffer(uri);
+		return false;
+	}
+
+	*pguri = strdup(uri->data);
+	destroyPQExpBuffer(uri);
+
+	log_trace("buildPostgresURIfromPieces: %s", *pguri);
+
 	return true;
+}
+
+
+/*
+ * charNeedsPercentEncoding returns true when a character needs special
+ * encoding for percent-encoding. See escapeWithPercentEncoding() for
+ * references.
+ */
+static inline bool
+charNeedsPercentEncoding(char c)
+{
+	return !(isalpha(c) ||
+			 isdigit(c) ||
+			 c == '-' ||
+			 c == '.' ||
+			 c == '_' ||
+			 c == '~');
+}
+
+
+/*
+ * computePercentEncodedSize returns how many bytes are necessary to hold a
+ * percent-encoded version of the given string.
+ */
+static inline size_t
+computePercentEncodedSize(const char *str)
+{
+	/* prepare room for the terminal char '\0' */
+	size_t size = 1;
+
+	for (int i = 0; str[i] != '\0'; i++)
+	{
+		if (charNeedsPercentEncoding(str[i]))
+		{
+			size += 3;
+		}
+		else
+		{
+			++size;
+		}
+	}
+
+	return size;
 }
 
 
@@ -771,22 +832,34 @@ buildPostgresURIfromPieces(URIParams *uriParams, char *pguri)
  * See https://datatracker.ietf.org/doc/html/rfc3986#section-2.1
  */
 bool
-escapeWithPercentEncoding(const char *str, char *dst)
+escapeWithPercentEncoding(const char *str, char **dst)
 {
-	const char empty[MAXCONNINFO] = { 0 };
 	const char *hex = "0123456789abcdef";
 
-	if (str == NULL || IS_EMPTY_STRING_BUFFER(str))
+	if (str == NULL)
 	{
-		strlcpy(dst, empty, MAXCONNINFO);
+		log_error("BUG: escapeWithPercentEncoding called with str == NULL");
+		return false;
+	}
 
-		return true;
+	if (dst == NULL)
+	{
+		log_error("BUG: escapeWithPercentEncoding called with dst == NULL");
+		return false;
+	}
+
+	size_t size = computePercentEncodedSize(str);
+	char *escaped = (char *) calloc(size, sizeof(char));
+
+	if (escaped == NULL)
+	{
+		log_error(ALLOCATION_FAILED_ERROR);
+		return false;
 	}
 
 	int pos = 0;
-	int len = strlen(str);
 
-	for (int i = 0; i < len; i++)
+	for (int i = 0; str[i] != '\0'; i++)
 	{
 		/*
 		 * 2.3 Unreserved Characters
@@ -795,20 +868,18 @@ escapeWithPercentEncoding(const char *str, char *dst)
 		 *
 		 *       unreserved  = ALPHA / DIGIT / "-" / "." / "_" / "~"
 		 */
-		if (isalpha(str[i]) || isdigit(str[i]) ||
-			str[i] == '-' ||
-			str[i] == '.' ||
-			str[i] == '_' ||
-			str[i] == '~')
+		if (!charNeedsPercentEncoding(str[i]))
 		{
-			if (MAXCONNINFO <= (pos + 1))
+			if (size <= (pos + 1))
 			{
 				/* we really do not expect that to ever happen */
 				log_error("BUG: percent-encoded Postgres URI does not fit "
-						  "in MAXCONNINFO (%d) bytes", MAXCONNINFO);
+						  "in the computed size: %lld bytes",
+						  (long long) size);
 				return false;
 			}
-			dst[pos++] = str[i];
+
+			escaped[pos++] = str[i];
 		}
 
 		/*
@@ -820,19 +891,22 @@ escapeWithPercentEncoding(const char *str, char *dst)
 		 */
 		else
 		{
-			if (MAXCONNINFO <= (pos + 3))
+			if (size <= (pos + 3))
 			{
 				/* we really do not expect that to ever happen */
 				log_error("BUG: percent-encoded Postgres URI does not fit "
-						  "in MAXCONNINFO (%d) bytes", MAXCONNINFO);
+						  "in the computed size: %lld bytes",
+						  (long long) size);
 				return false;
 			}
 
-			dst[pos++] = '%';
-			dst[pos++] = hex[str[i] >> 4];
-			dst[pos++] = hex[str[i] & 15];
+			escaped[pos++] = '%';
+			escaped[pos++] = hex[str[i] >> 4];
+			escaped[pos++] = hex[str[i] & 15];
 		}
 	}
+
+	*dst = escaped;
 
 	return true;
 }
@@ -884,10 +958,16 @@ uri_contains_password(const char *pguri)
  * allocated by the caller and has at least MAXCONNINFO bytes.
  */
 bool
-parse_and_scrub_connection_string(const char *pguri, char *scrubbedPguri)
+parse_and_scrub_connection_string(const char *pguri, SafeURI *safeURI)
 {
-	URIParams uriParams = { 0 };
+	URIParams *uriParams = &(safeURI->uriParams);
 	KeyVal overrides = { 0 };
+
+	if (pguri == NULL)
+	{
+		safeURI->pguri = NULL;
+		return true;
+	}
 
 	if (uri_contains_password(pguri))
 	{
@@ -902,75 +982,85 @@ parse_and_scrub_connection_string(const char *pguri, char *scrubbedPguri)
 
 	if (!parse_pguri_info_key_vals(pguri,
 								   &overrides,
-								   &uriParams,
-								   checkForCompleteURI))
-	{
-		return false;
-	}
-
-	buildPostgresURIfromPieces(&uriParams, scrubbedPguri);
-
-	return true;
-}
-
-
-/*
- * extract_connection_string_password parses the given connection string and if
- * it contains a password, then extracts it into the SafeURI structure and
- * provide a pguri without password instead.
- */
-bool
-extract_connection_string_password(const char *pguri, SafeURI *safeURI)
-{
-	char *errmsg;
-	PQconninfoOption *conninfo, *option;
-
-	conninfo = PQconninfoParse(pguri, &errmsg);
-	if (conninfo == NULL)
-	{
-		log_error("Failed to parse pguri: %s", errmsg);
-
-		PQfreemem(errmsg);
-		return false;
-	}
-
-	for (option = conninfo; option->keyword != NULL; option++)
-	{
-		if (streq(option->keyword, "password"))
-		{
-			if (option->val != NULL)
-			{
-				safeURI->password = strdup(option->val);
-				if (safeURI->password == NULL)
-				{
-					log_error(ALLOCATION_FAILED_ERROR);
-					return false;
-				}
-			}
-			continue;
-		}
-	}
-
-	PQconninfoFree(conninfo);
-
-	URIParams *uriParams = &(safeURI->uriParams);
-	KeyVal overrides = {
-		.count = 1,
-		.keywords = { "password" },
-		.values = { "" }
-	};
-
-	bool checkForCompleteURI = false;
-
-	if (!parse_pguri_info_key_vals(pguri,
-								   &overrides,
 								   uriParams,
 								   checkForCompleteURI))
 	{
 		return false;
 	}
 
-	buildPostgresURIfromPieces(uriParams, safeURI->pguri);
+	buildPostgresURIfromPieces(uriParams, &(safeURI->pguri));
+
+	/* also extract the password in case it's needed */
+	for (int i = 0; i < uriParams->parameters.count; i++)
+	{
+		if (streq(uriParams->parameters.keywords[i], "password"))
+		{
+			if (uriParams->parameters.values[i] != NULL)
+			{
+				safeURI->password = strdup(uriParams->parameters.values[i]);
+
+				if (safeURI->password == NULL)
+				{
+					log_error(ALLOCATION_FAILED_ERROR);
+					return false;
+				}
+			}
+			break;
+		}
+	}
 
 	return true;
+}
+
+
+/*
+ * freeSafeURI frees the dynamic memory allocated for handling the safe URI.
+ */
+void
+freeSafeURI(SafeURI *safeURI)
+{
+	free(safeURI->pguri);
+	free(safeURI->password);
+	freeURIParams(&(safeURI->uriParams));
+
+	safeURI->pguri = NULL;
+	safeURI->password = NULL;
+}
+
+
+/*
+ * freeURIParams frees the dynamic memory allocated for handling URI params.
+ */
+void
+freeURIParams(URIParams *params)
+{
+	free(params->username);
+	free(params->hostname);
+	free(params->port);
+	free(params->dbname);
+	freeKeyVal(&(params->parameters));
+
+	params->username = NULL;
+	params->hostname = NULL;
+	params->port = NULL;
+	params->dbname = NULL;
+}
+
+
+/*
+ * freeKeyVal frees the dynamic memory allocated for handling KeyVal parameters
+ */
+void
+freeKeyVal(KeyVal *parameters)
+{
+	for (int i = 0; i < parameters->count; i++)
+	{
+		free(parameters->keywords[i]);
+		free(parameters->values[i]);
+
+		parameters->keywords[i] = NULL;
+		parameters->values[i] = NULL;
+	}
+
+	parameters->count = 0;
 }

--- a/src/bin/pgcopydb/parsing_utils.c
+++ b/src/bin/pgcopydb/parsing_utils.c
@@ -941,6 +941,11 @@ extract_connection_string_password(const char *pguri, SafeURI *safeURI)
 			if (option->val != NULL)
 			{
 				safeURI->password = strdup(option->val);
+				if (safeURI->password == NULL)
+				{
+					log_error(ALLOCATION_FAILED_ERROR);
+					return false;
+				}
 			}
 			continue;
 		}

--- a/src/bin/pgcopydb/parsing_utils.h
+++ b/src/bin/pgcopydb/parsing_utils.h
@@ -81,7 +81,7 @@ typedef struct URIParams
 typedef struct SafeURI
 {
 	char pguri[MAXCONNINFO];
-	char *password;  	/* malloc'ed area */
+	char *password;     /* malloc'ed area */
 	URIParams uriParams;
 } SafeURI;
 

--- a/src/bin/pgcopydb/parsing_utils.h
+++ b/src/bin/pgcopydb/parsing_utils.h
@@ -81,7 +81,7 @@ typedef struct URIParams
 typedef struct SafeURI
 {
 	char pguri[MAXCONNINFO];
-	char *password;
+	char *password;  	/* malloc'ed area */
 	URIParams uriParams;
 } SafeURI;
 

--- a/src/bin/pgcopydb/parsing_utils.h
+++ b/src/bin/pgcopydb/parsing_utils.h
@@ -54,8 +54,8 @@ bool parse_pretty_printed_bytes(const char *value, uint64_t *result);
 typedef struct KeyVal
 {
 	int count;
-	char keywords[64][MAXCONNINFO];
-	char values[64][MAXCONNINFO];
+	char *keywords[64];
+	char *values[64];
 } KeyVal;
 
 
@@ -70,32 +70,46 @@ typedef struct KeyVal
  */
 typedef struct URIParams
 {
-	char username[MAXCONNINFO];
-	char hostname[MAXCONNINFO];
-	char port[MAXCONNINFO];
-	char dbname[MAXCONNINFO];
+	char *username;
+	char *hostname;
+	char *port;
+	char *dbname;
 	KeyVal parameters;
 } URIParams;
 
 
 typedef struct SafeURI
 {
-	char pguri[MAXCONNINFO];
-	char *password;     /* malloc'ed area */
+	char *pguri;                /* malloc'ed area */
+	char *password;             /* malloc'ed area */
 	URIParams uriParams;
 } SafeURI;
+
+
+typedef struct ConnStrings
+{
+	char *source_pguri;         /* malloc'ed area */
+	char *target_pguri;         /* malloc'ed area */
+	char *logrep_pguri;         /* malloc'ed area */
+
+	SafeURI safeSourcePGURI;
+	SafeURI safeTargetPGURI;
+} ConnStrings;
+
 
 bool parse_pguri_info_key_vals(const char *pguri,
 							   KeyVal *overrides,
 							   URIParams *uriParameters,
 							   bool checkForCompleteURI);
 
-bool buildPostgresURIfromPieces(URIParams *uriParams, char *pguri);
+bool buildPostgresURIfromPieces(URIParams *uriParams, char **pguri);
 
-bool escapeWithPercentEncoding(const char *str, char *dst);
+bool escapeWithPercentEncoding(const char *str, char **dst);
 
-bool parse_and_scrub_connection_string(const char *pguri, char *scrubbedPguri);
+bool parse_and_scrub_connection_string(const char *pguri, SafeURI *safeURI);
 
-bool extract_connection_string_password(const char *pguri, SafeURI *safeURI);
+void freeSafeURI(SafeURI *safeURI);
+void freeURIParams(URIParams *params);
+void freeKeyVal(KeyVal *parameters);
 
 #endif /* PARSING_UTILS_H */

--- a/src/bin/pgcopydb/parsing_utils.h
+++ b/src/bin/pgcopydb/parsing_utils.h
@@ -81,7 +81,7 @@ typedef struct URIParams
 typedef struct SafeURI
 {
 	char pguri[MAXCONNINFO];
-	char password[MAXCONNINFO];
+	char *password;
 	URIParams uriParams;
 } SafeURI;
 

--- a/src/bin/pgcopydb/pgcmd.c
+++ b/src/bin/pgcopydb/pgcmd.c
@@ -337,7 +337,7 @@ set_psql_from_pg_config(PostgresPaths *pgPaths)
  */
 bool
 pg_dump_db(PostgresPaths *pgPaths,
-		   const char *pguri,
+		   ConnStrings *connStrings,
 		   const char *snapshot,
 		   const char *section,
 		   SourceFilters *filters,
@@ -348,19 +348,13 @@ pg_dump_db(PostgresPaths *pgPaths,
 
 	char command[BUFSIZE] = { 0 };
 
-	SafeURI safeURI = { 0 };
-	bool pgpassword_found_in_env = env_exists("PGPASSWORD");
 	char *PGPASSWORD = NULL;
-	if (!extract_connection_string_password(pguri, &safeURI))
-	{
-		/* errors have already been logged */
-		return false;
-	}
+	bool pgpassword_found_in_env = env_exists("PGPASSWORD");
 
 	setenv("PGCONNECT_TIMEOUT", POSTGRES_CONNECT_TIMEOUT, 1);
 
 	/* override PGPASSWORD environment variable if the pguri contains one */
-	if (!IS_EMPTY_STRING_BUFFER(safeURI.password))
+	if (connStrings->safeSourcePGURI.password != NULL)
 	{
 		if (pgpassword_found_in_env &&
 			!get_env_dup("PGPASSWORD", &(PGPASSWORD)))
@@ -368,7 +362,7 @@ pg_dump_db(PostgresPaths *pgPaths,
 			/* errors have already been logged */
 			return false;
 		}
-		setenv("PGPASSWORD", safeURI.password, 1);
+		setenv("PGPASSWORD", connStrings->safeSourcePGURI.password, 1);
 	}
 
 	args[argsIndex++] = (char *) pgPaths->pg_dump;
@@ -404,7 +398,7 @@ pg_dump_db(PostgresPaths *pgPaths,
 
 	args[argsIndex++] = "--file";
 	args[argsIndex++] = (char *) filename;
-	args[argsIndex++] = (char *) safeURI.pguri;
+	args[argsIndex++] = (char *) connStrings->safeSourcePGURI.pguri;
 
 	args[argsIndex] = NULL;
 
@@ -432,7 +426,8 @@ pg_dump_db(PostgresPaths *pgPaths,
 	(void) execute_subprogram(&program);
 
 	/* make sure to reset the environment PGPASSWORD if we edited it */
-	if (pgpassword_found_in_env && !IS_EMPTY_STRING_BUFFER(safeURI.password))
+	if (pgpassword_found_in_env &&
+		connStrings->safeSourcePGURI.password != NULL)
 	{
 		setenv("PGPASSWORD", PGPASSWORD, 1);
 	}
@@ -455,7 +450,7 @@ pg_dump_db(PostgresPaths *pgPaths,
  */
 bool
 pg_dumpall_roles(PostgresPaths *pgPaths,
-				 const char *pguri,
+				 ConnStrings *connStrings,
 				 const char *filename,
 				 bool noRolesPasswords)
 {
@@ -464,20 +459,13 @@ pg_dumpall_roles(PostgresPaths *pgPaths,
 
 	char command[BUFSIZE] = { 0 };
 
-	SafeURI safeURI = { 0 };
-	bool pgpassword_found_in_env = env_exists("PGPASSWORD");
 	char *PGPASSWORD = NULL;
-
-	if (!extract_connection_string_password(pguri, &safeURI))
-	{
-		/* errors have already been logged */
-		return false;
-	}
+	bool pgpassword_found_in_env = env_exists("PGPASSWORD");
 
 	setenv("PGCONNECT_TIMEOUT", POSTGRES_CONNECT_TIMEOUT, 1);
 
 	/* override PGPASSWORD environment variable if the pguri contains one */
-	if (!IS_EMPTY_STRING_BUFFER(safeURI.password))
+	if (connStrings->safeSourcePGURI.password != NULL)
 	{
 		if (pgpassword_found_in_env &&
 			!get_env_dup("PGPASSWORD", &(PGPASSWORD)))
@@ -485,7 +473,7 @@ pg_dumpall_roles(PostgresPaths *pgPaths,
 			/* errors have already been logged */
 			return false;
 		}
-		setenv("PGPASSWORD", safeURI.password, 1);
+		setenv("PGPASSWORD", connStrings->safeSourcePGURI.password, 1);
 	}
 
 	args[argsIndex++] = (char *) pgPaths->pg_dumpall;
@@ -495,7 +483,7 @@ pg_dumpall_roles(PostgresPaths *pgPaths,
 	args[argsIndex++] = (char *) filename;
 
 	args[argsIndex++] = "--dbname";
-	args[argsIndex++] = (char *) safeURI.pguri;
+	args[argsIndex++] = (char *) connStrings->safeSourcePGURI.pguri;
 
 	if (noRolesPasswords)
 	{
@@ -528,7 +516,8 @@ pg_dumpall_roles(PostgresPaths *pgPaths,
 	(void) execute_subprogram(&program);
 
 	/* make sure to reset the environment PGPASSWORD if we edited it */
-	if (pgpassword_found_in_env && !IS_EMPTY_STRING_BUFFER(safeURI.password))
+	if (pgpassword_found_in_env &&
+		connStrings->safeSourcePGURI.password != NULL)
 	{
 		setenv("PGPASSWORD", PGPASSWORD, 1);
 	}
@@ -716,18 +705,17 @@ pg_restore_roles(PostgresPaths *pgPaths,
  */
 bool
 pg_copy_roles(PostgresPaths *pgPaths,
-			  const char *source_pguri,
-			  const char *target_pguri,
+			  ConnStrings *connStrings,
 			  const char *filename,
 			  bool noRolesPasswords)
 {
-	if (!pg_dumpall_roles(pgPaths, source_pguri, filename, noRolesPasswords))
+	if (!pg_dumpall_roles(pgPaths, connStrings, filename, noRolesPasswords))
 	{
 		/* errors have already been logged */
 		return false;
 	}
 
-	if (!pg_restore_roles(pgPaths, target_pguri, filename))
+	if (!pg_restore_roles(pgPaths, connStrings->target_pguri, filename))
 	{
 		/* errors have already been logged */
 		return false;
@@ -743,7 +731,7 @@ pg_copy_roles(PostgresPaths *pgPaths,
  */
 bool
 pg_restore_db(PostgresPaths *pgPaths,
-			  const char *pguri,
+			  ConnStrings *connStrings,
 			  SourceFilters *filters,
 			  const char *dumpFilename,
 			  const char *listFilename,
@@ -754,20 +742,13 @@ pg_restore_db(PostgresPaths *pgPaths,
 
 	char command[BUFSIZE] = { 0 };
 
-	SafeURI safeURI = { 0 };
-	bool pgpassword_found_in_env = env_exists("PGPASSWORD");
 	char *PGPASSWORD = NULL;
-
-	if (!extract_connection_string_password(pguri, &safeURI))
-	{
-		/* errors have already been logged */
-		return false;
-	}
+	bool pgpassword_found_in_env = env_exists("PGPASSWORD");
 
 	setenv("PGCONNECT_TIMEOUT", POSTGRES_CONNECT_TIMEOUT, 1);
 
 	/* override PGPASSWORD environment variable if the pguri contains one */
-	if (!IS_EMPTY_STRING_BUFFER(safeURI.password))
+	if (connStrings->safeSourcePGURI.password != NULL)
 	{
 		if (pgpassword_found_in_env &&
 			!get_env_dup("PGPASSWORD", &(PGPASSWORD)))
@@ -775,12 +756,12 @@ pg_restore_db(PostgresPaths *pgPaths,
 			/* errors have already been logged */
 			return false;
 		}
-		setenv("PGPASSWORD", safeURI.password, 1);
+		setenv("PGPASSWORD", connStrings->safeTargetPGURI.password, 1);
 	}
 
 	args[argsIndex++] = (char *) pgPaths->pg_restore;
 	args[argsIndex++] = "--dbname";
-	args[argsIndex++] = (char *) safeURI.pguri;
+	args[argsIndex++] = (char *) connStrings->safeTargetPGURI.pguri;
 	args[argsIndex++] = "--single-transaction";
 
 	if (options.dropIfExists)
@@ -856,7 +837,8 @@ pg_restore_db(PostgresPaths *pgPaths,
 	(void) execute_subprogram(&program);
 
 	/* make sure to reset the environment PGPASSWORD if we edited it */
-	if (pgpassword_found_in_env && !IS_EMPTY_STRING_BUFFER(safeURI.password))
+	if (pgpassword_found_in_env &&
+		connStrings->safeSourcePGURI.password != NULL)
 	{
 		setenv("PGPASSWORD", PGPASSWORD, 1);
 	}

--- a/src/bin/pgcopydb/pgcmd.c
+++ b/src/bin/pgcopydb/pgcmd.c
@@ -353,7 +353,8 @@ pg_dump_db(PostgresPaths *pgPaths,
 	size_t len = strlen(pguri) + 1;
 	char *PGPASSWORD = (char *) calloc(len, sizeof(char));
 	safeURI.password = (char *) calloc(len, sizeof(char));
-	if (PGPASSWORD  == NULL || safeURI.password  == NULL) {
+	if (PGPASSWORD  == NULL || safeURI.password  == NULL)
+	{
 		log_error(ALLOCATION_FAILED_ERROR);
 		return false;
 	}
@@ -475,7 +476,8 @@ pg_dumpall_roles(PostgresPaths *pgPaths,
 	size_t len = strlen(pguri) + 1;
 	char *PGPASSWORD = (char *) calloc(len, sizeof(char));
 	safeURI.password = (char *) calloc(len, sizeof(char));
-	if (PGPASSWORD  == NULL || safeURI.password  == NULL) {
+	if (PGPASSWORD  == NULL || safeURI.password  == NULL)
+	{
 		log_error(ALLOCATION_FAILED_ERROR);
 		return false;
 	}
@@ -771,7 +773,8 @@ pg_restore_db(PostgresPaths *pgPaths,
 	size_t len = strlen(pguri) + 1;
 	char *PGPASSWORD = (char *) calloc(len, sizeof(char));
 	safeURI.password = (char *) calloc(len, sizeof(char));
-	if (PGPASSWORD  == NULL || safeURI.password  == NULL) {
+	if (PGPASSWORD  == NULL || safeURI.password  == NULL)
+	{
 		log_error(ALLOCATION_FAILED_ERROR);
 		return false;
 	}

--- a/src/bin/pgcopydb/pgcmd.c
+++ b/src/bin/pgcopydb/pgcmd.c
@@ -350,9 +350,7 @@ pg_dump_db(PostgresPaths *pgPaths,
 
 	SafeURI safeURI = { 0 };
 	bool pgpassword_found_in_env = env_exists("PGPASSWORD");
-	size_t len = strlen(pguri) + 1;
-	char *PGPASSWORD = (char *) calloc(len, sizeof(char));
-	safeURI.password = (char *) calloc(len, sizeof(char));
+	char *PGPASSWORD = NULL;
 	if (!extract_connection_string_password(pguri, &safeURI))
 	{
 		/* errors have already been logged */
@@ -365,7 +363,7 @@ pg_dump_db(PostgresPaths *pgPaths,
 	if (!IS_EMPTY_STRING_BUFFER(safeURI.password))
 	{
 		if (pgpassword_found_in_env &&
-			!get_env_dup("PGPASSWORD", PGPASSWORD, NULL))
+			!get_env_dup("PGPASSWORD", &(PGPASSWORD)))
 		{
 			/* errors have already been logged */
 			return false;
@@ -468,9 +466,7 @@ pg_dumpall_roles(PostgresPaths *pgPaths,
 
 	SafeURI safeURI = { 0 };
 	bool pgpassword_found_in_env = env_exists("PGPASSWORD");
-	size_t len = strlen(pguri) + 1;
-	char *PGPASSWORD = (char *) calloc(len, sizeof(char));
-	safeURI.password = (char *) calloc(len, sizeof(char));
+	char *PGPASSWORD = NULL;
 
 	if (!extract_connection_string_password(pguri, &safeURI))
 	{
@@ -484,7 +480,7 @@ pg_dumpall_roles(PostgresPaths *pgPaths,
 	if (!IS_EMPTY_STRING_BUFFER(safeURI.password))
 	{
 		if (pgpassword_found_in_env &&
-			!get_env_dup("PGPASSWORD", PGPASSWORD, NULL))
+			!get_env_dup("PGPASSWORD", &(PGPASSWORD)))
 		{
 			/* errors have already been logged */
 			return false;
@@ -760,9 +756,7 @@ pg_restore_db(PostgresPaths *pgPaths,
 
 	SafeURI safeURI = { 0 };
 	bool pgpassword_found_in_env = env_exists("PGPASSWORD");
-	size_t len = strlen(pguri) + 1;
-	char *PGPASSWORD = (char *) calloc(len, sizeof(char));
-	safeURI.password = (char *) calloc(len, sizeof(char));
+	char *PGPASSWORD = NULL;
 
 	if (!extract_connection_string_password(pguri, &safeURI))
 	{
@@ -776,7 +770,7 @@ pg_restore_db(PostgresPaths *pgPaths,
 	if (!IS_EMPTY_STRING_BUFFER(safeURI.password))
 	{
 		if (pgpassword_found_in_env &&
-			!get_env_dup("PGPASSWORD", PGPASSWORD, NULL))
+			!get_env_dup("PGPASSWORD", &(PGPASSWORD)))
 		{
 			/* errors have already been logged */
 			return false;

--- a/src/bin/pgcopydb/pgcmd.c
+++ b/src/bin/pgcopydb/pgcmd.c
@@ -356,8 +356,7 @@ pg_dump_db(PostgresPaths *pgPaths,
 	/* override PGPASSWORD environment variable if the pguri contains one */
 	if (connStrings->safeSourcePGURI.password != NULL)
 	{
-		if (pgpassword_found_in_env &&
-			!get_env_dup("PGPASSWORD", &(PGPASSWORD)))
+		if (pgpassword_found_in_env && !get_env_dup("PGPASSWORD", &PGPASSWORD))
 		{
 			/* errors have already been logged */
 			return false;
@@ -467,8 +466,7 @@ pg_dumpall_roles(PostgresPaths *pgPaths,
 	/* override PGPASSWORD environment variable if the pguri contains one */
 	if (connStrings->safeSourcePGURI.password != NULL)
 	{
-		if (pgpassword_found_in_env &&
-			!get_env_dup("PGPASSWORD", &(PGPASSWORD)))
+		if (pgpassword_found_in_env && !get_env_dup("PGPASSWORD", &PGPASSWORD))
 		{
 			/* errors have already been logged */
 			return false;
@@ -750,8 +748,7 @@ pg_restore_db(PostgresPaths *pgPaths,
 	/* override PGPASSWORD environment variable if the pguri contains one */
 	if (connStrings->safeSourcePGURI.password != NULL)
 	{
-		if (pgpassword_found_in_env &&
-			!get_env_dup("PGPASSWORD", &(PGPASSWORD)))
+		if (pgpassword_found_in_env && !get_env_dup("PGPASSWORD", &PGPASSWORD))
 		{
 			/* errors have already been logged */
 			return false;

--- a/src/bin/pgcopydb/pgcmd.c
+++ b/src/bin/pgcopydb/pgcmd.c
@@ -369,7 +369,7 @@ pg_dump_db(PostgresPaths *pgPaths,
 	if (!IS_EMPTY_STRING_BUFFER(safeURI.password))
 	{
 		if (pgpassword_found_in_env &&
-			!get_env_copy("PGPASSWORD", PGPASSWORD, strlen(pguri)+1))
+			!get_env_dup("PGPASSWORD", PGPASSWORD, NULL))
 		{
 			/* errors have already been logged */
 			return false;
@@ -492,7 +492,7 @@ pg_dumpall_roles(PostgresPaths *pgPaths,
 	if (!IS_EMPTY_STRING_BUFFER(safeURI.password))
 	{
 		if (pgpassword_found_in_env &&
-			!get_env_copy("PGPASSWORD", PGPASSWORD, len))
+			!get_env_dup("PGPASSWORD", PGPASSWORD, NULL))
 		{
 			/* errors have already been logged */
 			return false;
@@ -788,7 +788,7 @@ pg_restore_db(PostgresPaths *pgPaths,
 	if (!IS_EMPTY_STRING_BUFFER(safeURI.password))
 	{
 		if (pgpassword_found_in_env &&
-			!get_env_copy("PGPASSWORD", PGPASSWORD, strlen(pguri)+1))
+			!get_env_dup("PGPASSWORD", PGPASSWORD, NULL))
 		{
 			/* errors have already been logged */
 			return false;

--- a/src/bin/pgcopydb/pgcmd.c
+++ b/src/bin/pgcopydb/pgcmd.c
@@ -353,11 +353,6 @@ pg_dump_db(PostgresPaths *pgPaths,
 	size_t len = strlen(pguri) + 1;
 	char *PGPASSWORD = (char *) calloc(len, sizeof(char));
 	safeURI.password = (char *) calloc(len, sizeof(char));
-	if (PGPASSWORD  == NULL || safeURI.password  == NULL)
-	{
-		log_error(ALLOCATION_FAILED_ERROR);
-		return false;
-	}
 	if (!extract_connection_string_password(pguri, &safeURI))
 	{
 		/* errors have already been logged */
@@ -476,11 +471,6 @@ pg_dumpall_roles(PostgresPaths *pgPaths,
 	size_t len = strlen(pguri) + 1;
 	char *PGPASSWORD = (char *) calloc(len, sizeof(char));
 	safeURI.password = (char *) calloc(len, sizeof(char));
-	if (PGPASSWORD  == NULL || safeURI.password  == NULL)
-	{
-		log_error(ALLOCATION_FAILED_ERROR);
-		return false;
-	}
 
 	if (!extract_connection_string_password(pguri, &safeURI))
 	{
@@ -773,11 +763,6 @@ pg_restore_db(PostgresPaths *pgPaths,
 	size_t len = strlen(pguri) + 1;
 	char *PGPASSWORD = (char *) calloc(len, sizeof(char));
 	safeURI.password = (char *) calloc(len, sizeof(char));
-	if (PGPASSWORD  == NULL || safeURI.password  == NULL)
-	{
-		log_error(ALLOCATION_FAILED_ERROR);
-		return false;
-	}
 
 	if (!extract_connection_string_password(pguri, &safeURI))
 	{

--- a/src/bin/pgcopydb/pgcmd.c
+++ b/src/bin/pgcopydb/pgcmd.c
@@ -350,8 +350,13 @@ pg_dump_db(PostgresPaths *pgPaths,
 
 	SafeURI safeURI = { 0 };
 	bool pgpassword_found_in_env = env_exists("PGPASSWORD");
-	char PGPASSWORD[MAXCONNINFO] = { 0 };
-
+	size_t len = strlen(pguri) + 1;
+	char *PGPASSWORD = (char *) calloc(len, sizeof(char));
+	safeURI.password = (char *) calloc(len, sizeof(char));
+	if (PGPASSWORD  == NULL || safeURI.password  == NULL) {
+		log_error(ALLOCATION_FAILED_ERROR);
+		return false;
+	}
 	if (!extract_connection_string_password(pguri, &safeURI))
 	{
 		/* errors have already been logged */
@@ -364,7 +369,7 @@ pg_dump_db(PostgresPaths *pgPaths,
 	if (!IS_EMPTY_STRING_BUFFER(safeURI.password))
 	{
 		if (pgpassword_found_in_env &&
-			!get_env_copy("PGPASSWORD", PGPASSWORD, MAXCONNINFO))
+			!get_env_copy("PGPASSWORD", PGPASSWORD, strlen(pguri)+1))
 		{
 			/* errors have already been logged */
 			return false;
@@ -467,7 +472,13 @@ pg_dumpall_roles(PostgresPaths *pgPaths,
 
 	SafeURI safeURI = { 0 };
 	bool pgpassword_found_in_env = env_exists("PGPASSWORD");
-	char PGPASSWORD[MAXCONNINFO] = { 0 };
+	size_t len = strlen(pguri) + 1;
+	char *PGPASSWORD = (char *) calloc(len, sizeof(char));
+	safeURI.password = (char *) calloc(len, sizeof(char));
+	if (PGPASSWORD  == NULL || safeURI.password  == NULL) {
+		log_error(ALLOCATION_FAILED_ERROR);
+		return false;
+	}
 
 	if (!extract_connection_string_password(pguri, &safeURI))
 	{
@@ -481,7 +492,7 @@ pg_dumpall_roles(PostgresPaths *pgPaths,
 	if (!IS_EMPTY_STRING_BUFFER(safeURI.password))
 	{
 		if (pgpassword_found_in_env &&
-			!get_env_copy("PGPASSWORD", PGPASSWORD, MAXCONNINFO))
+			!get_env_copy("PGPASSWORD", PGPASSWORD, len))
 		{
 			/* errors have already been logged */
 			return false;
@@ -757,7 +768,13 @@ pg_restore_db(PostgresPaths *pgPaths,
 
 	SafeURI safeURI = { 0 };
 	bool pgpassword_found_in_env = env_exists("PGPASSWORD");
-	char PGPASSWORD[MAXCONNINFO] = { 0 };
+	size_t len = strlen(pguri) + 1;
+	char *PGPASSWORD = (char *) calloc(len, sizeof(char));
+	safeURI.password = (char *) calloc(len, sizeof(char));
+	if (PGPASSWORD  == NULL || safeURI.password  == NULL) {
+		log_error(ALLOCATION_FAILED_ERROR);
+		return false;
+	}
 
 	if (!extract_connection_string_password(pguri, &safeURI))
 	{
@@ -771,7 +788,7 @@ pg_restore_db(PostgresPaths *pgPaths,
 	if (!IS_EMPTY_STRING_BUFFER(safeURI.password))
 	{
 		if (pgpassword_found_in_env &&
-			!get_env_copy("PGPASSWORD", PGPASSWORD, MAXCONNINFO))
+			!get_env_copy("PGPASSWORD", PGPASSWORD, strlen(pguri)+1))
 		{
 			/* errors have already been logged */
 			return false;

--- a/src/bin/pgcopydb/pgcmd.h
+++ b/src/bin/pgcopydb/pgcmd.h
@@ -16,6 +16,7 @@
 #include "defaults.h"
 #include "file_utils.h"
 #include "filtering.h"
+#include "parsing_utils.h"
 #include "pgsql.h"
 
 #define PG_VERSION_STRING_MAX 12
@@ -82,14 +83,14 @@ bool set_psql_from_config_bindir(PostgresPaths *pgPaths, const char *pg_config);
 bool set_psql_from_pg_config(PostgresPaths *pgPaths);
 
 bool pg_dump_db(PostgresPaths *pgPaths,
-				const char *pguri,
+				ConnStrings *connStrings,
 				const char *snapshot,
 				const char *section,
 				SourceFilters *filters,
 				const char *filename);
 
 bool pg_dumpall_roles(PostgresPaths *pgPaths,
-					  const char *pguri,
+					  ConnStrings *connStrings,
 					  const char *filename,
 					  bool noRolesPasswords);
 
@@ -98,13 +99,12 @@ bool pg_restore_roles(PostgresPaths *pgPaths,
 					  const char *filename);
 
 bool pg_copy_roles(PostgresPaths *pgPaths,
-				   const char *source_pguri,
-				   const char *target_pguri,
+				   ConnStrings *connStrings,
 				   const char *filename,
 				   bool noRolesPasswords);
 
 bool pg_restore_db(PostgresPaths *pgPaths,
-				   const char *pguri,
+				   ConnStrings *connStrings,
 				   SourceFilters *filters,
 				   const char *dumpFilename,
 				   const char *listFilename,

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -177,14 +177,7 @@ pgsql_init(PGSQL *pgsql, char *url, ConnectionType connectionType)
 	if (validate_connection_string(url))
 	{
 		/* size of url has already been validated. */
-		size_t len = strlen(url) + 1;
-		pgsql->connectionString = (char *) calloc(len, sizeof(char));
-		if (pgsql->connectionString == NULL) {
-			// Log or handle the error when memory allocation fails
-			log_error(ALLOCATION_FAILED_ERROR);
-			return false;
-		}
-		strlcpy(pgsql->connectionString, url, len);
+		pgsql->connectionString = url;
 	}
 	else
 	{

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -183,9 +183,6 @@ pgsql_init(PGSQL *pgsql, char *url, ConnectionType connectionType)
 		return false;
 	}
 
-	/* also keep around a print-safe version of the URL */
-	(void) parse_and_scrub_connection_string(url, &(pgsql->safeURI));
-
 	/* by default we log all the SQL queries and their parameters */
 	pgsql->logSQL = true;
 
@@ -501,6 +498,13 @@ pgsql_open_connection(PGSQL *pgsql)
 
 	if (pgsql->logSQL)
 	{
+		/* also keep around a print-safe version of the URL */
+		if (pgsql->safeURI.pguri == NULL)
+		{
+			(void) parse_and_scrub_connection_string(pgsql->connectionString,
+													 &(pgsql->safeURI));
+		}
+
 		log_sql("Connecting to [%s] \"%s\"",
 				ConnectionTypeToString(pgsql->connectionType),
 				pgsql->safeURI.pguri);

--- a/src/bin/pgcopydb/pgsql.h
+++ b/src/bin/pgcopydb/pgsql.h
@@ -167,7 +167,7 @@ typedef struct PGSQL
 {
 	ConnectionType connectionType;
 	ConnectionStatementType connectionStatementType;
-	char connectionString[MAXCONNINFO];
+	char *connectionString;
 	PGconn *connection;
 	ConnectionRetryPolicy retryPolicy;
 	PGConnStatus status;
@@ -288,8 +288,6 @@ bool pgsql_execute_with_params(PGSQL *pgsql, const char *sql, int paramCount,
 
 void pgAutoCtlDebugNoticeProcessor(void *arg, const char *message);
 
-bool hostname_from_uri(const char *pguri,
-					   char *hostname, int maxHostLength, int *port);
 bool validate_connection_string(const char *connectionString);
 
 bool pgsql_truncate(PGSQL *pgsql, const char *qname);

--- a/src/bin/pgcopydb/pgsql.h
+++ b/src/bin/pgcopydb/pgsql.h
@@ -167,7 +167,10 @@ typedef struct PGSQL
 {
 	ConnectionType connectionType;
 	ConnectionStatementType connectionStatementType;
+
 	char *connectionString;
+	SafeURI safeURI;
+
 	PGconn *connection;
 	ConnectionRetryPolicy retryPolicy;
 	PGConnStatus status;

--- a/src/bin/pgcopydb/pgsql.h
+++ b/src/bin/pgcopydb/pgsql.h
@@ -167,7 +167,7 @@ typedef struct PGSQL
 {
 	ConnectionType connectionType;
 	ConnectionStatementType connectionStatementType;
-	char *connectionString;
+	char *connectionString;		/* malloc'ed area */
 	PGconn *connection;
 	ConnectionRetryPolicy retryPolicy;
 	PGConnStatus status;

--- a/src/bin/pgcopydb/pgsql.h
+++ b/src/bin/pgcopydb/pgsql.h
@@ -288,6 +288,9 @@ bool pgsql_execute_with_params(PGSQL *pgsql, const char *sql, int paramCount,
 
 void pgAutoCtlDebugNoticeProcessor(void *arg, const char *message);
 
+bool hostname_from_uri(const char *pguri,
+					   char *hostname, int maxHostLength, int *port);
+
 bool validate_connection_string(const char *connectionString);
 
 bool pgsql_truncate(PGSQL *pgsql, const char *qname);

--- a/src/bin/pgcopydb/pgsql.h
+++ b/src/bin/pgcopydb/pgsql.h
@@ -167,7 +167,7 @@ typedef struct PGSQL
 {
 	ConnectionType connectionType;
 	ConnectionStatementType connectionStatementType;
-	char *connectionString;		/* malloc'ed area */
+	char *connectionString;
 	PGconn *connection;
 	ConnectionRetryPolicy retryPolicy;
 	PGConnStatus status;

--- a/src/bin/pgcopydb/progress.c
+++ b/src/bin/pgcopydb/progress.c
@@ -165,7 +165,7 @@ copydb_setup_as_json(CopyDataSpec *copySpecs,
 
 	json_object_set_number(jsSetupObj,
 						   "split-tables-larger-than",
-						   (double) copySpecs->splitTablesLargerThan);
+						   (double) copySpecs->splitTablesLargerThan.bytes);
 
 	/* attach the JSON array to the main JSON object under the provided key */
 	json_object_set_value(jsobj, key, jsSetup);

--- a/src/bin/pgcopydb/progress.c
+++ b/src/bin/pgcopydb/progress.c
@@ -143,17 +143,12 @@ copydb_setup_as_json(CopyDataSpec *copySpecs,
 	}
 
 	/* source and target URIs, without passwords */
-	char scrubbedSourceURI[MAXCONNINFO] = { 0 };
-	char scrubbedTargetURI[MAXCONNINFO] = { 0 };
+	ConnStrings *dsn = &(copySpecs->connStrings);
+	char *source = dsn->safeSourcePGURI.pguri;
+	char *target = dsn->safeTargetPGURI.pguri;
 
-	(void) parse_and_scrub_connection_string(copySpecs->source_pguri,
-											 scrubbedSourceURI);
-
-	(void) parse_and_scrub_connection_string(copySpecs->target_pguri,
-											 scrubbedTargetURI);
-
-	json_object_set_string(jsSetupObj, "source_pguri", scrubbedSourceURI);
-	json_object_set_string(jsSetupObj, "target_pguri", scrubbedTargetURI);
+	json_object_set_string(jsSetupObj, "source_pguri", source);
+	json_object_set_string(jsSetupObj, "target_pguri", target);
 
 	json_object_set_number(jsSetupObj,
 						   "table-jobs",

--- a/src/bin/pgcopydb/sequences.c
+++ b/src/bin/pgcopydb/sequences.c
@@ -174,7 +174,7 @@ copydb_copy_all_sequences(CopyDataSpec *specs)
 
 	PGSQL dst = { 0 };
 
-	if (!pgsql_init(&dst, specs->target_pguri, PGSQL_CONN_TARGET))
+	if (!pgsql_init(&dst, specs->connStrings.target_pguri, PGSQL_CONN_TARGET))
 	{
 		/* errors have already been logged */
 		return false;

--- a/src/bin/pgcopydb/snapshot.c
+++ b/src/bin/pgcopydb/snapshot.c
@@ -229,7 +229,7 @@ copydb_close_snapshot(CopyDataSpec *copySpecs)
 			/* only COMMIT sql snapshot kinds, no need for logical rep ones */
 			if (!pgsql_commit(pgsql))
 			{
-				char *pguri = (char *) calloc(strlen(snapshot->pguri)+1, sizeof(char));
+				char *pguri = (char *) calloc(strlen(snapshot->pguri) + 1, sizeof(char));
 
 				(void) parse_and_scrub_connection_string(snapshot->pguri, pguri);
 

--- a/src/bin/pgcopydb/snapshot.c
+++ b/src/bin/pgcopydb/snapshot.c
@@ -229,13 +229,9 @@ copydb_close_snapshot(CopyDataSpec *copySpecs)
 			/* only COMMIT sql snapshot kinds, no need for logical rep ones */
 			if (!pgsql_commit(pgsql))
 			{
-				char *pguri = (char *) calloc(strlen(snapshot->pguri) + 1, sizeof(char));
-
-				(void) parse_and_scrub_connection_string(snapshot->pguri, pguri);
-
 				log_fatal("Failed to close snapshot \"%s\" on \"%s\"",
 						  snapshot->snapshot,
-						  pguri);
+						  snapshot->safeURI.pguri);
 				return false;
 			}
 		}

--- a/src/bin/pgcopydb/snapshot.c
+++ b/src/bin/pgcopydb/snapshot.c
@@ -29,15 +29,7 @@ copydb_copy_snapshot(CopyDataSpec *specs, TransactionSnapshot *snapshot)
 
 	/* remember if the replication slot has been created already */
 	snapshot->exportedCreateSlotSnapshot = source->exportedCreateSlotSnapshot;
-
-	size_t len = strlen(source->pguri) + 1;
-	snapshot->pguri = (char *) calloc(len, sizeof(char));
-	if (snapshot->pguri  == NULL) {
-		// Log or handle the error when memory allocation fails
-		log_error(ALLOCATION_FAILED_ERROR);
-		return false;
-	}
-	strlcpy(snapshot->pguri, source->pguri, len);
+	snapshot->pguri = strdup(source->pguri);
 	strlcpy(snapshot->snapshot, source->snapshot, sizeof(snapshot->snapshot));
 
 	return true;

--- a/src/bin/pgcopydb/table-data.c
+++ b/src/bin/pgcopydb/table-data.c
@@ -910,7 +910,7 @@ copydb_copy_table(CopyDataSpec *specs, CopyTableDataSpec *tableSpecs)
 	CopyTableSummary *summary = tableSpecs->summary;
 
 	/* initialize our connection to the target database */
-	if (!pgsql_init(&dst, tableSpecs->target_pguri, PGSQL_CONN_TARGET))
+	if (!pgsql_init(&dst, tableSpecs->connStrings->target_pguri, PGSQL_CONN_TARGET))
 	{
 		/* errors have already been logged */
 		return false;

--- a/src/bin/pgcopydb/vacuum.c
+++ b/src/bin/pgcopydb/vacuum.c
@@ -202,7 +202,7 @@ vacuum_analyze_table_by_oid(CopyDataSpec *specs, uint32_t oid)
 	PGSQL dst = { 0 };
 
 	/* initialize our connection to the target database */
-	if (!pgsql_init(&dst, specs->target_pguri, PGSQL_CONN_TARGET))
+	if (!pgsql_init(&dst, specs->connStrings.target_pguri, PGSQL_CONN_TARGET))
 	{
 		/* errors have already been logged */
 		return false;


### PR DESCRIPTION
It turns out that Postgres interface libpq export MACONNINFO but does not uses it really. Switch to using dynamic memory for all our needs around connection strings, including print-safe variants (without password).

Replaces and fix #311.
Fixes #292.