### PR TITLE
Refactor how ld_stream writes to PIPE stdout.

### DIFF
--- a/src/bin/pgcopydb/file_utils.h
+++ b/src/bin/pgcopydb/file_utils.h
@@ -58,6 +58,7 @@ bool move_file(char *sourcePath, char *destinationPath);
 bool duplicate_file(char *sourcePath, char *destinationPath);
 bool create_symbolic_link(char *sourcePath, char *targetPath);
 
+bool write_to_stream(FILE *stream, const char *buffer, size_t size);
 bool read_from_stream(FILE *stream, ReadFromStreamContext *context);
 
 void path_in_same_directory(const char *basePath,


### PR DESCRIPTION
Implement a retry loop in case the PIPE buffer is full or something else requires several write attempts before succeeding to write the whole buffer there.