### PR TITLE
Have --skip-extensions also skip pre-existing schemas on the target.

### DIFF
--- a/docs/ref/pgcopydb_clone.rst
+++ b/docs/ref/pgcopydb_clone.rst
@@ -94,16 +94,16 @@ Base copy, or the clone operation
 
 The ``pgcopydb clone`` command implements the following steps:
 
-  1. ``pgcopydb`` calls into ``pg_dump`` to produce the ``pre-data`` section
-     and the ``post-data`` sections of the dump using Postgres custom
-     format.
-
-  2. ``pgcopydb`` gets the list of ordinary and partitioned tables from a
+  1. ``pgcopydb`` gets the list of ordinary and partitioned tables from a
      catalog query on the source database, and also the list of indexes, and
      the list of sequences with their current values.
 
      When filtering is used, the list of objects OIDs that are meant to be
      filtered out is built during this step.
+
+  2. ``pgcopydb`` calls into ``pg_dump`` to produce the ``pre-data`` section
+     and the ``post-data`` sections of the dump using Postgres custom
+     format.
 
   3. The ``pre-data`` section of the dump is restored on the target database
      using the ``pg_restore`` command, creating all the Postgres objects

--- a/src/bin/pgcopydb/cli_restore.c
+++ b/src/bin/pgcopydb/cli_restore.c
@@ -369,13 +369,6 @@ cli_restore_schema_getopts(int argc, char **argv)
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 
-	/* prepare safe versions of the connection strings (without password) */
-	if (!cli_prepare_pguris(&(options.connStrings)))
-	{
-		/* errors have already been logged */
-		exit(EXIT_CODE_INTERNAL_ERROR);
-	}
-
 	if (errors > 0)
 	{
 		exit(EXIT_CODE_BAD_ARGS);
@@ -535,13 +528,6 @@ cli_restore_prepare_specs(CopyDataSpec *copySpecs)
 	CopyFilePaths *cfPaths = &(copySpecs->cfPaths);
 	PostgresPaths *pgPaths = &(copySpecs->pgPaths);
 
-	ConnStrings *dsn = &(copySpecs->connStrings);
-	char *source = dsn->safeSourcePGURI.pguri;
-	char *target = dsn->safeTargetPGURI.pguri;
-
-	log_info("[SOURCE] Restoring database from \"%s\"", source);
-	log_info("[TARGET] Restoring database into \"%s\"", target);
-
 	(void) find_pg_commands(pgPaths);
 
 	char *dir =
@@ -586,4 +572,15 @@ cli_restore_prepare_specs(CopyDataSpec *copySpecs)
 	log_info("Using pg_restore for Postgres \"%s\" at \"%s\"",
 			 pgPaths->pg_version,
 			 pgPaths->pg_restore);
+
+	ConnStrings *dsn = &(copySpecs->connStrings);
+
+	if (!cli_prepare_pguris(dsn))
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+
+	char *target = dsn->safeTargetPGURI.pguri;
+	log_info("[TARGET] Restoring database into \"%s\"", target);
 }

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -259,6 +259,7 @@ typedef struct CopyDataSpec
 	bool hasDBTempPrivilege;
 
 	SourceCatalog catalog;
+	TargetCatalog targetCatalog;
 	CopyTableDataSpecsArray tableSpecsArray;
 } CopyDataSpec;
 
@@ -447,6 +448,11 @@ bool copydb_prepare_index_specs(CopyDataSpec *specs, PGSQL *pgsql);
 bool copydb_fetch_filtered_oids(CopyDataSpec *specs, PGSQL *pgsql);
 
 char * copydb_ObjectKindToString(ObjectKind kind);
+
+bool copydb_prepare_target_catalog(CopyDataSpec *specs);
+bool copydb_schema_already_exists(CopyDataSpec *specs,
+								  const char *restoreListName,
+								  bool *exists);
 
 /* table-data.c */
 bool copydb_copy_all_table_data(CopyDataSpec *specs);

--- a/src/bin/pgcopydb/copydb_schema.c
+++ b/src/bin/pgcopydb/copydb_schema.c
@@ -1052,5 +1052,7 @@ copydb_schema_already_exists(CopyDataSpec *specs,
 
 	HASH_FIND(hh, schemaHashByName, name, len, schema);
 
-	return schema != NULL;
+	*exists = schema != NULL;
+
+	return true;
 }

--- a/src/bin/pgcopydb/copydb_schema.c
+++ b/src/bin/pgcopydb/copydb_schema.c
@@ -228,6 +228,15 @@ copydb_fetch_schema_and_prepare_specs(CopyDataSpec *specs)
 		}
 	}
 
