### PR TITLE
pgcopydb compare schema|data

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -114,6 +114,13 @@ man_pages = [
         1,
     ),
     (
+        "ref/pgcopydb_compare",
+        "pgcopydb compare",
+        "pgcopydb compare",
+        [author],
+        1,
+    ),
+    (
         "ref/pgcopydb_copy",
         "pgcopydb copy",
         "pgcopydb copy",

--- a/docs/ref/manual.rst
+++ b/docs/ref/manual.rst
@@ -14,6 +14,7 @@ their own manual page.
    pgcopydb_clone
    pgcopydb_follow
    pgcopydb_snapshot
+   pgcopydb_compare
    pgcopydb_copy
    pgcopydb_dump
    pgcopydb_restore

--- a/docs/ref/pgcopydb_compare.rst
+++ b/docs/ref/pgcopydb_compare.rst
@@ -1,0 +1,254 @@
+.. _pgcopydb_compare:
+
+pgcopydb compare
+=================
+
+pgcopydb compare - Compare source and target databases
+
+The command ``pgcopydb compare`` connects to the source and target databases
+and executes SQL queries to get Postgres catalog information about the
+table, indexes and sequences that are migrated.
+
+The tool then compares either the schema definitions or the data contents of
+the selected tables, and report success by means of an Unix return code of
+zero.
+
+At the moment, the ``pgcopydb compare`` tool is pretty limited in terms of
+schema support: it only covers what pgcopydb needs to know about the
+database schema, which isn't much.
+
+::
+
+   pgcopydb compare: Compare source and target databases
+
+   Available commands:
+     pgcopydb compare
+       schema  Compare source and target schema
+       data    Compare source and target data
+
+.. _pgcopydb_compare_schema:
+
+pgcopydb compare schema
+-----------------------
+
+pgcopydb compare schema - Compare source and target schema
+
+The command ``pgcopydb compare schema`` connects to the source and target
+databases and executes SQL queries using the Postgres catalogs to get a list
+of tables, indexes, constraints and sequences there.
+
+::
+
+   pgcopydb compare schema: Compare source and target schema
+   usage: pgcopydb compare schema  --source ...
+
+     --source         Postgres URI to the source database
+     --target         Postgres URI to the target database
+     --dir            Work directory to use
+
+
+.. _pgcopydb_compare_data:
+
+pgcopydb compare data
+---------------------
+
+pgcopydb compare data - Compare source and target data
+
+The command ``pgcopydb compare data`` connects to the source and target
+databases and executes SQL queries using the Postgres catalogs to get a list
+of tables, indexes, constraints and sequences there.
+
+Then it uses a SQL query with the following template to compute the row
+count and a checksum for each table::
+
+  select count(1) as cnt,
+         sum(hashtext(_COLS_::text)::bigint) as chksum
+     from only _TABLE_
+
+Running such a query on a large table can take a lot of time.
+
+::
+
+   pgcopydb compare data: Compare source and target data
+   usage: pgcopydb compare data  --source ...
+
+     --source         Postgres URI to the source database
+     --target         Postgres URI to the target database
+     --dir            Work directory to use
+
+
+Options
+-------
+
+The following options are available to ``pgcopydb create`` and ``pgcopydb
+drop`` subcommands:
+
+--source
+
+  Connection string to the source Postgres instance. See the Postgres
+  documentation for `connection strings`__ for the details. In short both
+  the quoted form ``"host=... dbname=..."`` and the URI form
+  ``postgres://user@host:5432/dbname`` are supported.
+
+  __ https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
+
+--target
+
+  Connection string to the target Postgres instance.
+
+--dir
+
+  During its normal operations pgcopydb creates a lot of temporary files to
+  track sub-processes progress. Temporary files are created in the directory
+  location given by this option, or defaults to
+  ``${TMPDIR}/pgcopydb`` when the environment variable is set, or
+  then to ``/tmp/pgcopydb``.
+
+--verbose
+
+  Increase current verbosity. The default level of verbosity is INFO. In
+  ascending order pgcopydb knows about the following verbosity levels:
+  FATAL, ERROR, WARN, INFO, NOTICE, DEBUG, TRACE.
+
+--debug
+
+  Set current verbosity to DEBUG level.
+
+--trace
+
+  Set current verbosity to TRACE level.
+
+--quiet
+
+  Set current verbosity to ERROR level.
+
+Environment
+-----------
+
+PGCOPYDB_SOURCE_PGURI
+
+  Connection string to the source Postgres instance. When ``--source`` is
+  ommitted from the command line, then this environment variable is used.
+
+PGCOPYDB_TARGET_PGURI
+
+  Connection string to the target Postgres instance. When ``--target`` is
+  ommitted from the command line, then this environment variable is used.
+
+Examples
+--------
+
+Comparing pgcopydb limited understanding of the schema:
+
+::
+
+   $ pgcopydb compare schema --notice
+   15:08:47 24072 INFO   Running pgcopydb version 0.12.28.g34343c8.dirty from "/Users/dim/dev/PostgreSQL/pgcopydb/src/bin/pgcopydb/pgcopydb"
+   15:08:47 24072 NOTICE Using work dir "/var/folders/d7/zzxmgs9s16gdxxcm0hs0sssw0000gn/T//pgcopydb"
+   15:08:47 24072 NOTICE Work directory "/var/folders/d7/zzxmgs9s16gdxxcm0hs0sssw0000gn/T//pgcopydb" already exists
+   15:08:47 24072 INFO   A previous run has run through completion
+   15:08:47 24072 INFO   SOURCE: Connecting to "postgres:///pagila"
+   15:08:47 24072 INFO   Fetched information for 1 extensions
+   15:08:47 24072 INFO   Fetched information for 25 tables, with an estimated total of 5179  tuples and 190 MB
+   15:08:48 24072 INFO   Fetched information for 49 indexes
+   15:08:48 24072 INFO   Fetching information for 16 sequences
+   15:08:48 24072 NOTICE Skipping target catalog preparation
+   15:08:48 24072 NOTICE Storing migration schema in JSON file "/var/folders/d7/zzxmgs9s16gdxxcm0hs0sssw0000gn/T//pgcopydb/compare/source-schema.json"
+   15:08:48 24072 INFO   TARGET: Connecting to "postgres:///plop"
+   15:08:48 24072 INFO   Fetched information for 6 extensions
+   15:08:48 24072 INFO   Fetched information for 25 tables, with an estimated total of 5219  tuples and 190 MB
+   15:08:48 24072 INFO   Fetched information for 49 indexes
+   15:08:48 24072 INFO   Fetching information for 16 sequences
+   15:08:48 24072 NOTICE Skipping target catalog preparation
+   15:08:48 24072 NOTICE Storing migration schema in JSON file "/var/folders/d7/zzxmgs9s16gdxxcm0hs0sssw0000gn/T//pgcopydb/compare/target-schema.json"
+   15:08:48 24072 INFO   [SOURCE] table: 25 index: 49 sequence: 16
+   15:08:48 24072 INFO   [TARGET] table: 25 index: 49 sequence: 16
+   15:08:48 24072 NOTICE Matched table "public"."test": 1 columns ok, 0 indexes ok
+   15:08:48 24072 NOTICE Matched table "public"."rental": 7 columns ok, 3 indexes ok
+   15:08:48 24072 NOTICE Matched table "public"."film": 14 columns ok, 5 indexes ok
+   15:08:48 24072 NOTICE Matched table "public"."film_actor": 3 columns ok, 2 indexes ok
+   15:08:48 24072 NOTICE Matched table "public"."inventory": 4 columns ok, 2 indexes ok
+   15:08:48 24072 NOTICE Matched table "public"."payment_p2022_03": 6 columns ok, 3 indexes ok
+   15:08:48 24072 NOTICE Matched table "public"."payment_p2022_05": 6 columns ok, 3 indexes ok
+   15:08:48 24072 NOTICE Matched table "public"."payment_p2022_06": 6 columns ok, 3 indexes ok
+   15:08:48 24072 NOTICE Matched table "public"."payment_p2022_04": 6 columns ok, 3 indexes ok
+   15:08:48 24072 NOTICE Matched table "public"."payment_p2022_02": 6 columns ok, 3 indexes ok
+   15:08:48 24072 NOTICE Matched table "public"."payment_p2022_07": 6 columns ok, 0 indexes ok
+   15:08:48 24072 NOTICE Matched table "public"."customer": 10 columns ok, 4 indexes ok
+   15:08:48 24072 NOTICE Matched table "public"."address": 8 columns ok, 2 indexes ok
+   15:08:48 24072 NOTICE Matched table "public"."city": 4 columns ok, 2 indexes ok
+   15:08:48 24072 NOTICE Matched table "public"."film_category": 3 columns ok, 1 indexes ok
+   15:08:48 24072 NOTICE Matched table "public"."payment_p2022_01": 6 columns ok, 3 indexes ok
+   15:08:48 24072 NOTICE Matched table "public"."actor": 4 columns ok, 2 indexes ok
+   15:08:48 24072 NOTICE Matched table "public"."bar": 2 columns ok, 1 indexes ok
+   15:08:48 24072 NOTICE Matched table "public"."bin": 2 columns ok, 0 indexes ok
+   15:08:48 24072 NOTICE Matched table "public"."category": 3 columns ok, 1 indexes ok
+   15:08:48 24072 NOTICE Matched table "public"."country": 3 columns ok, 1 indexes ok
+   15:08:48 24072 NOTICE Matched table "public"."foo": 2 columns ok, 1 indexes ok
+   15:08:48 24072 NOTICE Matched table "public"."staff": 11 columns ok, 1 indexes ok
+   15:08:48 24072 NOTICE Matched table "public"."language": 3 columns ok, 1 indexes ok
+   15:08:48 24072 NOTICE Matched table "public"."store": 4 columns ok, 2 indexes ok
+   15:08:48 24072 NOTICE Matched sequence "public"."actor_actor_id_seq" (last value 200)
+   15:08:48 24072 NOTICE Matched sequence "public"."address_address_id_seq" (last value 605)
+   15:08:48 24072 NOTICE Matched sequence "public"."bar_id_seq" (last value 1)
+   15:08:48 24072 NOTICE Matched sequence "public"."bin_id_seq" (last value 17)
+   15:08:48 24072 NOTICE Matched sequence "public"."category_category_id_seq" (last value 16)
+   15:08:48 24072 NOTICE Matched sequence "public"."city_city_id_seq" (last value 600)
+   15:08:48 24072 NOTICE Matched sequence "public"."country_country_id_seq" (last value 109)
+   15:08:48 24072 NOTICE Matched sequence "public"."customer_customer_id_seq" (last value 599)
+   15:08:48 24072 NOTICE Matched sequence "public"."film_film_id_seq" (last value 1000)
+   15:08:48 24072 NOTICE Matched sequence "public"."foo_id_seq" (last value 1)
+   15:08:48 24072 NOTICE Matched sequence "public"."inventory_inventory_id_seq" (last value 4581)
+   15:08:48 24072 NOTICE Matched sequence "public"."language_language_id_seq" (last value 6)
+   15:08:48 24072 NOTICE Matched sequence "public"."payment_payment_id_seq" (last value 32102)
+   15:08:48 24072 NOTICE Matched sequence "public"."rental_rental_id_seq" (last value 16053)
+   15:08:48 24072 NOTICE Matched sequence "public"."staff_staff_id_seq" (last value 2)
+   15:08:48 24072 NOTICE Matched sequence "public"."store_store_id_seq" (last value 2)
+   15:08:48 24072 INFO   pgcopydb schema inspection is successful
+
+Comparing data:
+
+::
+
+   $ pgcopydb compare data
+   15:09:31 24090 INFO   Running pgcopydb version 0.12.28.g34343c8.dirty from "/Users/dim/dev/PostgreSQL/pgcopydb/src/bin/pgcopydb/pgcopydb"
+   15:09:31 24090 INFO   A previous run has run through completion
+   15:09:31 24090 INFO   SOURCE: Connecting to "postgres:///pagila"
+   15:09:31 24090 INFO   Fetched information for 1 extensions
+   15:09:31 24090 INFO   Fetched information for 25 tables, with an estimated total of 5179  tuples and 190 MB
+   15:09:31 24090 INFO   Fetched information for 49 indexes
+   15:09:31 24090 INFO   Fetching information for 16 sequences
+   15:09:31 24090 INFO   TARGET: Connecting to "postgres:///plop"
+   15:09:31 24090 INFO   Fetched information for 6 extensions
+   15:09:31 24090 INFO   Fetched information for 25 tables, with an estimated total of 5219  tuples and 190 MB
+   15:09:31 24090 INFO   Fetched information for 49 indexes
+   15:09:31 24090 INFO   Fetching information for 16 sequences
+   15:09:31 24090 INFO   Comparing data for 25 tables
+   15:09:34 24090 INFO   pgcopydb data inspection is successful
+                       Table Name |            Row Count |             Checksum
+   -------------------------------+----------------------+---------------------
+                  "public"."test" |              5173525 |     fffffe0eda6e8ed6
+                "public"."rental" |                16044 |            a9e94a0fd
+                  "public"."film" |                 1000 |            6c09234f3
+            "public"."film_actor" |                 5462 |            62de3e446
+             "public"."inventory" |                 4581 |            b8cd676ea
+      "public"."payment_p2022_03" |                 2713 |              83be351
+      "public"."payment_p2022_05" |                 2677 |           1f7db109e6
+      "public"."payment_p2022_06" |                 2654 |           136e71d157
+      "public"."payment_p2022_04" |                 2547 |     ffffffee3cc184de
+      "public"."payment_p2022_02" |                 2401 |            46630a420
+      "public"."payment_p2022_07" |                 2334 |            41ab5db80
+              "public"."customer" |                  599 |     fffffffd9f34bcc0
+               "public"."address" |                  603 |     fffffffe2feecfad
+                  "public"."city" |                  600 |            408b30b2b
+         "public"."film_category" |                 1000 |     fffffff7416d4e14
+      "public"."payment_p2022_01" |                  723 |     fffffffb62e13a74
+                 "public"."actor" |                  200 |             59093ce3
+                   "public"."bar" |                    1 |             4b05576b
+                   "public"."bin" |                   17 |     ffffffff8f6be7b1
+              "public"."category" |                   16 |     fffffffd669034f7
+               "public"."country" |                  109 |     fffffffd359c2b94
+                   "public"."foo" |                    2 |             6bc8e3ff
+                 "public"."staff" |                    2 |     ffffffff97467951
+              "public"."language" |                    6 |            1922751a8
+                 "public"."store" |                    2 |             441cc744

--- a/src/bin/pgcopydb/cli_compare.c
+++ b/src/bin/pgcopydb/cli_compare.c
@@ -1,0 +1,819 @@
+/*
+ * src/bin/pgcopydb/cli_compare.c
+ *     Implementation of a CLI which lets you run individual routines
+ *     directly
+ */
+
+#include <errno.h>
+#include <getopt.h>
+#include <inttypes.h>
+
+#include "cli_common.h"
+#include "cli_root.h"
+#include "commandline.h"
+#include "copydb.h"
+#include "env_utils.h"
+#include "ld_stream.h"
+#include "log.h"
+#include "pgcmd.h"
+#include "pgsql.h"
+#include "progress.h"
+#include "schema.h"
+#include "signals.h"
+#include "string_utils.h"
+
+static int cli_compare_getopts(int argc, char **argv);
+static void cli_compare_schema(int argc, char **argv);
+static void cli_compare_data(int argc, char **argv);
+
+static bool cli_compare_fetch_schemas(CopyDataSpec *copySpecs,
+									  CopyDataSpec *sourceSpecs,
+									  CopyDataSpec *targetSpecs);
+
+static CommandLine compare_schema_command =
+	make_command(
+		"schema",
+		"Compare source and target schema",
+		" --source ... ",
+		"  --source         Postgres URI to the source database\n"
+		"  --target         Postgres URI to the target database\n"
+		"  --dir            Work directory to use\n",
+		cli_compare_getopts,
+		cli_compare_schema);
+
+static CommandLine compare_data_command =
+	make_command(
+		"data",
+		"Compare source and target data",
+		" --source ... ",
+		"  --source         Postgres URI to the source database\n"
+		"  --target         Postgres URI to the target database\n"
+		"  --dir            Work directory to use\n",
+		cli_compare_getopts,
+		cli_compare_data);
+
+static CommandLine *compare_subcommands[] = {
+	&compare_schema_command,
+	&compare_data_command,
+	NULL
+};
+
+CommandLine compare_commands =
+	make_command_set("compare",
+					 "Compare source and target databases",
+					 NULL, NULL, NULL, compare_subcommands);
+
+CopyDBOptions compareOptions = { 0 };
+
+
+static int
+cli_compare_getopts(int argc, char **argv)
+{
+	CopyDBOptions options = { 0 };
+	int c, option_index = 0;
+	int errors = 0, verboseCount = 0;
+
+	static struct option long_options[] = {
+		{ "source", required_argument, NULL, 'S' },
+		{ "target", required_argument, NULL, 'T' },
+		{ "dir", required_argument, NULL, 'D' },
+		{ "version", no_argument, NULL, 'V' },
+		{ "verbose", no_argument, NULL, 'v' },
+		{ "notice", no_argument, NULL, 'v' },
+		{ "debug", no_argument, NULL, 'd' },
+		{ "trace", no_argument, NULL, 'z' },
+		{ "quiet", no_argument, NULL, 'q' },
+		{ "help", no_argument, NULL, 'h' },
+		{ NULL, 0, NULL, 0 }
+	};
+
+	optind = 0;
+
+	/* read values from the environment */
+	if (!cli_copydb_getenv(&options))
+	{
+		log_fatal("Failed to read default values from the environment");
+		exit(EXIT_CODE_BAD_ARGS);
+	}
+
+	while ((c = getopt_long(argc, argv, "S:T:D:Vvdzqh",
+							long_options, &option_index)) != -1)
+	{
+		switch (c)
+		{
+			case 'S':
+			{
+				if (!validate_connection_string(optarg))
+				{
+					log_fatal("Failed to parse --source connection string, "
+							  "see above for details.");
+					exit(EXIT_CODE_BAD_ARGS);
+				}
+				options.connStrings.source_pguri = pg_strdup(optarg);
+				log_trace("--source %s", options.connStrings.source_pguri);
+				break;
+			}
+
+			case 'T':
+			{
+				if (!validate_connection_string(optarg))
+				{
+					log_fatal("Failed to parse --target connection string, "
+							  "see above for details.");
+					++errors;
+				}
+				options.connStrings.target_pguri = pg_strdup(optarg);
+				log_trace("--target %s", options.connStrings.target_pguri);
+				break;
+			}
+
+			case 'D':
+			{
+				strlcpy(options.dir, optarg, MAXPGPATH);
+				log_trace("--dir %s", options.dir);
+				break;
+			}
+
+			case 'V':
+			{
+				/* keeper_cli_print_version prints version and exits. */
+				cli_print_version(argc, argv);
+				break;
+			}
+
+			case 'v':
+			{
+				++verboseCount;
+				switch (verboseCount)
+				{
+					case 1:
+					{
+						log_set_level(LOG_NOTICE);
+						break;
+					}
+
+					case 2:
+					{
+						log_set_level(LOG_SQL);
+						break;
+					}
+
+					case 3:
+					{
+						log_set_level(LOG_DEBUG);
+						break;
+					}
+
+					default:
+					{
+						log_set_level(LOG_TRACE);
+						break;
+					}
+				}
+				break;
+			}
+
+			case 'd':
+			{
+				verboseCount = 3;
+				log_set_level(LOG_DEBUG);
+				break;
+			}
+
+			case 'z':
+			{
+				verboseCount = 4;
+				log_set_level(LOG_TRACE);
+				break;
+			}
+
+			case 'q':
+			{
+				log_set_level(LOG_ERROR);
+				break;
+			}
+
+			case 'h':
+			{
+				commandline_help(stderr);
+				exit(EXIT_CODE_QUIT);
+				break;
+			}
+		}
+	}
+
+	if (options.connStrings.source_pguri == NULL ||
+		options.connStrings.target_pguri == NULL)
+	{
+		log_fatal("Option --source and --target are mandatory");
+		++errors;
+	}
+
+	/* prepare safe versions of the connection strings (without password) */
+	if (!cli_prepare_pguris(&(options.connStrings)))
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+
+	if (errors > 0)
+	{
+		exit(EXIT_CODE_BAD_ARGS);
+	}
+
+	/* publish our option parsing in the global variable */
+	compareOptions = options;
+
+	return optind;
+}
+
+
+/*
+ * cli_compare_schema compares the schema on the source and target databases.
+ */
+static void
+cli_compare_schema(int argc, char **argv)
+{
+	CopyDataSpec copySpecs = { 0 };
+
+	(void) find_pg_commands(&(copySpecs.pgPaths));
+
+	char *dir =
+		IS_EMPTY_STRING_BUFFER(compareOptions.dir)
+		? NULL
+		: compareOptions.dir;
+
+	bool createWorkDir = true;
+	bool service = true;
+	char *serviceName = "snapshot";
+
+	/* pretend that --resume --not-consistent have been used */
+	compareOptions.resume = true;
+	compareOptions.notConsistent = true;
+
+	if (!copydb_init_workdir(&copySpecs,
+							 dir,
+							 service,
+							 serviceName,
+							 compareOptions.restart,
+							 compareOptions.resume,
+							 createWorkDir))
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+
+	if (!copydb_init_specs(&copySpecs, &compareOptions, DATA_SECTION_ALL))
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+
+	/*
+	 * Now prepare two specifications with only the source uri.
+	 *
+	 * We don't free() any memory here as the two CopyDataSpecs copies are
+	 * going to share pointers to memory allocated in the main copySpecs
+	 * instance.
+	 */
+	CopyDataSpec sourceSpecs = { 0 };
+	CopyDataSpec targetSpecs = { 0 };
+
+	if (!cli_compare_fetch_schemas(&copySpecs, &sourceSpecs, &targetSpecs))
+	{
+		log_fatal("Failed to fetch source and target schemas, "
+				  "see above for details");
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+
+	log_info("[SOURCE] table: %d index: %d sequence: %d",
+			 sourceSpecs.catalog.sourceTableArray.count,
+			 sourceSpecs.catalog.sourceIndexArray.count,
+			 sourceSpecs.catalog.sequenceArray.count);
+
+	log_info("[TARGET] table: %d index: %d sequence: %d",
+			 targetSpecs.catalog.sourceTableArray.count,
+			 targetSpecs.catalog.sourceIndexArray.count,
+			 targetSpecs.catalog.sequenceArray.count);
+
+	uint64_t diffCount = 0;
+
+	SourceTable *targetTableHash = targetSpecs.catalog.sourceTableHashByQName;
+
+	for (int i = 0; i < sourceSpecs.catalog.sourceTableArray.count; i++)
+	{
+		SourceTable *source = &(sourceSpecs.catalog.sourceTableArray.array[i]);
+		SourceTable *target = NULL;
+
+		char *qname = source->qname;
+		size_t len = strlen(qname);
+
+		HASH_FIND(hhQName, targetTableHash, qname, len, target);
+
+		if (target == NULL)
+		{
+			++diffCount;
+			log_error("Failed to find table %s in target database",
+					  qname);
+			continue;
+		}
+
+		/* check table columns */
+		if (source->attributes.count != target->attributes.count)
+		{
+			++diffCount;
+			log_error("Table %s has %d columns on source, %d columns on target",
+					  qname,
+					  source->attributes.count,
+					  target->attributes.count);
+			continue;
+		}
+
+		for (int c = 0; c < source->attributes.count; c++)
+		{
+			char *srcAttName = source->attributes.array[c].attname;
+			char *tgtAttName = target->attributes.array[c].attname;
+
+			if (!streq(srcAttName, tgtAttName))
+			{
+				++diffCount;
+				log_error("Table %s attribute number %d "
+						  "has name \"%s\" (%d) on source and "
+						  "has name \"%s\" (%d) on target",
+						  qname,
+						  c,
+						  srcAttName,
+						  source->attributes.array[c].attnum,
+						  tgtAttName,
+						  target->attributes.array[c].attnum);
+			}
+		}
+
+		/* now check table index list */
+		uint64_t indexCount = 0;
+		SourceIndexList *sourceIndexList = source->firstIndex;
+		SourceIndexList *targetIndexList = target->firstIndex;
+
+		for (; sourceIndexList != NULL; sourceIndexList = sourceIndexList->next)
+		{
+			SourceIndex *sourceIndex = sourceIndexList->index;
+
+			++indexCount;
+
+			if (targetIndexList == NULL)
+			{
+				++diffCount;
+				log_error("Table %s is missing index \"%s\".\"%s\" on target",
+						  qname,
+						  sourceIndex->indexNamespace,
+						  sourceIndex->indexRelname);
+
+				continue;
+			}
+
+			SourceIndex *targetIndex = targetIndexList->index;
+
+			if (!streq(sourceIndex->indexNamespace, targetIndex->indexNamespace) ||
+				!streq(sourceIndex->indexRelname, targetIndex->indexRelname))
+			{
+				++diffCount;
+				log_error("Table %s index mismatch: \"%s\".\"%s\" on source, "
+						  "\"%s\".\"%s\" on target",
+						  qname,
+						  sourceIndex->indexNamespace,
+						  sourceIndex->indexRelname,
+						  targetIndex->indexNamespace,
+						  targetIndex->indexRelname);
+			}
+
+			if (!streq(sourceIndex->indexDef, targetIndex->indexDef))
+			{
+				++diffCount;
+				log_error("Table %s index \"%s\".\"%s\" mismatch "
+						  "on index definition",
+						  qname,
+						  sourceIndex->indexNamespace,
+						  sourceIndex->indexRelname);
+
+				log_info("Source index \"%s\".\"%s\": %s",
+						 sourceIndex->indexNamespace,
+						 sourceIndex->indexRelname,
+						 sourceIndex->indexDef);
+
+				log_info("Target index \"%s\".\"%s\": %s",
+						 targetIndex->indexNamespace,
+						 targetIndex->indexRelname,
+						 targetIndex->indexDef);
+			}
+
+			if (sourceIndex->isPrimary != targetIndex->isPrimary)
+			{
+				++diffCount;
+				log_error("Table %s index \"%s\".\"%s\" is %s on source "
+						  "and %s on target",
+						  qname,
+						  sourceIndex->indexNamespace,
+						  sourceIndex->indexRelname,
+						  sourceIndex->isPrimary ? "primary" : "not primary",
+						  targetIndex->isPrimary ? "primary" : "not primary");
+			}
+
+			if (sourceIndex->isUnique != targetIndex->isUnique)
+			{
+				++diffCount;
+				log_error("Table %s index \"%s\".\"%s\" is %s on source "
+						  "and %s on target",
+						  qname,
+						  sourceIndex->indexNamespace,
+						  sourceIndex->indexRelname,
+						  sourceIndex->isUnique ? "unique" : "not unique",
+						  targetIndex->isUnique ? "unique" : "not unique");
+			}
+
+			if (!streq(sourceIndex->constraintName, targetIndex->constraintName))
+			{
+				++diffCount;
+				log_error("Table %s index \"%s\".\"%s\" is supporting "
+						  " constraint named \"%s\" on source "
+						  "and \"%s\" on target",
+						  qname,
+						  sourceIndex->indexNamespace,
+						  sourceIndex->indexRelname,
+						  sourceIndex->constraintName,
+						  targetIndex->constraintName);
+			}
+
+			if (sourceIndex->constraintDef != NULL &&
+				(targetIndex->constraintDef == NULL ||
+				 !streq(sourceIndex->constraintDef, targetIndex->constraintDef)))
+			{
+				++diffCount;
+				log_error("Table %s index \"%s\".\"%s\" constraint \"%s\" "
+						  "definition mismatch.",
+						  qname,
+						  sourceIndex->indexNamespace,
+						  sourceIndex->indexRelname,
+						  sourceIndex->constraintName);
+
+				log_info("Source index \"%s\".\"%s\" constraint \"%s\": %s",
+						 sourceIndex->indexNamespace,
+						 sourceIndex->indexRelname,
+						 sourceIndex->constraintName,
+						 sourceIndex->constraintDef);
+
+				log_info("Target index \"%s\".\"%s\" constraint \"%s\": %s",
+						 targetIndex->indexNamespace,
+						 targetIndex->indexRelname,
+						 targetIndex->constraintName,
+						 targetIndex->constraintDef);
+			}
+
+			targetIndexList = targetIndexList->next;
+		}
+
+		log_notice("Matched table %s: %d columns ok, %lld indexes ok",
+				   qname,
+				   source->attributes.count,
+				   (long long) indexCount);
+	}
+
+	/*
+	 * Now focus on sequences. First, create the sequence names hash table to
+	 * be able to match source sequences with their target counterparts.
+	 */
+	SourceSequence *targetSeqHash = NULL;
+
+	for (int i = 0; i < targetSpecs.catalog.sequenceArray.count; i++)
+	{
+		SourceSequence *seq = &(targetSpecs.catalog.sequenceArray.array[i]);
+
+		char *qname = seq->qname;
+		size_t len = strlen(qname);
+
+		HASH_ADD(hhQName, targetSeqHash, qname, len, seq);
+	}
+
+	/* publish the now fill-in hash table to the catalog */
+	targetSpecs.catalog.sourceSeqHashByQname = targetSeqHash;
+
+	for (int i = 0; i < sourceSpecs.catalog.sequenceArray.count; i++)
+	{
+		SourceSequence *source = &(sourceSpecs.catalog.sequenceArray.array[i]);
+		SourceSequence *target = NULL;
+
+		char *qname = source->qname;
+		size_t len = strlen(qname);
+
+		HASH_FIND(hhQName, targetSeqHash, qname, len, target);
+
+		if (target == NULL)
+		{
+			++diffCount;
+			log_error("Failed to find sequence %s in target database",
+					  qname);
+			continue;
+		}
+
+		if (source->lastValue != target->lastValue)
+		{
+			++diffCount;
+			log_error("Sequence %s lastValue on source is %lld, on target %lld",
+					  qname,
+					  (long long) source->lastValue,
+					  (long long) target->lastValue);
+		}
+
+		if (source->isCalled != target->isCalled)
+		{
+			++diffCount;
+			log_error("Sequence %s isCalled on source is %s, on target %s",
+					  qname,
+					  source->isCalled ? "yes" : "no",
+					  target->isCalled ? "yes" : "no");
+		}
+
+		log_notice("Matched sequence %s (last value %lld)",
+				   qname,
+				   (long long) source->lastValue);
+	}
+
+	if (diffCount > 0)
+	{
+		log_fatal("Schemas on source and target database differ");
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+
+	log_info("pgcopydb schema inspection is successful");
+}
+
+
+/*
+ * cli_compare_data compares the data on the source and target databases.
+ */
+static void
+cli_compare_data(int argc, char **argv)
+{
+	CopyDataSpec copySpecs = { 0 };
+
+	(void) find_pg_commands(&(copySpecs.pgPaths));
+
+	char *dir =
+		IS_EMPTY_STRING_BUFFER(compareOptions.dir)
+		? NULL
+		: compareOptions.dir;
+
+	bool createWorkDir = true;
+	bool service = true;
+	char *serviceName = "snapshot";
+
+	/* pretend that --resume --not-consistent have been used */
+	compareOptions.resume = true;
+	compareOptions.notConsistent = true;
+
+	if (!copydb_init_workdir(&copySpecs,
+							 dir,
+							 service,
+							 serviceName,
+							 compareOptions.restart,
+							 compareOptions.resume,
+							 createWorkDir))
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+
+	if (!copydb_init_specs(&copySpecs, &compareOptions, DATA_SECTION_ALL))
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+
+	/*
+	 * Now prepare two specifications with only the source uri.
+	 *
+	 * We don't free() any memory here as the two CopyDataSpecs copies are
+	 * going to share pointers to memory allocated in the main copySpecs
+	 * instance.
+	 */
+	CopyDataSpec sourceSpecs = { 0 };
+	CopyDataSpec targetSpecs = { 0 };
+
+	if (!cli_compare_fetch_schemas(&copySpecs, &sourceSpecs, &targetSpecs))
+	{
+		log_fatal("Failed to fetch source and target schemas, "
+				  "see above for details");
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+
+	log_info("Comparing data for %d tables",
+			 sourceSpecs.catalog.sourceTableArray.count);
+
+	PGSQL src = { 0 };
+	char *srcURI = copySpecs.connStrings.source_pguri;
+
+	if (!pgsql_init(&src, srcURI, PGSQL_CONN_SOURCE))
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_SOURCE);
+	}
+
+	if (!pgsql_begin(&src))
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_SOURCE);
+	}
+
+	PGSQL dst = { 0 };
+	char *dstURI = copySpecs.connStrings.target_pguri;
+
+	if (!pgsql_init(&dst, dstURI, PGSQL_CONN_SOURCE))
+	{
+		/* errors have already been logged */
+		(void) pgsql_finish(&src);
+		exit(EXIT_CODE_TARGET);
+	}
+
+	if (!pgsql_begin(&dst))
+	{
+		/* errors have already been logged */
+		(void) pgsql_finish(&src);
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+
+	uint64_t diffCount = 0;
+
+	SourceTable *targetTableHash = targetSpecs.catalog.sourceTableHashByQName;
+
+	for (int i = 0; i < sourceSpecs.catalog.sourceTableArray.count; i++)
+	{
+		SourceTable *source = &(sourceSpecs.catalog.sourceTableArray.array[i]);
+		SourceTable *target = NULL;
+
+		char *qname = source->qname;
+		size_t len = strlen(qname);
+
+		HASH_FIND(hhQName, targetTableHash, qname, len, target);
+
+		if (target == NULL)
+		{
+			++diffCount;
+			log_error("Failed to find table %s in target database",
+					  qname);
+			continue;
+		}
+
+		if (!schema_checksum_table(&src, source))
+		{
+			/* errors have already been logged */
+			(void) pgsql_finish(&src);
+			(void) pgsql_finish(&dst);
+			exit(EXIT_CODE_SOURCE);
+		}
+
+		if (!schema_checksum_table(&dst, target))
+		{
+			/* errors have already been logged */
+			(void) pgsql_finish(&src);
+			(void) pgsql_finish(&dst);
+			exit(EXIT_CODE_TARGET);
+		}
+
+		if (source->rowcount != target->rowcount)
+		{
+			++diffCount;
+			log_error("Table %s has %lld rows on source, %lld rows on target",
+					  qname,
+					  (long long) source->rowcount,
+					  (long long) target->rowcount);
+		}
+
+		if (source->checksum != target->checksum)
+		{
+			++diffCount;
+			log_error("Table %s has checksum %lld on source, %lld on target",
+					  qname,
+					  (long long) source->checksum,
+					  (long long) target->checksum);
+		}
+
+		log_notice("%s: %lld rows, checksum %lld",
+				   qname,
+				   (long long) source->rowcount,
+				   (long long) source->checksum);
+	}
+
+	if (!pgsql_commit(&src))
+	{
+		/* errors have already been logged */
+		(void) pgsql_finish(&dst);
+		exit(EXIT_CODE_SOURCE);
+	}
+
+	if (!pgsql_commit(&dst))
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_TARGET);
+	}
+
+	if (diffCount == 0)
+	{
+		log_info("pgcopydb data inspection is successful");
+	}
+
+	fformat(stdout, "%30s | %20s | %20s \n",
+			"Table Name", "Row Count", "Checksum");
+
+	fformat(stdout, "%30s-+-%20s-+-%20s \n",
+			"------------------------------",
+			"--------------------",
+			"--------------------");
+
+	for (int i = 0; i < sourceSpecs.catalog.sourceTableArray.count; i++)
+	{
+		SourceTable *source = &(sourceSpecs.catalog.sourceTableArray.array[i]);
+
+		fformat(stdout, "%30s | %20lld | %20llx \n",
+				source->qname,
+				source->rowcount,
+				source->checksum);
+	}
+
+	fformat(stdout, "\n");
+}
+
+
+/*
+ * cli_compare_fetch_schemas fetches the source and target schemas.
+ */
+static bool
+cli_compare_fetch_schemas(CopyDataSpec *copySpecs,
+						  CopyDataSpec *sourceSpecs,
+						  CopyDataSpec *targetSpecs)
+{
+	/* copy the structure instances over */
+	*sourceSpecs = *copySpecs;
+	*targetSpecs = *copySpecs;
+
+	ConnStrings *sourceConnStrings = &(sourceSpecs->connStrings);
+
+	sourceConnStrings->target_pguri = NULL;
+
+	ConnStrings *targetConnStrings = &(targetSpecs->connStrings);
+
+	targetConnStrings->source_pguri = targetConnStrings->target_pguri;
+	targetConnStrings->target_pguri = NULL;
+
+	targetConnStrings->safeSourcePGURI = targetConnStrings->safeTargetPGURI;
+
+	/*
+	 * Retrieve our internal representation of the catalogs for both the source
+	 * and the target database.
+	 */
+	log_info("SOURCE: Connecting to \"%s\"",
+			 sourceConnStrings->safeSourcePGURI.pguri);
+
+	if (!copydb_fetch_schema_and_prepare_specs(sourceSpecs))
+	{
+		log_fatal("Failed to retrieve source database schema, "
+				  "see above for details.");
+		return false;
+	}
+
+	/* copy the source schema to the compare file */
+	strlcpy(sourceSpecs->cfPaths.schemafile,
+			sourceSpecs->cfPaths.compare.sschemafile,
+			MAXPGPATH);
+
+	if (!copydb_prepare_schema_json_file(sourceSpecs))
+	{
+		log_fatal("Failed to store the source database schema to file \"%s\", "
+				  "see above for details",
+				  sourceSpecs->cfPaths.schemafile);
+		return false;
+	}
+
+	log_info("TARGET: Connecting to \"%s\"",
+			 targetConnStrings->safeSourcePGURI.pguri);
+
+	if (!copydb_fetch_schema_and_prepare_specs(targetSpecs))
+	{
+		log_fatal("Failed to retrieve source database schema, "
+				  "see above for details.");
+		return false;
+	}
+
+	/* copy the target schema to the compare file */
+	strlcpy(targetSpecs->cfPaths.schemafile,
+			targetSpecs->cfPaths.compare.tschemafile,
+			MAXPGPATH);
+
+	if (!copydb_prepare_schema_json_file(targetSpecs))
+	{
+		log_fatal("Failed to store the target database schema to file \"%s\", "
+				  "see above for details",
+				  targetSpecs->cfPaths.schemafile);
+		return false;
+	}
+
+	return true;
+}

