### PR TITLE
Use Postgres async queries to compute checksums.

### DIFF
--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -36,12 +36,6 @@ static void pgAutoCtlDefaultNoticeProcessor(void *arg, const char *message);
 static PGconn * pgsql_open_connection(PGSQL *pgsql);
 static bool pgsql_retry_open_connection(PGSQL *pgsql);
 
-static bool pgsql_send_with_params(PGSQL *pgsql, const char *sql, int paramCount,
-								   const Oid *paramTypes, const char **paramValues);
-
-static bool pgsql_fetch_results(PGSQL *pgsql, bool *done,
-								void *context, ParsePostgresResultCB *parseFun);
-
 static bool is_response_ok(PGresult *result);
 static bool clear_results(PGSQL *pgsql);
 static void pgsql_handle_notifications(PGSQL *pgsql);
@@ -1610,7 +1604,7 @@ pgsql_execute_with_params(PGSQL *pgsql, const char *sql, int paramCount,
  * pgsql_send_with_params implements sending a SQL query using the libpq async
  * API. Use pgsql_fetch_results to see if results are available are fetch them.
  */
-static bool
+bool
 pgsql_send_with_params(PGSQL *pgsql, const char *sql, int paramCount,
 					   const Oid *paramTypes, const char **paramValues)
 {
@@ -1708,7 +1702,7 @@ pgsql_send_with_params(PGSQL *pgsql, const char *sql, int paramCount,
  * When the result is ready, the parseFun is called to parse the results as
  * when using pgsql_execute_with_params.
  */
-static bool
+bool
 pgsql_fetch_results(PGSQL *pgsql, bool *done,
 					void *context, ParsePostgresResultCB *parseFun)
 {

--- a/src/bin/pgcopydb/pgsql.h
+++ b/src/bin/pgcopydb/pgsql.h
@@ -289,6 +289,12 @@ bool pgsql_execute_with_params(PGSQL *pgsql, const char *sql, int paramCount,
 							   const Oid *paramTypes, const char **paramValues,
 							   void *parseContext, ParsePostgresResultCB *parseFun);
 
+bool pgsql_send_with_params(PGSQL *pgsql, const char *sql, int paramCount,
+							const Oid *paramTypes, const char **paramValues);
+
+bool pgsql_fetch_results(PGSQL *pgsql, bool *done,
+						 void *context, ParsePostgresResultCB *parseFun);
+
 void pgAutoCtlDebugNoticeProcessor(void *arg, const char *message);
 
 bool validate_connection_string(const char *connectionString);

--- a/src/bin/pgcopydb/schema.h
+++ b/src/bin/pgcopydb/schema.h
@@ -162,6 +162,12 @@ struct SourceIndexList;
 /* checksum is formatted as uuid */
 #define CHECKSUMLEN 36
 
+typedef struct TableChecksum
+{
+	uint64_t rowcount;
+	char checksum[CHECKSUMLEN];
+} TableChecksum;
+
 typedef struct SourceTable
 {
 	uint32_t oid;
@@ -175,8 +181,8 @@ typedef struct SourceTable
 	char bytesPretty[NAMEDATALEN]; /* pg_size_pretty */
 	bool excludeData;
 
-	uint64_t rowcount;
-	char checksum[CHECKSUMLEN];
+	TableChecksum sourceChecksum;
+	TableChecksum targetChecksum;
 
 	char restoreListName[RESTORE_LIST_NAMEDATALEN];
 	char partKey[NAMEDATALEN];
@@ -379,6 +385,7 @@ bool schema_list_pg_depend(PGSQL *pgsql,
 						   SourceFilters *filters,
 						   SourceDependArray *dependArray);
 
-bool schema_checksum_table(PGSQL *pgsql, SourceTable *table);
+bool schema_send_table_checksum(PGSQL *pgsql, SourceTable *table);
+bool schema_fetch_table_checksum(PGSQL *pgsql, TableChecksum *sum, bool *done);
 
 #endif /* SCHEMA_H */


### PR DESCRIPTION
That way pgcopydb compare data waits for as long as the slowest query that are running concurrently on source and target instances, which is better than serial execution on two different servers.

This changes the JSON format output, because we also now skip fetching the target database catalogs.