### PR TITLE
Fix transform to SQL to escape string values.

### DIFF
--- a/src/bin/pgcopydb/ld_stream.h
+++ b/src/bin/pgcopydb/ld_stream.h
@@ -537,6 +537,7 @@ bool stream_write_truncate(FILE *out, LogicalMessageTruncate *truncate);
 bool stream_write_update(FILE *out, LogicalMessageUpdate *update);
 bool stream_write_delete(FILE * out, LogicalMessageDelete *delete);
 bool stream_write_value(FILE *out, LogicalMessageValue *value);
+bool stream_write_sql_escape_string_constant(FILE *out, const char *str);
 
 bool parseMessage(StreamContext *privateContext, char *message, JSON_Value *json);
 

--- a/tests/cdc-endpos-between-transaction/000000010000000000000002.sql
+++ b/tests/cdc-endpos-between-transaction/000000010000000000000002.sql
@@ -1,14 +1,14 @@
 -- KEEPALIVE {"lsn":"0/2447888","timestamp":"2023-06-14 11:17:51.978694+0000"}
 BEGIN; -- {"xid":491,"lsn":"0/244A550","timestamp":"2023-06-14 11:17:51.979425+0000","commit_lsn":"0/244A850"}
-INSERT INTO "public"."category" ("category_id", "name", "last_update") overriding system value VALUES (1000, 'Fantasy', '2022-12-08 00:00:01+00');
-INSERT INTO "public"."category" ("category_id", "name", "last_update") overriding system value VALUES (1001, 'History', '2022-12-09 00:00:01+00');
-INSERT INTO "public"."category" ("category_id", "name", "last_update") overriding system value VALUES (1002, 'Adventure', '2022-12-10 00:00:01+00');
-INSERT INTO "public"."category" ("category_id", "name", "last_update") overriding system value VALUES (1003, 'Musical', '2022-12-11 00:00:01+00');
-INSERT INTO "public"."category" ("category_id", "name", "last_update") overriding system value VALUES (1004, 'Western', '2022-12-12 00:00:01+00');
+INSERT INTO "public"."category" ("category_id", "name", "last_update") overriding system value VALUES (1000, E'Fantasy', E'2022-12-08 00:00:01+00');
+INSERT INTO "public"."category" ("category_id", "name", "last_update") overriding system value VALUES (1001, E'History', E'2022-12-09 00:00:01+00');
+INSERT INTO "public"."category" ("category_id", "name", "last_update") overriding system value VALUES (1002, E'Adventure', E'2022-12-10 00:00:01+00');
+INSERT INTO "public"."category" ("category_id", "name", "last_update") overriding system value VALUES (1003, E'Musical', E'2022-12-11 00:00:01+00');
+INSERT INTO "public"."category" ("category_id", "name", "last_update") overriding system value VALUES (1004, E'Western', E'2022-12-12 00:00:01+00');
 COMMIT; -- {"xid":491,"lsn":"0/244A850","timestamp":"2023-06-14 11:17:51.979425+0000"}
 BEGIN; -- {"xid":492,"lsn":"0/244A850","timestamp":"2023-06-14 11:17:51.979452+0000"}
-INSERT INTO "public"."category" ("category_id", "name", "last_update") overriding system value VALUES (1005, 'Mystery', '2022-12-13 00:00:01+00');
-INSERT INTO "public"."category" ("category_id", "name", "last_update") overriding system value VALUES (1006, 'Historical drama', '2022-12-14 00:00:01+00');
-INSERT INTO "public"."category" ("category_id", "name", "last_update") overriding system value VALUES (1008, 'Thriller', '2022-12-15 00:00:01+00');
+INSERT INTO "public"."category" ("category_id", "name", "last_update") overriding system value VALUES (1005, E'Mystery', E'2022-12-13 00:00:01+00');
+INSERT INTO "public"."category" ("category_id", "name", "last_update") overriding system value VALUES (1006, E'Historical drama', E'2022-12-14 00:00:01+00');
+INSERT INTO "public"."category" ("category_id", "name", "last_update") overriding system value VALUES (1008, E'Thriller', E'2022-12-15 00:00:01+00');
 -- KEEPALIVE {"lsn":"0/244A978","timestamp":"2023-06-14 11:17:51.979481+0000"}
 -- ENDPOS {"lsn":"0/244A978"}

