### PR TITLE
Fix stream_apply_wait_for_sentinel() return value when interrupted.

### DIFF
--- a/src/bin/pgcopydb/follow.c
+++ b/src/bin/pgcopydb/follow.c
@@ -291,6 +291,12 @@ follow_main_loop(CopyDataSpec *copySpecs, StreamSpecs *streamSpecs)
 			return false;
 		}
 
+		if (asked_to_quit)
+		{
+			log_error("Main follow process received SIGQUIT, exiting");
+			return false;
+		}
+
 		bool done = false;
 
 		if (!follow_reached_endpos(streamSpecs, &done))

--- a/src/bin/pgcopydb/ld_stream.h
+++ b/src/bin/pgcopydb/ld_stream.h
@@ -588,6 +588,8 @@ bool parseWal2jsonMessage(StreamContext *privateContext,
 /* ld_apply.c */
 bool stream_apply_catchup(StreamSpecs *specs);
 
+bool stream_apply_setup(StreamSpecs *specs, StreamApplyContext *context);
+
 bool stream_apply_wait_for_sentinel(StreamSpecs *specs,
 									StreamApplyContext *context);
 


### PR DESCRIPTION
The return value should be about the success of the operation, not about the fact that the apply mode is enabled or disable: that information is tracked properly in the StreamApplyContext instance given as a parameter.