### PR TITLE
Use PREPARE/EXECUTE statements for applying DML in follow mode.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -25,4 +25,5 @@ src/bin/lib/libs/** -citus-style
 src/bin/lib/pg/** -citus-style
 src/bin/lib/subcommands.c/** -citus-style
 src/bin/lib/uthash/** -citus-style
+src/bin/lib/jenkins/** -citus-style
 src/bin/pgcopydb/pg_utils.c -citus-style

--- a/src/bin/lib/jenkins/Makefile
+++ b/src/bin/lib/jenkins/Makefile
@@ -1,0 +1,15 @@
+all: clean lookup3 test ;
+
+test: lookup3
+	./lookup3
+
+lookup3.o: lookup3.c
+	$(CC) -c -o $@ $<
+
+lookup3: lookup3.c
+	$(CC) -D SELF_TEST -Wno-format -o $@ $<
+
+clean:
+	rm -f lookup3.o lookup3
+
+.PHONY: all clean test

--- a/src/bin/lib/jenkins/Makefile
+++ b/src/bin/lib/jenkins/Makefile
@@ -7,7 +7,7 @@ lookup3.o: lookup3.c
 	$(CC) -c -o $@ $<
 
 lookup3: lookup3.c
-	$(CC) -D SELF_TEST -Wno-format -o $@ $<
+	$(CC) -D SELF_TEST -Wno-implicit-fallthrough -Wno-format -o $@ $<
 
 clean:
 	rm -f lookup3.o lookup3

--- a/src/bin/lib/jenkins/README.md
+++ b/src/bin/lib/jenkins/README.md
@@ -1,0 +1,12 @@
+# Jenkins hash function
+
+This directory contain public domain code from Bob Jenkins. The code is used
+to compute a hash value from a string.
+
+References:
+
+  https://en.wikipedia.org/wiki/Jenkins_hash_function
+
+Code origin:
+
+  http://burtleburtle.net/bob/c/lookup3.c

--- a/src/bin/lib/jenkins/lookup3.c
+++ b/src/bin/lib/jenkins/lookup3.c
@@ -1,0 +1,1763 @@
+/*
+ * -------------------------------------------------------------------------------
+ * lookup3.c, by Bob Jenkins, May 2006, Public Domain.
+ *
+ * These are functions for producing 32-bit hashes for hash table lookup.
+ * hashword(), hashlittle(), hashlittle2(), hashbig(), mix(), and final()
+ * are externally useful functions.  Routines to test the hash are included
+ * if SELF_TEST is defined.  You can use this free for any purpose.  It's in
+ * the public domain.  It has no warranty.
+ *
+ * You probably want to use hashlittle().  hashlittle() and hashbig()
+ * hash byte arrays.  hashlittle() is is faster than hashbig() on
+ * little-endian machines.  Intel and AMD are little-endian machines.
+ * On second thought, you probably want hashlittle2(), which is identical to
+ * hashlittle() except it returns two 32-bit hashes for the price of one.
+ * You could implement hashbig2() if you wanted but I haven't bothered here.
+ *
+ * If you want to find a hash of, say, exactly 7 integers, do
+ * a = i1;  b = i2;  c = i3;
+ * mix(a,b,c);
+ * a += i4; b += i5; c += i6;
+ * mix(a,b,c);
+ * a += i7;
+ * final(a,b,c);
+ * then use c as the hash value.  If you have a variable length array of
+ * 4-byte integers to hash, use hashword().  If you have a byte array (like
+ * a character string), use hashlittle().  If you have several byte arrays, or
+ * a mix of things, see the comments above hashlittle().
+ *
+ * Why is this so big?  I read 12 bytes at a time into 3 4-byte integers,
+ * then mix those integers.  This is fast (you can do a lot more thorough
+ * mixing with 12*3 instructions on 3 integers than you can with 3 instructions
+ * on 1 byte), but shoehorning those bytes into integers efficiently is messy.
+ * -------------------------------------------------------------------------------
+ */
+
+/* #define SELF_TEST 1 */
+
+#include <stdio.h>      /* defines printf for tests */
+#include <time.h>       /* defines time_t for timings in the test */
+#include <stdint.h>     /* defines uint32_t etc */
+#include <sys/param.h>  /* attempt to define endianness */
+#ifdef linux
+# include <endian.h>    /* attempt to define endianness */
+#endif
+
+#include "lookup3.h"
+
+/*
+ * My best guess at if you are big-endian or little-endian.  This may
+ * need adjustment.
+ */
+#if (defined(__BYTE_ORDER) && defined(__LITTLE_ENDIAN) && \
+	__BYTE_ORDER == __LITTLE_ENDIAN) || \
+	(defined(i386) || defined(__i386__) || defined(__i486__) || \
+	defined(__i586__) || defined(__i686__) || defined(vax) || defined(MIPSEL))
+# define HASH_LITTLE_ENDIAN 1
+# define HASH_BIG_ENDIAN 0
+#elif (defined(__BYTE_ORDER) && defined(__BIG_ENDIAN) && \
+	__BYTE_ORDER == __BIG_ENDIAN) || \
+	(defined(sparc) || defined(POWERPC) || defined(mc68000) || defined(sel))
+# define HASH_LITTLE_ENDIAN 0
+# define HASH_BIG_ENDIAN 1
+#else
+# define HASH_LITTLE_ENDIAN 0
+# define HASH_BIG_ENDIAN 0
+#endif
+
+#define hashsize(n) ((uint32_t) 1 << (n))
+#define hashmask(n) (hashsize(n) - 1)
+#define rot(x, k) (((x) << (k)) | ((x) >> (32 - (k))))
+
+/*
+ * -------------------------------------------------------------------------------
+ * mix -- mix 3 32-bit values reversibly.
+ *
+ * This is reversible, so any information in (a,b,c) before mix() is
+ * still in (a,b,c) after mix().
+ *
+ * If four pairs of (a,b,c) inputs are run through mix(), or through
+ * mix() in reverse, there are at least 32 bits of the output that
+ * are sometimes the same for one pair and different for another pair.
+ * This was tested for:
+ * pairs that differed by one bit, by two bits, in any combination
+ * of top bits of (a,b,c), or in any combination of bottom bits of
+ * (a,b,c).
+ * "differ" is defined as +, -, ^, or ~^.  For + and -, I transformed
+ * the output delta to a Gray code (a^(a>>1)) so a string of 1's (as
+ * is commonly produced by subtraction) look like a single 1-bit
+ * difference.
+ * the base values were pseudorandom, all zero but one bit set, or
+ * all zero plus a counter that starts at zero.
+ *
+ * Some k values for my "a-=c; a^=rot(c,k); c+=b;" arrangement that
+ * satisfy this are
+ *  4  6  8 16 19  4
+ *  9 15  3 18 27 15
+ * 14  9  3  7 17  3
+ * Well, "9 15 3 18 27 15" didn't quite get 32 bits diffing
+ * for "differ" defined as + with a one-bit base and a two-bit delta.  I
+ * used http://burtleburtle.net/bob/hash/avalanche.html to choose
+ * the operations, constants, and arrangements of the variables.
+ *
+ * This does not achieve avalanche.  There are input bits of (a,b,c)
+ * that fail to affect some output bits of (a,b,c), especially of a.  The
+ * most thoroughly mixed value is c, but it doesn't really even achieve
+ * avalanche in c.
+ *
+ * This allows some parallelism.  Read-after-writes are good at doubling
+ * the number of bits affected, so the goal of mixing pulls in the opposite
+ * direction as the goal of parallelism.  I did what I could.  Rotates
+ * seem to cost as much as shifts on every machine I could lay my hands
+ * on, and rotates are much kinder to the top and bottom bits, so I used
+ * rotates.
+ * -------------------------------------------------------------------------------
+ */
+#define mix(a, b, c) \
+	{ \
+		a -= c;  a ^= rot(c, 4);  c += b; \
+		b -= a;  b ^= rot(a, 6);  a += c; \
+		c -= b;  c ^= rot(b, 8);  b += a; \
+		a -= c;  a ^= rot(c, 16);  c += b; \
+		b -= a;  b ^= rot(a, 19);  a += c; \
+		c -= b;  c ^= rot(b, 4);  b += a; \
+	}
+
+/*
+ * -------------------------------------------------------------------------------
+ * final -- final mixing of 3 32-bit values (a,b,c) into c
+ *
+ * Pairs of (a,b,c) values differing in only a few bits will usually
+ * produce values of c that look totally different.  This was tested for
+ * pairs that differed by one bit, by two bits, in any combination
+ * of top bits of (a,b,c), or in any combination of bottom bits of
+ * (a,b,c).
+ * "differ" is defined as +, -, ^, or ~^.  For + and -, I transformed
+ * the output delta to a Gray code (a^(a>>1)) so a string of 1's (as
+ * is commonly produced by subtraction) look like a single 1-bit
+ * difference.
+ * the base values were pseudorandom, all zero but one bit set, or
+ * all zero plus a counter that starts at zero.
+ *
+ * These constants passed:
+ * 14 11 25 16 4 14 24
+ * 12 14 25 16 4 14 24
+ * and these came close:
+ * 4  8 15 26 3 22 24
+ * 10  8 15 26 3 22 24
+ * 11  8 15 26 3 22 24
+ * -------------------------------------------------------------------------------
+ */
+#define final(a, b, c) \
+	{ \
+		c ^= b; c -= rot(b, 14); \
+		a ^= c; a -= rot(c, 11); \
+		b ^= a; b -= rot(a, 25); \
+		c ^= b; c -= rot(b, 16); \
+		a ^= c; a -= rot(c, 4); \
+		b ^= a; b -= rot(a, 14); \
+		c ^= b; c -= rot(b, 24); \
+	}
+
+/*
+ * --------------------------------------------------------------------
+ * This works on all machines.  To be useful, it requires
+ * -- that the key be an array of uint32_t's, and
+ * -- that the length be the number of uint32_t's in the key
+ *
+ * The function hashword() is identical to hashlittle() on little-endian
+ * machines, and identical to hashbig() on big-endian machines,
+ * except that the length has to be measured in uint32_ts rather than in
+ * bytes.  hashlittle() is more complicated than hashword() only because
+ * hashlittle() has to dance around fitting the key bytes into registers.
+ * --------------------------------------------------------------------
+ */
+uint32_t
+hashword(const uint32_t *k,          /* the key, an array of uint32_t values */
+		 size_t length,               /* the length of the key, in uint32_ts */
+		 uint32_t initval)       /* the previous hash, or an arbitrary value */
+{
+	uint32_t a, b, c;
+
+	/* Set up the internal state */
+	a = b = c = 0xdeadbeef + (((uint32_t) length) << 2) + initval;
+
+	/*------------------------------------------------- handle most of the key */
+	while (length > 3)
+	{
+		a += k[0];
+		b += k[1];
+		c += k[2];
+		mix(a, b, c);
+		length -= 3;
+		k += 3;
+	}
+
+	/*------------------------------------------- handle the last 3 uint32_t's */
+	switch (length)                  /* all the case statements fall through */
+	{
+		case 3:
+		{
+			c += k[2];
+		}
+
+		case 2:
+		{
+			b += k[1];
+		}
+
+		case 1:
+		{
+			a += k[0];
+			final(a, b, c);
+		}
+
+		case 0: /* case 0: nothing left to add */
+		{
+			break;
+		}
+	}
+
+	/*------------------------------------------------------ report the result */
+	return c;
+}
+
+
+/*
+ * --------------------------------------------------------------------
+ * hashword2() -- same as hashword(), but take two seeds and return two
+ * 32-bit values.  pc and pb must both be nonnull, and *pc and *pb must
+ * both be initialized with seeds.  If you pass in (*pb)==0, the output
+ * (*pc) will be the same as the return value from hashword().
+ * --------------------------------------------------------------------
+ */
+void
+hashword2(const uint32_t *k,         /* the key, an array of uint32_t values */
+		  size_t length,              /* the length of the key, in uint32_ts */
+		  uint32_t *pc,                  /* IN: seed OUT: primary hash value */
+		  uint32_t *pb)           /* IN: more seed OUT: secondary hash value */
+{
+	uint32_t a, b, c;
+
+	/* Set up the internal state */
+	a = b = c = 0xdeadbeef + ((uint32_t) (length << 2)) + *pc;
+	c += *pb;
+
+	/*------------------------------------------------- handle most of the key */
+	while (length > 3)
+	{
+		a += k[0];
+		b += k[1];
+		c += k[2];
+		mix(a, b, c);
+		length -= 3;
+		k += 3;
+	}
+
+	/*------------------------------------------- handle the last 3 uint32_t's */
+	switch (length)                  /* all the case statements fall through */
+	{
+		case 3:
+		{
+			c += k[2];
+		}
+
+		case 2:
+		{
+			b += k[1];
+		}
+
+		case 1:
+		{
+			a += k[0];
+			final(a, b, c);
+		}
+
+		case 0: /* case 0: nothing left to add */
+		{
+			break;
+		}
+	}
+
+	/*------------------------------------------------------ report the result */
+	*pc = c;
+	*pb = b;
+}
+
+
+/*
+ * -------------------------------------------------------------------------------
+ * hashlittle() -- hash a variable-length key into a 32-bit value
+ * k       : the key (the unaligned variable-length array of bytes)
+ * length  : the length of the key, counting by bytes
+ * initval : can be any 4-byte value
+ * Returns a 32-bit value.  Every bit of the key affects every bit of
+ * the return value.  Two keys differing by one or two bits will have
+ * totally different hash values.
+ *
+ * The best hash table sizes are powers of 2.  There is no need to do
+ * mod a prime (mod is sooo slow!).  If you need less than 32 bits,
+ * use a bitmask.  For example, if you need only 10 bits, do
+ * h = (h & hashmask(10));
+ * In which case, the hash table should have hashsize(10) elements.
+ *
+ * If you are hashing n strings (uint8_t **)k, do it like this:
+ * for (i=0, h=0; i<n; ++i) h = hashlittle( k[i], len[i], h);
+ *
+ * By Bob Jenkins, 2006.  bob_jenkins@burtleburtle.net.  You may use this
+ * code any way you wish, private, educational, or commercial.  It's free.
+ *
+ * Use for hash table lookup, or anything where one collision in 2^^32 is
+ * acceptable.  Do NOT use for cryptographic purposes.
+ * -------------------------------------------------------------------------------
+ */
+uint32_t
+hashlittle(const void *key, size_t length, uint32_t initval)
+{
+	uint32_t a, b, c;                                      /* internal state */
+	union
+	{
+		const void *ptr;
+		size_t i;
+	}
+	u;                                        /* needed for Mac Powerbook G4 */
+
+	/* Set up the internal state */
+	a = b = c = 0xdeadbeef + ((uint32_t) length) + initval;
+
+	u.ptr = key;
+	if (HASH_LITTLE_ENDIAN && ((u.i & 0x3) == 0))
+	{
+		const uint32_t *k = (const uint32_t *) key;    /* read 32-bit chunks */
+
+#ifdef VALGRIND
+		const uint8_t *k8;
+#endif
+
+		/*------ all but last block: aligned reads and affect 32 bits of (a,b,c) */
+		while (length > 12)
+		{
+			a += k[0];
+			b += k[1];
+			c += k[2];
+			mix(a, b, c);
+			length -= 12;
+			k += 3;
+		}
+
+		/*----------------------------- handle the last (probably partial) block */
+
+		/*
+		 * "k[2]&0xffffff" actually reads beyond the end of the string, but
+		 * then masks off the part it's not allowed to read.  Because the
+		 * string is aligned, the masked-off tail is in the same word as the
+		 * rest of the string.  Every machine with memory protection I've seen
+		 * does it on word boundaries, so is OK with this.  But VALGRIND will
+		 * still catch it and complain.  The masking trick does make the hash
+		 * noticably faster for short strings (like English words).
+		 */
+#ifndef VALGRIND
+
+		switch (length)
+		{
+			case 12:
+			{
+				c += k[2];
+				b += k[1];
+				a += k[0];
+				break;
+			}
+
+			case 11:
+			{
+				c += k[2] & 0xffffff;
+				b += k[1];
+				a += k[0];
+				break;
+			}
+
+			case 10:
+			{
+				c += k[2] & 0xffff;
+				b += k[1];
+				a += k[0];
+				break;
+			}
+
+			case 9:
+			{
+				c += k[2] & 0xff;
+				b += k[1];
+				a += k[0];
+				break;
+			}
+
+			case 8:
+			{
+				b += k[1];
+				a += k[0];
+				break;
+			}
+
+			case 7:
+			{
+				b += k[1] & 0xffffff;
+				a += k[0];
+				break;
+			}
+
+			case 6:
+			{
+				b += k[1] & 0xffff;
+				a += k[0];
+				break;
+			}
+
+			case 5:
+			{
+				b += k[1] & 0xff;
+				a += k[0];
+				break;
+			}
+
+			case 4:
+			{
+				a += k[0];
+				break;
+			}
+
+			case 3:
+			{
+				a += k[0] & 0xffffff;
+				break;
+			}
+
+			case 2:
+			{
+				a += k[0] & 0xffff;
+				break;
+			}
+
+			case 1:
+			{
+				a += k[0] & 0xff;
+				break;
+			}
+
+			case 0:
+				return c;           /* zero length strings require no mixing */
+		}
+
+#else /* make valgrind happy */
+
+		k8 = (const uint8_t *) k;
+		switch (length)
+		{
+			case 12:
+			{
+				c += k[2];
+				b += k[1];
+				a += k[0];
+				break;
+			}
+
+			case 11:
+			{
+				c += ((uint32_t) k8[10]) << 16; /* fall through */
+			}
+
+			case 10:
+			{
+				c += ((uint32_t) k8[9]) << 8; /* fall through */
+			}
+
+			case 9:
+			{
+				c += k8[8];              /* fall through */
+			}
+
+			case 8:
+			{
+				b += k[1];
+				a += k[0];
+				break;
+			}
+
+			case 7:
+			{
+				b += ((uint32_t) k8[6]) << 16; /* fall through */
+			}
+
+			case 6:
+			{
+				b += ((uint32_t) k8[5]) << 8; /* fall through */
+			}
+
+			case 5:
+			{
+				b += k8[4];              /* fall through */
+			}
+
+			case 4:
+			{
+				a += k[0];
+				break;
+			}
+
+			case 3:
+			{
+				a += ((uint32_t) k8[2]) << 16; /* fall through */
+			}
+
+			case 2:
+			{
+				a += ((uint32_t) k8[1]) << 8; /* fall through */
+			}
+
+			case 1:
+			{
+				a += k8[0];
+				break;
+			}
+
+			case 0:
+				return c;
+		}
+
+#endif /* !valgrind */
+	}
+	else if (HASH_LITTLE_ENDIAN && ((u.i & 0x1) == 0))
+	{
+		const uint16_t *k = (const uint16_t *) key;    /* read 16-bit chunks */
+		const uint8_t *k8;
+
+		/*--------------- all but last block: aligned reads and different mixing */
+		while (length > 12)
+		{
+			a += k[0] + (((uint32_t) k[1]) << 16);
+			b += k[2] + (((uint32_t) k[3]) << 16);
+			c += k[4] + (((uint32_t) k[5]) << 16);
+			mix(a, b, c);
+			length -= 12;
+			k += 6;
+		}
+
+		/*----------------------------- handle the last (probably partial) block */
+		k8 = (const uint8_t *) k;
+		switch (length)
+		{
+			case 12:
+			{
+				c += k[4] + (((uint32_t) k[5]) << 16);
+				b += k[2] + (((uint32_t) k[3]) << 16);
+				a += k[0] + (((uint32_t) k[1]) << 16);
+				break;
+			}
+
+			case 11:
+			{
+				c += ((uint32_t) k8[10]) << 16; /* fall through */
+			}
+
+			case 10:
+			{
+				c += k[4];
+				b += k[2] + (((uint32_t) k[3]) << 16);
+				a += k[0] + (((uint32_t) k[1]) << 16);
+				break;
+			}
+
+			case 9:
+			{
+				c += k8[8];                 /* fall through */
+			}
+
+			case 8:
+			{
+				b += k[2] + (((uint32_t) k[3]) << 16);
+				a += k[0] + (((uint32_t) k[1]) << 16);
+				break;
+			}
+
+			case 7:
+			{
+				b += ((uint32_t) k8[6]) << 16; /* fall through */
+			}
+
+			case 6:
+			{
+				b += k[2];
+				a += k[0] + (((uint32_t) k[1]) << 16);
+				break;
+			}
+
+			case 5:
+			{
+				b += k8[4];                 /* fall through */
+			}
+
+			case 4:
+			{
+				a += k[0] + (((uint32_t) k[1]) << 16);
+				break;
+			}
+
+			case 3:
+			{
+				a += ((uint32_t) k8[2]) << 16; /* fall through */
+			}
+
+			case 2:
+			{
+				a += k[0];
+				break;
+			}
+
+			case 1:
+			{
+				a += k8[0];
+				break;
+			}
+
+			case 0:
+				return c;                  /* zero length requires no mixing */
+		}
+	}
+	else                          /* need to read the key one byte at a time */
+	{
+		const uint8_t *k = (const uint8_t *) key;
+
+		/*--------------- all but the last block: affect some 32 bits of (a,b,c) */
+		while (length > 12)
+		{
+			a += k[0];
+			a += ((uint32_t) k[1]) << 8;
+			a += ((uint32_t) k[2]) << 16;
+			a += ((uint32_t) k[3]) << 24;
+			b += k[4];
+			b += ((uint32_t) k[5]) << 8;
+			b += ((uint32_t) k[6]) << 16;
+			b += ((uint32_t) k[7]) << 24;
+			c += k[8];
+			c += ((uint32_t) k[9]) << 8;
+			c += ((uint32_t) k[10]) << 16;
+			c += ((uint32_t) k[11]) << 24;
+			mix(a, b, c);
+			length -= 12;
+			k += 12;
+		}
+
+		/*-------------------------------- last block: affect all 32 bits of (c) */
+		switch (length)              /* all the case statements fall through */
+		{
+			case 12:
+			{
+				c += ((uint32_t) k[11]) << 24;
+			}
+
+			case 11:
+			{
+				c += ((uint32_t) k[10]) << 16;
+			}
+
+			case 10:
+			{
+				c += ((uint32_t) k[9]) << 8;
+			}
+
+			case 9:
+			{
+				c += k[8];
+			}
+
+			case 8:
+			{
+				b += ((uint32_t) k[7]) << 24;
+			}
+
+			case 7:
+			{
+				b += ((uint32_t) k[6]) << 16;
+			}
+
+			case 6:
+			{
+				b += ((uint32_t) k[5]) << 8;
+			}
+
+			case 5:
+			{
+				b += k[4];
+			}
+
+			case 4:
+			{
+				a += ((uint32_t) k[3]) << 24;
+			}
+
+			case 3:
+			{
+				a += ((uint32_t) k[2]) << 16;
+			}
+
+			case 2:
+			{
+				a += ((uint32_t) k[1]) << 8;
+			}
+
+			case 1:
+			{
+				a += k[0];
+				break;
+			}
+
+			case 0:
+				return c;
+		}
+	}
+
+	final(a, b, c);
+	return c;
+}
+
+
+/*
+ * hashlittle2: return 2 32-bit hash values
+ *
+ * This is identical to hashlittle(), except it returns two 32-bit hash
+ * values instead of just one.  This is good enough for hash table
+ * lookup with 2^^64 buckets, or if you want a second hash if you're not
+ * happy with the first, or if you want a probably-unique 64-bit ID for
+ * the key.  *pc is better mixed than *pb, so use *pc first.  If you want
+ * a 64-bit value do something like "*pc + (((uint64_t)*pb)<<32)".
+ */
+void
+hashlittle2(const void *key, /* the key to hash */
+			size_t length, /* length of the key */
+			uint32_t *pc, /* IN: primary initval, OUT: primary hash */
+			uint32_t *pb) /* IN: secondary initval, OUT: secondary hash */
+{
+	uint32_t a, b, c;                                      /* internal state */
+	union
+	{
+		const void *ptr;
+		size_t i;
+	}
+	u;                                        /* needed for Mac Powerbook G4 */
+
+	/* Set up the internal state */
+	a = b = c = 0xdeadbeef + ((uint32_t) length) + *pc;
+	c += *pb;
+
+	u.ptr = key;
+	if (HASH_LITTLE_ENDIAN && ((u.i & 0x3) == 0))
+	{
+		const uint32_t *k = (const uint32_t *) key;    /* read 32-bit chunks */
+
+#ifdef VALGRIND
+		const uint8_t *k8;
+#endif
+
+		/*------ all but last block: aligned reads and affect 32 bits of (a,b,c) */
+		while (length > 12)
+		{
+			a += k[0];
+			b += k[1];
+			c += k[2];
+			mix(a, b, c);
+			length -= 12;
+			k += 3;
+		}
+
+		/*----------------------------- handle the last (probably partial) block */
+
+		/*
+		 * "k[2]&0xffffff" actually reads beyond the end of the string, but
+		 * then masks off the part it's not allowed to read.  Because the
+		 * string is aligned, the masked-off tail is in the same word as the
+		 * rest of the string.  Every machine with memory protection I've seen
+		 * does it on word boundaries, so is OK with this.  But VALGRIND will
+		 * still catch it and complain.  The masking trick does make the hash
+		 * noticably faster for short strings (like English words).
+		 */
+#ifndef VALGRIND
+
+		switch (length)
+		{
+			case 12:
+			{
+				c += k[2];
+				b += k[1];
+				a += k[0];
+				break;
+			}
+
+			case 11:
+			{
+				c += k[2] & 0xffffff;
+				b += k[1];
+				a += k[0];
+				break;
+			}
+
+			case 10:
+			{
+				c += k[2] & 0xffff;
+				b += k[1];
+				a += k[0];
+				break;
+			}
+
+			case 9:
+			{
+				c += k[2] & 0xff;
+				b += k[1];
+				a += k[0];
+				break;
+			}
+
+			case 8:
+			{
+				b += k[1];
+				a += k[0];
+				break;
+			}
+
+			case 7:
+			{
+				b += k[1] & 0xffffff;
+				a += k[0];
+				break;
+			}
+
+			case 6:
+			{
+				b += k[1] & 0xffff;
+				a += k[0];
+				break;
+			}
+
+			case 5:
+			{
+				b += k[1] & 0xff;
+				a += k[0];
+				break;
+			}
+
+			case 4:
+			{
+				a += k[0];
+				break;
+			}
+
+			case 3:
+			{
+				a += k[0] & 0xffffff;
+				break;
+			}
+
+			case 2:
+			{
+				a += k[0] & 0xffff;
+				break;
+			}
+
+			case 1:
+			{
+				a += k[0] & 0xff;
+				break;
+			}
+
+			case 0:
+				*pc = c;
+				*pb = b;
+				return;             /* zero length strings require no mixing */
+		}
+
+#else /* make valgrind happy */
+
+		k8 = (const uint8_t *) k;
+		switch (length)
+		{
+			case 12:
+			{
+				c += k[2];
+				b += k[1];
+				a += k[0];
+				break;
+			}
+
+			case 11:
+			{
+				c += ((uint32_t) k8[10]) << 16; /* fall through */
+			}
+
+			case 10:
+			{
+				c += ((uint32_t) k8[9]) << 8; /* fall through */
+			}
+
+			case 9:
+			{
+				c += k8[8];              /* fall through */
+			}
+
+			case 8:
+			{
+				b += k[1];
+				a += k[0];
+				break;
+			}
+
+			case 7:
+			{
+				b += ((uint32_t) k8[6]) << 16; /* fall through */
+			}
+
+			case 6:
+			{
+				b += ((uint32_t) k8[5]) << 8; /* fall through */
+			}
+
+			case 5:
+			{
+				b += k8[4];              /* fall through */
+			}
+
+			case 4:
+			{
+				a += k[0];
+				break;
+			}
+
+			case 3:
+			{
+				a += ((uint32_t) k8[2]) << 16; /* fall through */
+			}
+
+			case 2:
+			{
+				a += ((uint32_t) k8[1]) << 8; /* fall through */
+			}
+
+			case 1:
+			{
+				a += k8[0];
+				break;
+			}
+
+			case 0:
+				*pc = c;
+				*pb = b;
+				return;             /* zero length strings require no mixing */
+		}
+
+#endif /* !valgrind */
+	}
+	else if (HASH_LITTLE_ENDIAN && ((u.i & 0x1) == 0))
+	{
+		const uint16_t *k = (const uint16_t *) key;    /* read 16-bit chunks */
+		const uint8_t *k8;
+
+		/*--------------- all but last block: aligned reads and different mixing */
+		while (length > 12)
+		{
+			a += k[0] + (((uint32_t) k[1]) << 16);
+			b += k[2] + (((uint32_t) k[3]) << 16);
+			c += k[4] + (((uint32_t) k[5]) << 16);
+			mix(a, b, c);
+			length -= 12;
+			k += 6;
+		}
+
+		/*----------------------------- handle the last (probably partial) block */
+		k8 = (const uint8_t *) k;
+		switch (length)
+		{
+			case 12:
+			{
+				c += k[4] + (((uint32_t) k[5]) << 16);
+				b += k[2] + (((uint32_t) k[3]) << 16);
+				a += k[0] + (((uint32_t) k[1]) << 16);
+				break;
+			}
+
+			case 11:
+			{
+				c += ((uint32_t) k8[10]) << 16; /* fall through */
+			}
+
+			case 10:
+			{
+				c += k[4];
+				b += k[2] + (((uint32_t) k[3]) << 16);
+				a += k[0] + (((uint32_t) k[1]) << 16);
+				break;
+			}
+
+			case 9:
+			{
+				c += k8[8];                 /* fall through */
+			}
+
+			case 8:
+			{
+				b += k[2] + (((uint32_t) k[3]) << 16);
+				a += k[0] + (((uint32_t) k[1]) << 16);
+				break;
+			}
+
+			case 7:
+			{
+				b += ((uint32_t) k8[6]) << 16; /* fall through */
+			}
+
+			case 6:
+			{
+				b += k[2];
+				a += k[0] + (((uint32_t) k[1]) << 16);
+				break;
+			}
+
+			case 5:
+			{
+				b += k8[4];                 /* fall through */
+			}
+
+			case 4:
+			{
+				a += k[0] + (((uint32_t) k[1]) << 16);
+				break;
+			}
+
+			case 3:
+			{
+				a += ((uint32_t) k8[2]) << 16; /* fall through */
+			}
+
+			case 2:
+			{
+				a += k[0];
+				break;
+			}
+
+			case 1:
+			{
+				a += k8[0];
+				break;
+			}
+
+			case 0:
+				*pc = c;
+				*pb = b;
+				return;             /* zero length strings require no mixing */
+		}
+	}
+	else                          /* need to read the key one byte at a time */
+	{
+		const uint8_t *k = (const uint8_t *) key;
+
+		/*--------------- all but the last block: affect some 32 bits of (a,b,c) */
+		while (length > 12)
+		{
+			a += k[0];
+			a += ((uint32_t) k[1]) << 8;
+			a += ((uint32_t) k[2]) << 16;
+			a += ((uint32_t) k[3]) << 24;
+			b += k[4];
+			b += ((uint32_t) k[5]) << 8;
+			b += ((uint32_t) k[6]) << 16;
+			b += ((uint32_t) k[7]) << 24;
+			c += k[8];
+			c += ((uint32_t) k[9]) << 8;
+			c += ((uint32_t) k[10]) << 16;
+			c += ((uint32_t) k[11]) << 24;
+			mix(a, b, c);
+			length -= 12;
+			k += 12;
+		}
+
+		/*-------------------------------- last block: affect all 32 bits of (c) */
+		switch (length)              /* all the case statements fall through */
+		{
+			case 12:
+			{
+				c += ((uint32_t) k[11]) << 24;
+			}
+
+			case 11:
+			{
+				c += ((uint32_t) k[10]) << 16;
+			}
+
+			case 10:
+			{
+				c += ((uint32_t) k[9]) << 8;
+			}
+
+			case 9:
+			{
+				c += k[8];
+			}
+
+			case 8:
+			{
+				b += ((uint32_t) k[7]) << 24;
+			}
+
+			case 7:
+			{
+				b += ((uint32_t) k[6]) << 16;
+			}
+
+			case 6:
+			{
+				b += ((uint32_t) k[5]) << 8;
+			}
+
+			case 5:
+			{
+				b += k[4];
+			}
+
+			case 4:
+			{
+				a += ((uint32_t) k[3]) << 24;
+			}
+
+			case 3:
+			{
+				a += ((uint32_t) k[2]) << 16;
+			}
+
+			case 2:
+			{
+				a += ((uint32_t) k[1]) << 8;
+			}
+
+			case 1:
+			{
+				a += k[0];
+				break;
+			}
+
+			case 0:
+				*pc = c;
+				*pb = b;
+				return;             /* zero length strings require no mixing */
+		}
+	}
+
+	final(a, b, c);
+	*pc = c;
+	*pb = b;
+}
+
+
+/*
+ * hashbig():
+ * This is the same as hashword() on big-endian machines.  It is different
+ * from hashlittle() on all machines.  hashbig() takes advantage of
+ * big-endian byte ordering.
+ */
+uint32_t
+hashbig(const void *key, size_t length, uint32_t initval)
+{
+	uint32_t a, b, c;
+	union
+	{
+		const void *ptr;
+		size_t i;
+	}
+	u;                                    /* to cast key to (size_t) happily */
+
+	/* Set up the internal state */
+	a = b = c = 0xdeadbeef + ((uint32_t) length) + initval;
+
+	u.ptr = key;
+	if (HASH_BIG_ENDIAN && ((u.i & 0x3) == 0))
+	{
+		const uint32_t *k = (const uint32_t *) key;    /* read 32-bit chunks */
+
+#ifdef VALGRIND
+		const uint8_t *k8;
+#endif
+
+		/*------ all but last block: aligned reads and affect 32 bits of (a,b,c) */
+		while (length > 12)
+		{
+			a += k[0];
+			b += k[1];
+			c += k[2];
+			mix(a, b, c);
+			length -= 12;
+			k += 3;
+		}
+
+		/*----------------------------- handle the last (probably partial) block */
+
+		/*
+		 * "k[2]<<8" actually reads beyond the end of the string, but
+		 * then shifts out the part it's not allowed to read.  Because the
+		 * string is aligned, the illegal read is in the same word as the
+		 * rest of the string.  Every machine with memory protection I've seen
+		 * does it on word boundaries, so is OK with this.  But VALGRIND will
+		 * still catch it and complain.  The masking trick does make the hash
+		 * noticably faster for short strings (like English words).
+		 */
+#ifndef VALGRIND
+
+		switch (length)
+		{
+			case 12:
+			{
+				c += k[2];
+				b += k[1];
+				a += k[0];
+				break;
+			}
+
+			case 11:
+			{
+				c += k[2] & 0xffffff00;
+				b += k[1];
+				a += k[0];
+				break;
+			}
+
+			case 10:
+			{
+				c += k[2] & 0xffff0000;
+				b += k[1];
+				a += k[0];
+				break;
+			}
+
+			case 9:
+			{
+				c += k[2] & 0xff000000;
+				b += k[1];
+				a += k[0];
+				break;
+			}
+
+			case 8:
+			{
+				b += k[1];
+				a += k[0];
+				break;
+			}
+
+			case 7:
+			{
+				b += k[1] & 0xffffff00;
+				a += k[0];
+				break;
+			}
+
+			case 6:
+			{
+				b += k[1] & 0xffff0000;
+				a += k[0];
+				break;
+			}
+
+			case 5:
+			{
+				b += k[1] & 0xff000000;
+				a += k[0];
+				break;
+			}
+
+			case 4:
+			{
+				a += k[0];
+				break;
+			}
+
+			case 3:
+			{
+				a += k[0] & 0xffffff00;
+				break;
+			}
+
+			case 2:
+			{
+				a += k[0] & 0xffff0000;
+				break;
+			}
+
+			case 1:
+			{
+				a += k[0] & 0xff000000;
+				break;
+			}
+
+			case 0:
+				return c;           /* zero length strings require no mixing */
+		}
+
+#else  /* make valgrind happy */
+
+		k8 = (const uint8_t *) k;
+		switch (length)              /* all the case statements fall through */
+		{
+			case 12:
+			{
+				c += k[2];
+				b += k[1];
+				a += k[0];
+				break;
+			}
+
+			case 11:
+			{
+				c += ((uint32_t) k8[10]) << 8; /* fall through */
+			}
+
+			case 10:
+			{
+				c += ((uint32_t) k8[9]) << 16; /* fall through */
+			}
+
+			case 9:
+			{
+				c += ((uint32_t) k8[8]) << 24; /* fall through */
+			}
+
+			case 8:
+			{
+				b += k[1];
+				a += k[0];
+				break;
+			}
+
+			case 7:
+			{
+				b += ((uint32_t) k8[6]) << 8; /* fall through */
+			}
+
+			case 6:
+			{
+				b += ((uint32_t) k8[5]) << 16; /* fall through */
+			}
+
+			case 5:
+			{
+				b += ((uint32_t) k8[4]) << 24; /* fall through */
+			}
+
+			case 4:
+			{
+				a += k[0];
+				break;
+			}
+
+			case 3:
+			{
+				a += ((uint32_t) k8[2]) << 8; /* fall through */
+			}
+
+			case 2:
+			{
+				a += ((uint32_t) k8[1]) << 16; /* fall through */
+			}
+
+			case 1:
+			{
+				a += ((uint32_t) k8[0]) << 24;
+				break;
+			}
+
+			case 0:
+				return c;
+		}
+
+#endif /* !VALGRIND */
+	}
+	else                          /* need to read the key one byte at a time */
+	{
+		const uint8_t *k = (const uint8_t *) key;
+
+		/*--------------- all but the last block: affect some 32 bits of (a,b,c) */
+		while (length > 12)
+		{
+			a += ((uint32_t) k[0]) << 24;
+			a += ((uint32_t) k[1]) << 16;
+			a += ((uint32_t) k[2]) << 8;
+			a += ((uint32_t) k[3]);
+			b += ((uint32_t) k[4]) << 24;
+			b += ((uint32_t) k[5]) << 16;
+			b += ((uint32_t) k[6]) << 8;
+			b += ((uint32_t) k[7]);
+			c += ((uint32_t) k[8]) << 24;
+			c += ((uint32_t) k[9]) << 16;
+			c += ((uint32_t) k[10]) << 8;
+			c += ((uint32_t) k[11]);
+			mix(a, b, c);
+			length -= 12;
+			k += 12;
+		}
+
+		/*-------------------------------- last block: affect all 32 bits of (c) */
+		switch (length)              /* all the case statements fall through */
+		{
+			case 12:
+			{
+				c += k[11];
+			}
+
+			case 11:
+			{
+				c += ((uint32_t) k[10]) << 8;
+			}
+
+			case 10:
+			{
+				c += ((uint32_t) k[9]) << 16;
+			}
+
+			case 9:
+			{
+				c += ((uint32_t) k[8]) << 24;
+			}
+
+			case 8:
+			{
+				b += k[7];
+			}
+
+			case 7:
+			{
+				b += ((uint32_t) k[6]) << 8;
+			}
+
+			case 6:
+			{
+				b += ((uint32_t) k[5]) << 16;
+			}
+
+			case 5:
+			{
+				b += ((uint32_t) k[4]) << 24;
+			}
+
+			case 4:
+			{
+				a += k[3];
+			}
+
+			case 3:
+			{
+				a += ((uint32_t) k[2]) << 8;
+			}
+
+			case 2:
+			{
+				a += ((uint32_t) k[1]) << 16;
+			}
+
+			case 1:
+			{
+				a += ((uint32_t) k[0]) << 24;
+				break;
+			}
+
+			case 0:
+				return c;
+		}
+	}
+
+	final(a, b, c);
+	return c;
+}
+
+
+#ifdef SELF_TEST
+
+/* used for timings */
+void
+driver1()
+{
+	uint8_t buf[256];
+	uint32_t i;
+	uint32_t h = 0;
+	time_t a, z;
+
+	time(&a);
+	for (i = 0; i < 256; ++i)
+	{
+		buf[i] = 'x';
+	}
+	for (i = 0; i < 1; ++i)
+	{
+		h = hashlittle(&buf[0], 1, h);
+	}
+	time(&z);
+	if (z - a > 0)
+	{
+		printf("time %d %.8x\n", z - a, h);
+	}
+}
+
+
+/* check that every input bit changes every output bit half the time */
+#define HASHSTATE 1
+#define HASHLEN 1
+#define MAXPAIR 60
+#define MAXLEN 70
+void
+driver2()
+{
+	uint8_t qa[MAXLEN + 1], qb[MAXLEN + 2], *a = &qa[0], *b = &qb[1];
+	uint32_t c[HASHSTATE], d[HASHSTATE], i = 0, j = 0, k, l, m = 0, z;
+	uint32_t e[HASHSTATE], f[HASHSTATE], g[HASHSTATE], h[HASHSTATE];
+	uint32_t x[HASHSTATE], y[HASHSTATE];
+	uint32_t hlen;
+
+	printf("No more than %d trials should ever be needed \n", MAXPAIR / 2);
+	for (hlen = 0; hlen < MAXLEN; ++hlen)
+	{
+		z = 0;
+		for (i = 0; i < hlen; ++i) /*----------------------- for each input byte, */
+		{
+			for (j = 0; j < 8; ++j) /*------------------------ for each input bit, */
+			{
+				for (m = 1; m < 8; ++m) /*------------ for serveral possible initvals, */
+				{
+					for (l = 0; l < HASHSTATE; ++l)
+					{
+						e[l] = f[l] = g[l] = h[l] = x[l] = y[l] = ~((uint32_t) 0);
+					}
+
+					/*---- check that every output bit is affected by that input bit */
+					for (k = 0; k < MAXPAIR; k += 2)
+					{
+						uint32_t finished = 1;
+
+						/* keys have one bit different */
+						for (l = 0; l < hlen + 1; ++l)
+						{
+							a[l] = b[l] = (uint8_t) 0;
+						}
+
+						/* have a and b be two keys differing in only one bit */
+						a[i] ^= (k << j);
+						a[i] ^= (k >> (8 - j));
+						c[0] = hashlittle(a, hlen, m);
+						b[i] ^= ((k + 1) << j);
+						b[i] ^= ((k + 1) >> (8 - j));
+						d[0] = hashlittle(b, hlen, m);
+
+						/* check every bit is 1, 0, set, and not set at least once */
+						for (l = 0; l < HASHSTATE; ++l)
+						{
+							e[l] &= (c[l] ^ d[l]);
+							f[l] &= ~(c[l] ^ d[l]);
+							g[l] &= c[l];
+							h[l] &= ~c[l];
+							x[l] &= d[l];
+							y[l] &= ~d[l];
+							if (e[l] | f[l] | g[l] | h[l] | x[l] | y[l])
+							{
+								finished = 0;
+							}
+						}
+						if (finished)
+						{
+							break;
+						}
+					}
+					if (k > z)
+					{
+						z = k;
+					}
+					if (k == MAXPAIR)
+					{
+						printf("Some bit didn't change: ");
+						printf("%.8x %.8x %.8x %.8x %.8x %.8x  ",
+							   e[0], f[0], g[0], h[0], x[0], y[0]);
+						printf("i %d j %d m %d len %d\n", i, j, m, hlen);
+					}
+					if (z == MAXPAIR)
+					{
+						goto done;
+					}
+				}
+			}
+		}
+done:
+		if (z < MAXPAIR)
+		{
+			printf("Mix success  %2d bytes  %2d initvals  ", i, m);
+			printf("required  %d  trials\n", z / 2);
+		}
+	}
+	printf("\n");
+}
+
+
+/* Check for reading beyond the end of the buffer and alignment problems */
+void
+driver3()
+{
+	uint8_t buf[MAXLEN + 20], *b;
+	uint32_t len;
+	uint8_t q[] =
+		"This is the time for all good men to come to the aid of their country...";
+	uint32_t h;
+	uint8_t qq[] =
+		"xThis is the time for all good men to come to the aid of their country...";
+	uint32_t i;
+	uint8_t qqq[] =
+		"xxThis is the time for all good men to come to the aid of their country...";
+	uint32_t j;
+	uint8_t qqqq[] =
+		"xxxThis is the time for all good men to come to the aid of their country...";
+	uint32_t ref, x, y;
+	uint8_t *p;
+
+	printf("Endianness.  These lines should all be the same (for values filled in):\n");
+	printf("%.8x                            %.8x                            %.8x\n",
+		   hashword((const uint32_t *) q, (sizeof(q) - 1) / 4, 13),
+		   hashword((const uint32_t *) q, (sizeof(q) - 5) / 4, 13),
+		   hashword((const uint32_t *) q, (sizeof(q) - 9) / 4, 13));
+	p = q;
+	printf("%.8x %.8x %.8x %.8x %.8x %.8x %.8x %.8x %.8x %.8x %.8x %.8x\n",
+		   hashlittle(p, sizeof(q) - 1, 13), hashlittle(p, sizeof(q) - 2, 13),
+		   hashlittle(p, sizeof(q) - 3, 13), hashlittle(p, sizeof(q) - 4, 13),
+		   hashlittle(p, sizeof(q) - 5, 13), hashlittle(p, sizeof(q) - 6, 13),
+		   hashlittle(p, sizeof(q) - 7, 13), hashlittle(p, sizeof(q) - 8, 13),
+		   hashlittle(p, sizeof(q) - 9, 13), hashlittle(p, sizeof(q) - 10, 13),
+		   hashlittle(p, sizeof(q) - 11, 13), hashlittle(p, sizeof(q) - 12, 13));
+	p = &qq[1];
+	printf("%.8x %.8x %.8x %.8x %.8x %.8x %.8x %.8x %.8x %.8x %.8x %.8x\n",
+		   hashlittle(p, sizeof(q) - 1, 13), hashlittle(p, sizeof(q) - 2, 13),
+		   hashlittle(p, sizeof(q) - 3, 13), hashlittle(p, sizeof(q) - 4, 13),
+		   hashlittle(p, sizeof(q) - 5, 13), hashlittle(p, sizeof(q) - 6, 13),
+		   hashlittle(p, sizeof(q) - 7, 13), hashlittle(p, sizeof(q) - 8, 13),
+		   hashlittle(p, sizeof(q) - 9, 13), hashlittle(p, sizeof(q) - 10, 13),
+		   hashlittle(p, sizeof(q) - 11, 13), hashlittle(p, sizeof(q) - 12, 13));
+	p = &qqq[2];
+	printf("%.8x %.8x %.8x %.8x %.8x %.8x %.8x %.8x %.8x %.8x %.8x %.8x\n",
+		   hashlittle(p, sizeof(q) - 1, 13), hashlittle(p, sizeof(q) - 2, 13),
+		   hashlittle(p, sizeof(q) - 3, 13), hashlittle(p, sizeof(q) - 4, 13),
+		   hashlittle(p, sizeof(q) - 5, 13), hashlittle(p, sizeof(q) - 6, 13),
+		   hashlittle(p, sizeof(q) - 7, 13), hashlittle(p, sizeof(q) - 8, 13),
+		   hashlittle(p, sizeof(q) - 9, 13), hashlittle(p, sizeof(q) - 10, 13),
+		   hashlittle(p, sizeof(q) - 11, 13), hashlittle(p, sizeof(q) - 12, 13));
+	p = &qqqq[3];
+	printf("%.8x %.8x %.8x %.8x %.8x %.8x %.8x %.8x %.8x %.8x %.8x %.8x\n",
+		   hashlittle(p, sizeof(q) - 1, 13), hashlittle(p, sizeof(q) - 2, 13),
+		   hashlittle(p, sizeof(q) - 3, 13), hashlittle(p, sizeof(q) - 4, 13),
+		   hashlittle(p, sizeof(q) - 5, 13), hashlittle(p, sizeof(q) - 6, 13),
+		   hashlittle(p, sizeof(q) - 7, 13), hashlittle(p, sizeof(q) - 8, 13),
+		   hashlittle(p, sizeof(q) - 9, 13), hashlittle(p, sizeof(q) - 10, 13),
+		   hashlittle(p, sizeof(q) - 11, 13), hashlittle(p, sizeof(q) - 12, 13));
+	printf("\n");
+
+	/* check that hashlittle2 and hashlittle produce the same results */
+	i = 47;
+	j = 0;
+	hashlittle2(q, sizeof(q), &i, &j);
+	if (hashlittle(q, sizeof(q), 47) != i)
+	{
+		printf("hashlittle2 and hashlittle mismatch\n");
+	}
+
+	/* check that hashword2 and hashword produce the same results */
+	len = 0xdeadbeef;
+	i = 47, j = 0;
+	hashword2(&len, 1, &i, &j);
+	if (hashword(&len, 1, 47) != i)
+	{
+		printf("hashword2 and hashword mismatch %x %x\n",
+			   i, hashword(&len, 1, 47));
+	}
+
+	/* check hashlittle doesn't read before or after the ends of the string */
+	for (h = 0, b = buf + 1; h < 8; ++h, ++b)
+	{
+		for (i = 0; i < MAXLEN; ++i)
+		{
+			len = i;
+			for (j = 0; j < i; ++j)
+			{
+				*(b + j) = 0;
+			}
+
+			/* these should all be equal */
+			ref = hashlittle(b, len, (uint32_t) 1);
+			*(b + i) = (uint8_t) ~0;
+			*(b - 1) = (uint8_t) ~0;
+			x = hashlittle(b, len, (uint32_t) 1);
+			y = hashlittle(b, len, (uint32_t) 1);
+			if ((ref != x) || (ref != y))
+			{
+				printf("alignment error: %.8x %.8x %.8x %d %d\n", ref, x, y,
+					   h, i);
+			}
+		}
+	}
+}
+
+
+/* check for problems with nulls */
+void
+driver4()
+{
+	uint8_t buf[1];
+	uint32_t h, i, state[HASHSTATE];
+
+
+	buf[0] = ~0;
+	for (i = 0; i < HASHSTATE; ++i)
+	{
+		state[i] = 1;
+	}
+	printf("These should all be different\n");
+	for (i = 0, h = 0; i < 8; ++i)
+	{
+		h = hashlittle(buf, 0, h);
+		printf("%2ld  0-byte strings, hash is  %.8x\n", i, h);
+	}
+}
+
+
+void
+driver5()
+{
+	uint32_t b, c;
+	b = 0, c = 0, hashlittle2("", 0, &c, &b);
+	printf("hash is %.8lx %.8lx\n", c, b); /* deadbeef deadbeef */
+	b = 0xdeadbeef, c = 0, hashlittle2("", 0, &c, &b);
+	printf("hash is %.8lx %.8lx\n", c, b); /* bd5b7dde deadbeef */
+	b = 0xdeadbeef, c = 0xdeadbeef, hashlittle2("", 0, &c, &b);
+	printf("hash is %.8lx %.8lx\n", c, b); /* 9c093ccd bd5b7dde */
+	b = 0, c = 0, hashlittle2("Four score and seven years ago", 30, &c, &b);
+	printf("hash is %.8lx %.8lx\n", c, b); /* 17770551 ce7226e6 */
+	b = 1, c = 0, hashlittle2("Four score and seven years ago", 30, &c, &b);
+	printf("hash is %.8lx %.8lx\n", c, b); /* e3607cae bd371de4 */
+	b = 0, c = 1, hashlittle2("Four score and seven years ago", 30, &c, &b);
+	printf("hash is %.8lx %.8lx\n", c, b); /* cd628161 6cbea4b3 */
+	c = hashlittle("Four score and seven years ago", 30, 0);
+	printf("hash is %.8lx\n", c); /* 17770551 */
+	c = hashlittle("Four score and seven years ago", 30, 1);
+	printf("hash is %.8lx\n", c); /* cd628161 */
+}
+
+
+int
+main()
+{
+	driver1(); /* test that the key is hashed: used for timings */
+	driver2(); /* test that whole key is hashed thoroughly */
+	driver3(); /* test that nothing but the key is hashed */
+	driver4(); /* test hashing multiple buffers (all buffers are null) */
+	driver5(); /* test the hash against known vectors */
+	return 0;
+}
+
+
+#endif  /* SELF_TEST */

