### PR TITLE
The cli_stream module didn't get the pg_strdup() memo for DSNs.

### DIFF
--- a/src/bin/pgcopydb/cli_sentinel.c
+++ b/src/bin/pgcopydb/cli_sentinel.c
@@ -172,7 +172,7 @@ cli_sentinel_getopts(int argc, char **argv)
 							  "see above for details.");
 					exit(EXIT_CODE_BAD_ARGS);
 				}
-				strlcpy(options.connStrings.source_pguri, optarg, MAXCONNINFO);
+				options.connStrings.source_pguri = pg_strdup(optarg);
 				log_trace("--source %s", options.connStrings.source_pguri);
 				break;
 			}


### PR DESCRIPTION
See #323.
Fixes #377.