### PR TITLE
Fix stream_transform_resume() cache invalidation of the SQL file.

### DIFF
--- a/src/bin/pgcopydb/ld_transform.c
+++ b/src/bin/pgcopydb/ld_transform.c
@@ -159,11 +159,13 @@ stream_transform_resume(StreamSpecs *specs)
 			   sqlFileName);
 
 	/*
-	 * If the target SQL file already exists on-disk, make sure to read the
-	 * JSON file again now. The previous round of streaming might have stopped
-	 * at an endpos that fits in the middle of a transaction.
+	 * If the JSON file already exists on-disk, make sure to read it file again
+	 * now. The previous round of streaming might have stopped at an endpos
+	 * that fits in the middle of a transaction.
+	 *
+	 * We can think about this as "cache invalidation" of the SQL file on-disk.
 	 */
-	if (file_exists(sqlFileName))
+	if (file_exists(jsonFileName))
 	{
 		if (!stream_transform_file(specs, jsonFileName, sqlFileName))
 		{


### PR DESCRIPTION
We probably should parse the JSON file as soon as it exists rather than only when a SQL file was already produced in the previous round.

See https://github.com/dimitri/pgcopydb/issues/354.
See https://github.com/dimitri/pgcopydb/pull/348.
See https://github.com/dimitri/pgcopydb/issues/331.
See #355.