### PR TITLE
Improve pgcopydb compare data checksum computation.

### DIFF
--- a/src/bin/pgcopydb/schema.h
+++ b/src/bin/pgcopydb/schema.h
@@ -159,6 +159,9 @@ typedef struct SourceTableAttributeArray
 /* forward declaration */
 struct SourceIndexList;
 
+/* checksum is formatted as uuid */
+#define CHECKSUMLEN 36
+
 typedef struct SourceTable
 {
 	uint32_t oid;
@@ -173,7 +176,7 @@ typedef struct SourceTable
 	bool excludeData;
 
 	uint64_t rowcount;
-	uint64_t checksum;
+	char checksum[CHECKSUMLEN];
 
 	char restoreListName[RESTORE_LIST_NAMEDATALEN];
 	char partKey[NAMEDATALEN];


### PR DESCRIPTION
Use an output format that is stable in number of digits and can deal with a bigint overflow (in Postgres a sum(bigint) is numeric): use an MD5 sum and represent it as an UUID.

Also, include the row count in the MD5 computation to better protect against collisions.

Finally, add support for pgcopydb compare data --json.