--- a/src/bin/lib/jenkins/lookup3.h
+++ b/src/bin/lib/jenkins/lookup3.h
@@ -1,0 +1,92 @@
+/* added to compile lookup3.c cleanly */
+
+#ifndef __LOOKUP3_h__
+#define __LOOKUP3_h__
+
+#include <stdint.h>     /* defines uint32_t etc */
+
+/*
+ * --------------------------------------------------------------------
+ * This works on all machines.  To be useful, it requires
+ * -- that the key be an array of uint32_t's, and
+ * -- that the length be the number of uint32_t's in the key
+ *
+ * The function hashword() is identical to hashlittle() on little-endian
+ * machines, and identical to hashbig() on big-endian machines,
+ * except that the length has to be measured in uint32_ts rather than in
+ * bytes.  hashlittle() is more complicated than hashword() only because
+ * hashlittle() has to dance around fitting the key bytes into registers.
+ * --------------------------------------------------------------------
+ */
+uint32_t hashword(const uint32_t *k,                   /* the key, an array of uint32_t values */
+				  size_t length,      /* the length of the key, in uint32_ts */
+				  uint32_t initval) /* the previous hash, or an arbitrary value */
+;
+
+/*
+ * --------------------------------------------------------------------
+ * hashword2() -- same as hashword(), but take two seeds and return two
+ * 32-bit values.  pc and pb must both be nonnull, and *pc and *pb must
+ * both be initialized with seeds.  If you pass in (*pb)==0, the output
+ * (*pc) will be the same as the return value from hashword().
+ * --------------------------------------------------------------------
+ */
+void hashword2(const uint32_t *k,                   /* the key, an array of uint32_t values */
+			   size_t length,         /* the length of the key, in uint32_ts */
+			   uint32_t *pc,             /* IN: seed OUT: primary hash value */
+			   uint32_t *pb)      /* IN: more seed OUT: secondary hash value */
+;
+
+/*
+ * -------------------------------------------------------------------------------
+ * hashlittle() -- hash a variable-length key into a 32-bit value
+ * k       : the key (the unaligned variable-length array of bytes)
+ * length  : the length of the key, counting by bytes
+ * initval : can be any 4-byte value
+ * Returns a 32-bit value.  Every bit of the key affects every bit of
+ * the return value.  Two keys differing by one or two bits will have
+ * totally different hash values.
+ *
+ * The best hash table sizes are powers of 2.  There is no need to do
+ * mod a prime (mod is sooo slow!).  If you need less than 32 bits,
+ * use a bitmask.  For example, if you need only 10 bits, do
+ * h = (h & hashmask(10));
+ * In which case, the hash table should have hashsize(10) elements.
+ *
+ * If you are hashing n strings (uint8_t **)k, do it like this:
+ * for (i=0, h=0; i<n; ++i) h = hashlittle( k[i], len[i], h);
+ *
+ * By Bob Jenkins, 2006.  bob_jenkins@burtleburtle.net.  You may use this
+ * code any way you wish, private, educational, or commercial.  It's free.
+ *
+ * Use for hash table lookup, or anything where one collision in 2^^32 is
+ * acceptable.  Do NOT use for cryptographic purposes.
+ * -------------------------------------------------------------------------------
+ */
+uint32_t hashlittle(const void *key, size_t length, uint32_t initval);
+
+/*
+ * hashlittle2: return 2 32-bit hash values
+ *
+ * This is identical to hashlittle(), except it returns two 32-bit hash
+ * values instead of just one.  This is good enough for hash table
+ * lookup with 2^^64 buckets, or if you want a second hash if you're not
+ * happy with the first, or if you want a probably-unique 64-bit ID for
+ * the key.  *pc is better mixed than *pb, so use *pc first.  If you want
+ * a 64-bit value do something like "*pc + (((uint64_t)*pb)<<32)".
+ */
+void hashlittle2(const void *key,       /* the key to hash */
+				 size_t length, /* length of the key */
+				 uint32_t *pc, /* IN: primary initval, OUT: primary hash */
+				 uint32_t *pb) /* IN: secondary initval, OUT: secondary hash */
+;
+
+/*
+ * hashbig():
+ * This is the same as hashword() on big-endian machines.  It is different
+ * from hashlittle() on all machines.  hashbig() takes advantage of
+ * big-endian byte ordering.
+ */
+uint32_t hashbig(const void *key, size_t length, uint32_t initval);
+
+#endif

