### PR TITLE
Assorted fixes for the test_decoding parser.

### DIFF
--- a/tests/follow-data-only/copydb.sh
+++ b/tests/follow-data-only/copydb.sh
@@ -29,7 +29,7 @@ BACKGROUND_TRAFFIC_PID=$!
 sleep 2
 
 # grab a snapshot on the source database
-coproc ( pgcopydb snapshot --follow --plugin wal2json --notice )
+coproc ( pgcopydb snapshot --follow --plugin test_decoding --notice )
 
 sleep 2
 

--- a/tests/follow-data-only/ddl.sql
+++ b/tests/follow-data-only/ddl.sql
@@ -6,5 +6,6 @@
 begin;
 
 CREATE TABLE table_a (id serial PRIMARY KEY, f1 int4, f2 text);
+CREATE TABLE table_b (id serial PRIMARY KEY, f1 int4, f2 text[]);
 
 commit;

--- a/tests/follow-data-only/dml.sql
+++ b/tests/follow-data-only/dml.sql
@@ -5,3 +5,8 @@ INSERT INTO table_a (f1, f2)
                    E'test \rreturn',
                    E'test ''single'' quote'])[(x - 1) % 4 + 1]
        FROM generate_series(:a,:b) as t(x);
+
+INSERT INTO table_b(f1, f2)
+    SELECT x, (regexp_split_to_array(lorem.ipsum, '[ ,.]'))[x:x+5]
+      FROM (values('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.')) as lorem(ipsum),
+           generate_series(:a,:b) as t(x);


### PR DESCRIPTION
First, Postgres type names might contain square brackets (arrays), which are used as a delimited in the test_decoding format for typenames. Fix the code to handle the following properly:

    f2[text[]]:'{incididunt,ut,labore,et,dolore,magna}'

Then, it turns out that test_decoding emits text in standard SQL form, which is to say in single-quotes and with single-quotes doubled, but with the \n and other characters not-escaped. We need to edit the representation a little so that the ld_transform module processes the text correctly.

Fixes #376 