### PR TITLE
When applying --follow changes, set synchronous_commit to off.

### DIFF
--- a/src/bin/pgcopydb/cli_stream.c
+++ b/src/bin/pgcopydb/cli_stream.c
@@ -1069,15 +1069,20 @@ cli_stream_apply(int argc, char **argv)
 		/* prepare the replication origin tracking */
 		StreamApplyContext context = { 0 };
 
+		if (!stream_apply_init_context(&context,
+									   &(copySpecs.cfPaths.cdc),
+									   &(streamDBoptions.connStrings),
+									   streamDBoptions.origin,
+									   streamDBoptions.endpos))
+		{
+			/* errors have already been logged */
+			exit(EXIT_CODE_TARGET);
+		}
+
+		context.apply = true;
 		strlcpy(context.sqlFileName, sqlfilename, sizeof(context.sqlFileName));
 
-		if (!setupReplicationOrigin(&context,
-									&(copySpecs.cfPaths.cdc),
-									&(streamDBoptions.connStrings),
-									streamDBoptions.origin,
-									streamDBoptions.endpos,
-									true,
-									logSQL))
+		if (!setupReplicationOrigin(&context, logSQL))
 		{
 			log_error("Failed to setup replication origin on the target database");
 			exit(EXIT_CODE_TARGET);

--- a/src/bin/pgcopydb/copydb.c
+++ b/src/bin/pgcopydb/copydb.c
@@ -547,6 +547,10 @@ copydb_prepare_filepaths(CopyFilePaths *cfPaths,
 			"%s/wal_segment_size",
 			cfPaths->cdc.dir);
 
+	sformat(cfPaths->cdc.lsntrackingfile, MAXPGPATH,
+			"%s/lsn.json",
+			cfPaths->cdc.dir);
+
 	/*
 	 * Now prepare the "compare" files we need to compare schema and data
 	 * between the source and target instance.

--- a/src/bin/pgcopydb/copydb_paths.h
+++ b/src/bin/pgcopydb/copydb_paths.h
@@ -53,6 +53,7 @@ typedef struct CDCPaths
 	char walsegsizefile[MAXPGPATH];   /* /tmp/pgcopydb/cdc/wal_segment_size */
 	char tlifile[MAXPGPATH];          /* /tmp/pgcopydb/cdc/tli */
 	char tlihistfile[MAXPGPATH];      /* /tmp/pgcopydb/cdc/tli.history */
+	char lsntrackingfile[MAXPGPATH];  /* /tmp/pgcopydb/cdc/lsn.json */
 } CDCPaths;
 
 

--- a/src/bin/pgcopydb/ld_replay.c
+++ b/src/bin/pgcopydb/ld_replay.c
@@ -48,7 +48,7 @@ stream_apply_replay(StreamSpecs *specs)
 
 	if (!stream_apply_setup(specs, context))
 	{
-		log_error("Failed to setup for catchup, see above for details");
+		log_error("Failed to setup for replay, see above for details");
 		return false;
 	}
 
@@ -99,9 +99,6 @@ stream_apply_replay(StreamSpecs *specs)
 		pg_usleep(100 * 1000);
 	}
 
-	/* we might still have to disconnect now */
-	(void) pgsql_finish(&(context->pgsql));
-
 	/* make sure to send a last round of sentinel update before exit */
 	if (!stream_apply_sync_sentinel(context))
 	{
@@ -109,6 +106,9 @@ stream_apply_replay(StreamSpecs *specs)
 				  LSN_FORMAT_ARGS(context->replay_lsn));
 		return false;
 	}
+
+	/* we might still have to disconnect now */
+	(void) pgsql_finish(&(context->pgsql));
 
 	if (context->endpos != InvalidXLogRecPtr &&
 		context->endpos <= context->replay_lsn)

--- a/src/bin/pgcopydb/pgsql.h
+++ b/src/bin/pgcopydb/pgsql.h
@@ -527,6 +527,8 @@ bool pgsql_table_exists(PGSQL *pgsql,
 						const char *nspname,
 						bool *exists);
 
+bool pgsql_current_wal_flush_lsn(PGSQL *pgsql, uint64_t *lsn);
+bool pgsql_current_wal_insert_lsn(PGSQL *pgsql, uint64_t *lsn);
 
 /*
  * pgcopydb sentinel is a table that's created on the source database and


### PR DESCRIPTION
This allows a way faster replay because we don't have to wait for Postgres disk sync operation before sending the next SQL command. We need to be careful with what replay_lsn value is sent back to the replication protocol, and for that we need to introduce a tracking between the source LSN and the replay insert LSN.

We still restart applying from the latest LSN that we manage to commit durably using the replication origin API. The advantage of that API is that it's as durable as the transactions replayed on the target system.

See #414.