--- a/src/bin/pgcopydb/Makefile
+++ b/src/bin/pgcopydb/Makefile
@@ -14,6 +14,7 @@ INCLUDES  = $(patsubst ${SRC_DIR}%.h,%.h,$(wildcard ${SRC_DIR}*.h))
 SRC   = $(patsubst ${SRC_DIR}%.c,%.c,$(wildcard ${SRC_DIR}*.c))
 OBJS  = $(patsubst %.c,%.o,$(SRC))
 OBJS += lib-log.o lib-commandline.o lib-parson.o lib-snprintf.o lib-strerror.o
+OBJS += lib-lookup3.o
 
 PG_CONFIG ?= pg_config
 BINDIR    ?= $(shell $(PG_CONFIG) --bindir)
@@ -22,13 +23,15 @@ PG_SNPRINTF     = $(wildcard ${SRC_DIR}../lib/pg/snprintf.*)
 LOG_SRC         = $(wildcard ${SRC_DIR}../lib/log/src/log.*)
 COMMANDLINE_SRC = $(wildcard ${SRC_DIR}../lib/subcommands.c/commandline.*)
 PARSON_SRC      = $(wildcard ${SRC_DIR}../lib/parson/parson.*)
+JENKINS_SRC     = $(wildcard ${SRC_DIR}../lib/jenkins/lookup3.*)
 
 COMMON_LIBS  = -I${SRC_DIR}../lib/pg
 COMMON_LIBS += -I${SRC_DIR}../lib/log/src/
 COMMON_LIBS += -I${SRC_DIR}../lib/subcommands.c/
 COMMON_LIBS += -I${SRC_DIR}../lib/libs/
 COMMON_LIBS += -I${SRC_DIR}../lib/parson/
