### PR TITLE
Ensure startpos is updated when closing stream.

### DIFF
--- a/src/bin/pgcopydb/follow.c
+++ b/src/bin/pgcopydb/follow.c
@@ -204,6 +204,9 @@ follow_get_sentinel(StreamSpecs *specs, CopyDBSentinel *sentinel)
 		return false;
 	}
 
+	/* always accept the startpos and apply values from the sentinel */
+	specs->startpos = sentinel->startpos;
+
 	/* the endpos might have changed on the sentinel table */
 	if (sentinel->endpos != InvalidXLogRecPtr &&
 		sentinel->endpos != specs->endpos)

--- a/src/bin/pgcopydb/ld_stream.c
+++ b/src/bin/pgcopydb/ld_stream.c
@@ -1392,11 +1392,14 @@ streamFeedback(LogicalStreamContext *context)
 
 	int feedbackInterval = 1 * 1000; /* 1s */
 
-	if (!feTimestampDifferenceExceeds(context->lastFeedbackSync,
-									  context->now,
-									  feedbackInterval))
+	if (!context->forceFeedback)
 	{
-		return true;
+		if (!feTimestampDifferenceExceeds(context->lastFeedbackSync,
+										  context->now,
+										  feedbackInterval))
+		{
+			return true;
+		}
 	}
 
 	PGSQL src = { 0 };
@@ -1433,11 +1436,12 @@ streamFeedback(LogicalStreamContext *context)
 	context->lastFeedbackSync = context->now;
 
 	log_debug("streamFeedback: written %X/%X flushed %X/%X applied %X/%X "
-			  " endpos %X/%X apply %s",
+			  " startpos %X/%X endpos %X/%X apply %s",
 			  LSN_FORMAT_ARGS(context->tracking->written_lsn),
 			  LSN_FORMAT_ARGS(context->tracking->flushed_lsn),
 			  LSN_FORMAT_ARGS(context->tracking->applied_lsn),
-			  LSN_FORMAT_ARGS(context->endpos),
+			  LSN_FORMAT_ARGS(privateContext->startpos),
+			  LSN_FORMAT_ARGS(privateContext->endpos),
 			  privateContext->apply ? "enabled" : "disabled");
 
 	return true;

--- a/src/bin/pgcopydb/ld_stream.h
+++ b/src/bin/pgcopydb/ld_stream.h
@@ -506,6 +506,7 @@ bool stream_compute_pathnames(uint32_t WalSegSz,
 							  char *sqlFileName);
 
 bool stream_transform_stream(StreamSpecs *specs);
+bool stream_transform_resume(StreamContext *privateContext);
 bool stream_transform_line(void *ctx, const char *line, bool *stop);
 
 bool stream_transform_write_message(StreamContext *privateContext,

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -3357,12 +3357,12 @@ pgsql_init_stream(LogicalStreamClient *client,
 	client->fsync_interval = 10 * 1000;          /* 10 sec = default */
 	client->standby_message_timeout = 10 * 1000; /* 10 sec = default */
 
-	client->current.written_lsn = InvalidXLogRecPtr;
-	client->current.flushed_lsn = InvalidXLogRecPtr;
+	client->current.written_lsn = startpos;
+	client->current.flushed_lsn = startpos;
 	client->current.applied_lsn = InvalidXLogRecPtr;
 
-	client->feedback.written_lsn = InvalidXLogRecPtr;
-	client->feedback.flushed_lsn = InvalidXLogRecPtr;
+	client->feedback.written_lsn = startpos;
+	client->feedback.flushed_lsn = startpos;
 	client->feedback.applied_lsn = InvalidXLogRecPtr;
 
 	return true;
@@ -3740,7 +3740,6 @@ pgsql_stream_logical(LogicalStreamClient *client, LogicalStreamContext *context)
 
 	client->last_fsync = -1;
 	client->last_status = -1;
-	client->current.written_lsn = InvalidXLogRecPtr;
 
 	context->plugin = client->plugin;
 

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -4256,6 +4256,8 @@ pgsqlSendFeedback(LogicalStreamClient *client,
 	}
 
 	/* call the callback function from the streaming client first */
+	context->forceFeedback = force;
+
 	if ((*client->feedbackFunction)(context))
 	{
 		/* we might have a new endpos from the client callback */

--- a/src/bin/pgcopydb/pgsql.h
+++ b/src/bin/pgcopydb/pgsql.h
@@ -399,6 +399,8 @@ typedef struct LogicalStreamContext
 	const char *buffer;         /* expose internal buffer */
 	StreamOutputPlugin plugin;
 
+	bool forceFeedback;
+
 	TimestampTz now;
 	TimestampTz lastFeedbackSync;
 	TimestampTz sendTime;


### PR DESCRIPTION
At flushAndSendFeedback time make sure that the current LSN position that we have written is updated as our next startpos. This also makes the startpos available to the other sub-modules (such as transform) at their start-time and when switching between operation modes.

See #331 