### PR TITLE
Implement the new filter "include-only-schema".

### DIFF
--- a/docs/ref/pgcopydb_config.rst
+++ b/docs/ref/pgcopydb_config.rst
@@ -88,6 +88,18 @@ going to be ignored by the pgcopydb command.
 This section is not allowed when the section ``include-only-table`` is
 used.
 
+include-only-schema
+^^^^^^^^^^^^^^^^^^^
+
+This section allows editing schema (Postgres namespaces) to the exclusion
+filters by listing the schema that are not going to be excluded. This is a
+syntaxic sugar facility that helps with entering a long list of schemas to
+exclude when a single schema is to be selected.
+
+Despite the name, this section is an exclusion filter.
+
+This section is not allowed when the section ``exclude-schema`` is used.
+
 exclude-table
 ^^^^^^^^^^^^^
 

--- a/src/bin/pgcopydb/filtering.h
+++ b/src/bin/pgcopydb/filtering.h
@@ -16,7 +16,9 @@
 
 typedef enum
 {
-	SOURCE_FILTER_EXCLUDE_SCHEMA = 0,
+	SOURCE_FILTER_UNKNOWN = 0,
+	SOURCE_FILTER_INCLUDE_ONLY_SCHEMA,
+	SOURCE_FILTER_EXCLUDE_SCHEMA,
 	SOURCE_FILTER_EXCLUDE_TABLE,
 	SOURCE_FILTER_EXCLUDE_TABLE_DATA,
 	SOURCE_FILTER_EXCLUDE_INDEX,
@@ -85,6 +87,7 @@ typedef struct SourceFilters
 {
 	bool prepared;
 	SourceFilterType type;
+	SourceFilterSchemaList includeOnlySchemaList;
 	SourceFilterSchemaList excludeSchemaList;
 	SourceFilterTableList includeOnlyTableList;
 	SourceFilterTableList excludeTableList;

--- a/src/bin/pgcopydb/pgcmd.h
+++ b/src/bin/pgcopydb/pgcmd.h
@@ -20,6 +20,7 @@
 #include "pgsql.h"
 #include "schema.h"
 
+#define PG_CMD_MAX_ARG 128
 #define PG_VERSION_STRING_MAX 12
 
 typedef struct PostgresPaths

--- a/src/bin/pgcopydb/progress.c
+++ b/src/bin/pgcopydb/progress.c
@@ -195,6 +195,22 @@ copydb_filtering_as_json(CopyDataSpec *copySpecs,
 						   "type",
 						   filterTypeToString(filters->type));
 
+	/* include-only-schema */
+	if (filters->includeOnlySchemaList.count > 0)
+	{
+		JSON_Value *jsSchema = json_value_init_array();
+		JSON_Array *jsSchemaArray = json_value_get_array(jsSchema);
+
+		for (int i = 0; i < filters->includeOnlySchemaList.count; i++)
+		{
+			char *nspname = filters->includeOnlySchemaList.array[i].nspname;
+
+			json_array_append_string(jsSchemaArray, nspname);
+		}
+
+		json_object_set_value(jsFilterObj, "include-only-schema", jsSchema);
+	}
+
 	/* exclude-schema */
 	if (filters->excludeSchemaList.count > 0)
 	{

--- a/tests/filtering/copydb.sh
+++ b/tests/filtering/copydb.sh
@@ -20,16 +20,16 @@ psql -o /tmp/e.out -d ${PGCOPYDB_SOURCE_PGURI} -1 -f /usr/src/pgcopydb/extra.sql
 # list the exclude filters now, and the computed dependencies
 cat /usr/src/pgcopydb/exclude.ini
 
-# list the dependencies of objects that are selected by the filters
-pgcopydb list depends --filters /usr/src/pgcopydb/exclude.ini
+# list the tables that are (not) selected by the filters
+pgcopydb list tables --filters /usr/src/pgcopydb/exclude.ini
+pgcopydb list tables --filters /usr/src/pgcopydb/exclude.ini --list-skipped
 
-# list the dependencies of objects that are NOT selected by the filters
+# list the dependencies of objects that are (not) selected by the filters
+pgcopydb list depends --filters /usr/src/pgcopydb/exclude.ini
 pgcopydb list depends --filters /usr/src/pgcopydb/exclude.ini --list-skipped
 
-# list the sequences that are selected
+# list the sequences that are (not) selected by the filters
 pgcopydb list sequences --filters /usr/src/pgcopydb/exclude.ini
-
-# list the sequences that are NOT selected
 pgcopydb list sequences --filters /usr/src/pgcopydb/exclude.ini --list-skipped
 
 pgcopydb clone --filters /usr/src/pgcopydb/exclude.ini

--- a/tests/filtering/include.ini
+++ b/tests/filtering/include.ini
@@ -1,6 +1,5 @@
-[exclude-schema]
-foo
-bar
+[include-only-schema]
+public
 
 [include-only-table]
 public.actor


### PR DESCRIPTION
Despite the name, this filter is an exclusion filter and works exactly the same as the existing "exclude-schema" filter. The new facility is syntactic sugar and allows listing schemas to keep around, which is useful when keeping a single schema and excluding the rest of them.

Fixes #167.
Fixes #218.