-COMMON_LIBS += -I${SRC_DIR}../lib/uthash
+COMMON_LIBS += -I${SRC_DIR}../lib/uthash/
+COMMON_LIBS += -I${SRC_DIR}../lib/jenkins/
 
 CC = $(shell $(PG_CONFIG) --cc)
 
@@ -97,6 +100,9 @@ lib-commandline.o: $(COMMANDLINE_SRC)
 
 lib-parson.o: $(PARSON_SRC)
 	$(CC) $(CFLAGS) -c -MMD -MP -MF$(DEPDIR)/$(*F).Po -MT$@ -o $@ ${SRC_DIR}../lib/parson/parson.c
+
+lib-lookup3.o: $(JENKINS_SRC)
+	$(CC) $(CFLAGS) -c -MMD -MP -MF$(DEPDIR)/$(*F).Po -MT$@ -o $@ ${SRC_DIR}../lib/jenkins/lookup3.c
 
 VERSION-FILE: git-version.h ;
 

--- a/src/bin/pgcopydb/Makefile
+++ b/src/bin/pgcopydb/Makefile
@@ -62,6 +62,8 @@ endif
 
 override CFLAGS := $(DEFAULT_CFLAGS) $(CFLAGS)
 
+JENKINS_CFLAGS = $(CFAGS) -Wno-implicit-fallthrough -Wno-format
+
 LIBS  = -L $(shell $(PG_CONFIG) --pkglibdir)
 LIBS += -L $(shell $(PG_CONFIG) --libdir)
 LIBS += $(shell $(PG_CONFIG) --ldflags)
@@ -102,7 +104,7 @@ lib-parson.o: $(PARSON_SRC)
 	$(CC) $(CFLAGS) -c -MMD -MP -MF$(DEPDIR)/$(*F).Po -MT$@ -o $@ ${SRC_DIR}../lib/parson/parson.c
 
 lib-lookup3.o: $(JENKINS_SRC)
-	$(CC) $(CFLAGS) -c -MMD -MP -MF$(DEPDIR)/$(*F).Po -MT$@ -o $@ ${SRC_DIR}../lib/jenkins/lookup3.c
+	$(CC) $(JENKINS_CFLAGS) -c -MMD -MP -MF$(DEPDIR)/$(*F).Po -MT$@ -o $@ ${SRC_DIR}../lib/jenkins/lookup3.c
 
 VERSION-FILE: git-version.h ;
 

--- a/src/bin/pgcopydb/ld_stream.h
+++ b/src/bin/pgcopydb/ld_stream.h
@@ -20,6 +20,14 @@
 #define OUTPUT_KEEPALIVE "-- KEEPALIVE "
 #define OUTPUT_ENDPOS "-- ENDPOS "
 
+#define PREPARE "PREPARE "
+#define EXECUTE "EXECUTE "
+#define TRUNCATE "TRUNCATE "
+
+#define INSERT "AS INSERT INTO "
+#define UPDATE "AS UPDATE "
+#define DELETE "AS DELETE "
+
 typedef enum
 {
 	STREAM_ACTION_UNKNOWN = 0,
@@ -28,6 +36,7 @@ typedef enum
 	STREAM_ACTION_INSERT = 'I',
 	STREAM_ACTION_UPDATE = 'U',
 	STREAM_ACTION_DELETE = 'D',
+	STREAM_ACTION_EXECUTE = 'x',
 	STREAM_ACTION_TRUNCATE = 'T',
 	STREAM_ACTION_MESSAGE = 'M',
 	STREAM_ACTION_SWITCH = 'X',
@@ -63,6 +72,7 @@ typedef struct LogicalMessageMetadata
 
 	/* from parsing the message itself */
 	StreamAction action;
+	uint32_t hash;              /* PREPARE/EXECUTE statement name is a hash */
 	uint32_t xid;
 	uint64_t lsn;
 	uint64_t txnCommitLSN;      /* COMMIT LSN of the transaction */
@@ -71,6 +81,9 @@ typedef struct LogicalMessageMetadata
 	/* our own internal decision making */
 	bool filterOut;
 	bool skipping;
+
+	/* the statement part of a PREPARE dseadbeef AS ... */
+	char *stmt;
 
 	/* the raw message in our internal JSON format */
 	char *jsonBuffer;           /* malloc'ed area */
@@ -306,6 +319,19 @@ typedef struct StreamContext
 
 
 /*
+ * Keep track of the statements that have already been prepared in this
+ * session.
+ */
+typedef struct PreparedStmt
+{
+	uint32_t hash;
+	bool prepared;
+
+	UT_hash_handle hh;          /* makes this structure hashable */
+} PreparedStmt;
+
+
+/*
  * StreamApplyContext allows tracking the apply progress.
  */
 typedef struct StreamApplyContext
@@ -340,6 +366,8 @@ typedef struct StreamApplyContext
 
 	char wal[MAXPGPATH];
 	char sqlFileName[MAXPGPATH];
+
+	PreparedStmt *preparedStmt;
 } StreamApplyContext;
 
 
@@ -552,6 +580,10 @@ bool stream_write_update(FILE *out, LogicalMessageUpdate *update);
 bool stream_write_delete(FILE * out, LogicalMessageDelete *delete);
 bool stream_write_value(FILE *out, LogicalMessageValue *value);
 bool stream_write_sql_escape_string_constant(FILE *out, const char *str);
+
+bool stream_add_value_in_json_array(LogicalMessageValue *value,
+									JSON_Array *jsArray);
+
 
 bool parseMessage(StreamContext *privateContext, char *message, JSON_Value *json);
 

--- a/src/bin/pgcopydb/ld_stream.h
+++ b/src/bin/pgcopydb/ld_stream.h
@@ -578,7 +578,6 @@ bool stream_write_insert(FILE *out, LogicalMessageInsert *insert);
 bool stream_write_truncate(FILE *out, LogicalMessageTruncate *truncate);
 bool stream_write_update(FILE *out, LogicalMessageUpdate *update);
 bool stream_write_delete(FILE * out, LogicalMessageDelete *delete);
-bool stream_write_value(FILE *out, LogicalMessageValue *value);
 bool stream_write_sql_escape_string_constant(FILE *out, const char *str);
 
 bool stream_add_value_in_json_array(LogicalMessageValue *value,

--- a/src/bin/pgcopydb/ld_test_decoding.c
+++ b/src/bin/pgcopydb/ld_test_decoding.c
@@ -788,8 +788,9 @@ parseNextColumn(TestDecodingColumns *cols,
 			return false;
 		}
 
+		/* do not capture the quotes */
 		cols->valueStart = start;
-		cols->valueLen = end - start + 1;
+		cols->valueLen = end - start;
 
 		/* advance to past the value, skip the next space */
 		ptr = end + 1;
@@ -892,7 +893,7 @@ listToTuple(LogicalMessageTuple *tuple, TestDecodingColumns *cols, int count)
 			 */
 			valueColumn->isQuoted = false;
 
-			int len = cur->valueLen - 2;
+			int len = cur->valueLen;
 			valueColumn->val.str = (char *) calloc(len, sizeof(char));
 
 			if (valueColumn->val.str == NULL)
@@ -901,7 +902,7 @@ listToTuple(LogicalMessageTuple *tuple, TestDecodingColumns *cols, int count)
 				return false;
 			}
 
-			/* skip the opening single-quote, the closing one, and \0 */
+			/* copy the string contents without the surrounding quotes */
 			for (int i = 0, j = 0; i < cur->valueLen; i++)
 			{
 				char *ptr = cur->valueStart + i;

--- a/src/bin/pgcopydb/ld_test_decoding.c
+++ b/src/bin/pgcopydb/ld_test_decoding.c
@@ -759,8 +759,9 @@ parseNextColumn(TestDecodingColumns *cols,
 		/* now skip closing single quote */
 		++cur;
 
-		cols->valueStart = ptr;
-		cols->valueLen = cur - ptr + 1;
+		/* do not capture the quotes */
+		cols->valueStart = ptr + 1;
+		cols->valueLen = (cur - 1) - (ptr + 1);
 
 		/* advance the ptr to past the value, skip the next space */
 		ptr = cur;
@@ -810,7 +811,7 @@ parseNextColumn(TestDecodingColumns *cols,
 		if (spc != NULL)
 		{
 			header->pos = spc - header->message + 1;
-			cols->valueLen = spc - ptr + 1;
+			cols->valueLen = spc - ptr;
 		}
 		else
 		{
@@ -901,7 +902,7 @@ listToTuple(LogicalMessageTuple *tuple, TestDecodingColumns *cols, int count)
 			}
 
 			/* skip the opening single-quote, the closing one, and \0 */
-			for (int i = 1, j = 0; i < (cur->valueLen - 2); i++)
+			for (int i = 0, j = 0; i < cur->valueLen; i++)
 			{
 				char *ptr = cur->valueStart + i;
 				char *nxt = cur->valueStart + i + 1;

--- a/src/bin/pgcopydb/ld_transform.c
+++ b/src/bin/pgcopydb/ld_transform.c
@@ -17,6 +17,7 @@
 #include "access/xlog_internal.h"
 #include "access/xlogdefs.h"
 
+#include "lookup3.h"
 #include "parson.h"
 
 #include "cli_common.h"
@@ -1742,17 +1743,29 @@ stream_write_insert(FILE *out, LogicalMessageInsert *insert)
 	{
 		LogicalMessageTuple *stmt = &(insert->new.array[s]);
 
-		FFORMAT(out, "INSERT INTO \"%s\".\"%s\" ",
-				insert->nspname,
-				insert->relname);
+		PQExpBuffer buf = createPQExpBuffer();
+
+		JSON_Value *js = json_value_init_array();
+		JSON_Array *jsArray = json_value_get_array(js);
+
+		/*
+		 * First, the PREPARE part.
+		 */
+		appendPQExpBuffer(buf, "INSERT INTO \"%s\".\"%s\" ",
+						  insert->nspname,
+						  insert->relname);
 
 		/* loop over column names and add them to the out stream */
-		FFORMAT(out, "%s", "(");
+		appendPQExpBuffer(buf, "%s", "(");
+
 		for (int c = 0; c < stmt->cols; c++)
 		{
-			FFORMAT(out, "%s\"%s\"", c > 0 ? ", " : "", stmt->columns[c]);
+			appendPQExpBuffer(buf, "%s\"%s\"",
+							  c > 0 ? ", " : "",
+							  stmt->columns[c]);
 		}
-		FFORMAT(out, "%s", ")");
+
+		appendPQExpBuffer(buf, "%s", ")");
 
 		/*
 		 * See https://www.postgresql.org/docs/current/sql-insert.html
@@ -1769,34 +1782,54 @@ stream_write_insert(FILE *out, LogicalMessageInsert *insert)
 		 * VALUE is the normal behavior and specifying it does nothing, but
 		 * PostgreSQL allows it as an extension.)
 		 */
-		FFORMAT(out, "%s", " overriding system value ");
+		appendPQExpBufferStr(buf, " overriding system value VALUES ");
 
-		/* now loop over VALUES rows */
-		FFORMAT(out, "%s", "VALUES ");
+		int pos = 0;
 
 		for (int r = 0; r < stmt->values.count; r++)
 		{
 			LogicalMessageValues *values = &(stmt->values.array[r]);
 
 			/* now loop over column values for this VALUES row */
-			FFORMAT(out, "%s(", r > 0 ? ", " : "");
+			appendPQExpBuffer(buf, "%s(", r > 0 ? ", " : "");
+
 			for (int v = 0; v < values->cols; v++)
 			{
 				LogicalMessageValue *value = &(values->array[v]);
 
-				FFORMAT(out, "%s", v > 0 ? ", " : "");
+				appendPQExpBuffer(buf, "%s$%d",
+								  v > 0 ? ", " : "",
+								  ++pos);
 
-				if (!stream_write_value(out, value))
+				if (!stream_add_value_in_json_array(value, jsArray))
 				{
 					/* errors have already been logged */
 					return false;
 				}
 			}
 
-			FFORMAT(out, "%s", ")");
+			appendPQExpBufferStr(buf, ")");
 		}
 
-		FFORMAT(out, "%s", ";\n");
+		if (PQExpBufferBroken(buf))
+		{
+			log_error("Failed to transform INSERT statement: Out of Memory");
+			return false;
+		}
+
+		uint32_t hash = hashlittle(buf->data, buf->len, 5381);
+
+		FFORMAT(out, "PREPARE %x AS %s;\n", hash, buf->data);
+
+		/*
+		 * Second, the EXECUTE part.
+		 */
+		char *serialized_string = json_serialize_to_string(js);
+
+		FFORMAT(out, "EXECUTE %x%s;\n", hash, serialized_string);
+
+		json_free_serialized_string(serialized_string);
+		json_value_free(js);
 	}
 
 	return true;
@@ -1825,8 +1858,6 @@ stream_write_update(FILE *out, LogicalMessageUpdate *update)
 		LogicalMessageTuple *old = &(update->old.array[s]);
 		LogicalMessageTuple *new = &(update->new.array[s]);
 
-		FFORMAT(out, "UPDATE \"%s\".\"%s\" ", update->nspname, update->relname);
-
 		if (old->values.count != new->values.count ||
 			old->values.count != 1 ||
 			new->values.count != 1)
@@ -1838,7 +1869,18 @@ stream_write_update(FILE *out, LogicalMessageUpdate *update)
 			return false;
 		}
 
-		FFORMAT(out, "%s", "SET ");
+		PQExpBuffer buf = createPQExpBuffer();
+
+		JSON_Value *js = json_value_init_array();
+		JSON_Array *jsArray = json_value_get_array(js);
+
+		/*
+		 * First, the PREPARE part.
+		 */
+		appendPQExpBuffer(buf, "UPDATE \"%s\".\"%s\" SET ",
+						  update->nspname,
+						  update->relname);
+		int pos = 0;
 
 		for (int r = 0; r < new->values.count; r++)
 		{
@@ -1886,24 +1928,26 @@ stream_write_update(FILE *out, LogicalMessageUpdate *update)
 
 				if (!skip)
 				{
-					FFORMAT(out, "%s", first ? "" : ", ");
-					FFORMAT(out, "\"%s\" = ", colname);
+					appendPQExpBuffer(buf, "%s\"%s\" = $%d",
+									  first ? "" : ", ",
+									  colname,
+									  ++pos);
+
+					if (!stream_add_value_in_json_array(value, jsArray))
+					{
+						/* errors have already been logged */
+						return false;
+					}
 
 					if (first)
 					{
 						first = false;
 					}
-
-					if (!stream_write_value(out, value))
-					{
-						/* errors have already been logged */
-						return false;
-					}
 				}
 			}
 		}
 
-		FFORMAT(out, "%s", " WHERE ");
+		appendPQExpBufferStr(buf, " WHERE ");
 
 		for (int r = 0; r < old->values.count; r++)
 		{
@@ -1923,10 +1967,12 @@ stream_write_update(FILE *out, LogicalMessageUpdate *update)
 					return false;
 				}
 
-				FFORMAT(out, "%s", v > 0 ? " and " : "");
-				FFORMAT(out, "\"%s\" = ", old->columns[v]);
+				appendPQExpBuffer(buf, "%s\"%s\" = $%d",
+								  v > 0 ? " and " : "",
+								  old->columns[v],
+								  ++pos);
 
-				if (!stream_write_value(out, value))
+				if (!stream_add_value_in_json_array(value, jsArray))
 				{
 					/* errors have already been logged */
 					return false;
@@ -1934,7 +1980,25 @@ stream_write_update(FILE *out, LogicalMessageUpdate *update)
 			}
 		}
 
-		FFORMAT(out, "%s", ";\n");
+		if (PQExpBufferBroken(buf))
+		{
+			log_error("Failed to transform INSERT statement: Out of Memory");
+			return false;
+		}
+
+		uint32_t hash = hashlittle(buf->data, buf->len, 5381);
+
+		FFORMAT(out, "PREPARE %x AS %s;\n", hash, buf->data);
+
+		/*
+		 * Second, the EXECUTE part.
+		 */
+		char *serialized_string = json_serialize_to_string(js);
+
+		FFORMAT(out, "EXECUTE %x%s;\n", hash, serialized_string);
+
+		json_free_serialized_string(serialized_string);
+		json_value_free(js);
 	}
 
 	return true;
