### PR TITLE
Fix our PG_VERSION_STRING_MAX_LENGTH to host more.

### DIFF
--- a/src/bin/pgcopydb/cli_ping.c
+++ b/src/bin/pgcopydb/cli_ping.c
@@ -212,7 +212,17 @@ cli_ping(int argc, char **argv)
 				exit(EXIT_CODE_SOURCE);
 			}
 
-			if (!pgsql_set_gucs(&src, srcSettings))
+			/* also set our GUC values for the source connection */
+			if (!pgsql_server_version(&src))
+			{
+				/* errors have already been logged */
+				exit(EXIT_CODE_SOURCE);
+			}
+
+			GUC *settings =
+				src.pgversion_num < 90600 ? srcSettings95 : srcSettings;
+
+			if (!pgsql_set_gucs(&src, settings))
 			{
 				log_fatal("Failed to set our GUC settings on the target connection, "
 						  "see above for details");

--- a/src/bin/pgcopydb/copydb.c
+++ b/src/bin/pgcopydb/copydb.c
@@ -33,10 +33,7 @@ GUC srcSettings95[] = {
 
 GUC srcSettings[] = {
 	COMMON_GUC_SETTINGS,
-	{ "extra_float_digits", "3" },
 	{ "idle_in_transaction_session_timeout", "0" },
-	{ "statement_timeout", "0" },
-	{ "lock_timeout", "0" },
 	{ NULL, NULL },
 };
 

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -19,7 +19,9 @@
 
 #define COMMON_GUC_SETTINGS \
 	{ "client_encoding", "'UTF-8'" }, \
-	{ "tcp_keepalives_idle", "'60s'" }
+	{ "tcp_keepalives_idle", "'60s'" }, \
+	{ "extra_float_digits", "3" }, \
+	{ "statement_timeout", "0" }
 
 /*
  * pgcopydb creates System V OS level objects such as message queues and

--- a/src/bin/pgcopydb/pgsql.h
+++ b/src/bin/pgcopydb/pgsql.h
@@ -155,8 +155,9 @@ typedef enum
 /*
  * That's "x.yy.zz" or "xx.zz" or maybe a debian style version string such as:
  *  "13.8 (Debian 13.8-1.pgdg110+1)"
+ *  "16beta1 (Debian 16~beta1-2.pgdg+~20230605.2256.g3f1aaaa)"
  */
-#define PG_VERSION_STRING_MAX_LENGTH 45
+#define PG_VERSION_STRING_MAX_LENGTH 128
 
 /* notification processing */
 typedef bool (*ProcessNotificationFunction)(int notificationGroupId,


### PR DESCRIPTION
The current debian Postgres version string is longer than we anticipated:

    "16beta1 (Debian 16~beta1-2.pgdg+~20230605.2256.g3f1aaaa)"

In passing, also make sure that `pgcopydb ping` sets the right GUCs even when using Postgres 9.5, and allow more GUCs for that version too.