--- a/tests/cdc-test-decoding/000000010000000000000002.sql
+++ b/tests/cdc-test-decoding/000000010000000000000002.sql
@@ -1,9 +1,9 @@
--- KEEPALIVE {"lsn":"0/24485B0","timestamp":"2023-06-20 15:26:05.667006+0000"}
-BEGIN; -- {"xid":491,"lsn":"0/244B260","timestamp":"2023-06-20 15:26:05.667766+0000","commit_lsn":"0/244B6C8"}
+-- KEEPALIVE {"lsn":"0/2448E08","timestamp":"2023-06-20 15:40:11.982016+0000"}
+BEGIN; -- {"xid":491,"lsn":"0/244BAB8","timestamp":"2023-06-20 15:40:11.982679+0000","commit_lsn":"0/244BF20"}
 INSERT INTO "public"."rental" ("rental_id", "rental_date", "inventory_id", "customer_id", "return_date", "staff_id", "last_update") overriding system value VALUES (16050 , '2022-06-01 00:00:00+00' , 371 , 291 , NULL, 1 , '2022-06-01 00:00:00+00');
 INSERT INTO "public"."payment_p2022_06" ("payment_id", "customer_id", "staff_id", "rental_id", "amount", "payment_date") overriding system value VALUES (32099 , 291 , 1 , 16050 , 5.99 , '2022-06-01 00:00:00+00');
-COMMIT; -- {"xid":491,"lsn":"0/244B9E8","timestamp":"2023-06-14 11:32:46.363530+0000"}
-BEGIN; -- {"xid":492,"lsn":"0/244B9E8","timestamp":"2023-06-14 11:32:46.364079+0000","commit_lsn":"0/244CAD0"}
+COMMIT; -- {"xid":491,"lsn":"0/244BF20","timestamp":"2023-06-20 15:40:11.982679+0000"}
+BEGIN; -- {"xid":492,"lsn":"0/244BF20","timestamp":"2023-06-20 15:40:11.983092+0000","commit_lsn":"0/244D008"}
 UPDATE "public"."payment_p2022_02" SET "amount" = 11.95 , "payment_date" = '2022-02-11 03:52:25.634006+00' WHERE "payment_id" = 23757  and "customer_id" = 116  and "staff_id" = 2  and "rental_id" = 14763  and "amount" = 11.99  and "payment_date" = '2022-02-11 03:52:25.634006+00' ;
 UPDATE "public"."payment_p2022_02" SET "amount" = 11.95 , "payment_date" = '2022-02-07 18:37:34.579143+00' WHERE "payment_id" = 24866  and "customer_id" = 237  and "staff_id" = 2  and "rental_id" = 11479  and "amount" = 11.99  and "payment_date" = '2022-02-07 18:37:34.579143+00' ;
 UPDATE "public"."payment_p2022_03" SET "amount" = 11.95 , "payment_date" = '2022-03-18 18:50:39.243747+00' WHERE "payment_id" = 17055  and "customer_id" = 196  and "staff_id" = 2  and "rental_id" = 106  and "amount" = 11.99  and "payment_date" = '2022-03-18 18:50:39.243747+00' ;
