### PR TITLE
Review the TCP keepalives settings.

### DIFF
--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -19,7 +19,9 @@
 
 #define COMMON_GUC_SETTINGS \
 	{ "client_encoding", "'UTF-8'" }, \
-	{ "tcp_keepalives_idle", "'60s'" }, \
+	{ "tcp_keepalives_idle", "'10s'" }, \
+	{ "tcp_keepalives_interval", "'10s'" }, \
+	{ "tcp_keepalives_count", "60" }, \
 	{ "extra_float_digits", "3" }, \
 	{ "statement_timeout", "0" }
 

--- a/src/bin/pgcopydb/ld_stream.c
+++ b/src/bin/pgcopydb/ld_stream.c
@@ -2038,9 +2038,19 @@ buildReplicationURI(const char *pguri, char **repl_pguri)
 	bool checkForCompleteURI = false;
 
 	KeyVal replicationParams = {
-		.count = 1,
-		.keywords = { "replication" },
-		.values = { "database" }
+		.count = 4,
+		.keywords = {
+			"replication",
+			"tcp_keepalives_idle",
+			"tcp_keepalives_interval",
+			"tcp_keepalives_count"
+		},
+		.values = {
+			"database",
+			"'10s'",
+			"'10s'",
+			"60"
+		}
 	};
 
 	/* if replication is already found, we override it to value "1" */

--- a/src/bin/pgcopydb/parsing_utils.c
+++ b/src/bin/pgcopydb/parsing_utils.c
@@ -962,9 +962,19 @@ parse_and_scrub_connection_string(const char *pguri, SafeURI *safeURI)
 	URIParams *uriParams = &(safeURI->uriParams);
 
 	KeyVal overrides = {
-		.count = 1,
-		.keywords = { "password" },
-		.values = { "" }
+		.count = 4,
+		.keywords = {
+			"password",
+			"tcp_keepalives_idle",
+			"tcp_keepalives_interval",
+			"tcp_keepalives_count",
+		},
+		.values = {
+			"",
+			"'10s'",
+			"'10s'",
+			"60",
+		}
 	};
 
 	if (pguri == NULL)


### PR DESCRIPTION
To work with shorter timeouts in network stacks (firewall, NAT settings, etc), adjust to TCP keepalive settings to quite short values.