### PR TITLE
Fix issue with resuming streaming of interleaved transactions.

### DIFF
--- a/src/bin/pgcopydb/ld_stream.h
+++ b/src/bin/pgcopydb/ld_stream.h
@@ -269,7 +269,7 @@ typedef struct StreamContext
 	uint64_t endpos;
 	bool apply;
 
-	bool startposComputedFromJSON;
+	bool reachedStartPos;
 	StreamAction startposActionFromJSON;
 
 	bool stdIn;


### PR DESCRIPTION
This resolves a problem encountered during the transition from prefetch to replay mode, where the transform process identifies some incomplete transactions. This issue also arises when we interrupt 'follow' and execute a 'follow --resume'.

The root cause is upon resumption of streaming, we may encounter a transaction where the initial messages have LSNs less than the startpos calculated from the latest json file.

The implemented fix involves comparing the LSNs with 'startpos' only when resuming streaming of partially complete transactions. Once 'startpos' is reached, comparison of LSNs for subsequent messages is discontinued.

Fixes: #373