@@ -14,12 +14,12 @@ UPDATE "public"."payment_p2022_06" SET "amount" = 11.95 , "payment_date" = '2022
 UPDATE "public"."payment_p2022_06" SET "amount" = 11.95 , "payment_date" = '2022-06-15 02:21:00.279776+00' WHERE "payment_id" = 24553  and "customer_id" = 195  and "staff_id" = 2  and "rental_id" = 16040  and "amount" = 11.99  and "payment_date" = '2022-06-15 02:21:00.279776+00' ;
 UPDATE "public"."payment_p2022_07" SET "amount" = 11.95 , "payment_date" = '2022-07-06 12:15:38.928947+00' WHERE "payment_id" = 28814  and "customer_id" = 592  and "staff_id" = 1  and "rental_id" = 3973  and "amount" = 11.99  and "payment_date" = '2022-07-06 12:15:38.928947+00' ;
 UPDATE "public"."payment_p2022_07" SET "amount" = 11.95 , "payment_date" = '2022-07-22 16:15:40.797771+00' WHERE "payment_id" = 29136  and "customer_id" = 13  and "staff_id" = 2  and "rental_id" = 8831  and "amount" = 11.99  and "payment_date" = '2022-07-22 16:15:40.797771+00' ;
-COMMIT; -- {"xid":492,"lsn":"0/244CAD0","timestamp":"2023-06-14 11:32:46.364079+0000"}
-BEGIN; -- {"xid":493,"lsn":"0/244CC90","timestamp":"2023-06-14 11:32:46.364128+0000","commit_lsn":"0/244CDA0"}
+COMMIT; -- {"xid":492,"lsn":"0/244D008","timestamp":"2023-06-20 15:40:11.983092+0000"}
+BEGIN; -- {"xid":493,"lsn":"0/244D1C8","timestamp":"2023-06-20 15:40:11.983134+0000","commit_lsn":"0/244D2D8"}
 DELETE FROM "public"."payment_p2022_06" WHERE "payment_id" = 32099  and "customer_id" = 291  and "staff_id" = 1  and "rental_id" = 16050  and "amount" = 5.99  and "payment_date" = '2022-06-01 00:00:00+00';
 DELETE FROM "public"."rental" WHERE "rental_id" = 16050;
-COMMIT; -- {"xid":493,"lsn":"0/244CDA0","timestamp":"2023-06-14 11:32:46.364128+0000"}
-BEGIN; -- {"xid":494,"lsn":"0/244CDA0","timestamp":"2023-06-14 11:32:46.364413+0000","commit_lsn":"0/244D320"}
+COMMIT; -- {"xid":493,"lsn":"0/244D2D8","timestamp":"2023-06-20 15:40:11.983134+0000"}
+BEGIN; -- {"xid":494,"lsn":"0/244D2D8","timestamp":"2023-06-20 15:40:11.983253+0000","commit_lsn":"0/244D858"}
 UPDATE "public"."payment_p2022_02" SET "amount" = 11.99 , "payment_date" = '2022-02-11 03:52:25.634006+00' WHERE "payment_id" = 23757  and "customer_id" = 116  and "staff_id" = 2  and "rental_id" = 14763  and "amount" = 11.95  and "payment_date" = '2022-02-11 03:52:25.634006+00' ;
 UPDATE "public"."payment_p2022_02" SET "amount" = 11.99 , "payment_date" = '2022-02-07 18:37:34.579143+00' WHERE "payment_id" = 24866  and "customer_id" = 237  and "staff_id" = 2  and "rental_id" = 11479  and "amount" = 11.95  and "payment_date" = '2022-02-07 18:37:34.579143+00' ;
 UPDATE "public"."payment_p2022_03" SET "amount" = 11.99 , "payment_date" = '2022-03-18 18:50:39.243747+00' WHERE "payment_id" = 17055  and "customer_id" = 196  and "staff_id" = 2  and "rental_id" = 106  and "amount" = 11.95  and "payment_date" = '2022-03-18 18:50:39.243747+00' ;
