### PR TITLE
Skip importing snapshot we won't use, fix pgsql error handling.

### DIFF
--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -337,6 +337,7 @@ bool copydb_cleanup_sysv_resources(SysVResArray *array);
 /* snapshot.c */
 bool copydb_copy_snapshot(CopyDataSpec *specs, TransactionSnapshot *snapshot);
 bool copydb_prepare_snapshot(CopyDataSpec *copySpecs);
+bool copydb_should_export_snapshot(CopyDataSpec *copySpecs);
 bool copydb_set_snapshot(CopyDataSpec *copySpecs);
 bool copydb_close_snapshot(CopyDataSpec *copySpecs);
 


### PR DESCRIPTION
Fix pgsql.c for the case when we fail to execute a SQL command without parameters, such as e.g. the very simple "COMMIT;" command. First, we might not be given a SQLSTATE, and second, we need to pay attention about that lack of debugParameters.

Also improve `pgcopydb clone` command to avoid importing a snapshot in the top-level process. This process might need to export a snapshot and hold-on to it while sub-processes are running, but never executes SQL itself so won't need to import a snapshot in its own transaction.