### PR TITLE
Fix a SEGFAULT that was hidden by our waitpid() calls.

### DIFF
--- a/src/bin/pgcopydb/ld_stream.c
+++ b/src/bin/pgcopydb/ld_stream.c
@@ -404,16 +404,6 @@ startLogicalStreaming(StreamSpecs *specs)
 	StreamContext *privateContext = &(specs->private);
 	context.private = (void *) privateContext;
 
-	if (specs->stdOut)
-	{
-		/* switch stdout from block buffered to line buffered mode */
-		if (setvbuf(specs->out, NULL, _IOLBF, 0) != 0)
-		{
-			log_error("Failed to set stdout to line buffered mode: %m");
-			return false;
-		}
-	}
-
 	log_notice("Connecting to logical decoding replication stream");
 
 	/*
@@ -2474,7 +2464,7 @@ stream_create_sentinel(CopyDataSpec *copySpecs,
 		if (!pgsql_execute(pgsql, sql[i]))
 		{
 			/* errors have already been logged */
-			exit(EXIT_CODE_SOURCE);
+			return false;
 		}
 	}
 

--- a/src/bin/pgcopydb/ld_stream.h
+++ b/src/bin/pgcopydb/ld_stream.h
@@ -395,6 +395,7 @@ typedef struct FollowSubProcess
 	pid_t pid;
 	bool exited;
 	int returnCode;
+	int sig;
 } FollowSubProcess;
 
 
@@ -418,6 +419,7 @@ struct StreamSpecs
 
 	uint64_t startpos;
 	uint64_t endpos;
+	CopyDBSentinel sentinel;
 
 	bool startposComputedFromJSON;
 	StreamAction startposActionFromJSON;
@@ -682,6 +684,6 @@ void follow_exit_early(StreamSpecs *specs);
 bool follow_wait_subprocesses(StreamSpecs *specs);
 bool follow_terminate_subprocesses(StreamSpecs *specs);
 
-bool follow_wait_pid(pid_t subprocess, bool *exited, int *returnCode);
+bool follow_wait_pid(pid_t subprocess, bool *exited, int *returnCode, int *sig);
 
 #endif /* LD_STREAM_H */

--- a/src/bin/pgcopydb/ld_transform.c
+++ b/src/bin/pgcopydb/ld_transform.c
@@ -95,13 +95,6 @@ stream_transform_stream(StreamSpecs *specs)
 		.ctx = &ctx
 	};
 
-	/* switch out stream from block buffered to line buffered mode */
-	if (setvbuf(privateContext->out, NULL, _IOLBF, 0) != 0)
-	{
-		log_error("Failed to set stdout to line buffered mode: %m");
-		exit(EXIT_CODE_INTERNAL_ERROR);
-	}
-
 	if (!read_from_stream(privateContext->in, &context))
 	{
 		log_error("Failed to transform JSON messages from input stream, "

--- a/src/bin/pgcopydb/signals.c
+++ b/src/bin/pgcopydb/signals.c
@@ -165,6 +165,7 @@ void
 catch_quit_and_exit(int sig)
 {
 	/* default signal handler disposition is to core dump, we don't */
+	log_warn("SIGQUIT");
 	exit(EXIT_CODE_QUIT);
 }
 
@@ -265,6 +266,8 @@ signal_to_string(int signal)
 		}
 
 		default:
-			return "unknown signal";
+		{
+			return strsignal(signal);
+		}
 	}
 }


### PR DESCRIPTION
When a subprocess terminates with a successful return code, it might still have been terminated by a signal, one signal would be SIGSEGV. Arrange our code to report when that happens.

This happened in initialisation of the streaming module when trying to call setvbuf on a un-assigned file descriptor. This is fixed in follow.c when preparing the call.