@@ -30,6 +30,9 @@ UPDATE "public"."payment_p2022_06" SET "amount" = 11.99 , "payment_date" = '2022
 UPDATE "public"."payment_p2022_06" SET "amount" = 11.99 , "payment_date" = '2022-06-15 02:21:00.279776+00' WHERE "payment_id" = 24553  and "customer_id" = 195  and "staff_id" = 2  and "rental_id" = 16040  and "amount" = 11.95  and "payment_date" = '2022-06-15 02:21:00.279776+00' ;
 UPDATE "public"."payment_p2022_07" SET "amount" = 11.99 , "payment_date" = '2022-07-06 12:15:38.928947+00' WHERE "payment_id" = 28814  and "customer_id" = 592  and "staff_id" = 1  and "rental_id" = 3973  and "amount" = 11.95  and "payment_date" = '2022-07-06 12:15:38.928947+00' ;
 UPDATE "public"."payment_p2022_07" SET "amount" = 11.99 , "payment_date" = '2022-07-22 16:15:40.797771+00' WHERE "payment_id" = 29136  and "customer_id" = 13  and "staff_id" = 2  and "rental_id" = 8831  and "amount" = 11.95  and "payment_date" = '2022-07-22 16:15:40.797771+00' ;
-COMMIT; -- {"xid":494,"lsn":"0/244D320","timestamp":"2023-06-14 11:32:46.364413+0000"}
--- KEEPALIVE {"lsn":"0/244D320","timestamp":"2023-06-14 11:32:46.364517+0000"}
--- ENDPOS {"lsn":"0/244D320"}
+COMMIT; -- {"xid":494,"lsn":"0/244D858","timestamp":"2023-06-20 15:40:11.983253+0000"}
+BEGIN; -- {"xid":495,"lsn":"0/244D858","timestamp":"2023-06-20 15:40:11.983352+0000","commit_lsn":"0/244D988"}
+UPDATE "public"."staff" SET "first_name" = 'Mike' , "last_name" = 'Hillyer' , "address_id" = 3 , "email" = 'Mike.Hillyer@sakilastaff.com' , "store_id" = 1 , "active" = true , "username" = 'Mike' , "password" = '8cb2237d0679ca88db6464eac60da96345513964' , "last_update" = '2023-06-20 15:40:11.823094+00' , "picture" = '\x89504e470d0a5a0a' WHERE "staff_id" = 1 ;
+COMMIT; -- {"xid":495,"lsn":"0/244D988","timestamp":"2023-06-20 15:40:11.983352+0000"}
+-- KEEPALIVE {"lsn":"0/244D988","timestamp":"2023-06-20 15:40:11.983399+0000"}
+-- ENDPOS {"lsn":"0/244D988"}

--- a/tests/cdc-wal2json/000000010000000000000002.sql
+++ b/tests/cdc-wal2json/000000010000000000000002.sql
@@ -1,35 +1,35 @@
 -- KEEPALIVE {"lsn":"0/2448720","timestamp":"2023-06-14 11:34:23.437739+0000"}
 BEGIN; -- {"xid":491,"lsn":"0/244B3D0","timestamp":"2023-06-14 11:34:23.438636+0000","commit_lsn":"0/244B838"}
-INSERT INTO "public"."rental" ("rental_id", "rental_date", "inventory_id", "customer_id", "return_date", "staff_id", "last_update") overriding system value VALUES (16050, '2022-06-01 00:00:00+00', 371, 291, NULL, 1, '2022-06-01 00:00:00+00');
-INSERT INTO "public"."payment_p2022_06" ("payment_id", "customer_id", "staff_id", "rental_id", "amount", "payment_date") overriding system value VALUES (32099, 291, 1, 16050, 5.99, '2022-06-01 00:00:00+00');
+INSERT INTO "public"."rental" ("rental_id", "rental_date", "inventory_id", "customer_id", "return_date", "staff_id", "last_update") overriding system value VALUES (16050, E'2022-06-01 00:00:00+00', 371, 291, NULL, 1, E'2022-06-01 00:00:00+00');
+INSERT INTO "public"."payment_p2022_06" ("payment_id", "customer_id", "staff_id", "rental_id", "amount", "payment_date") overriding system value VALUES (32099, 291, 1, 16050, 5.99, E'2022-06-01 00:00:00+00');
 COMMIT; -- {"xid":491,"lsn":"0/244B838","timestamp":"2023-06-14 11:34:23.438636+0000"}
 BEGIN; -- {"xid":492,"lsn":"0/244B838","timestamp":"2023-06-14 11:34:23.439932+0000","commit_lsn":"0/244C920"}
