### PR TITLE
Implement extension requirements support.

### DIFF
--- a/docs/ref/pgcopydb_clone.rst
+++ b/docs/ref/pgcopydb_clone.rst
@@ -42,6 +42,7 @@ Postgres instance to the target Postgres instance.
      --skip-ext-comments        Skip restoring COMMENT ON EXTENSION
      --skip-collations          Skip restoring collations
      --skip-vacuum              Skip running VACUUM ANALYZE
+     --requirements <filename>  List extensions requirements
      --filters <filename>       Use the filters defined in <filename>
      --fail-fast                Abort early in case of error
      --restart                  Allow restarting when temp files exist already
@@ -495,6 +496,21 @@ The following options are available to ``pgcopydb clone``:
 
   Skip copying COMMENT ON EXTENSION commands. This is implicit when using
   --skip-extensions.
+
+--requirements <filename>
+
+  This option allows to specify which version of an extension to install on
+  the target database. The given filename is expected to be a JSON file, and
+  the JSON contents must be an array of objects with the keys ``"name"`` and
+  ``"version"``.
+
+  The command ``pgcopydb list extension --requirements --json`` produces
+  such a JSON file and can be used on the target database instance to get
+  started.
+
+  See also the command ``pgcopydb list extension --available-versions``.
+
+  See also :ref:`pgcopydb_list_extensions`.
 
 --skip-collations
 

--- a/docs/ref/pgcopydb_list.rst
+++ b/docs/ref/pgcopydb_list.rst
@@ -56,16 +56,16 @@ extensions to COPY to the target database.
    pgcopydb list extensions: List all the source extensions to copy
    usage: pgcopydb list extensions  --source ...
 
-     --source               Postgres URI to the source database
-     --json                 Format the output using JSON
-     --available-extensions List available extension versions
-     --requirements         List extensions requirements
+     --source              Postgres URI to the source database
+     --json                Format the output using JSON
+     --available-versions  List available extension versions
+     --requirements        List extensions requirements
 
-The command ``pgcopydb list extensions --available-extensions`` is typically
+The command ``pgcopydb list extensions --available-versions`` is typically
 used with the target database. If you're using the connection string
 environment variables, that looks like the following::
 
-  $ pgcopydb list extensions --available-extensions --source ${PGCOPYDB_TARGET_PGURI}
+  $ pgcopydb list extensions --available-versions --source ${PGCOPYDB_TARGET_PGURI}
 
 .. _pgcopydb_list_collations:
 

--- a/src/bin/pgcopydb/cli_clone_follow.c
+++ b/src/bin/pgcopydb/cli_clone_follow.c
@@ -41,6 +41,7 @@
 	"  --skip-ext-comments        Skip restoring COMMENT ON EXTENSION\n" \
 	"  --skip-collations          Skip restoring collations\n" \
 	"  --skip-vacuum              Skip running VACUUM ANALYZE\n" \
+	"  --requirements <filename>  List extensions requirements\n" \
 	"  --filters <filename>       Use the filters defined in <filename>\n" \
 	"  --fail-fast                Abort early in case of error\n" \
 	"  --restart                  Allow restarting when temp files exist already\n" \

--- a/src/bin/pgcopydb/cli_common.h
+++ b/src/bin/pgcopydb/cli_common.h
@@ -68,6 +68,7 @@ typedef struct CopyDBOptions
 	uint64_t startpos;
 
 	char filterFileName[MAXPGPATH];
+	char requirementsFileName[MAXPGPATH];
 } CopyDBOptions;
 
 extern bool outputJSON;

--- a/src/bin/pgcopydb/cli_copy.c
+++ b/src/bin/pgcopydb/cli_copy.c
@@ -89,7 +89,8 @@ static CommandLine copy_extensions_command =
 		" --source ... --target ... ",
 		"  --source              Postgres URI to the source database\n"
 		"  --target              Postgres URI to the target database\n"
-		"  --dir                 Work directory to use\n",
+		"  --dir                 Work directory to use\n"
+		"  --requirements        List extensions requirements\n",
 		cli_copy_db_getopts,
 		cli_copy_extensions);
 

