### PR TITLE
Add facilities to list extension versions.

### DIFF
--- a/docs/ref/pgcopydb_list.rst
+++ b/docs/ref/pgcopydb_list.rst
@@ -56,7 +56,16 @@ extensions to COPY to the target database.
    pgcopydb list extensions: List all the source extensions to copy
    usage: pgcopydb list extensions  --source ...
 
-     --source            Postgres URI to the source database
+     --source               Postgres URI to the source database
+     --json                 Format the output using JSON
+     --available-extensions List available extension versions
+     --requirements         List extensions requirements
+
+The command ``pgcopydb list extensions --available-extensions`` is typically
+used with the target database. If you're using the connection string
+environment variables, that looks like the following::
+
+  $ pgcopydb list extensions --available-extensions --source ${PGCOPYDB_TARGET_PGURI}
 
 .. _pgcopydb_list_collations:
 

--- a/src/bin/pgcopydb/cli_list.h
+++ b/src/bin/pgcopydb/cli_list.h
@@ -30,6 +30,8 @@ typedef struct ListDBOptions
 	bool cache;
 	bool dropCache;
 	bool summary;
+	bool availableVersions;
+	bool requirements;
 
 	SplitTableLargerThan splitTablesLargerThan;
 } ListDBOptions;

--- a/src/bin/pgcopydb/schema.h
+++ b/src/bin/pgcopydb/schema.h
@@ -8,6 +8,7 @@
 
 #include <stdbool.h>
 
+#include "parson.h"
 #include "uthash.h"
 
 #include "filtering.h"
@@ -88,6 +89,20 @@ typedef struct SourceExtensionArray
 	SourceExtension *array;         /* malloc'ed area */
 } SourceExtensionArray;
 
+
+typedef struct ExtensionsVersions
+{
+	char name[NAMEDATALEN];
+	char defaultVersion[BUFSIZE];
+	char installedVersion[BUFSIZE];
+	JSON_Value *json;           /* malloc'ed area */
+} ExtensionsVersions;
+
+typedef struct ExtensionsVersionsArray
+{
+	int count;
+	ExtensionsVersions *array;  /* malloc'ed area */
+} ExtensionsVersionsArray;
 
 typedef struct SourceCollation
 {
@@ -303,6 +318,8 @@ bool schema_list_schemas(PGSQL *pgsql, SourceSchemaArray *array);
 bool schema_list_ext_schemas(PGSQL *pgsql, SourceSchemaArray *array);
 
 bool schema_list_extensions(PGSQL *pgsql, SourceExtensionArray *extArray);
+
+bool schema_list_ext_versions(PGSQL *pgsql, ExtensionsVersionsArray *array);
 
 bool schema_list_collations(PGSQL *pgsql, SourceCollationArray *array);
 


### PR DESCRIPTION
The new commands allow listing extension versions in different ways and formats (human-friendly table, JSON):

    $ pgcopydb list extensions --available-versions
    $ pgcopydb list extensions --requirements

The idea is to prepare for a feature where the extension versions to install on the target database can be provided by the user. To prepare for that, the new commands allow listing available extension versions on the target database and preparing the current requirements file from the extensions available on the target and their default version.