### PR TITLE
Assorted transform fixes.

### DIFF
--- a/src/bin/pgcopydb/ld_transform.c
+++ b/src/bin/pgcopydb/ld_transform.c
@@ -1988,8 +1988,21 @@ stream_write_value(FILE *out, LogicalMessageValue *value)
 				break;
 			}
 
-			case TEXTOID:
 			case BYTEAOID:
+			{
+				if (value->isQuoted)
+				{
+					fformat(out, "%s", value->val.str);
+				}
+				else
+				{
+					fformat(out, "'%s'", value->val.str);
+				}
+
+				break;
+			}
+
+			case TEXTOID:
 			{
 				if (value->isQuoted)
 				{
@@ -2093,7 +2106,7 @@ LogicalMessageValueEq(LogicalMessageValue *a, LogicalMessageValue *b)
 
 		case INT8OID:
 		{
-			return a->val.int8 == a->val.int8;
+			return a->val.int8 == b->val.int8;
 		}
 
 		case FLOAT8OID:


### PR DESCRIPTION
  - Fix BYTEA handling: refrain from using C-Style Escapes for BYTEA values.
  - Fix LogicalMessageValueEq for INT8OID (typo).

Fixes #338 