### PR TITLE
Fix filtering on schema names.

### DIFF
--- a/src/bin/pgcopydb/dump_restore.c
+++ b/src/bin/pgcopydb/dump_restore.c
@@ -411,7 +411,9 @@ copydb_write_restore_list(CopyDataSpec *specs, PostgresDumpSection section)
 			{
 				skip = true;
 
-				log_notice("Skipping already existing schema %u: %s",
+				log_notice("Skipping already existing dumpId %d: %s %u %s",
+						   contents.array[i].dumpId,
+						   contents.array[i].desc,
 						   contents.array[i].objectOid,
 						   contents.array[i].restoreListName);
 			}

--- a/tests/filtering/copydb.sh
+++ b/tests/filtering/copydb.sh
@@ -34,6 +34,10 @@ pgcopydb list sequences --filters /usr/src/pgcopydb/exclude.ini --list-skipped
 
 pgcopydb clone --filters /usr/src/pgcopydb/exclude.ini
 
+# list the tables that are (not) selected by the filters
+pgcopydb list tables --filters /usr/src/pgcopydb/include.ini
+pgcopydb list tables --filters /usr/src/pgcopydb/include.ini --list-skipped
+
 # now another migration with the "include-only" parts of the data
 pgcopydb clone --filters /usr/src/pgcopydb/include.ini --restart
 

--- a/tests/filtering/exclude.ini
+++ b/tests/filtering/exclude.ini
@@ -1,6 +1,7 @@
 [exclude-schema]
 public
 bar
+schema_name_20_chars
 
 [exclude-table]
 # public.actor

--- a/tests/filtering/expected/3-schema-bar-does-not-exists.out
+++ b/tests/filtering/expected/3-schema-bar-does-not-exists.out
@@ -1,9 +1,11 @@
--[ RECORD 1 ]---
-nspname | public
--[ RECORD 2 ]---
+-[ RECORD 1 ]-----------------
 nspname | app
--[ RECORD 3 ]---
+-[ RECORD 2 ]-----------------
 nspname | copy
--[ RECORD 4 ]---
+-[ RECORD 3 ]-----------------
 nspname | foo
+-[ RECORD 4 ]-----------------
+nspname | public
+-[ RECORD 5 ]-----------------
+nspname | schema_name_20_chars
 

--- a/tests/filtering/extra.sql
+++ b/tests/filtering/extra.sql
@@ -51,3 +51,14 @@ create schema copy;
 
 create table app.foo(id bigserial, f1 text);
 create table copy.foo(like app.foo including all);
+
+
+--
+-- See https://github.com/dimitri/pgcopydb/issues/413
+--
+create schema schema_name_20_chars;
+
+create table schema_name_20_chars.very______long______table______name_______50_chars
+ (
+   id serial
+ );

--- a/tests/filtering/include.ini
+++ b/tests/filtering/include.ini
@@ -1,5 +1,6 @@
 [include-only-schema]
 public
+schema_name_20_chars
 
 [include-only-table]
 public.actor
@@ -9,6 +10,7 @@ public.film_actor
 public.film_category
 public.language
 public.rental
+schema_name_20_chars.very______long______table______name_______50_chars
 
 [exclude-index]
 public.idx_store_id_film_id

--- a/tests/filtering/sql/3-schema-bar-does-not-exists.sql
+++ b/tests/filtering/sql/3-schema-bar-does-not-exists.sql
@@ -1,3 +1,4 @@
-select nspname
-  from pg_namespace
- where nspname !~ '^pg_' and nspname <> 'information_schema';
+  select nspname
+    from pg_namespace
+   where nspname !~ '^pg_' and nspname <> 'information_schema'
+order by nspname;


### PR DESCRIPTION
First, the parsing of the schema and table names from the INI file was done wrong, in a way that shows with long schema and table names.

Then, I just learned we can't use pg_restore --schema in our context, because it would then skip the CREATE SCHEMA statement and pgcopydb relies on pg_restore to create the schema on the target database.

Fixes #413 