### PR TITLE
The cli_stream module didn't get the pg_strdup() memo for DSNs.

### DIFF
--- a/src/bin/pgcopydb/cli_stream.c
+++ b/src/bin/pgcopydb/cli_stream.c
@@ -245,7 +245,7 @@ cli_stream_getopts(int argc, char **argv)
 							  "see above for details.");
 					++errors;
 				}
-				strlcpy(options.connStrings.source_pguri, optarg, MAXCONNINFO);
+				options.connStrings.source_pguri = pg_strdup(optarg);
 				log_trace("--source %s", options.connStrings.source_pguri);
 				break;
 			}
@@ -258,7 +258,7 @@ cli_stream_getopts(int argc, char **argv)
 							  "see above for details.");
 					++errors;
 				}
-				strlcpy(options.connStrings.target_pguri, optarg, MAXCONNINFO);
+				options.connStrings.target_pguri = pg_strdup(optarg);
 				log_trace("--target %s", options.connStrings.target_pguri);
 				break;
 			}


### PR DESCRIPTION
The connection strings are now dynamically allocated but cli_stream somehow didn't get the memo so far.

See #323.
Fixes #360.