### PR TITLE
Fix skipping streaming messages when resuming from latest JSON file.

### DIFF
--- a/src/bin/pgcopydb/follow.c
+++ b/src/bin/pgcopydb/follow.c
@@ -572,6 +572,12 @@ follow_start_prefetch(StreamSpecs *specs)
 		close_fd_or_exit(specs->pipe_ta[1]);
 	}
 
+	if (!stream_cleanup_context(specs))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
 	bool success = startLogicalStreaming(specs);
 
 	close_fd_or_exit(specs->pipe_rt[1]);

--- a/src/bin/pgcopydb/ld_stream.c
+++ b/src/bin/pgcopydb/ld_stream.c
@@ -606,7 +606,7 @@ streamCheckResumePosition(StreamSpecs *specs)
 				 lineNb);
 
 		char *latestMessage = latestStreamedContent.lines[lineNb];
-		log_fatal("Last message read was: %s", latestMessage);
+		log_notice("Resume replication from latest message: %s", latestMessage);
 	}
 
 	bool flush = false;

--- a/src/bin/pgcopydb/ld_stream.h
+++ b/src/bin/pgcopydb/ld_stream.h
@@ -267,9 +267,10 @@ typedef struct StreamContext
 
 	uint64_t startpos;
 	uint64_t endpos;
+	bool apply;
 
 	bool startposComputedFromJSON;
-	bool apply;
+	StreamAction startposActionFromJSON;
 
 	bool stdIn;
 	bool stdOut;
@@ -391,6 +392,7 @@ struct StreamSpecs
 	uint64_t endpos;
 
 	bool startposComputedFromJSON;
+	StreamAction startposActionFromJSON;
 
 	LogicalStreamMode mode;
 


### PR DESCRIPTION
It might happen that several JSON messages have the same LSN in our stream, usually that concerns KEEPALIVE and BEGIN and COMMIT message. Unless paying attention to the latest message action, we could skip a BEGIN message that has the same LSN as the latest message even if that message was a KEEPALIVE.

Fix this by keeping around the latest message action. It should be all we need to distinguish a new message from the latest one.

See #354.