### PR TITLE
Fix NULL connection string in: pgcopydb list schema.

### DIFF
--- a/src/bin/pgcopydb/copydb_schema.c
+++ b/src/bin/pgcopydb/copydb_schema.c
@@ -983,6 +983,12 @@ copydb_prepare_target_catalog(CopyDataSpec *specs)
 {
 	PGSQL dst = { 0 };
 
+	if (specs->connStrings.target_pguri == NULL)
+	{
+		log_notice("Skipping target catalog preparation");
+		return true;
+	}
+
 	if (!pgsql_init(&dst, specs->connStrings.target_pguri, PGSQL_CONN_SOURCE))
 	{
 		/* errors have already been logged */

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -2607,15 +2607,14 @@ getSequenceValue(void *ctx, PGresult *result)
 	}
 
 	/* 2. is_called */
-	value = PQgetvalue(result, 0, 1);
-
-	if (value == NULL || ((*value != 't') && (*value != 'f')))
+	if (PQgetisnull(result, 0, 1))
 	{
-		log_error("Invalid is_called value \"%s\"", value);
+		log_error("Invalid sequence is_called value: NULL");
 		++errors;
 	}
 	else
 	{
+		value = PQgetvalue(result, 0, 1);
 		context->isCalled = (*value) == 't';
 	}
 


### PR DESCRIPTION
The list command does not use a --target connection string, so we skip preparing the target catalogs in that case. In passing, also fix a strange way that PQgetisnull() was done for sequences, as the misleading error meant this code got a free round of review.