@@ -1953,12 +2017,18 @@ stream_write_delete(FILE *out, LogicalMessageDelete *delete)
 	{
 		LogicalMessageTuple *old = &(delete->old.array[s]);
 
-		FFORMAT(out,
-				"DELETE FROM \"%s\".\"%s\"",
-				delete->nspname,
-				delete->relname);
+		PQExpBuffer buf = createPQExpBuffer();
+		JSON_Value *js = json_value_init_array();
+		JSON_Array *jsArray = json_value_get_array(js);
 
-		FFORMAT(out, "%s", " WHERE ");
+		/*
+		 * First, the PREPARE part.
+		 */
+		appendPQExpBuffer(buf, "DELETE FROM \"%s\".\"%s\" WHERE ",
+						  delete->nspname,
+						  delete->relname);
+
+		int pos = 0;
 
 		for (int r = 0; r < old->values.count; r++)
 		{
@@ -1978,10 +2048,12 @@ stream_write_delete(FILE *out, LogicalMessageDelete *delete)
 					return false;
 				}
 
-				FFORMAT(out, "%s", v > 0 ? " and " : "");
-				FFORMAT(out, "\"%s\" = ", old->columns[v]);
+				appendPQExpBuffer(buf, "%s\"%s\" = $%d",
+								  v > 0 ? " and " : "",
+								  old->columns[v],
+								  ++pos);
 
-				if (!stream_write_value(out, value))
+				if (!stream_add_value_in_json_array(value, jsArray))
 				{
 					/* errors have already been logged */
 					return false;
@@ -1989,7 +2061,19 @@ stream_write_delete(FILE *out, LogicalMessageDelete *delete)
 			}
 		}
 
-		FFORMAT(out, "%s", ";\n");
+		uint32_t hash = hashlittle(buf->data, buf->len, 5381);
+
+		FFORMAT(out, "PREPARE %x AS %s;\n", hash, buf->data);
+
+		/*
+		 * Second, the EXECUTE part.
+		 */
+		char *serialized_string = json_serialize_to_string(js);
+
+		FFORMAT(out, "EXECUTE %x%s;\n", hash, serialized_string);
+
+		json_free_serialized_string(serialized_string);
+		json_value_free(js);
 	}
 
 	return true;