-UPDATE "public"."payment_p2022_02" SET "amount" = 11.95 WHERE "payment_id" = 23757 and "customer_id" = 116 and "staff_id" = 2 and "rental_id" = 14763 and "amount" = 11.99 and "payment_date" = '2022-02-11 03:52:25.634006+00';
-UPDATE "public"."payment_p2022_02" SET "amount" = 11.95 WHERE "payment_id" = 24866 and "customer_id" = 237 and "staff_id" = 2 and "rental_id" = 11479 and "amount" = 11.99 and "payment_date" = '2022-02-07 18:37:34.579143+00';
-UPDATE "public"."payment_p2022_03" SET "amount" = 11.95 WHERE "payment_id" = 17055 and "customer_id" = 196 and "staff_id" = 2 and "rental_id" = 106 and "amount" = 11.99 and "payment_date" = '2022-03-18 18:50:39.243747+00';
-UPDATE "public"."payment_p2022_03" SET "amount" = 11.95 WHERE "payment_id" = 28799 and "customer_id" = 591 and "staff_id" = 2 and "rental_id" = 4383 and "amount" = 11.99 and "payment_date" = '2022-03-08 16:41:23.911522+00';
-UPDATE "public"."payment_p2022_04" SET "amount" = 11.95 WHERE "payment_id" = 20403 and "customer_id" = 362 and "staff_id" = 1 and "rental_id" = 14759 and "amount" = 11.99 and "payment_date" = '2022-04-16 04:35:36.904758+00';
-UPDATE "public"."payment_p2022_05" SET "amount" = 11.95 WHERE "payment_id" = 17354 and "customer_id" = 305 and "staff_id" = 1 and "rental_id" = 2166 and "amount" = 11.99 and "payment_date" = '2022-05-12 11:28:17.949049+00';
-UPDATE "public"."payment_p2022_06" SET "amount" = 11.95 WHERE "payment_id" = 22650 and "customer_id" = 204 and "staff_id" = 2 and "rental_id" = 15415 and "amount" = 11.99 and "payment_date" = '2022-06-11 11:17:22.428079+00';
-UPDATE "public"."payment_p2022_06" SET "amount" = 11.95 WHERE "payment_id" = 24553 and "customer_id" = 195 and "staff_id" = 2 and "rental_id" = 16040 and "amount" = 11.99 and "payment_date" = '2022-06-15 02:21:00.279776+00';
-UPDATE "public"."payment_p2022_07" SET "amount" = 11.95 WHERE "payment_id" = 28814 and "customer_id" = 592 and "staff_id" = 1 and "rental_id" = 3973 and "amount" = 11.99 and "payment_date" = '2022-07-06 12:15:38.928947+00';
-UPDATE "public"."payment_p2022_07" SET "amount" = 11.95 WHERE "payment_id" = 29136 and "customer_id" = 13 and "staff_id" = 2 and "rental_id" = 8831 and "amount" = 11.99 and "payment_date" = '2022-07-22 16:15:40.797771+00';
+UPDATE "public"."payment_p2022_02" SET "amount" = 11.95 WHERE "payment_id" = 23757 and "customer_id" = 116 and "staff_id" = 2 and "rental_id" = 14763 and "amount" = 11.99 and "payment_date" = E'2022-02-11 03:52:25.634006+00';
+UPDATE "public"."payment_p2022_02" SET "amount" = 11.95 WHERE "payment_id" = 24866 and "customer_id" = 237 and "staff_id" = 2 and "rental_id" = 11479 and "amount" = 11.99 and "payment_date" = E'2022-02-07 18:37:34.579143+00';
+UPDATE "public"."payment_p2022_03" SET "amount" = 11.95 WHERE "payment_id" = 17055 and "customer_id" = 196 and "staff_id" = 2 and "rental_id" = 106 and "amount" = 11.99 and "payment_date" = E'2022-03-18 18:50:39.243747+00';
+UPDATE "public"."payment_p2022_03" SET "amount" = 11.95 WHERE "payment_id" = 28799 and "customer_id" = 591 and "staff_id" = 2 and "rental_id" = 4383 and "amount" = 11.99 and "payment_date" = E'2022-03-08 16:41:23.911522+00';
+UPDATE "public"."payment_p2022_04" SET "amount" = 11.95 WHERE "payment_id" = 20403 and "customer_id" = 362 and "staff_id" = 1 and "rental_id" = 14759 and "amount" = 11.99 and "payment_date" = E'2022-04-16 04:35:36.904758+00';
+UPDATE "public"."payment_p2022_05" SET "amount" = 11.95 WHERE "payment_id" = 17354 and "customer_id" = 305 and "staff_id" = 1 and "rental_id" = 2166 and "amount" = 11.99 and "payment_date" = E'2022-05-12 11:28:17.949049+00';
+UPDATE "public"."payment_p2022_06" SET "amount" = 11.95 WHERE "payment_id" = 22650 and "customer_id" = 204 and "staff_id" = 2 and "rental_id" = 15415 and "amount" = 11.99 and "payment_date" = E'2022-06-11 11:17:22.428079+00';
+UPDATE "public"."payment_p2022_06" SET "amount" = 11.95 WHERE "payment_id" = 24553 and "customer_id" = 195 and "staff_id" = 2 and "rental_id" = 16040 and "amount" = 11.99 and "payment_date" = E'2022-06-15 02:21:00.279776+00';
+UPDATE "public"."payment_p2022_07" SET "amount" = 11.95 WHERE "payment_id" = 28814 and "customer_id" = 592 and "staff_id" = 1 and "rental_id" = 3973 and "amount" = 11.99 and "payment_date" = E'2022-07-06 12:15:38.928947+00';
+UPDATE "public"."payment_p2022_07" SET "amount" = 11.95 WHERE "payment_id" = 29136 and "customer_id" = 13 and "staff_id" = 2 and "rental_id" = 8831 and "amount" = 11.99 and "payment_date" = E'2022-07-22 16:15:40.797771+00';
 COMMIT; -- {"xid":492,"lsn":"0/244C920","timestamp":"2023-06-14 11:34:23.439932+0000"}
 BEGIN; -- {"xid":493,"lsn":"0/244CAE0","timestamp":"2023-06-14 11:34:23.440143+0000","commit_lsn":"0/244CBF0"}
