### PR TITLE
Fix stream_transform_resume to share context with stream_transform_file.

### DIFF
--- a/src/bin/pgcopydb/cli_stream.c
+++ b/src/bin/pgcopydb/cli_stream.c
@@ -915,6 +915,12 @@ cli_stream_transform(int argc, char **argv)
 		exit(EXIT_CODE_INTERNAL_ERROR);
 	}
 
+	if (!stream_init_context(&specs))
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+
 	/*
 	 * Do we use the file API, or the stream API?
 	 *

--- a/src/bin/pgcopydb/ld_stream.c
+++ b/src/bin/pgcopydb/ld_stream.c
@@ -290,8 +290,10 @@ LogicalStreamModeToString(LogicalStreamMode mode)
  * stream_init_context initializes a LogicalStreamContext.
  */
 bool
-stream_init_context(StreamContext *privateContext, StreamSpecs *specs)
+stream_init_context(StreamSpecs *specs)
 {
+	StreamContext *privateContext = &(specs->private);
+
 	privateContext->endpos = specs->endpos;
 	privateContext->startpos = specs->startpos;
 	privateContext->startposComputedFromJSON = specs->startposComputedFromJSON;
@@ -369,15 +371,15 @@ startLogicalStreaming(StreamSpecs *specs)
 	}
 
 	LogicalStreamContext context = { 0 };
-	StreamContext privateContext = { 0 };
 
-	if (!stream_init_context(&privateContext, specs))
+	if (!stream_init_context(specs))
 	{
 		/* errors have already been logged */
 		return false;
 	}
 
-	context.private = (void *) &(privateContext);
+	StreamContext *privateContext = &(specs->private);
+	context.private = (void *) privateContext;
 
 	if (specs->stdOut)
 	{
@@ -451,8 +453,8 @@ startLogicalStreaming(StreamSpecs *specs)
 			log_warn("Streaming got interrupted at %X/%X "
 					 "after processing %lld message%s",
 					 LSN_FORMAT_ARGS(context.tracking->written_lsn),
-					 (long long) privateContext.counters.total,
-					 privateContext.counters.total > 0 ? "s" : "");
+					 (long long) privateContext->counters.total,
+					 privateContext->counters.total > 0 ? "s" : "");
 		}
 
 		/* sleep for one entire second before retrying */

--- a/src/bin/pgcopydb/ld_transform.c
+++ b/src/bin/pgcopydb/ld_transform.c
@@ -117,7 +117,7 @@ stream_transform_stream(StreamSpecs *specs)
 			return false;
 		}
 
-		/* reset the jsonFile FILE * pointer to NULL, it's closed now */
+		/* reset the sqlFile FILE * pointer to NULL, it's closed now */
 		privateContext->sqlFile = NULL;
 
 		log_notice("Closed file \"%s\"", privateContext->sqlFileName);
@@ -833,6 +833,9 @@ stream_transform_file(StreamSpecs *specs, char *jsonfilename, char *sqlfilename)
 		log_error("Failed to write file \"%s\"", tempfilename);
 		return false;
 	}
+
+	/* reset the sqlFile FILE * pointer to NULL, it's closed now */
+	privateContext->sqlFile = NULL;
 
 	log_debug("stream_transform_file: mv \"%s\" \"%s\"",
 			  tempfilename, sqlfilename);


### PR DESCRIPTION
When resuming operations from pre-existing files on-disk, we implement some cache invalidation by transforming the JSON file again from scratch, and tracking progress in our internal data structures.

That's needed in case the previous version of the file terminates in the middle of a transaction rather than at a clean transaction boundary.

The previous approach missed that the internal tracking state kept in the StreamContext instance was not shared. Now it is.

See #354.
See #348.
See #331.