### PR TITLE
Fix a couple bugs in pgcopydb clone --follow.

### DIFF
--- a/src/bin/pgcopydb/cli_clone_follow.c
+++ b/src/bin/pgcopydb/cli_clone_follow.c
@@ -215,6 +215,23 @@ clone_and_follow(CopyDataSpec *copySpecs)
 	}
 
 	/*
+	 * When using pgcopydb clone --follow --restart we first cleanup the
+	 * previous setup, and that includes dropping the replication slot.
+	 */
+	if (copySpecs->restart)
+	{
+		log_info("Clean-up replication setup, per --restart");
+
+		if (!stream_cleanup_databases(copySpecs,
+									  copyDBoptions.slot.slotName,
+									  copyDBoptions.origin))
+		{
+			/* errors have already been logged */
+			exit(EXIT_CODE_INTERNAL_ERROR);
+		}
+	}
+
+	/*
 	 * First create/export a snapshot for the whole clone --follow operations.
 	 */
 	if (!follow_export_snapshot(copySpecs, &streamSpecs))

--- a/src/bin/pgcopydb/follow.c
+++ b/src/bin/pgcopydb/follow.c
@@ -107,8 +107,6 @@ follow_reset_sequences(CopyDataSpec *copySpecs, StreamSpecs *streamSpecs)
 	/* copy our structure wholesale */
 	seqSpecs = *copySpecs;
 
-	log_info("follow_reset_sequences: %s", seqSpecs.connStrings.source_pguri);
-
 	/* then force some options such as --resume --not-consistent */
 	seqSpecs.restart = false;
 	seqSpecs.resume = true;
@@ -337,6 +335,12 @@ follow_main_loop(CopyDataSpec *copySpecs, StreamSpecs *streamSpecs)
 		{
 			/* errors have already been logged */
 			return false;
+		}
+
+		if (asked_to_stop || asked_to_stop_fast || asked_to_quit)
+		{
+			log_warn("Main follow process was asked to terminate, exiting");
+			return true;
 		}
 
 		if (done)

--- a/src/bin/pgcopydb/ld_apply.c
+++ b/src/bin/pgcopydb/ld_apply.c
@@ -175,7 +175,7 @@ stream_apply_setup(StreamSpecs *specs, StreamApplyContext *context)
 
 	if (!context->apply)
 	{
-		log_error("Apply mode is still disabled, quitting now");
+		log_notice("Apply mode is still disabled, quitting now");
 		return true;
 	}
 


### PR DESCRIPTION
First, when interrupting the pgcopydb process interactively with C-c while the transform process is running, we should exit the follow loop cleanup.

Second, when using pgcopydb clone --follow --restart we should do a replication setup cleanup first, the same as the pgcopydb stream cleanup command, so that we can actually restart from scratch as the command says.