-DELETE FROM "public"."payment_p2022_06" WHERE "payment_id" = 32099 and "customer_id" = 291 and "staff_id" = 1 and "rental_id" = 16050 and "amount" = 5.99 and "payment_date" = '2022-06-01 00:00:00+00';
+DELETE FROM "public"."payment_p2022_06" WHERE "payment_id" = 32099 and "customer_id" = 291 and "staff_id" = 1 and "rental_id" = 16050 and "amount" = 5.99 and "payment_date" = E'2022-06-01 00:00:00+00';
 DELETE FROM "public"."rental" WHERE "rental_id" = 16050;
 COMMIT; -- {"xid":493,"lsn":"0/244CBF0","timestamp":"2023-06-14 11:34:23.440143+0000"}
 BEGIN; -- {"xid":494,"lsn":"0/244CBF0","timestamp":"2023-06-14 11:34:23.440564+0000","commit_lsn":"0/244D170"}
-UPDATE "public"."payment_p2022_02" SET "amount" = 11.99 WHERE "payment_id" = 23757 and "customer_id" = 116 and "staff_id" = 2 and "rental_id" = 14763 and "amount" = 11.95 and "payment_date" = '2022-02-11 03:52:25.634006+00';
-UPDATE "public"."payment_p2022_02" SET "amount" = 11.99 WHERE "payment_id" = 24866 and "customer_id" = 237 and "staff_id" = 2 and "rental_id" = 11479 and "amount" = 11.95 and "payment_date" = '2022-02-07 18:37:34.579143+00';
-UPDATE "public"."payment_p2022_03" SET "amount" = 11.99 WHERE "payment_id" = 17055 and "customer_id" = 196 and "staff_id" = 2 and "rental_id" = 106 and "amount" = 11.95 and "payment_date" = '2022-03-18 18:50:39.243747+00';
-UPDATE "public"."payment_p2022_03" SET "amount" = 11.99 WHERE "payment_id" = 28799 and "customer_id" = 591 and "staff_id" = 2 and "rental_id" = 4383 and "amount" = 11.95 and "payment_date" = '2022-03-08 16:41:23.911522+00';
-UPDATE "public"."payment_p2022_04" SET "amount" = 11.99 WHERE "payment_id" = 20403 and "customer_id" = 362 and "staff_id" = 1 and "rental_id" = 14759 and "amount" = 11.95 and "payment_date" = '2022-04-16 04:35:36.904758+00';
-UPDATE "public"."payment_p2022_05" SET "amount" = 11.99 WHERE "payment_id" = 17354 and "customer_id" = 305 and "staff_id" = 1 and "rental_id" = 2166 and "amount" = 11.95 and "payment_date" = '2022-05-12 11:28:17.949049+00';
-UPDATE "public"."payment_p2022_06" SET "amount" = 11.99 WHERE "payment_id" = 22650 and "customer_id" = 204 and "staff_id" = 2 and "rental_id" = 15415 and "amount" = 11.95 and "payment_date" = '2022-06-11 11:17:22.428079+00';
-UPDATE "public"."payment_p2022_06" SET "amount" = 11.99 WHERE "payment_id" = 24553 and "customer_id" = 195 and "staff_id" = 2 and "rental_id" = 16040 and "amount" = 11.95 and "payment_date" = '2022-06-15 02:21:00.279776+00';
-UPDATE "public"."payment_p2022_07" SET "amount" = 11.99 WHERE "payment_id" = 28814 and "customer_id" = 592 and "staff_id" = 1 and "rental_id" = 3973 and "amount" = 11.95 and "payment_date" = '2022-07-06 12:15:38.928947+00';
-UPDATE "public"."payment_p2022_07" SET "amount" = 11.99 WHERE "payment_id" = 29136 and "customer_id" = 13 and "staff_id" = 2 and "rental_id" = 8831 and "amount" = 11.95 and "payment_date" = '2022-07-22 16:15:40.797771+00';
+UPDATE "public"."payment_p2022_02" SET "amount" = 11.99 WHERE "payment_id" = 23757 and "customer_id" = 116 and "staff_id" = 2 and "rental_id" = 14763 and "amount" = 11.95 and "payment_date" = E'2022-02-11 03:52:25.634006+00';
+UPDATE "public"."payment_p2022_02" SET "amount" = 11.99 WHERE "payment_id" = 24866 and "customer_id" = 237 and "staff_id" = 2 and "rental_id" = 11479 and "amount" = 11.95 and "payment_date" = E'2022-02-07 18:37:34.579143+00';
+UPDATE "public"."payment_p2022_03" SET "amount" = 11.99 WHERE "payment_id" = 17055 and "customer_id" = 196 and "staff_id" = 2 and "rental_id" = 106 and "amount" = 11.95 and "payment_date" = E'2022-03-18 18:50:39.243747+00';
+UPDATE "public"."payment_p2022_03" SET "amount" = 11.99 WHERE "payment_id" = 28799 and "customer_id" = 591 and "staff_id" = 2 and "rental_id" = 4383 and "amount" = 11.95 and "payment_date" = E'2022-03-08 16:41:23.911522+00';
+UPDATE "public"."payment_p2022_04" SET "amount" = 11.99 WHERE "payment_id" = 20403 and "customer_id" = 362 and "staff_id" = 1 and "rental_id" = 14759 and "amount" = 11.95 and "payment_date" = E'2022-04-16 04:35:36.904758+00';
+UPDATE "public"."payment_p2022_05" SET "amount" = 11.99 WHERE "payment_id" = 17354 and "customer_id" = 305 and "staff_id" = 1 and "rental_id" = 2166 and "amount" = 11.95 and "payment_date" = E'2022-05-12 11:28:17.949049+00';
+UPDATE "public"."payment_p2022_06" SET "amount" = 11.99 WHERE "payment_id" = 22650 and "customer_id" = 204 and "staff_id" = 2 and "rental_id" = 15415 and "amount" = 11.95 and "payment_date" = E'2022-06-11 11:17:22.428079+00';
+UPDATE "public"."payment_p2022_06" SET "amount" = 11.99 WHERE "payment_id" = 24553 and "customer_id" = 195 and "staff_id" = 2 and "rental_id" = 16040 and "amount" = 11.95 and "payment_date" = E'2022-06-15 02:21:00.279776+00';
+UPDATE "public"."payment_p2022_07" SET "amount" = 11.99 WHERE "payment_id" = 28814 and "customer_id" = 592 and "staff_id" = 1 and "rental_id" = 3973 and "amount" = 11.95 and "payment_date" = E'2022-07-06 12:15:38.928947+00';
+UPDATE "public"."payment_p2022_07" SET "amount" = 11.99 WHERE "payment_id" = 29136 and "customer_id" = 13 and "staff_id" = 2 and "rental_id" = 8831 and "amount" = 11.95 and "payment_date" = E'2022-07-22 16:15:40.797771+00';
 COMMIT; -- {"xid":494,"lsn":"0/244D170","timestamp":"2023-06-14 11:34:23.440564+0000"}
 -- KEEPALIVE {"lsn":"0/244D170","timestamp":"2023-06-14 11:34:23.440632+0000"}
 -- ENDPOS {"lsn":"0/244D170"}

