### PR TITLE
Fix sequences dependencies tracking.

### DIFF
--- a/src/bin/pgcopydb/cli_list.c
+++ b/src/bin/pgcopydb/cli_list.c
@@ -1278,21 +1278,26 @@ cli_list_sequences(int argc, char **argv)
 
 	log_info("Fetched information for %d sequences", sequenceArray.count);
 
-	fformat(stdout, "%8s | %20s | %30s | %10s \n",
-			"OID", "Schema Name", "Sequence Name", "attroid");
+	fformat(stdout, "%8s | %20s | %30s | %10s | %10s | %10s \n",
+			"OID", "Schema Name", "Sequence Name",
+			"Owned By", "attrelid", "attroid");
 
-	fformat(stdout, "%8s-+-%20s-+-%30s-+-%10s\n",
+	fformat(stdout, "%8s-+-%20s-+-%30s-+-%10s-+-%10s-+-%10s\n",
 			"--------",
 			"--------------------",
 			"------------------------------",
+			"----------",
+			"----------",
 			"----------");
 
 	for (int i = 0; i < sequenceArray.count; i++)
 	{
-		fformat(stdout, "%8d | %20s | %30s | %10d\n",
+		fformat(stdout, "%8d | %20s | %30s | %10d | %10d | %10d\n",
 				sequenceArray.array[i].oid,
 				sequenceArray.array[i].nspname,
 				sequenceArray.array[i].relname,
+				sequenceArray.array[i].ownedby,
+				sequenceArray.array[i].attrelid,
 				sequenceArray.array[i].attroid);
 	}
 

--- a/src/bin/pgcopydb/schema.h
+++ b/src/bin/pgcopydb/schema.h
@@ -200,13 +200,19 @@ typedef struct SourceTableArray
 typedef struct SourceSequence
 {
 	uint32_t oid;
-	uint32_t attroid;           /* pg_attrdef default value OID */
+	uint32_t ownedby;           /* pg_class oid of OWNED BY table */
+	uint32_t attrelid;          /* pg_class oid of table using as DEFAULT */
+	uint32_t attroid;           /* pg_attrdef DEFAULT value OID */
+
+	char qname[NAMEDATALEN * 2 + 5 + 1];
 	char nspname[NAMEDATALEN];
 	char relname[NAMEDATALEN];
 	int64_t lastValue;
 	bool isCalled;
 
 	char restoreListName[RESTORE_LIST_NAMEDATALEN];
+
+	UT_hash_handle hh;          /* makes this structure hashable */
 } SourceSequence;
 
 
@@ -297,6 +303,7 @@ typedef struct SourceCatalog
 	SourceTable *sourceTableHashByOid;
 	SourceTable *sourceTableHashByQName;
 	SourceIndex *sourceIndexHashByOid;
+	SourceSequence *sourceSeqHashByOid;
 } SourceCatalog;
 
 

--- a/tests/filtering/copydb.sh
+++ b/tests/filtering/copydb.sh
@@ -37,6 +37,10 @@ pgcopydb clone --filters /usr/src/pgcopydb/exclude.ini
 # now another migration with the "include-only" parts of the data
 pgcopydb clone --filters /usr/src/pgcopydb/include.ini --restart
 
+# print out the definition of the copy.foo table
+psql -d ${PGCOPYDB_SOURCE_PGURI} -c '\d app|copy.foo'
+psql -d ${PGCOPYDB_TARGET_PGURI} -c '\d app|copy.foo'
+
 # now compare the output of running the SQL command with what's expected
 # as we're not root when running tests, can't write in /usr/src
 mkdir -p /tmp/results
@@ -52,5 +56,6 @@ do
     e=./expected/${t}.out
     psql -d "${PGCOPYDB_TARGET_PGURI}" ${pgopts} --file ./sql/$t.sql &> $r
     test -f $e || cat $r
+    diff $e $r || cat $r
     diff $e $r || exit 1
 done

--- a/tests/filtering/exclude.ini
+++ b/tests/filtering/exclude.ini
@@ -11,3 +11,4 @@ bar
 # public.language
 # public.rental
 foo.test_tbl_2
+app.foo

--- a/tests/filtering/expected/3-schema-bar-does-not-exists.out
+++ b/tests/filtering/expected/3-schema-bar-does-not-exists.out
@@ -1,5 +1,9 @@
 -[ RECORD 1 ]---
 nspname | public
 -[ RECORD 2 ]---
+nspname | app
+-[ RECORD 3 ]---
+nspname | copy
+-[ RECORD 4 ]---
 nspname | foo
 

--- a/tests/filtering/extra.sql
+++ b/tests/filtering/extra.sql
@@ -41,3 +41,13 @@ create index if not exists tbl2_tbl1_id_idx on foo.tbl2(tbl1_id);
 -- And another schema that we exclude wholesale.
 --
 create schema bar;
+
+
+--
+-- See https://github.com/dimitri/pgcopydb/issues/390
+--
+create schema app;
+create schema copy;
+
+create table app.foo(id bigserial, f1 text);
+create table copy.foo(like app.foo including all);


### PR DESCRIPTION
A single sequence could be used by more than one table/column thanks to calling the nextval() function in the default value definition of the column. That said, a sequence is OWNED BY a single table.

In this patch we fix the case where the table that owns the sequence is filtered out from the pgcopydb scope while another table that uses the same sequence is to be copied over... with the sequence, then.

A simple way to create the situation is using the following DDL:

    create table app.foo(id bigserial, f1 text);
    create table copy.foo(like app.foo including all);

And then filter-out schema app from pgcopydb scope.

Fixes #390.