+	/*
+	 * Now also fetch the list of schemas from the target database.
+	 */
+	if (!copydb_prepare_target_catalog(specs))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
 	return true;
 }
 
@@ -961,4 +970,87 @@ copydb_ObjectKindToString(ObjectKind kind)
 	}
 
 	return "unknown";
+}
+
+
+/*
+ * copydb_prepare_target_catalog connects to the target database and fetches
+ * pieces of the catalogs that we need, such as the list of the already
+ * existing schemas.
+ */
+bool
+copydb_prepare_target_catalog(CopyDataSpec *specs)
+{
+	PGSQL dst = { 0 };
+
+	if (!pgsql_init(&dst, specs->connStrings.target_pguri, PGSQL_CONN_SOURCE))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	SourceSchema *schemaHashByName = NULL;
+	SourceSchemaArray *schemaArray = &(specs->targetCatalog.schemaArray);
+
+	if (!schema_list_schemas(&dst, schemaArray))
+	{
+		log_error("Failed to list schemas on the target database");
+		return false;
+	}
+
+	for (int i = 0; i < schemaArray->count; i++)
+	{
+		SourceSchema *schema = &(schemaArray->array[i]);
+		size_t len = strlen(schema->nspname);
+
+		HASH_ADD(hh, schemaHashByName, nspname, len, schema);
+	}
+
+	specs->targetCatalog.schemaHashByName = schemaHashByName;
+
+	return true;
+}
+
+
+/*
+ * copydb_schema_already_exists checks if the given SCHEMA name extracted from
+ * a pg_dump Archive matches an existing schema name on the target database.
+ */
+bool
+copydb_schema_already_exists(CopyDataSpec *specs,
+							 const char *restoreListName,
+							 bool *exists)
+{
+	SourceSchema *schemaHashByName = specs->targetCatalog.schemaHashByName;
+
+	if (strncmp(restoreListName, "- ", 2) != 0)
+	{
+		log_error("Failed to parse restore list name \"%s\"", restoreListName);
+		return false;
+	}
+
+	char *name = strdup(restoreListName + 2);
+
+	if (name == NULL)
+	{
+		log_error(ALLOCATION_FAILED_ERROR);
+		return false;
+	}
+
+	char *spc = strchr(name, ' ');
+
+	if (spc == NULL)
+	{
+		log_error("Failed to parse restore list name \"%s\"", restoreListName);
+		return false;
+	}
+
+	*spc = '\0';
+
+	SourceSchema *schema = NULL;
+	size_t len = strlen(name);
+
+	HASH_FIND(hh, schemaHashByName, name, len, schema);
+
+	return schema != NULL;
 }

--- a/src/bin/pgcopydb/dump_restore.c
+++ b/src/bin/pgcopydb/dump_restore.c
@@ -367,7 +367,7 @@ copydb_write_restore_list(CopyDataSpec *specs, PostgresDumpSection section)
 	if (listContents == NULL)
 	{
 		log_error(ALLOCATION_FAILED_ERROR);
-		free(listContents);
+		destroyPQExpBuffer(listContents);
 		return false;
 	}
 
@@ -385,7 +385,9 @@ copydb_write_restore_list(CopyDataSpec *specs, PostgresDumpSection section)
 
 			if (!copydb_schema_already_exists(specs, name, &exists))
 			{
-				/* errors have already been logged */
+				log_error("Failed to check if restore name \"%s\" "
+						  "already exists",
+						  name);
 				return false;
 			}
 

