### PR TITLE
Set statement_timeout and lock_timeout to 0.

### DIFF
--- a/src/bin/pgcopydb/copydb.c
+++ b/src/bin/pgcopydb/copydb.c
@@ -35,6 +35,8 @@ GUC srcSettings[] = {
 	COMMON_GUC_SETTINGS,
 	{ "extra_float_digits", "3" },
 	{ "idle_in_transaction_session_timeout", "0" },
+	{ "statement_timeout", "0" },
+	{ "lock_timeout", "0" },
 	{ NULL, NULL },
 };
 
@@ -43,6 +45,8 @@ GUC dstSettings[] = {
 	COMMON_GUC_SETTINGS,
 	{ "maintenance_work_mem", "'1 GB'" },
 	{ "synchronous_commit", "'off'" },
+	{ "statement_timeout", "0" },
+	{ "lock_timeout", "0" },
 	{ NULL, NULL },
 };
 


### PR DESCRIPTION
The `COPY` statement was timing out because the `statement_timeout` was set to a non-zero value in a migration. Additionally, I quickly checked `pg_dump` to see what other parameters were set for the connection, and I found `lock_timeout`.