--- a/src/bin/pgcopydb/cli_root.c
+++ b/src/bin/pgcopydb/cli_root.c
@@ -27,6 +27,7 @@ CommandLine *root_subcommands_with_debug[] = {
 	&follow_command,
 	&copy__db_command,          /* backward compat */
 	&create_snapshot_command,
+	&compare_commands,
 	&copy_commands,
 	&dump_commands,
 	&restore_commands,
@@ -53,6 +54,7 @@ CommandLine *root_subcommands[] = {
 	&follow_command,
 	&copy__db_command,          /* backward compat */
 	&create_snapshot_command,
+	&compare_commands,
 	&copy_commands,
 	&dump_commands,
 	&restore_commands,

--- a/src/bin/pgcopydb/cli_root.h
+++ b/src/bin/pgcopydb/cli_root.h
@@ -46,22 +46,25 @@ extern CommandLine copy_commands;
 /* cli_snapshot.c */
 extern CommandLine create_snapshot_command;
 
-/* cli_dump.h */
+/* cli_dump.c */
 extern CommandLine dump_commands;
 
-/* cli_ping.h */
+/* cli_ping.c */
 extern CommandLine ping_command;
 
-/* cli_restore.h */
+/* cli_restore.c */
 extern CommandLine restore_commands;
 
-/* cli_list.h */
+/* cli_list.c */
 extern CommandLine list_commands;
 
-/* cli_stream.h */
+/* cli_stream.c */
 extern CommandLine stream_commands;
 
-/* cli_sentinel.h */
+/* cli_sentinel.c */
 extern CommandLine sentinel_commands;
+
+/* cli_compare.c */
+extern CommandLine compare_commands;
 
 #endif  /* CLI_ROOT_H */

--- a/src/bin/pgcopydb/copydb.c
+++ b/src/bin/pgcopydb/copydb.c
@@ -181,6 +181,7 @@ copydb_init_workdir(CopyDataSpec *copySpecs,
 		cfPaths->tbldir,
 		cfPaths->idxdir,
 		cfPaths->cdc.dir,
+		cfPaths->compare.dir,
 		NULL
 	};
 
@@ -545,6 +546,28 @@ copydb_prepare_filepaths(CopyFilePaths *cfPaths,
 	sformat(cfPaths->cdc.walsegsizefile, MAXPGPATH,
 			"%s/wal_segment_size",
 			cfPaths->cdc.dir);
+
+	/*
+	 * Now prepare the "compare" files we need to compare schema and data
+	 * between the source and target instance.
+	 */
+	sformat(cfPaths->compare.dir, MAXPGPATH, "%s/compare", cfPaths->topdir);
+
+	sformat(cfPaths->compare.sschemafile, MAXPGPATH,
+			"%s/source-schema.json",
+			cfPaths->compare.dir);
+
+	sformat(cfPaths->compare.tschemafile, MAXPGPATH,
+			"%s/target-schema.json",
+			cfPaths->compare.dir);
+
+	sformat(cfPaths->compare.sdatafile, MAXPGPATH,
+			"%s/source-data.json",
+			cfPaths->compare.dir);
+
+	sformat(cfPaths->compare.tdatafile, MAXPGPATH,
+			"%s/target-data.json",
+			cfPaths->compare.dir);
 
 	return true;
 }

--- a/src/bin/pgcopydb/copydb_paths.h
+++ b/src/bin/pgcopydb/copydb_paths.h
@@ -55,6 +55,17 @@ typedef struct CDCPaths
 	char tlihistfile[MAXPGPATH];      /* /tmp/pgcopydb/cdc/tli.history */
 } CDCPaths;
 
+
+/* Compare Paths */
+typedef struct ComparePaths
+{
+	char dir[MAXPGPATH];          /* /tmp/pgcopydb/compare */
+	char sschemafile[MAXPGPATH]; /* /tmp/pgcopydb/compare/source-schema.json */
+	char tschemafile[MAXPGPATH];  /* /tmp/pgcopydb/compare/target-schema.json */
+	char sdatafile[MAXPGPATH];    /* /tmp/pgcopydb/compare/source-data.json */
+	char tdatafile[MAXPGPATH];    /* /tmp/pgcopydb/compare/target-data.json */
+} ComparePaths;
+
 /* maintain all the internal paths we need in one place */
 typedef struct CopyFilePaths
 {
@@ -71,6 +82,7 @@ typedef struct CopyFilePaths
 
 	CDCPaths cdc;
 	CopyDoneFilePaths done;
+	ComparePaths compare;
 } CopyFilePaths;
 
 

--- a/src/bin/pgcopydb/schema.h
+++ b/src/bin/pgcopydb/schema.h
@@ -172,6 +172,9 @@ typedef struct SourceTable
 	char bytesPretty[NAMEDATALEN]; /* pg_size_pretty */
 	bool excludeData;
 
+	uint64_t rowcount;
+	uint64_t checksum;
+
 	char restoreListName[RESTORE_LIST_NAMEDATALEN];
 	char partKey[NAMEDATALEN];
 	SourceTablePartsArray partsArray;
@@ -213,6 +216,7 @@ typedef struct SourceSequence
 	char restoreListName[RESTORE_LIST_NAMEDATALEN];
 
 	UT_hash_handle hh;          /* makes this structure hashable */
+	UT_hash_handle hhQName;     /* makes this structure hashable */
 } SourceSequence;
 
 
