### PR TITLE
Fix transform escape rules for SQL escape syntax, again.

### DIFF
--- a/src/bin/pgcopydb/ld_transform.c
+++ b/src/bin/pgcopydb/ld_transform.c
@@ -2106,12 +2106,37 @@ stream_write_sql_escape_string_constant(FILE *out, const char *str)
 	{
 		switch (str[i])
 		{
-			case '\'':
 			case '\b':
+			{
+				fformat(out, "\\b");
+				break;
+			}
+
 			case '\f':
+			{
+				fformat(out, "\\f");
+				break;
+			}
+
 			case '\n':
+			{
+				fformat(out, "\\n");
+				break;
+			}
+
 			case '\r':
+			{
+				fformat(out, "\\r");
+				break;
+			}
+
 			case '\t':
+			{
+				fformat(out, "\\t");
+				break;
+			}
+
+			case '\'':
 			case '\\':
 			{
 				fformat(out, "\\%c", str[i]);

--- a/tests/follow-data-only/copydb.sh
+++ b/tests/follow-data-only/copydb.sh
@@ -50,7 +50,7 @@ pgcopydb copy table-data
 psql -v a=11 -v b=20 -d ${PGCOPYDB_SOURCE_PGURI} -f /usr/src/pgcopydb/dml.sql
 
 # start following and applying changes from source to target
-pgcopydb follow --notice
+pgcopydb follow --verbose
 
 # the follow command ends when reaching endpos, set in inject.sh
 pgcopydb stream cleanup
@@ -59,7 +59,13 @@ kill -TERM ${COPROC_PID}
 wait ${COPROC_PID}
 
 # check how many rows we have on source and target
-sql="select count(*), sum(some_field) from table_a"
+sql="select count(*), sum(f1) from table_a"
+psql -d ${PGCOPYDB_SOURCE_PGURI} -c "${sql}" > /tmp/s.out
+psql -d ${PGCOPYDB_TARGET_PGURI} -c "${sql}" > /tmp/t.out
+
+diff /tmp/s.out /tmp/t.out
+
+sql="select f1, f2 from table_a where f2 is not null order by f1"
 psql -d ${PGCOPYDB_SOURCE_PGURI} -c "${sql}" > /tmp/s.out
 psql -d ${PGCOPYDB_TARGET_PGURI} -c "${sql}" > /tmp/t.out
 

--- a/tests/follow-data-only/ddl.sql
+++ b/tests/follow-data-only/ddl.sql
@@ -4,5 +4,5 @@
 --- This file implements DDL changes in the pagila database.
 
 begin;
-CREATE TABLE table_a ( id serial PRIMARY KEY, some_field int4 );
+CREATE TABLE table_a (id serial PRIMARY KEY, f1 int4, f2 text);
 commit;

--- a/tests/follow-data-only/dml.sql
+++ b/tests/follow-data-only/dml.sql
@@ -1,1 +1,7 @@
-INSERT INTO table_a ( some_field ) SELECT generate_series(:a,:b);
+INSERT INTO table_a (f1, f2)
+     SELECT x,
+            (array[E'test new\nline',
+                   E'\\\\Client\\S$\\2023\\Dir1\\Test_Doc №2',
+                   E'test \rreturn',
+                   E'test ''single'' quote'])[(x - 1) % 4 + 1]
+       FROM generate_series(:a,:b) as t(x);

--- a/tests/follow-data-only/multi-wal-txn.sql
+++ b/tests/follow-data-only/multi-wal-txn.sql
@@ -2,20 +2,19 @@
 
 BEGIN;
 
-INSERT INTO table_a(some_field) VALUES ((random() * 100 + 1)::int);
+INSERT INTO table_a(f1) VALUES ((random() * 100 + 1)::int);
 
 SELECT
     pg_switch_wal();
 
-INSERT INTO table_a(some_field) VALUES ((random() * 100 + 1)::int);
+INSERT INTO table_a(f1) VALUES ((random() * 100 + 1)::int);
 
 SELECT
     pg_switch_wal();
 
-INSERT INTO table_a(some_field) VALUES ((random() * 100 + 1)::int);
+INSERT INTO table_a(f1) VALUES ((random() * 100 + 1)::int);
 
 SELECT
     pg_switch_wal();
 
 COMMIT;
-

--- a/tests/follow-data-only/run-background-traffic.sh
+++ b/tests/follow-data-only/run-background-traffic.sh
@@ -5,9 +5,10 @@ set -e
 # Run transactions that insert a variable number of rows at a time. The number
 # of rows inserted varies between 1 and 100. Each insert will occur in the
 # background and finish quickly which avoids excessive connections.
+sql="INSERT INTO table_a(f1) SELECT generate_series(1,(random() * 100 + 1)::int);"
+
 while true; do
-    psql -d ${PGCOPYDB_SOURCE_PGURI} \
-         -c "INSERT INTO table_a(some_field) SELECT generate_series(1,(random() * 100 + 1)::int);" &
+    psql -d ${PGCOPYDB_SOURCE_PGURI} -c "${sql}" &
     # To control the rate, we include a sleep of 0.1 seconds between each insert
     # operation.
     sleep 0.1


### PR DESCRIPTION
This time we add unit testing to make sure we get it right and avoid regressions.

Fixes #347.