--- a/tests/unit/expected/3-string-escape.out
+++ b/tests/unit/expected/3-string-escape.out
@@ -1,0 +1,12 @@
+-[ RECORD 1 ]
+id | 1
+f1 | aaa  +
+   | aaa
+-[ RECORD 2 ]
+id | 2
+f1 | bbb\r+
+   | bbb
+-[ RECORD 3 ]
+id | 3
+f1 | ccc
+

--- a/tests/unit/setup/8-string-escape.sql
+++ b/tests/unit/setup/8-string-escape.sql
@@ -1,0 +1,10 @@
+create table test_str_escape
+ (
+   id bigint not null generated always as identity primary key,
+   f1 text
+ );
+
+insert into test_str_escape (f1)
+     values (E'aaa\naaa'),
+            (E'bbb\r\nbbb'),
+            (E'ccc');

--- a/tests/unit/setup/setup.sql
+++ b/tests/unit/setup/setup.sql
@@ -5,3 +5,4 @@
 \ir 5-long-index-def.sql
 \ir 6-multiline-table-name.sql
 \ir 7-identity.sql
+\ir 8-string-escape.sql

--- a/tests/unit/sql/3-string-escape.sql
+++ b/tests/unit/sql/3-string-escape.sql
@@ -1,0 +1,1 @@
+table test_str_escape;


### PR DESCRIPTION
Escape string constants in our SQL files by following the Postgres documentation about String Constants With C-Style Escapes, see:

  https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-STRINGS

This format helps guarantee that a single SQL statement in our SQL files are always found on one-line only, which we use in the apply process to avoid having to actually parse the SQL files.

Fixes #336 