@@ -306,6 +310,7 @@ typedef struct SourceCatalog
 	SourceTable *sourceTableHashByQName;
 	SourceIndex *sourceIndexHashByOid;
 	SourceSequence *sourceSeqHashByOid;
+	SourceSequence *sourceSeqHashByQname;
 } SourceCatalog;
 
 
@@ -370,5 +375,7 @@ bool schema_list_table_indexes(PGSQL *pgsql,
 bool schema_list_pg_depend(PGSQL *pgsql,
 						   SourceFilters *filters,
 						   SourceDependArray *dependArray);
+
+bool schema_checksum_table(PGSQL *pgsql, SourceTable *table);
 
 #endif /* SCHEMA_H */

--- a/tests/pagila/copydb.sh
+++ b/tests/pagila/copydb.sh
@@ -43,3 +43,11 @@ psql -o /tmp/d.out -d ${PAGILA_SOURCE_PGURI} -1 -f /usr/src/pagila/pagila-data.s
 pgcopydb clone --skip-ext-comments       \
          --source ${PAGILA_SOURCE_PGURI} \
          --target ${PAGILA_TARGET_PGURI}
+
+pgcopydb compare schema \
+         --source ${PAGILA_SOURCE_PGURI} \
+         --target ${PAGILA_TARGET_PGURI}
+
+pgcopydb compare data \
+         --source ${PAGILA_SOURCE_PGURI} \
+         --target ${PAGILA_TARGET_PGURI}


### PR DESCRIPTION
Implement a set of pgcopydb commands to compare databases, so that it's possible to make sense of a success criteria for the migration. The current implementation is pretty limited and provides a starting point in that direction.