### PR TITLE
Also escape backslash character when using E'' notation.

### DIFF
--- a/src/bin/pgcopydb/ld_transform.c
+++ b/src/bin/pgcopydb/ld_transform.c
@@ -2055,6 +2055,7 @@ stream_write_sql_escape_string_constant(FILE *out, const char *str)
 			case '\n':
 			case '\r':
 			case '\t':
+			case '\\':
 			{
 				fformat(out, "\\%c", str[i]);
 				break;


### PR DESCRIPTION
Should fix #342