--- a/src/bin/pgcopydb/dump_restore.c
+++ b/src/bin/pgcopydb/dump_restore.c
@@ -47,6 +47,13 @@ copydb_dump_source_schema(CopyDataSpec *specs,
 						  const char *snapshot,
 						  PostgresDumpSection section)
 {
+	SourceExtensionArray *extensionArray = NULL;
+
+	if (specs->skipExtensions)
+	{
+		extensionArray = &(specs->catalog.extensionArray);
+	}
+
 	if (section == PG_DUMP_SECTION_SCHEMA ||
 		section == PG_DUMP_SECTION_PRE_DATA ||
 		section == PG_DUMP_SECTION_ALL)
@@ -62,6 +69,7 @@ copydb_dump_source_schema(CopyDataSpec *specs,
 							 snapshot,
 							 "pre-data",
 							 &(specs->filters),
+							 extensionArray,
 							 specs->dumpPaths.preFilename))
 		{
 			/* errors have already been logged */
@@ -92,6 +100,7 @@ copydb_dump_source_schema(CopyDataSpec *specs,
 							 snapshot,
 							 "post-data",
 							 &(specs->filters),
+							 extensionArray,
 							 specs->dumpPaths.postFilename))
 		{
 			/* errors have already been logged */
@@ -366,8 +375,29 @@ copydb_write_restore_list(CopyDataSpec *specs, PostgresDumpSection section)
 	for (int i = 0; i < contents.count; i++)
 	{
 		uint32_t oid = contents.array[i].objectOid;
+		uint32_t catOid = contents.array[i].catalogOid;
 		char *name = contents.array[i].restoreListName;
 		char *prefix = "";
+
+		if (catOid == PG_NAMESPACE_OID)
+		{
+			bool exists = false;
+
+			if (!copydb_schema_already_exists(specs, name, &exists))
+			{
+				/* errors have already been logged */
+				return false;
+			}
+
+			if (exists)
+			{
+				prefix = ";";
+
+				log_notice("Skipping already existing schema %u: %s",
+						   contents.array[i].objectOid,
+						   contents.array[i].restoreListName);
+			}
+		}
 
 		if (copydb_objectid_has_been_processed_already(specs, oid))
 		{

--- a/src/bin/pgcopydb/pg_utils.h
+++ b/src/bin/pgcopydb/pg_utils.h
@@ -39,6 +39,11 @@
 #define TIMESTAMPTZOID 1184
 
 /*
+ * Catalog OID values from PostgreSQL src/include/catalog/pg_namespace.h
+ */
+#define PG_NAMESPACE_OID 2615
+
+/*
  * Error codes that we use internally.
  */
 #define STR_ERRCODE_DUPLICATE_OBJECT "42710"

--- a/src/bin/pgcopydb/pgcmd.c
+++ b/src/bin/pgcopydb/pgcmd.c
@@ -21,6 +21,7 @@
 #include "log.h"
 #include "parsing_utils.h"
 #include "pgcmd.h"
+#include "schema.h"
 #include "signals.h"
 #include "string_utils.h"
 
@@ -341,6 +342,7 @@ pg_dump_db(PostgresPaths *pgPaths,
 		   const char *snapshot,
 		   const char *section,
 		   SourceFilters *filters,
+		   SourceExtensionArray *extensionArray,
 		   const char *filename)
 {
 	char *args[128];
@@ -376,14 +378,14 @@ pg_dump_db(PostgresPaths *pgPaths,
 	args[argsIndex++] = "--section";
 	args[argsIndex++] = (char *) section;
 
-	/* we use 10 other args array items beside schema filtering */
-	if (128 < (filters->excludeSchemaList.count + 10))
+	/* check that we still have room for --exclude-schema arguments */
+	if ((128 - argsIndex) < (filters->excludeSchemaList.count * 2))
 	{
 		log_fatal("Failed to pg_dump section %s when using %d exclude-schema "
 				  "filters, only %d filters are supported by pgcopydb",
 				  section,
 				  filters->excludeSchemaList.count,
-				  128 - 10);
+				  (128 - argsIndex) / 2);
 		return false;
 	}
 
@@ -393,6 +395,28 @@ pg_dump_db(PostgresPaths *pgPaths,
 
 		args[argsIndex++] = "--exclude-schema";
 		args[argsIndex++] = nspname;
+	}
+
+	/* now --exclude-schema for extension's own schemas */
+	if (extensionArray != NULL)
+	{
+		for (int i = 0; i < extensionArray->count; i++)
+		{
+			char *nspname = extensionArray->array[i].extnamespace;
+
+			if (!streq(nspname, "public") && !streq(nspname, "pg_catalog"))
+			{
+				if (128 < (argsIndex + 2))
+				{
+					log_error("Failed to pg_dump section %s, argsIndex %d > %d",
+							  section, argsIndex + 2, 128);
+					return false;
+				}
+
+				args[argsIndex++] = "--exclude-schema";
+				args[argsIndex++] = nspname;
+			}
+		}
 	}
 
 	args[argsIndex++] = "--file";

--- a/src/bin/pgcopydb/pgcmd.h
+++ b/src/bin/pgcopydb/pgcmd.h
@@ -18,6 +18,7 @@
 #include "filtering.h"
 #include "parsing_utils.h"
 #include "pgsql.h"
+#include "schema.h"
 
 #define PG_VERSION_STRING_MAX 12
 
@@ -87,6 +88,7 @@ bool pg_dump_db(PostgresPaths *pgPaths,
 				const char *snapshot,
 				const char *section,
 				SourceFilters *filters,
+				SourceExtensionArray *extensionArray,
 				const char *filename);
 
 bool pg_dumpall_roles(PostgresPaths *pgPaths,

--- a/src/bin/pgcopydb/schema.h
+++ b/src/bin/pgcopydb/schema.h
@@ -41,6 +41,8 @@ typedef struct SourceSchema
 	uint32_t oid;
 	char nspname[NAMEDATALEN];
 	char restoreListName[RESTORE_LIST_NAMEDATALEN];
+
+	UT_hash_handle hh;          /* makes this structure hashable */
 } SourceSchema;
 
 typedef struct SourceSchemaArray
@@ -283,11 +285,20 @@ typedef struct SourceCatalog
 } SourceCatalog;
 
 
+typedef struct TargetCatalog
+{
+	SourceSchemaArray schemaArray;
+	SourceSchema *schemaHashByName;
+} TargetCatalog;
+
+
 bool schema_query_privileges(PGSQL *pgsql,
 							 bool *hasDBCreatePrivilage,
 							 bool *hasDBTempPrivilege);
 
 bool schema_list_databases(PGSQL *pgsql, SourceDatabaseArray *catArray);
+
+bool schema_list_schemas(PGSQL *pgsql, SourceSchemaArray *array);
 
 bool schema_list_ext_schemas(PGSQL *pgsql, SourceSchemaArray *array);
 

--- a/src/bin/pgcopydb/summary.c
+++ b/src/bin/pgcopydb/summary.c
@@ -668,8 +668,8 @@ summary_prepare_toplevel_durations(Summary *summary)
 	uint64_t durationMs;
 
 	/* compute schema dump duration, part of schemaDurationMs */
-	duration = timings->beforeSchemaFetch;
-	INSTR_TIME_SUBTRACT(duration, timings->beforeSchemaDump);
+	duration = timings->beforeSchemaDump;
+	INSTR_TIME_SUBTRACT(duration, timings->beforeSchemaFetch);
 	durationMs = INSTR_TIME_MS(duration);
 
 	IntervalToString(durationMs, timings->dumpSchemaMs, INTSTRING_MAX_DIGITS);
@@ -679,7 +679,7 @@ summary_prepare_toplevel_durations(Summary *summary)
 
 	/* compute schema fetch duration, part of schemaDurationMs */
 	duration = timings->beforePrepareSchema;
-	INSTR_TIME_SUBTRACT(duration, timings->beforeSchemaFetch);
+	INSTR_TIME_SUBTRACT(duration, timings->beforeSchemaDump);
 	durationMs = INSTR_TIME_MS(duration);
 
 	IntervalToString(durationMs, timings->fetchSchemaMs, INTSTRING_MAX_DIGITS);

--- a/tests/extensions/copydb.sh
+++ b/tests/extensions/copydb.sh
@@ -29,7 +29,10 @@ EOF
 
 # create extensions on the source pagila database (needs superuser)
 psql -a -1 ${PGCOPYDB_SOURCE_PGURI_SU} <<EOF
+create extension intarray cascade;
 create extension postgis cascade;
+create extension postgis_tiger_geocoder cascade;
+create extension pg_partman cascade;
 EOF
 
 # the partman extension needs to be installed as the pagila role

--- a/tests/extensions/copydb.sh
+++ b/tests/extensions/copydb.sh
@@ -31,14 +31,19 @@ EOF
 psql -a -1 ${PGCOPYDB_SOURCE_PGURI_SU} <<EOF
 create extension intarray cascade;
 create extension postgis cascade;
-create extension postgis_tiger_geocoder cascade;
-create extension pg_partman cascade;
 EOF
 
-# the partman extension needs to be installed as the pagila role
-# psql -a -1 ${PGCOPYDB_SOURCE_PGURI} <<EOF
+#
 # create extension pg_partman cascade;
-# EOF
+# create extension postgis_tiger_geocoder cascade;
+#
+# At the moment we don't have full support for pg_partman or
+# postgis_tiger_geocoder without being superuser, because of a pg_dump
+# limitation when it comes to extensions.
+#
+# pg_dump: error: query failed: ERROR:  permission denied for schema tiger
+# pg_dump: error: query was: LOCK TABLE tiger.geocode_settings IN ACCESS SHARE MODE
+#
 
 # create the application schema and data in the pagila database, role pagila
 grep -v "OWNER TO postgres" /usr/src/pagila/pagila-schema.sql > /tmp/pagila-schema.sql


### PR DESCRIPTION
When skipping extensions we assume that another process did take care of creating the needed extensions on the target instance, such as e.g. the `pgcopydb copy extensions` command.

The "CREATE EXTENSION" command may create a schema, and we need to skip schemas that such a command would have created on the target already. It is not always possible to track schemas created by extensions, some extension scripts are going out of their way to make sure of that:

    DO $$
      CREATE SCHEMA tiger_data;
    $$;

So we track all the schemas that already exist on the target database and skip creating them when the --skip-extensions command is used.

Fixes #327 