--- a/src/bin/pgcopydb/cli_list.c
+++ b/src/bin/pgcopydb/cli_list.c
@@ -56,10 +56,10 @@ static CommandLine list_extensions_command =
 		"extensions",
 		"List all the source extensions to copy",
 		" --source ... ",
-		"  --source               Postgres URI to the source database\n"
-		"  --json                 Format the output using JSON\n"
-		"  --available-extensions List available extension versions\n"
-		"  --requirements         List extensions requirements\n",
+		"  --source              Postgres URI to the source database\n"
+		"  --json                Format the output using JSON\n"
+		"  --available-versions  List available extension versions\n"
+		"  --requirements        List extensions requirements\n",
 		cli_list_db_getopts,
 		cli_list_extensions);
 

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -211,6 +211,18 @@ typedef struct SourceFilterItem
 } SourceFilterItem;
 
 
+/*
+ * Extensions versions to install on the target can be specified by the user.
+ */
+typedef struct ExtensionReqs
+{
+	char extname[NAMEDATALEN];
+	char version[BUFSIZE];
+
+	UT_hash_handle hh;          /* makes this structure hashable */
+} ExtensionReqs;
+
+
 /* all that's needed to start a TABLE DATA copy for a whole database */
 typedef struct CopyDataSpec
 {
@@ -221,6 +233,8 @@ typedef struct CopyDataSpec
 	SourceFilters filters;
 	SourceFilterItem *hOid;     /* hash table of objects, by Oid */
 	SourceFilterItem *hName;    /* hash table of objects, by pg_restore name */
+
+	ExtensionReqs *extRequirements;
 
 	ConnStrings connStrings;
 	TransactionSnapshot sourceSnapshot;
@@ -355,6 +369,9 @@ bool snapshot_read_slot(const char *filename, ReplicationSlot *slot);
 /* extensions.c */
 bool copydb_start_extension_data_process(CopyDataSpec *specs);
 bool copydb_copy_extensions(CopyDataSpec *copySpecs, bool createExtensions);
+
+bool copydb_parse_extensions_requirements(CopyDataSpec *copySpecs,
+										  char *filename);
 
 /* indexes.c */
 

--- a/tests/extensions/copydb.sh
+++ b/tests/extensions/copydb.sh
@@ -60,9 +60,21 @@ sleep 1
 # copy the extensions separately, needs superuser (both on source and target)
 pgcopydb list extensions
 
+# now get the extension versions requirements from the target server
+e=/tmp/extensions.json
+r=/tmp/requirements.json
+
+pgcopydb list extensions --source ${PGCOPYDB_TARGET_PGURI} --requirements --json > ${e}
+
+jq 'map(select(.name == "postgis" or .name == "address_standardizer" or .name == "address_standardizer_data_us" or .name == "postgis_tiger_geocoder" or .name == "postgis_topology"))' < ${e} > ${r}
+
+cat ${r}
+
 pgcopydb copy extensions \
          --source ${PGCOPYDB_SOURCE_PGURI_SU} \
-         --target ${PGCOPYDB_TARGET_PGURI_SU}
+         --target ${PGCOPYDB_TARGET_PGURI_SU} \
+         --requirements ${r} \
+         --notice
 
 # now clone without superuser privileges (using role pagila on source and target)
 pgcopydb clone --skip-extensions


### PR DESCRIPTION
This option allows specifying which version of an extension to install on the target database. The version might be different from the version on the source, and in some cases installing the default version of an extension is not desired. Examples are PostGIS v2 and v3 series, for instance.

A requirement file in JSON can be given to pgcopydb commands. The JSON file should be an array of objects with the "name" and "version" keys, and can be given to either of these commands:

    pgcopydb copy extensions --requirements requirements.json
    pgcopydb clone ... --requirements requirements.json

To list the available extension versions on the target database use the following commands:

    pgcopydb list extension --available-versions
    pgcopydb list extension --available-versions --json

    pgcopydb list extension --requirements
    pgcopydb list extension --requirements --json

The last command will output all the extensions available on the target database with their default version. It's then possible to edit the output file and change the version numbers before giving it back to the copy and clone commands.