@@ -2089,6 +2173,84 @@ stream_write_value(FILE *out, LogicalMessageValue *value)
 			default:
 			{
 				log_error("BUG: stream_write_insert value with oid %d",
+						  value->oid);
+				return false;
+			}
+		}
+	}
+
+	return true;
+}
+
+
+/*
+ * stream_values_as_json_array fills-in a JSON array with the string
+ * representation of the given values.
+ */
+bool
+stream_add_value_in_json_array(LogicalMessageValue *value, JSON_Array *jsArray)
+{
+	if (value == NULL)
+	{
+		log_error("BUG: stream_values_as_json_array value is NULL");
+		return false;
+	}
+
+	if (value->isNull)
+	{
+		json_array_append_null(jsArray);
+	}
+	else
+	{
+		switch (value->oid)
+		{
+			case BOOLOID:
+			{
+				char *string = value->val.boolean ? "t" : "f";
+				json_array_append_string(jsArray, string);
+				break;
+			}
+
+			case INT8OID:
+			{
+				char string[BUFSIZE] = { 0 };
+
+				sformat(string, sizeof(string), "%lld",
+						(long long) value->val.int8);
+
+				json_array_append_string(jsArray, string);
+				break;
+			}
+
+			case FLOAT8OID:
+			{
+				char string[BUFSIZE] = { 0 };
+
+				if (fmod(value->val.float8, 1) == 0.0)
+				{
+					sformat(string, sizeof(string), "%lld",
+							(long long) value->val.float8);
+				}
+				else
+				{
+					sformat(string, sizeof(string), "%f", value->val.float8);
+				}
+
+				json_array_append_string(jsArray, string);
+				break;
+			}
+
+			case TEXTOID:
+			case BYTEAOID:
+			{
+				/* TODO: unquote? */
+				json_array_append_string(jsArray, value->val.str);
+				break;
+			}
+
+			default:
+			{
+				log_error("BUG: stream_values_as_json_array value with oid %d",
 						  value->oid);
 				return false;
 			}

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -1827,6 +1827,236 @@ pgsql_fetch_results(PGSQL *pgsql, bool *done,
 
 
 /*
+ * pgsql_prepare implements server-side prepared statements by using the
+ * Postgres protocol prepare/bind/execute messages. Use with
+ * pgsql_execute_prepared().
+ */
+bool
+pgsql_prepare(PGSQL *pgsql, const char *name, const char *sql,
+			  int paramCount, const Oid *paramTypes)
+{
+	PGconn *connection = pgsql_open_connection(pgsql);
+
+	if (connection == NULL)
+	{
+		return false;
+	}
+
+	char *endpoint =
+		pgsql->connectionType == PGSQL_CONN_SOURCE ? "SOURCE" : "TARGET";
+
+	if (pgsql->logSQL)
+	{
+		log_sql("[%s %d] PREPARE %s AS %s;",
+				endpoint, PQbackendPID(connection), name, sql);
+	}
+
+	PGresult *result = PQprepare(connection, name, sql, paramCount, paramTypes);
+
+	if (!is_response_ok(result))
+	{
+		char *sqlstate = PQresultErrorField(result, PG_DIAG_SQLSTATE);
+
+		if (sqlstate)
+		{
+			strlcpy(pgsql->sqlstate, sqlstate, sizeof(pgsql->sqlstate));
+		}
+
+		/*
+		 * PostgreSQL Error message might contain several lines. Log each of
+		 * them as a separate ERROR line here.
+		 */
+		char *message = PQerrorMessage(connection);
+
+		char *errorLines[BUFSIZE] = { 0 };
+		int lineCount = splitLines(message, errorLines, BUFSIZE);
+
+		for (int lineNumber = 0; lineNumber < lineCount; lineNumber++)
+		{
+			log_error("[%s %d] %s",
+					  endpoint,
+					  PQbackendPID(connection),
+					  errorLines[lineNumber]);
+		}
+
+		if (pgsql->logSQL)
+		{
+			log_error("[%s %d] SQL query: %s",
+					  endpoint,
+					  PQbackendPID(connection),
+					  sql);
+		}
+
+		/* if we get a connection exception, track that */
+		if (sqlstate &&
+			strncmp(sqlstate, STR_ERRCODE_CLASS_CONNECTION_EXCEPTION, 2) == 0)
+		{
+			pgsql->status = PG_CONNECTION_BAD;
+		}
+
+		PQclear(result);
+		clear_results(pgsql);
+
+		/*
+		 * Multi statements might want to ROLLBACK and hold to the open
+		 * connection for a retry step.
+		 */
+		if (pgsql->connectionStatementType == PGSQL_CONNECTION_SINGLE_STATEMENT)
+		{
+			(void) pgsql_finish(pgsql);
+		}
+
+		return false;
+	}
+
+	PQclear(result);
+	clear_results(pgsql);
+	if (pgsql->connectionStatementType == PGSQL_CONNECTION_SINGLE_STATEMENT)
+	{
+		(void) pgsql_finish(pgsql);
+	}
+
+	return true;
+}
+
+
+/*
+ * pgsql_prepare implements server-side prepared statements by using the
+ * Postgres protocol prepare/bind/execute messages. Use with
+ * pgsql_prepare().
+ */
+bool
+pgsql_execute_prepared(PGSQL *pgsql, const char *name,
+					   int paramCount, const char **paramValues,
+					   void *context, ParsePostgresResultCB *parseFun)
+{
+	PQExpBuffer debugParameters = NULL;
+
+	PGconn *connection = pgsql_open_connection(pgsql);
+
+	if (connection == NULL)
+	{
+		return false;
+	}
+
+	char *endpoint =
+		pgsql->connectionType == PGSQL_CONN_SOURCE ? "SOURCE" : "TARGET";
+
+	if (pgsql->logSQL)
+	{
+		debugParameters = createPQExpBuffer();
+
+		if (!build_parameters_list(debugParameters, paramCount, paramValues))
+		{
+			/* errors have already been logged */
+			destroyPQExpBuffer(debugParameters);
+			return false;
+		}
+
+		log_sql("[%s %d] EXECUTE %s;",
+				endpoint, PQbackendPID(connection), name);
+
+		if (paramCount > 0)
+		{
+			log_sql("[%s %d] %s",
+					endpoint,
+					PQbackendPID(connection),
+					debugParameters->data);
+		}
+	}
+
+	PGresult *result = PQexecPrepared(connection, name,
+									  paramCount, paramValues,
+									  NULL, NULL, 0);
+
+	if (!is_response_ok(result))
+	{
+		char *sqlstate = PQresultErrorField(result, PG_DIAG_SQLSTATE);
+
+		if (sqlstate)
+		{
+			strlcpy(pgsql->sqlstate, sqlstate, sizeof(pgsql->sqlstate));
+		}
+
+		/*
+		 * PostgreSQL Error message might contain several lines. Log each of
+		 * them as a separate ERROR line here.
+		 */
+		char *message = PQerrorMessage(connection);
+
+		char *errorLines[BUFSIZE] = { 0 };
+		int lineCount = splitLines(message, errorLines, BUFSIZE);
+
+		for (int lineNumber = 0; lineNumber < lineCount; lineNumber++)
+		{
+			log_error("[%s %d] %s",
+					  endpoint,
+					  PQbackendPID(connection),
+					  errorLines[lineNumber]);
+		}
+
+		if (pgsql->logSQL)
+		{
+			if (paramCount > 0)
+			{
+				log_error("[%s %d] SQL params: %s",
+						  endpoint,
+						  PQbackendPID(connection),
+						  debugParameters->data);
+			}
+
+			destroyPQExpBuffer(debugParameters);
+		}
+
+		/* now stash away the SQL STATE if any */
+		if (context && sqlstate)
+		{
+			AbstractResultContext *ctx = (AbstractResultContext *) context;
+
+			strlcpy(ctx->sqlstate, sqlstate, SQLSTATE_LENGTH);
+		}
+
+		/* if we get a connection exception, track that */
+		if (sqlstate &&
+			strncmp(sqlstate, STR_ERRCODE_CLASS_CONNECTION_EXCEPTION, 2) == 0)
+		{
+			pgsql->status = PG_CONNECTION_BAD;
+		}
+
+		PQclear(result);
+		clear_results(pgsql);
+
+		/*
+		 * Multi statements might want to ROLLBACK and hold to the open
+		 * connection for a retry step.
+		 */
+		if (pgsql->connectionStatementType == PGSQL_CONNECTION_SINGLE_STATEMENT)
+		{
+			(void) pgsql_finish(pgsql);
+		}
+
+		return false;
+	}
+
+	if (parseFun != NULL)
+	{
+		(*parseFun)(context, result);
+	}
+
+	destroyPQExpBuffer(debugParameters);
+
+	PQclear(result);
+	clear_results(pgsql);
+	if (pgsql->connectionStatementType == PGSQL_CONNECTION_SINGLE_STATEMENT)
+	{
+		(void) pgsql_finish(pgsql);
+	}
+
+	return true;
+}
+
+
+/*
  * build_parameters_list builds a string representation of the SQL query
  * parameter list given.
  */

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -40,6 +40,12 @@ static bool is_response_ok(PGresult *result);
 static bool clear_results(PGSQL *pgsql);
 static void pgsql_handle_notifications(PGSQL *pgsql);
 
+static void pgsql_execute_log_error(PGSQL *pgsql,
+									PGresult *result,
+									const char *sql,
+									PQExpBuffer debugParameters,
+									void *context);
+
 static bool build_parameters_list(PQExpBuffer buffer,
 								  int paramCount,
 								  const char **paramValues);
@@ -1510,65 +1516,8 @@ pgsql_execute_with_params(PGSQL *pgsql, const char *sql, int paramCount,
 
 	if (!is_response_ok(result))
 	{
-		char *sqlstate = PQresultErrorField(result, PG_DIAG_SQLSTATE);
-
-		if (sqlstate)
-		{
-			strlcpy(pgsql->sqlstate, sqlstate, sizeof(pgsql->sqlstate));
-		}
-
-		/*
-		 * PostgreSQL Error message might contain several lines. Log each of
-		 * them as a separate ERROR line here.
-		 */
-		char *message = PQerrorMessage(connection);
-
-		char *errorLines[BUFSIZE] = { 0 };
-		int lineCount = splitLines(message, errorLines, BUFSIZE);
-
-		for (int lineNumber = 0; lineNumber < lineCount; lineNumber++)
-		{
-			log_error("[%s %d] %s",
-					  endpoint,
-					  PQbackendPID(connection),
-					  errorLines[lineNumber]);
-		}
-
-		if (pgsql->logSQL)
-		{
-			log_error("[%s %d] SQL query: %s",
-					  endpoint,
-					  PQbackendPID(connection),
-					  sql);
-
-			if (paramCount > 0)
-			{
-				log_error("[%s %d] SQL params: %s",
-						  endpoint,
-						  PQbackendPID(connection),
-						  debugParameters->data);
-			}
-
-			destroyPQExpBuffer(debugParameters);
-		}
-
-		/* now stash away the SQL STATE if any */
-		if (context && sqlstate)
-		{
-			AbstractResultContext *ctx = (AbstractResultContext *) context;
-
-			strlcpy(ctx->sqlstate, sqlstate, SQLSTATE_LENGTH);
-		}
-
-		/* if we get a connection exception, track that */
-		if (sqlstate &&
-			strncmp(sqlstate, STR_ERRCODE_CLASS_CONNECTION_EXCEPTION, 2) == 0)
-		{
-			pgsql->status = PG_CONNECTION_BAD;
-		}
-
-		PQclear(result);
-		clear_results(pgsql);
+		pgsql_execute_log_error(pgsql, result, sql, debugParameters, context);
+		destroyPQExpBuffer(debugParameters);
 
 		/*
 		 * Multi statements might want to ROLLBACK and hold to the open
@@ -1770,44 +1719,7 @@ pgsql_fetch_results(PGSQL *pgsql, bool *done,
 
 		if (!is_response_ok(result))
 		{
-			char *sqlstate = PQresultErrorField(result, PG_DIAG_SQLSTATE);
-			char *message = PQerrorMessage(conn);
-
-			char *endpoint =
-				pgsql->connectionType == PGSQL_CONN_SOURCE ? "SOURCE" : "TARGET";
-
-			strlcpy(pgsql->sqlstate, sqlstate, sizeof(pgsql->sqlstate));
-
-			/*
-			 * PostgreSQL Error message might contain several lines. Log each of
-			 * them as a separate ERROR line here.
-			 */
-			char *errorLines[BUFSIZE] = { 0 };
-			int lineCount = splitLines(message, errorLines, BUFSIZE);
-
-			for (int lineNumber = 0; lineNumber < lineCount; lineNumber++)
-			{
-				log_error("[%s] %s", endpoint, errorLines[lineNumber]);
-			}
-
-			/* now stash away the SQL STATE if any */
-			if (context && sqlstate)
-			{
-				AbstractResultContext *ctx = (AbstractResultContext *) context;
-
-				strlcpy(ctx->sqlstate, sqlstate, SQLSTATE_LENGTH);
-			}
-
-			/* if we get a connection exception, track that */
-			if (sqlstate &&
-				strncmp(sqlstate, STR_ERRCODE_CLASS_CONNECTION_EXCEPTION, 2) == 0)
-			{
-				pgsql->status = PG_CONNECTION_BAD;
-			}
-
-			PQclear(result);
-			clear_results(pgsql);
-
+			pgsql_execute_log_error(pgsql, result, NULL, NULL, context);
 			return false;
 		}
 
@@ -1855,47 +1767,7 @@ pgsql_prepare(PGSQL *pgsql, const char *name, const char *sql,
 
 	if (!is_response_ok(result))
 	{
-		char *sqlstate = PQresultErrorField(result, PG_DIAG_SQLSTATE);
-
-		if (sqlstate)
-		{
-			strlcpy(pgsql->sqlstate, sqlstate, sizeof(pgsql->sqlstate));
-		}
-
-		/*
-		 * PostgreSQL Error message might contain several lines. Log each of
-		 * them as a separate ERROR line here.
-		 */
-		char *message = PQerrorMessage(connection);
-
-		char *errorLines[BUFSIZE] = { 0 };
-		int lineCount = splitLines(message, errorLines, BUFSIZE);
-
-		for (int lineNumber = 0; lineNumber < lineCount; lineNumber++)
-		{
-			log_error("[%s %d] %s",
-					  endpoint,
-					  PQbackendPID(connection),
-					  errorLines[lineNumber]);
-		}
-
-		if (pgsql->logSQL)
-		{
-			log_error("[%s %d] SQL query: %s",
-					  endpoint,
-					  PQbackendPID(connection),
-					  sql);
-		}
-
-		/* if we get a connection exception, track that */
-		if (sqlstate &&
-			strncmp(sqlstate, STR_ERRCODE_CLASS_CONNECTION_EXCEPTION, 2) == 0)
-		{
-			pgsql->status = PG_CONNECTION_BAD;
-		}
-
-		PQclear(result);
-		clear_results(pgsql);
+		pgsql_execute_log_error(pgsql, result, sql, NULL, NULL);
 
 		/*
 		 * Multi statements might want to ROLLBACK and hold to the open
@@ -1971,60 +1843,11 @@ pgsql_execute_prepared(PGSQL *pgsql, const char *name,
 
 	if (!is_response_ok(result))
 	{
-		char *sqlstate = PQresultErrorField(result, PG_DIAG_SQLSTATE);
+		char sql[BUFSIZE] = { 0 };
+		sformat(sql, sizeof(sql), "EXECUTE %s;", name);
 
-		if (sqlstate)
-		{
-			strlcpy(pgsql->sqlstate, sqlstate, sizeof(pgsql->sqlstate));
-		}
-
-		/*
-		 * PostgreSQL Error message might contain several lines. Log each of
-		 * them as a separate ERROR line here.
-		 */
-		char *message = PQerrorMessage(connection);
-
-		char *errorLines[BUFSIZE] = { 0 };
-		int lineCount = splitLines(message, errorLines, BUFSIZE);
-
-		for (int lineNumber = 0; lineNumber < lineCount; lineNumber++)
-		{
-			log_error("[%s %d] %s",
-					  endpoint,
-					  PQbackendPID(connection),
-					  errorLines[lineNumber]);
-		}
-
-		if (pgsql->logSQL)
-		{
-			if (paramCount > 0)
-			{
-				log_error("[%s %d] SQL params: %s",
-						  endpoint,
-						  PQbackendPID(connection),
-						  debugParameters->data);
-			}
-
-			destroyPQExpBuffer(debugParameters);
-		}
-
-		/* now stash away the SQL STATE if any */
-		if (context && sqlstate)
-		{
-			AbstractResultContext *ctx = (AbstractResultContext *) context;
-
-			strlcpy(ctx->sqlstate, sqlstate, SQLSTATE_LENGTH);
-		}
-
-		/* if we get a connection exception, track that */
-		if (sqlstate &&
-			strncmp(sqlstate, STR_ERRCODE_CLASS_CONNECTION_EXCEPTION, 2) == 0)
-		{
-			pgsql->status = PG_CONNECTION_BAD;
-		}
-
-		PQclear(result);
-		clear_results(pgsql);
+		pgsql_execute_log_error(pgsql, result, sql, debugParameters, context);
+		destroyPQExpBuffer(debugParameters);
 
 		/*
 		 * Multi statements might want to ROLLBACK and hold to the open
@@ -2053,6 +1876,83 @@ pgsql_execute_prepared(PGSQL *pgsql, const char *name,
 	}
 
 	return true;
+}
+
+
+/*
+ * pgsql_execute_log_error logs an error when !is_response_ok(result).
+ */
+static void
+pgsql_execute_log_error(PGSQL *pgsql,
+						PGresult *result,
+						const char *sql,
+						PQExpBuffer debugParameters,
+						void *context)
+{
+	char *sqlstate = PQresultErrorField(result, PG_DIAG_SQLSTATE);
+
+	if (sqlstate)
+	{
+		strlcpy(pgsql->sqlstate, sqlstate, sizeof(pgsql->sqlstate));
+	}
+
+	char *endpoint =
+		pgsql->connectionType == PGSQL_CONN_SOURCE ? "SOURCE" : "TARGET";
+
+	/*
+	 * PostgreSQL Error message might contain several lines. Log each of
+	 * them as a separate ERROR line here.
+	 */
+	char *message = PQerrorMessage(pgsql->connection);
+
+	char *errorLines[BUFSIZE] = { 0 };
+	int lineCount = splitLines(message, errorLines, BUFSIZE);
+
+	for (int lineNumber = 0; lineNumber < lineCount; lineNumber++)
+	{
+		log_error("[%s %d] %s",
+				  endpoint,
+				  PQbackendPID(pgsql->connection),
+				  errorLines[lineNumber]);
+	}
+
+	if (pgsql->logSQL)
+	{
+		/* when using send/fetch async queries, fetch doesn't have the sql */
+		if (sql != NULL)
+		{
+			log_error("[%s %d] SQL query: %s",
+					  endpoint,
+					  PQbackendPID(pgsql->connection),
+					  sql);
+		}
+
+		if (debugParameters != NULL)
+		{
+			log_error("[%s %d] SQL params: %s",
+					  endpoint,
+					  PQbackendPID(pgsql->connection),
+					  debugParameters->data);
+		}
+	}
+
+	/* now stash away the SQL STATE if any */
+	if (context && sqlstate)
+	{
+		AbstractResultContext *ctx = (AbstractResultContext *) context;
+
+		strlcpy(ctx->sqlstate, sqlstate, SQLSTATE_LENGTH);
+	}
+
+	/* if we get a connection exception, track that */
+	if (sqlstate &&
+		strncmp(sqlstate, STR_ERRCODE_CLASS_CONNECTION_EXCEPTION, 2) == 0)
+	{
+		pgsql->status = PG_CONNECTION_BAD;
+	}
+
+	PQclear(result);
+	clear_results(pgsql);
 }
 
 

--- a/src/bin/pgcopydb/pgsql.h
+++ b/src/bin/pgcopydb/pgsql.h
@@ -295,6 +295,13 @@ bool pgsql_send_with_params(PGSQL *pgsql, const char *sql, int paramCount,
 bool pgsql_fetch_results(PGSQL *pgsql, bool *done,
 						 void *context, ParsePostgresResultCB *parseFun);
 
+bool pgsql_prepare(PGSQL *pgsql, const char *name, const char *sql,
+				   int paramCount, const Oid *paramTypes);
+
+bool pgsql_execute_prepared(PGSQL *pgsql, const char *name,
+							int paramCount, const char **paramValues,
+							void *context, ParsePostgresResultCB *parseFun);
+
 void pgAutoCtlDebugNoticeProcessor(void *arg, const char *message);
 
 bool validate_connection_string(const char *connectionString);

--- a/src/bin/pgcopydb/string_utils.c
+++ b/src/bin/pgcopydb/string_utils.c
@@ -446,6 +446,51 @@ stringToDouble(const char *str, double *number)
 
 
 /*
+ * converts given hexadecimal string to 32 bit unsigned int value.
+ * returns 0 upon failure and sets error flag
+ */
+bool
+hexStringToUInt32(const char *str, uint32_t *number)
+{
+	char *endptr;
+
+	if (str == NULL)
+	{
+		return false;
+	}
+
+	if (number == NULL)
+	{
+		return false;
+	}
+
+	errno = 0;
+	unsigned long long n = strtoull(str, &endptr, 16);
+
+	if (str == endptr)
+	{
+		return false;
+	}
+	else if (errno != 0)
+	{
+		return false;
+	}
+	else if (*endptr != '\0')
+	{
+		return false;
+	}
+	else if (n > UINT32_MAX)
+	{
+		return false;
+	}
+
+	*number = n;
+
+	return true;
+}
+
+
+/*
  * IntervalToString prepares a string buffer to represent a given interval
  * value given as a double precision float number.
  */

--- a/src/bin/pgcopydb/string_utils.h
+++ b/src/bin/pgcopydb/string_utils.h
@@ -39,6 +39,9 @@ bool stringToInt32(const char *str, int32_t *number);
 bool stringToUInt32(const char *str, uint32_t *number);
 
 bool stringToDouble(const char *str, double *number);
+
+bool hexStringToUInt32(const char *str, uint32_t *number);
+
 bool IntervalToString(uint64_t millisecs, char *buffer, size_t size);
 
 int countLines(char *buffer);

--- a/tests/cdc-endpos-between-transaction/000000010000000000000002.sql
+++ b/tests/cdc-endpos-between-transaction/000000010000000000000002.sql
@@ -1,14 +1,22 @@
 -- KEEPALIVE {"lsn":"0/2447888","timestamp":"2023-06-14 11:17:51.978694+0000"}
 BEGIN; -- {"xid":491,"lsn":"0/244A550","timestamp":"2023-06-14 11:17:51.979425+0000","commit_lsn":"0/244A850"}
-INSERT INTO "public"."category" ("category_id", "name", "last_update") overriding system value VALUES (1000, E'Fantasy', E'2022-12-08 00:00:01+00');
-INSERT INTO "public"."category" ("category_id", "name", "last_update") overriding system value VALUES (1001, E'History', E'2022-12-09 00:00:01+00');
-INSERT INTO "public"."category" ("category_id", "name", "last_update") overriding system value VALUES (1002, E'Adventure', E'2022-12-10 00:00:01+00');
-INSERT INTO "public"."category" ("category_id", "name", "last_update") overriding system value VALUES (1003, E'Musical', E'2022-12-11 00:00:01+00');
-INSERT INTO "public"."category" ("category_id", "name", "last_update") overriding system value VALUES (1004, E'Western', E'2022-12-12 00:00:01+00');
+PREPARE 80429e6 AS INSERT INTO "public"."category" ("category_id", "name", "last_update") overriding system value VALUES ($1, $2, $3);
+EXECUTE 80429e6["1000","Fantasy","2022-12-08 00:00:01+00"];
+PREPARE 80429e6 AS INSERT INTO "public"."category" ("category_id", "name", "last_update") overriding system value VALUES ($1, $2, $3);
+EXECUTE 80429e6["1001","History","2022-12-09 00:00:01+00"];
+PREPARE 80429e6 AS INSERT INTO "public"."category" ("category_id", "name", "last_update") overriding system value VALUES ($1, $2, $3);
+EXECUTE 80429e6["1002","Adventure","2022-12-10 00:00:01+00"];
+PREPARE 80429e6 AS INSERT INTO "public"."category" ("category_id", "name", "last_update") overriding system value VALUES ($1, $2, $3);
+EXECUTE 80429e6["1003","Musical","2022-12-11 00:00:01+00"];
+PREPARE 80429e6 AS INSERT INTO "public"."category" ("category_id", "name", "last_update") overriding system value VALUES ($1, $2, $3);
+EXECUTE 80429e6["1004","Western","2022-12-12 00:00:01+00"];
 COMMIT; -- {"xid":491,"lsn":"0/244A850","timestamp":"2023-06-14 11:17:51.979425+0000"}
 BEGIN; -- {"xid":492,"lsn":"0/244A850","timestamp":"2023-06-14 11:17:51.979452+0000"}
-INSERT INTO "public"."category" ("category_id", "name", "last_update") overriding system value VALUES (1005, E'Mystery', E'2022-12-13 00:00:01+00');
-INSERT INTO "public"."category" ("category_id", "name", "last_update") overriding system value VALUES (1006, E'Historical drama', E'2022-12-14 00:00:01+00');
-INSERT INTO "public"."category" ("category_id", "name", "last_update") overriding system value VALUES (1008, E'Thriller', E'2022-12-15 00:00:01+00');
+PREPARE 80429e6 AS INSERT INTO "public"."category" ("category_id", "name", "last_update") overriding system value VALUES ($1, $2, $3);
+EXECUTE 80429e6["1005","Mystery","2022-12-13 00:00:01+00"];
+PREPARE 80429e6 AS INSERT INTO "public"."category" ("category_id", "name", "last_update") overriding system value VALUES ($1, $2, $3);
+EXECUTE 80429e6["1006","Historical drama","2022-12-14 00:00:01+00"];
+PREPARE 80429e6 AS INSERT INTO "public"."category" ("category_id", "name", "last_update") overriding system value VALUES ($1, $2, $3);
+EXECUTE 80429e6["1008","Thriller","2022-12-15 00:00:01+00"];
 -- KEEPALIVE {"lsn":"0/244A978","timestamp":"2023-06-14 11:17:51.979481+0000"}
 -- ENDPOS {"lsn":"0/244A978"}

--- a/tests/cdc-low-level/000000010000000000000002.sql
+++ b/tests/cdc-low-level/000000010000000000000002.sql
@@ -1,35 +1,59 @@
 -- KEEPALIVE {"lsn":"0/2449498","timestamp":"2023-06-14 11:26:56.659768+0000"}
 BEGIN; -- {"xid":491,"lsn":"0/244C160","timestamp":"2023-06-14 11:26:56.660491+0000","commit_lsn":"0/244C5C8"}
-INSERT INTO "public"."rental" ("rental_id", "rental_date", "inventory_id", "customer_id", "return_date", "staff_id", "last_update") overriding system value VALUES (16050 , '2022-06-01 00:00:00+00' , 371 , 291 , NULL, 1 , '2022-06-01 00:00:00+00');
-INSERT INTO "public"."payment_p2022_06" ("payment_id", "customer_id", "staff_id", "rental_id", "amount", "payment_date") overriding system value VALUES (32099 , 291 , 1 , 16050 , 5.99 , '2022-06-01 00:00:00+00');
+PREPARE ec9f2790 AS INSERT INTO "public"."rental" ("rental_id", "rental_date", "inventory_id", "customer_id", "return_date", "staff_id", "last_update") overriding system value VALUES ($1, $2, $3, $4, $5, $6, $7);
+EXECUTE ec9f2790["16050","2022-06-01 00:00:00+00","371","291",null,"1","2022-06-01 00:00:00+00"];
+PREPARE 4afa901a AS INSERT INTO "public"."payment_p2022_06" ("payment_id", "customer_id", "staff_id", "rental_id", "amount", "payment_date") overriding system value VALUES ($1, $2, $3, $4, $5, $6);
+EXECUTE 4afa901a["32099","291","1","16050","5.99","2022-06-01 00:00:00+00"];
 COMMIT; -- {"xid":491,"lsn":"0/244C5C8","timestamp":"2023-06-14 11:26:56.660491+0000"}
 BEGIN; -- {"xid":492,"lsn":"0/244C5C8","timestamp":"2023-06-14 11:26:56.661095+0000","commit_lsn":"0/244D698"}
-UPDATE "public"."payment_p2022_02" SET "amount" = 11.95 , "payment_date" = '2022-02-11 03:52:25.634006+00' WHERE "payment_id" = 23757  and "customer_id" = 116  and "staff_id" = 2  and "rental_id" = 14763  and "amount" = 11.99  and "payment_date" = '2022-02-11 03:52:25.634006+00' ;
-UPDATE "public"."payment_p2022_02" SET "amount" = 11.95 , "payment_date" = '2022-02-07 18:37:34.579143+00' WHERE "payment_id" = 24866  and "customer_id" = 237  and "staff_id" = 2  and "rental_id" = 11479  and "amount" = 11.99  and "payment_date" = '2022-02-07 18:37:34.579143+00' ;
-UPDATE "public"."payment_p2022_03" SET "amount" = 11.95 , "payment_date" = '2022-03-18 18:50:39.243747+00' WHERE "payment_id" = 17055  and "customer_id" = 196  and "staff_id" = 2  and "rental_id" = 106  and "amount" = 11.99  and "payment_date" = '2022-03-18 18:50:39.243747+00' ;
-UPDATE "public"."payment_p2022_03" SET "amount" = 11.95 , "payment_date" = '2022-03-08 16:41:23.911522+00' WHERE "payment_id" = 28799  and "customer_id" = 591  and "staff_id" = 2  and "rental_id" = 4383  and "amount" = 11.99  and "payment_date" = '2022-03-08 16:41:23.911522+00' ;
-UPDATE "public"."payment_p2022_04" SET "amount" = 11.95 , "payment_date" = '2022-04-16 04:35:36.904758+00' WHERE "payment_id" = 20403  and "customer_id" = 362  and "staff_id" = 1  and "rental_id" = 14759  and "amount" = 11.99  and "payment_date" = '2022-04-16 04:35:36.904758+00' ;
-UPDATE "public"."payment_p2022_05" SET "amount" = 11.95 , "payment_date" = '2022-05-12 11:28:17.949049+00' WHERE "payment_id" = 17354  and "customer_id" = 305  and "staff_id" = 1  and "rental_id" = 2166  and "amount" = 11.99  and "payment_date" = '2022-05-12 11:28:17.949049+00' ;
-UPDATE "public"."payment_p2022_06" SET "amount" = 11.95 , "payment_date" = '2022-06-11 11:17:22.428079+00' WHERE "payment_id" = 22650  and "customer_id" = 204  and "staff_id" = 2  and "rental_id" = 15415  and "amount" = 11.99  and "payment_date" = '2022-06-11 11:17:22.428079+00' ;
-UPDATE "public"."payment_p2022_06" SET "amount" = 11.95 , "payment_date" = '2022-06-15 02:21:00.279776+00' WHERE "payment_id" = 24553  and "customer_id" = 195  and "staff_id" = 2  and "rental_id" = 16040  and "amount" = 11.99  and "payment_date" = '2022-06-15 02:21:00.279776+00' ;
-UPDATE "public"."payment_p2022_07" SET "amount" = 11.95 , "payment_date" = '2022-07-06 12:15:38.928947+00' WHERE "payment_id" = 28814  and "customer_id" = 592  and "staff_id" = 1  and "rental_id" = 3973  and "amount" = 11.99  and "payment_date" = '2022-07-06 12:15:38.928947+00' ;
-UPDATE "public"."payment_p2022_07" SET "amount" = 11.95 , "payment_date" = '2022-07-22 16:15:40.797771+00' WHERE "payment_id" = 29136  and "customer_id" = 13  and "staff_id" = 2  and "rental_id" = 8831  and "amount" = 11.99  and "payment_date" = '2022-07-22 16:15:40.797771+00' ;
+PREPARE 6ee4a968 AS UPDATE "public"."payment_p2022_02" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE 6ee4a968["11.95","23757","116","2","14763","11.99","2022-02-11 03:52:25.634006+00"];
+PREPARE 6ee4a968 AS UPDATE "public"."payment_p2022_02" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE 6ee4a968["11.95","24866","237","2","11479","11.99","2022-02-07 18:37:34.579143+00"];
+PREPARE 61566f27 AS UPDATE "public"."payment_p2022_03" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE 61566f27["11.95","17055","196","2","106","11.99","2022-03-18 18:50:39.243747+00"];
+PREPARE 61566f27 AS UPDATE "public"."payment_p2022_03" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE 61566f27["11.95","28799","591","2","4383","11.99","2022-03-08 16:41:23.911522+00"];
+PREPARE 6e01df31 AS UPDATE "public"."payment_p2022_04" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE 6e01df31["11.95","20403","362","1","14759","11.99","2022-04-16 04:35:36.904758+00"];
+PREPARE b44f83e2 AS UPDATE "public"."payment_p2022_05" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE b44f83e2["11.95","17354","305","1","2166","11.99","2022-05-12 11:28:17.949049+00"];
+PREPARE 547dee5b AS UPDATE "public"."payment_p2022_06" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE 547dee5b["11.95","22650","204","2","15415","11.99","2022-06-11 11:17:22.428079+00"];
+PREPARE 547dee5b AS UPDATE "public"."payment_p2022_06" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE 547dee5b["11.95","24553","195","2","16040","11.99","2022-06-15 02:21:00.279776+00"];
+PREPARE dc973d3c AS UPDATE "public"."payment_p2022_07" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE dc973d3c["11.95","28814","592","1","3973","11.99","2022-07-06 12:15:38.928947+00"];
+PREPARE dc973d3c AS UPDATE "public"."payment_p2022_07" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE dc973d3c["11.95","29136","13","2","8831","11.99","2022-07-22 16:15:40.797771+00"];
 COMMIT; -- {"xid":492,"lsn":"0/244D698","timestamp":"2023-06-14 11:26:56.661095+0000"}
 BEGIN; -- {"xid":493,"lsn":"0/244D858","timestamp":"2023-06-14 11:26:56.661192+0000","commit_lsn":"0/244D968"}
-DELETE FROM "public"."payment_p2022_06" WHERE "payment_id" = 32099  and "customer_id" = 291  and "staff_id" = 1  and "rental_id" = 16050  and "amount" = 5.99  and "payment_date" = '2022-06-01 00:00:00+00';
-DELETE FROM "public"."rental" WHERE "rental_id" = 16050;
+PREPARE 9b3560f5 AS DELETE FROM "public"."payment_p2022_06" WHERE "payment_id" = $1 and "customer_id" = $2 and "staff_id" = $3 and "rental_id" = $4 and "amount" = $5 and "payment_date" = $6;
+EXECUTE 9b3560f5["32099","291","1","16050","5.99","2022-06-01 00:00:00+00"];
+PREPARE 2ca9993d AS DELETE FROM "public"."rental" WHERE "rental_id" = $1;
+EXECUTE 2ca9993d["16050"];
 COMMIT; -- {"xid":493,"lsn":"0/244D968","timestamp":"2023-06-14 11:26:56.661192+0000"}
 BEGIN; -- {"xid":494,"lsn":"0/244D968","timestamp":"2023-06-14 11:26:56.661495+0000","commit_lsn":"0/244DEE8"}
-UPDATE "public"."payment_p2022_02" SET "amount" = 11.99 , "payment_date" = '2022-02-11 03:52:25.634006+00' WHERE "payment_id" = 23757  and "customer_id" = 116  and "staff_id" = 2  and "rental_id" = 14763  and "amount" = 11.95  and "payment_date" = '2022-02-11 03:52:25.634006+00' ;
-UPDATE "public"."payment_p2022_02" SET "amount" = 11.99 , "payment_date" = '2022-02-07 18:37:34.579143+00' WHERE "payment_id" = 24866  and "customer_id" = 237  and "staff_id" = 2  and "rental_id" = 11479  and "amount" = 11.95  and "payment_date" = '2022-02-07 18:37:34.579143+00' ;
-UPDATE "public"."payment_p2022_03" SET "amount" = 11.99 , "payment_date" = '2022-03-18 18:50:39.243747+00' WHERE "payment_id" = 17055  and "customer_id" = 196  and "staff_id" = 2  and "rental_id" = 106  and "amount" = 11.95  and "payment_date" = '2022-03-18 18:50:39.243747+00' ;
-UPDATE "public"."payment_p2022_03" SET "amount" = 11.99 , "payment_date" = '2022-03-08 16:41:23.911522+00' WHERE "payment_id" = 28799  and "customer_id" = 591  and "staff_id" = 2  and "rental_id" = 4383  and "amount" = 11.95  and "payment_date" = '2022-03-08 16:41:23.911522+00' ;
-UPDATE "public"."payment_p2022_04" SET "amount" = 11.99 , "payment_date" = '2022-04-16 04:35:36.904758+00' WHERE "payment_id" = 20403  and "customer_id" = 362  and "staff_id" = 1  and "rental_id" = 14759  and "amount" = 11.95  and "payment_date" = '2022-04-16 04:35:36.904758+00' ;
-UPDATE "public"."payment_p2022_05" SET "amount" = 11.99 , "payment_date" = '2022-05-12 11:28:17.949049+00' WHERE "payment_id" = 17354  and "customer_id" = 305  and "staff_id" = 1  and "rental_id" = 2166  and "amount" = 11.95  and "payment_date" = '2022-05-12 11:28:17.949049+00' ;
-UPDATE "public"."payment_p2022_06" SET "amount" = 11.99 , "payment_date" = '2022-06-11 11:17:22.428079+00' WHERE "payment_id" = 22650  and "customer_id" = 204  and "staff_id" = 2  and "rental_id" = 15415  and "amount" = 11.95  and "payment_date" = '2022-06-11 11:17:22.428079+00' ;
-UPDATE "public"."payment_p2022_06" SET "amount" = 11.99 , "payment_date" = '2022-06-15 02:21:00.279776+00' WHERE "payment_id" = 24553  and "customer_id" = 195  and "staff_id" = 2  and "rental_id" = 16040  and "amount" = 11.95  and "payment_date" = '2022-06-15 02:21:00.279776+00' ;
-UPDATE "public"."payment_p2022_07" SET "amount" = 11.99 , "payment_date" = '2022-07-06 12:15:38.928947+00' WHERE "payment_id" = 28814  and "customer_id" = 592  and "staff_id" = 1  and "rental_id" = 3973  and "amount" = 11.95  and "payment_date" = '2022-07-06 12:15:38.928947+00' ;
-UPDATE "public"."payment_p2022_07" SET "amount" = 11.99 , "payment_date" = '2022-07-22 16:15:40.797771+00' WHERE "payment_id" = 29136  and "customer_id" = 13  and "staff_id" = 2  and "rental_id" = 8831  and "amount" = 11.95  and "payment_date" = '2022-07-22 16:15:40.797771+00' ;
+PREPARE 6ee4a968 AS UPDATE "public"."payment_p2022_02" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE 6ee4a968["11.99","23757","116","2","14763","11.95","2022-02-11 03:52:25.634006+00"];
+PREPARE 6ee4a968 AS UPDATE "public"."payment_p2022_02" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE 6ee4a968["11.99","24866","237","2","11479","11.95","2022-02-07 18:37:34.579143+00"];
+PREPARE 61566f27 AS UPDATE "public"."payment_p2022_03" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE 61566f27["11.99","17055","196","2","106","11.95","2022-03-18 18:50:39.243747+00"];
+PREPARE 61566f27 AS UPDATE "public"."payment_p2022_03" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE 61566f27["11.99","28799","591","2","4383","11.95","2022-03-08 16:41:23.911522+00"];
+PREPARE 6e01df31 AS UPDATE "public"."payment_p2022_04" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE 6e01df31["11.99","20403","362","1","14759","11.95","2022-04-16 04:35:36.904758+00"];
+PREPARE b44f83e2 AS UPDATE "public"."payment_p2022_05" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE b44f83e2["11.99","17354","305","1","2166","11.95","2022-05-12 11:28:17.949049+00"];
+PREPARE 547dee5b AS UPDATE "public"."payment_p2022_06" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE 547dee5b["11.99","22650","204","2","15415","11.95","2022-06-11 11:17:22.428079+00"];
+PREPARE 547dee5b AS UPDATE "public"."payment_p2022_06" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE 547dee5b["11.99","24553","195","2","16040","11.95","2022-06-15 02:21:00.279776+00"];
+PREPARE dc973d3c AS UPDATE "public"."payment_p2022_07" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE dc973d3c["11.99","28814","592","1","3973","11.95","2022-07-06 12:15:38.928947+00"];
+PREPARE dc973d3c AS UPDATE "public"."payment_p2022_07" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE dc973d3c["11.99","29136","13","2","8831","11.95","2022-07-22 16:15:40.797771+00"];
 COMMIT; -- {"xid":494,"lsn":"0/244DEE8","timestamp":"2023-06-14 11:26:56.661495+0000"}
 -- KEEPALIVE {"lsn":"0/244DEE8","timestamp":"2023-06-14 11:26:56.661676+0000"}
 -- ENDPOS {"lsn":"0/244DEE8"}

--- a/tests/cdc-test-decoding/000000010000000000000002.sql
+++ b/tests/cdc-test-decoding/000000010000000000000002.sql
@@ -1,38 +1,63 @@
 -- KEEPALIVE {"lsn":"0/2448E08","timestamp":"2023-06-20 15:40:11.982016+0000"}
 BEGIN; -- {"xid":491,"lsn":"0/244BAB8","timestamp":"2023-06-20 15:40:11.982679+0000","commit_lsn":"0/244BF20"}
-INSERT INTO "public"."rental" ("rental_id", "rental_date", "inventory_id", "customer_id", "return_date", "staff_id", "last_update") overriding system value VALUES (16050 , '2022-06-01 00:00:00+00' , 371 , 291 , NULL, 1 , '2022-06-01 00:00:00+00');
-INSERT INTO "public"."payment_p2022_06" ("payment_id", "customer_id", "staff_id", "rental_id", "amount", "payment_date") overriding system value VALUES (32099 , 291 , 1 , 16050 , 5.99 , '2022-06-01 00:00:00+00');
+PREPARE ec9f2790 AS INSERT INTO "public"."rental" ("rental_id", "rental_date", "inventory_id", "customer_id", "return_date", "staff_id", "last_update") overriding system value VALUES ($1, $2, $3, $4, $5, $6, $7);
+EXECUTE ec9f2790["16050","2022-06-01 00:00:00+00","371","291",null,"1","2022-06-01 00:00:00+00"];
+PREPARE 4afa901a AS INSERT INTO "public"."payment_p2022_06" ("payment_id", "customer_id", "staff_id", "rental_id", "amount", "payment_date") overriding system value VALUES ($1, $2, $3, $4, $5, $6);
+EXECUTE 4afa901a["32099","291","1","16050","5.99","2022-06-01 00:00:00+00"];
 COMMIT; -- {"xid":491,"lsn":"0/244BF20","timestamp":"2023-06-20 15:40:11.982679+0000"}
 BEGIN; -- {"xid":492,"lsn":"0/244BF20","timestamp":"2023-06-20 15:40:11.983092+0000","commit_lsn":"0/244D008"}
-UPDATE "public"."payment_p2022_02" SET "amount" = 11.95 , "payment_date" = '2022-02-11 03:52:25.634006+00' WHERE "payment_id" = 23757  and "customer_id" = 116  and "staff_id" = 2  and "rental_id" = 14763  and "amount" = 11.99  and "payment_date" = '2022-02-11 03:52:25.634006+00' ;
-UPDATE "public"."payment_p2022_02" SET "amount" = 11.95 , "payment_date" = '2022-02-07 18:37:34.579143+00' WHERE "payment_id" = 24866  and "customer_id" = 237  and "staff_id" = 2  and "rental_id" = 11479  and "amount" = 11.99  and "payment_date" = '2022-02-07 18:37:34.579143+00' ;
-UPDATE "public"."payment_p2022_03" SET "amount" = 11.95 , "payment_date" = '2022-03-18 18:50:39.243747+00' WHERE "payment_id" = 17055  and "customer_id" = 196  and "staff_id" = 2  and "rental_id" = 106  and "amount" = 11.99  and "payment_date" = '2022-03-18 18:50:39.243747+00' ;
-UPDATE "public"."payment_p2022_03" SET "amount" = 11.95 , "payment_date" = '2022-03-08 16:41:23.911522+00' WHERE "payment_id" = 28799  and "customer_id" = 591  and "staff_id" = 2  and "rental_id" = 4383  and "amount" = 11.99  and "payment_date" = '2022-03-08 16:41:23.911522+00' ;
-UPDATE "public"."payment_p2022_04" SET "amount" = 11.95 , "payment_date" = '2022-04-16 04:35:36.904758+00' WHERE "payment_id" = 20403  and "customer_id" = 362  and "staff_id" = 1  and "rental_id" = 14759  and "amount" = 11.99  and "payment_date" = '2022-04-16 04:35:36.904758+00' ;
-UPDATE "public"."payment_p2022_05" SET "amount" = 11.95 , "payment_date" = '2022-05-12 11:28:17.949049+00' WHERE "payment_id" = 17354  and "customer_id" = 305  and "staff_id" = 1  and "rental_id" = 2166  and "amount" = 11.99  and "payment_date" = '2022-05-12 11:28:17.949049+00' ;
-UPDATE "public"."payment_p2022_06" SET "amount" = 11.95 , "payment_date" = '2022-06-11 11:17:22.428079+00' WHERE "payment_id" = 22650  and "customer_id" = 204  and "staff_id" = 2  and "rental_id" = 15415  and "amount" = 11.99  and "payment_date" = '2022-06-11 11:17:22.428079+00' ;
-UPDATE "public"."payment_p2022_06" SET "amount" = 11.95 , "payment_date" = '2022-06-15 02:21:00.279776+00' WHERE "payment_id" = 24553  and "customer_id" = 195  and "staff_id" = 2  and "rental_id" = 16040  and "amount" = 11.99  and "payment_date" = '2022-06-15 02:21:00.279776+00' ;
-UPDATE "public"."payment_p2022_07" SET "amount" = 11.95 , "payment_date" = '2022-07-06 12:15:38.928947+00' WHERE "payment_id" = 28814  and "customer_id" = 592  and "staff_id" = 1  and "rental_id" = 3973  and "amount" = 11.99  and "payment_date" = '2022-07-06 12:15:38.928947+00' ;
-UPDATE "public"."payment_p2022_07" SET "amount" = 11.95 , "payment_date" = '2022-07-22 16:15:40.797771+00' WHERE "payment_id" = 29136  and "customer_id" = 13  and "staff_id" = 2  and "rental_id" = 8831  and "amount" = 11.99  and "payment_date" = '2022-07-22 16:15:40.797771+00' ;
+PREPARE 6ee4a968 AS UPDATE "public"."payment_p2022_02" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE 6ee4a968["11.95","23757","116","2","14763","11.99","2022-02-11 03:52:25.634006+00"];
+PREPARE 6ee4a968 AS UPDATE "public"."payment_p2022_02" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE 6ee4a968["11.95","24866","237","2","11479","11.99","2022-02-07 18:37:34.579143+00"];
+PREPARE 61566f27 AS UPDATE "public"."payment_p2022_03" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE 61566f27["11.95","17055","196","2","106","11.99","2022-03-18 18:50:39.243747+00"];
+PREPARE 61566f27 AS UPDATE "public"."payment_p2022_03" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE 61566f27["11.95","28799","591","2","4383","11.99","2022-03-08 16:41:23.911522+00"];
+PREPARE 6e01df31 AS UPDATE "public"."payment_p2022_04" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE 6e01df31["11.95","20403","362","1","14759","11.99","2022-04-16 04:35:36.904758+00"];
+PREPARE b44f83e2 AS UPDATE "public"."payment_p2022_05" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE b44f83e2["11.95","17354","305","1","2166","11.99","2022-05-12 11:28:17.949049+00"];
+PREPARE 547dee5b AS UPDATE "public"."payment_p2022_06" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE 547dee5b["11.95","22650","204","2","15415","11.99","2022-06-11 11:17:22.428079+00"];
+PREPARE 547dee5b AS UPDATE "public"."payment_p2022_06" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE 547dee5b["11.95","24553","195","2","16040","11.99","2022-06-15 02:21:00.279776+00"];
+PREPARE dc973d3c AS UPDATE "public"."payment_p2022_07" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE dc973d3c["11.95","28814","592","1","3973","11.99","2022-07-06 12:15:38.928947+00"];
+PREPARE dc973d3c AS UPDATE "public"."payment_p2022_07" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE dc973d3c["11.95","29136","13","2","8831","11.99","2022-07-22 16:15:40.797771+00"];
 COMMIT; -- {"xid":492,"lsn":"0/244D008","timestamp":"2023-06-20 15:40:11.983092+0000"}
 BEGIN; -- {"xid":493,"lsn":"0/244D1C8","timestamp":"2023-06-20 15:40:11.983134+0000","commit_lsn":"0/244D2D8"}
-DELETE FROM "public"."payment_p2022_06" WHERE "payment_id" = 32099  and "customer_id" = 291  and "staff_id" = 1  and "rental_id" = 16050  and "amount" = 5.99  and "payment_date" = '2022-06-01 00:00:00+00';
-DELETE FROM "public"."rental" WHERE "rental_id" = 16050;
+PREPARE 9b3560f5 AS DELETE FROM "public"."payment_p2022_06" WHERE "payment_id" = $1 and "customer_id" = $2 and "staff_id" = $3 and "rental_id" = $4 and "amount" = $5 and "payment_date" = $6;
+EXECUTE 9b3560f5["32099","291","1","16050","5.99","2022-06-01 00:00:00+00"];
+PREPARE 2ca9993d AS DELETE FROM "public"."rental" WHERE "rental_id" = $1;
+EXECUTE 2ca9993d["16050"];
 COMMIT; -- {"xid":493,"lsn":"0/244D2D8","timestamp":"2023-06-20 15:40:11.983134+0000"}
 BEGIN; -- {"xid":494,"lsn":"0/244D2D8","timestamp":"2023-06-20 15:40:11.983253+0000","commit_lsn":"0/244D858"}
-UPDATE "public"."payment_p2022_02" SET "amount" = 11.99 , "payment_date" = '2022-02-11 03:52:25.634006+00' WHERE "payment_id" = 23757  and "customer_id" = 116  and "staff_id" = 2  and "rental_id" = 14763  and "amount" = 11.95  and "payment_date" = '2022-02-11 03:52:25.634006+00' ;
-UPDATE "public"."payment_p2022_02" SET "amount" = 11.99 , "payment_date" = '2022-02-07 18:37:34.579143+00' WHERE "payment_id" = 24866  and "customer_id" = 237  and "staff_id" = 2  and "rental_id" = 11479  and "amount" = 11.95  and "payment_date" = '2022-02-07 18:37:34.579143+00' ;
-UPDATE "public"."payment_p2022_03" SET "amount" = 11.99 , "payment_date" = '2022-03-18 18:50:39.243747+00' WHERE "payment_id" = 17055  and "customer_id" = 196  and "staff_id" = 2  and "rental_id" = 106  and "amount" = 11.95  and "payment_date" = '2022-03-18 18:50:39.243747+00' ;
-UPDATE "public"."payment_p2022_03" SET "amount" = 11.99 , "payment_date" = '2022-03-08 16:41:23.911522+00' WHERE "payment_id" = 28799  and "customer_id" = 591  and "staff_id" = 2  and "rental_id" = 4383  and "amount" = 11.95  and "payment_date" = '2022-03-08 16:41:23.911522+00' ;
-UPDATE "public"."payment_p2022_04" SET "amount" = 11.99 , "payment_date" = '2022-04-16 04:35:36.904758+00' WHERE "payment_id" = 20403  and "customer_id" = 362  and "staff_id" = 1  and "rental_id" = 14759  and "amount" = 11.95  and "payment_date" = '2022-04-16 04:35:36.904758+00' ;
-UPDATE "public"."payment_p2022_05" SET "amount" = 11.99 , "payment_date" = '2022-05-12 11:28:17.949049+00' WHERE "payment_id" = 17354  and "customer_id" = 305  and "staff_id" = 1  and "rental_id" = 2166  and "amount" = 11.95  and "payment_date" = '2022-05-12 11:28:17.949049+00' ;
-UPDATE "public"."payment_p2022_06" SET "amount" = 11.99 , "payment_date" = '2022-06-11 11:17:22.428079+00' WHERE "payment_id" = 22650  and "customer_id" = 204  and "staff_id" = 2  and "rental_id" = 15415  and "amount" = 11.95  and "payment_date" = '2022-06-11 11:17:22.428079+00' ;
-UPDATE "public"."payment_p2022_06" SET "amount" = 11.99 , "payment_date" = '2022-06-15 02:21:00.279776+00' WHERE "payment_id" = 24553  and "customer_id" = 195  and "staff_id" = 2  and "rental_id" = 16040  and "amount" = 11.95  and "payment_date" = '2022-06-15 02:21:00.279776+00' ;
-UPDATE "public"."payment_p2022_07" SET "amount" = 11.99 , "payment_date" = '2022-07-06 12:15:38.928947+00' WHERE "payment_id" = 28814  and "customer_id" = 592  and "staff_id" = 1  and "rental_id" = 3973  and "amount" = 11.95  and "payment_date" = '2022-07-06 12:15:38.928947+00' ;
-UPDATE "public"."payment_p2022_07" SET "amount" = 11.99 , "payment_date" = '2022-07-22 16:15:40.797771+00' WHERE "payment_id" = 29136  and "customer_id" = 13  and "staff_id" = 2  and "rental_id" = 8831  and "amount" = 11.95  and "payment_date" = '2022-07-22 16:15:40.797771+00' ;
+PREPARE 6ee4a968 AS UPDATE "public"."payment_p2022_02" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE 6ee4a968["11.99","23757","116","2","14763","11.95","2022-02-11 03:52:25.634006+00"];
+PREPARE 6ee4a968 AS UPDATE "public"."payment_p2022_02" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE 6ee4a968["11.99","24866","237","2","11479","11.95","2022-02-07 18:37:34.579143+00"];
+PREPARE 61566f27 AS UPDATE "public"."payment_p2022_03" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE 61566f27["11.99","17055","196","2","106","11.95","2022-03-18 18:50:39.243747+00"];
+PREPARE 61566f27 AS UPDATE "public"."payment_p2022_03" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE 61566f27["11.99","28799","591","2","4383","11.95","2022-03-08 16:41:23.911522+00"];
+PREPARE 6e01df31 AS UPDATE "public"."payment_p2022_04" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE 6e01df31["11.99","20403","362","1","14759","11.95","2022-04-16 04:35:36.904758+00"];
+PREPARE b44f83e2 AS UPDATE "public"."payment_p2022_05" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE b44f83e2["11.99","17354","305","1","2166","11.95","2022-05-12 11:28:17.949049+00"];
+PREPARE 547dee5b AS UPDATE "public"."payment_p2022_06" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE 547dee5b["11.99","22650","204","2","15415","11.95","2022-06-11 11:17:22.428079+00"];
+PREPARE 547dee5b AS UPDATE "public"."payment_p2022_06" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE 547dee5b["11.99","24553","195","2","16040","11.95","2022-06-15 02:21:00.279776+00"];
+PREPARE dc973d3c AS UPDATE "public"."payment_p2022_07" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE dc973d3c["11.99","28814","592","1","3973","11.95","2022-07-06 12:15:38.928947+00"];
+PREPARE dc973d3c AS UPDATE "public"."payment_p2022_07" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE dc973d3c["11.99","29136","13","2","8831","11.95","2022-07-22 16:15:40.797771+00"];
 COMMIT; -- {"xid":494,"lsn":"0/244D858","timestamp":"2023-06-20 15:40:11.983253+0000"}
 BEGIN; -- {"xid":495,"lsn":"0/244D858","timestamp":"2023-06-20 15:40:11.983352+0000","commit_lsn":"0/244D988"}
-UPDATE "public"."staff" SET "first_name" = 'Mike' , "last_name" = 'Hillyer' , "address_id" = 3 , "email" = 'Mike.Hillyer@sakilastaff.com' , "store_id" = 1 , "active" = true , "username" = 'Mike' , "password" = '8cb2237d0679ca88db6464eac60da96345513964' , "last_update" = '2023-06-20 15:40:11.823094+00' , "picture" = '\x89504e470d0a5a0a' WHERE "staff_id" = 1 ;
+PREPARE 73b7f705 AS UPDATE "public"."staff" SET "first_name" = $1, "last_name" = $2, "address_id" = $3, "email" = $4, "store_id" = $5, "active" = $6, "username" = $7, "password" = $8, "last_update" = $9, "picture" = $10 WHERE "staff_id" = $11;
+EXECUTE 73b7f705["Mike","Hillyer","3","Mike.Hillyer@sakilastaff.com","1","true","Mike","8cb2237d0679ca88db6464eac60da96345513964","2023-06-20 15:40:11.823094+00","\\x89504e470d0a5a0a","1"];
 COMMIT; -- {"xid":495,"lsn":"0/244D988","timestamp":"2023-06-20 15:40:11.983352+0000"}
 -- KEEPALIVE {"lsn":"0/244D988","timestamp":"2023-06-20 15:40:11.983399+0000"}
 -- ENDPOS {"lsn":"0/244D988"}

--- a/tests/cdc-test-decoding/copydb.sh
+++ b/tests/cdc-test-decoding/copydb.sh
@@ -73,7 +73,8 @@ pgcopydb stream transform --debug ${SHAREDIR}/${WALFILE} /tmp/${SQLFILENAME}
 diff ${SHAREDIR}/${SQLFILE} /tmp/${SQLFILENAME}
 
 # we should also get the same result as expected (discarding LSN numbers)
-DIFFOPTS='-I BEGIN -I COMMIT -I KEEPALIVE -I SWITCH -I ENDPOS -I last_update'
+# and also discarding ON UPDATE triggers for the timestamps (EXECUTE/last_update)
+DIFFOPTS='-I BEGIN -I COMMIT -I KEEPALIVE -I SWITCH -I ENDPOS -I EXECUTE'
 
 diff ${DIFFOPTS} /usr/src/pgcopydb/${SQLFILE} ${SHAREDIR}/${SQLFILENAME}
 

--- a/tests/cdc-wal2json/000000010000000000000002.sql
+++ b/tests/cdc-wal2json/000000010000000000000002.sql
@@ -1,35 +1,59 @@
 -- KEEPALIVE {"lsn":"0/2448720","timestamp":"2023-06-14 11:34:23.437739+0000"}
 BEGIN; -- {"xid":491,"lsn":"0/244B3D0","timestamp":"2023-06-14 11:34:23.438636+0000","commit_lsn":"0/244B838"}
-INSERT INTO "public"."rental" ("rental_id", "rental_date", "inventory_id", "customer_id", "return_date", "staff_id", "last_update") overriding system value VALUES (16050, E'2022-06-01 00:00:00+00', 371, 291, NULL, 1, E'2022-06-01 00:00:00+00');
-INSERT INTO "public"."payment_p2022_06" ("payment_id", "customer_id", "staff_id", "rental_id", "amount", "payment_date") overriding system value VALUES (32099, 291, 1, 16050, 5.990000, E'2022-06-01 00:00:00+00');
+PREPARE ec9f2790 AS INSERT INTO "public"."rental" ("rental_id", "rental_date", "inventory_id", "customer_id", "return_date", "staff_id", "last_update") overriding system value VALUES ($1, $2, $3, $4, $5, $6, $7);
+EXECUTE ec9f2790["16050","2022-06-01 00:00:00+00","371","291",null,"1","2022-06-01 00:00:00+00"];
+PREPARE 4afa901a AS INSERT INTO "public"."payment_p2022_06" ("payment_id", "customer_id", "staff_id", "rental_id", "amount", "payment_date") overriding system value VALUES ($1, $2, $3, $4, $5, $6);
+EXECUTE 4afa901a["32099","291","1","16050","5.990000","2022-06-01 00:00:00+00"];
 COMMIT; -- {"xid":491,"lsn":"0/244B838","timestamp":"2023-06-14 11:34:23.438636+0000"}
 BEGIN; -- {"xid":492,"lsn":"0/244B838","timestamp":"2023-06-14 11:34:23.439932+0000","commit_lsn":"0/244C920"}
-UPDATE "public"."payment_p2022_02" SET "amount" = 11.950000 WHERE "payment_id" = 23757 and "customer_id" = 116 and "staff_id" = 2 and "rental_id" = 14763 and "amount" = 11.990000 and "payment_date" = E'2022-02-11 03:52:25.634006+00';
-UPDATE "public"."payment_p2022_02" SET "amount" = 11.950000 WHERE "payment_id" = 24866 and "customer_id" = 237 and "staff_id" = 2 and "rental_id" = 11479 and "amount" = 11.990000 and "payment_date" = E'2022-02-07 18:37:34.579143+00';
-UPDATE "public"."payment_p2022_03" SET "amount" = 11.950000 WHERE "payment_id" = 17055 and "customer_id" = 196 and "staff_id" = 2 and "rental_id" = 106 and "amount" = 11.990000 and "payment_date" = E'2022-03-18 18:50:39.243747+00';
-UPDATE "public"."payment_p2022_03" SET "amount" = 11.950000 WHERE "payment_id" = 28799 and "customer_id" = 591 and "staff_id" = 2 and "rental_id" = 4383 and "amount" = 11.990000 and "payment_date" = E'2022-03-08 16:41:23.911522+00';
-UPDATE "public"."payment_p2022_04" SET "amount" = 11.950000 WHERE "payment_id" = 20403 and "customer_id" = 362 and "staff_id" = 1 and "rental_id" = 14759 and "amount" = 11.990000 and "payment_date" = E'2022-04-16 04:35:36.904758+00';
-UPDATE "public"."payment_p2022_05" SET "amount" = 11.950000 WHERE "payment_id" = 17354 and "customer_id" = 305 and "staff_id" = 1 and "rental_id" = 2166 and "amount" = 11.990000 and "payment_date" = E'2022-05-12 11:28:17.949049+00';
-UPDATE "public"."payment_p2022_06" SET "amount" = 11.950000 WHERE "payment_id" = 22650 and "customer_id" = 204 and "staff_id" = 2 and "rental_id" = 15415 and "amount" = 11.990000 and "payment_date" = E'2022-06-11 11:17:22.428079+00';
-UPDATE "public"."payment_p2022_06" SET "amount" = 11.950000 WHERE "payment_id" = 24553 and "customer_id" = 195 and "staff_id" = 2 and "rental_id" = 16040 and "amount" = 11.990000 and "payment_date" = E'2022-06-15 02:21:00.279776+00';
-UPDATE "public"."payment_p2022_07" SET "amount" = 11.950000 WHERE "payment_id" = 28814 and "customer_id" = 592 and "staff_id" = 1 and "rental_id" = 3973 and "amount" = 11.990000 and "payment_date" = E'2022-07-06 12:15:38.928947+00';
-UPDATE "public"."payment_p2022_07" SET "amount" = 11.950000 WHERE "payment_id" = 29136 and "customer_id" = 13 and "staff_id" = 2 and "rental_id" = 8831 and "amount" = 11.990000 and "payment_date" = E'2022-07-22 16:15:40.797771+00';
+PREPARE 6ee4a968 AS UPDATE "public"."payment_p2022_02" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE 6ee4a968["11.950000","23757","116","2","14763","11.990000","2022-02-11 03:52:25.634006+00"];
+PREPARE 6ee4a968 AS UPDATE "public"."payment_p2022_02" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE 6ee4a968["11.950000","24866","237","2","11479","11.990000","2022-02-07 18:37:34.579143+00"];
+PREPARE 61566f27 AS UPDATE "public"."payment_p2022_03" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE 61566f27["11.950000","17055","196","2","106","11.990000","2022-03-18 18:50:39.243747+00"];
+PREPARE 61566f27 AS UPDATE "public"."payment_p2022_03" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE 61566f27["11.950000","28799","591","2","4383","11.990000","2022-03-08 16:41:23.911522+00"];
+PREPARE 6e01df31 AS UPDATE "public"."payment_p2022_04" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE 6e01df31["11.950000","20403","362","1","14759","11.990000","2022-04-16 04:35:36.904758+00"];
+PREPARE b44f83e2 AS UPDATE "public"."payment_p2022_05" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE b44f83e2["11.950000","17354","305","1","2166","11.990000","2022-05-12 11:28:17.949049+00"];
+PREPARE 547dee5b AS UPDATE "public"."payment_p2022_06" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE 547dee5b["11.950000","22650","204","2","15415","11.990000","2022-06-11 11:17:22.428079+00"];
+PREPARE 547dee5b AS UPDATE "public"."payment_p2022_06" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE 547dee5b["11.950000","24553","195","2","16040","11.990000","2022-06-15 02:21:00.279776+00"];
+PREPARE dc973d3c AS UPDATE "public"."payment_p2022_07" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE dc973d3c["11.950000","28814","592","1","3973","11.990000","2022-07-06 12:15:38.928947+00"];
+PREPARE dc973d3c AS UPDATE "public"."payment_p2022_07" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE dc973d3c["11.950000","29136","13","2","8831","11.990000","2022-07-22 16:15:40.797771+00"];
 COMMIT; -- {"xid":492,"lsn":"0/244C920","timestamp":"2023-06-14 11:34:23.439932+0000"}
 BEGIN; -- {"xid":493,"lsn":"0/244CAE0","timestamp":"2023-06-14 11:34:23.440143+0000","commit_lsn":"0/244CBF0"}
-DELETE FROM "public"."payment_p2022_06" WHERE "payment_id" = 32099 and "customer_id" = 291 and "staff_id" = 1 and "rental_id" = 16050 and "amount" = 5.990000 and "payment_date" = E'2022-06-01 00:00:00+00';
-DELETE FROM "public"."rental" WHERE "rental_id" = 16050;
+PREPARE 9b3560f5 AS DELETE FROM "public"."payment_p2022_06" WHERE "payment_id" = $1 and "customer_id" = $2 and "staff_id" = $3 and "rental_id" = $4 and "amount" = $5 and "payment_date" = $6;
+EXECUTE 9b3560f5["32099","291","1","16050","5.990000","2022-06-01 00:00:00+00"];
+PREPARE 2ca9993d AS DELETE FROM "public"."rental" WHERE "rental_id" = $1;
+EXECUTE 2ca9993d["16050"];
 COMMIT; -- {"xid":493,"lsn":"0/244CBF0","timestamp":"2023-06-14 11:34:23.440143+0000"}
 BEGIN; -- {"xid":494,"lsn":"0/244CBF0","timestamp":"2023-06-14 11:34:23.440564+0000","commit_lsn":"0/244D170"}
-UPDATE "public"."payment_p2022_02" SET "amount" = 11.990000 WHERE "payment_id" = 23757 and "customer_id" = 116 and "staff_id" = 2 and "rental_id" = 14763 and "amount" = 11.950000 and "payment_date" = E'2022-02-11 03:52:25.634006+00';
-UPDATE "public"."payment_p2022_02" SET "amount" = 11.990000 WHERE "payment_id" = 24866 and "customer_id" = 237 and "staff_id" = 2 and "rental_id" = 11479 and "amount" = 11.950000 and "payment_date" = E'2022-02-07 18:37:34.579143+00';
-UPDATE "public"."payment_p2022_03" SET "amount" = 11.990000 WHERE "payment_id" = 17055 and "customer_id" = 196 and "staff_id" = 2 and "rental_id" = 106 and "amount" = 11.950000 and "payment_date" = E'2022-03-18 18:50:39.243747+00';
-UPDATE "public"."payment_p2022_03" SET "amount" = 11.990000 WHERE "payment_id" = 28799 and "customer_id" = 591 and "staff_id" = 2 and "rental_id" = 4383 and "amount" = 11.950000 and "payment_date" = E'2022-03-08 16:41:23.911522+00';
-UPDATE "public"."payment_p2022_04" SET "amount" = 11.990000 WHERE "payment_id" = 20403 and "customer_id" = 362 and "staff_id" = 1 and "rental_id" = 14759 and "amount" = 11.950000 and "payment_date" = E'2022-04-16 04:35:36.904758+00';
-UPDATE "public"."payment_p2022_05" SET "amount" = 11.990000 WHERE "payment_id" = 17354 and "customer_id" = 305 and "staff_id" = 1 and "rental_id" = 2166 and "amount" = 11.950000 and "payment_date" = E'2022-05-12 11:28:17.949049+00';
-UPDATE "public"."payment_p2022_06" SET "amount" = 11.990000 WHERE "payment_id" = 22650 and "customer_id" = 204 and "staff_id" = 2 and "rental_id" = 15415 and "amount" = 11.950000 and "payment_date" = E'2022-06-11 11:17:22.428079+00';
-UPDATE "public"."payment_p2022_06" SET "amount" = 11.990000 WHERE "payment_id" = 24553 and "customer_id" = 195 and "staff_id" = 2 and "rental_id" = 16040 and "amount" = 11.950000 and "payment_date" = E'2022-06-15 02:21:00.279776+00';
-UPDATE "public"."payment_p2022_07" SET "amount" = 11.990000 WHERE "payment_id" = 28814 and "customer_id" = 592 and "staff_id" = 1 and "rental_id" = 3973 and "amount" = 11.950000 and "payment_date" = E'2022-07-06 12:15:38.928947+00';
-UPDATE "public"."payment_p2022_07" SET "amount" = 11.990000 WHERE "payment_id" = 29136 and "customer_id" = 13 and "staff_id" = 2 and "rental_id" = 8831 and "amount" = 11.950000 and "payment_date" = E'2022-07-22 16:15:40.797771+00';
+PREPARE 6ee4a968 AS UPDATE "public"."payment_p2022_02" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE 6ee4a968["11.990000","23757","116","2","14763","11.950000","2022-02-11 03:52:25.634006+00"];
+PREPARE 6ee4a968 AS UPDATE "public"."payment_p2022_02" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE 6ee4a968["11.990000","24866","237","2","11479","11.950000","2022-02-07 18:37:34.579143+00"];
+PREPARE 61566f27 AS UPDATE "public"."payment_p2022_03" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE 61566f27["11.990000","17055","196","2","106","11.950000","2022-03-18 18:50:39.243747+00"];
+PREPARE 61566f27 AS UPDATE "public"."payment_p2022_03" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE 61566f27["11.990000","28799","591","2","4383","11.950000","2022-03-08 16:41:23.911522+00"];
+PREPARE 6e01df31 AS UPDATE "public"."payment_p2022_04" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE 6e01df31["11.990000","20403","362","1","14759","11.950000","2022-04-16 04:35:36.904758+00"];
+PREPARE b44f83e2 AS UPDATE "public"."payment_p2022_05" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE b44f83e2["11.990000","17354","305","1","2166","11.950000","2022-05-12 11:28:17.949049+00"];
+PREPARE 547dee5b AS UPDATE "public"."payment_p2022_06" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE 547dee5b["11.990000","22650","204","2","15415","11.950000","2022-06-11 11:17:22.428079+00"];
+PREPARE 547dee5b AS UPDATE "public"."payment_p2022_06" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE 547dee5b["11.990000","24553","195","2","16040","11.950000","2022-06-15 02:21:00.279776+00"];
+PREPARE dc973d3c AS UPDATE "public"."payment_p2022_07" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE dc973d3c["11.990000","28814","592","1","3973","11.950000","2022-07-06 12:15:38.928947+00"];
+PREPARE dc973d3c AS UPDATE "public"."payment_p2022_07" SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
+EXECUTE dc973d3c["11.990000","29136","13","2","8831","11.950000","2022-07-22 16:15:40.797771+00"];
 COMMIT; -- {"xid":494,"lsn":"0/244D170","timestamp":"2023-06-14 11:34:23.440564+0000"}
 -- KEEPALIVE {"lsn":"0/244D170","timestamp":"2023-06-14 11:34:23.440632+0000"}
 -- ENDPOS {"lsn":"0/244D170"}


### PR DESCRIPTION
When replaying INSERT/UPDATE/DELETE statements, switch to using PREPARE and
EXECUTE at the protocol level (using the libpq functions PQprepare and
PQexecPrepared). When a statement has already been prepared previously in
our session, we then only send the EXECUTE statement.

This should provide nice performance improvements.

See #414.