### PR TITLE
Improve connection string TCP keepalive parameters handling.

### DIFF
--- a/src/bin/pgcopydb/copydb.c
+++ b/src/bin/pgcopydb/copydb.c
@@ -61,6 +61,27 @@ GUC serverSetttings[] = {
 
 
 /*
+ * These parameters are added to the connection strings, unless the user has
+ * added them, allowing user-defined values to be taken into account.
+ */
+KeyVal connStringDefaults = {
+	.count = 4,
+	.keywords = {
+		"keepalives",
+		"keepalives_idle",
+		"keepalives_interval",
+		"keepalives_count"
+	},
+	.values = {
+		"1",
+		"10",
+		"10",
+		"60"
+	}
+};
+
+
+/*
  * copydb_init_tempdir initialises the file paths that are going to be used to
  * store temporary information while the pgcopydb process is running.
  */

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -17,13 +17,21 @@
 #include "summary.h"
 
 
+/*
+ * These GUC settings are set with the SET command, and are meant to be
+ * controled by pgcopydb without a way for the user to override them.
+ */
 #define COMMON_GUC_SETTINGS \
 	{ "client_encoding", "'UTF-8'" }, \
-	{ "tcp_keepalives_idle", "'10s'" }, \
-	{ "tcp_keepalives_interval", "'10s'" }, \
-	{ "tcp_keepalives_count", "60" }, \
 	{ "extra_float_digits", "3" }, \
 	{ "statement_timeout", "0" }
+
+/*
+ * These parameters are added to the connection strings, unless the user has
+ * added them, allowing user-defined values to be taken into account.
+ */
+extern KeyVal connStringDefaults;
+
 
 /*
  * pgcopydb creates System V OS level objects such as message queues and

--- a/src/bin/pgcopydb/ld_stream.c
+++ b/src/bin/pgcopydb/ld_stream.c
@@ -2038,23 +2038,14 @@ buildReplicationURI(const char *pguri, char **repl_pguri)
 	bool checkForCompleteURI = false;
 
 	KeyVal replicationParams = {
-		.count = 4,
-		.keywords = {
-			"replication",
-			"tcp_keepalives_idle",
-			"tcp_keepalives_interval",
-			"tcp_keepalives_count"
-		},
-		.values = {
-			"database",
-			"'10s'",
-			"'10s'",
-			"60"
-		}
+		.count = 1,
+		.keywords = { "replication" },
+		.values = { "database" }
 	};
 
 	/* if replication is already found, we override it to value "1" */
 	if (!parse_pguri_info_key_vals(pguri,
+								   &connStringDefaults,
 								   &replicationParams,
 								   &params,
 								   checkForCompleteURI))

--- a/src/bin/pgcopydb/parsing_utils.h
+++ b/src/bin/pgcopydb/parsing_utils.h
@@ -98,6 +98,7 @@ typedef struct ConnStrings
 
 
 bool parse_pguri_info_key_vals(const char *pguri,
+							   KeyVal *defaults,
 							   KeyVal *overrides,
 							   URIParams *uriParameters,
 							   bool checkForCompleteURI);

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -496,15 +496,15 @@ pgsql_open_connection(PGSQL *pgsql)
 		return pgsql->connection;
 	}
 
+	/* compute the URL without the password, we set it separately */
+	if (pgsql->safeURI.pguri == NULL)
+	{
+		(void) parse_and_scrub_connection_string(pgsql->connectionString,
+												 &(pgsql->safeURI));
+	}
+
 	if (pgsql->logSQL)
 	{
-		/* also keep around a print-safe version of the URL */
-		if (pgsql->safeURI.pguri == NULL)
-		{
-			(void) parse_and_scrub_connection_string(pgsql->connectionString,
-													 &(pgsql->safeURI));
-		}
-
 		log_sql("Connecting to [%s] \"%s\"",
 				ConnectionTypeToString(pgsql->connectionType),
 				pgsql->safeURI.pguri);

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -516,6 +516,12 @@ pgsql_open_connection(PGSQL *pgsql)
 		setenv("PGAPPNAME", PGCOPYDB_PGAPPNAME, 1);
 	}
 
+	/* use the parsed password, unless the environment already is set */
+	if (!env_exists("PGPASSWORD") && pgsql->safeURI.password != NULL)
+	{
+		setenv("PGPASSWORD", pgsql->safeURI.password, 1);
+	}
+
 	/* we implement our own retry strategy */
 	setenv("PGCONNECT_TIMEOUT", POSTGRES_CONNECT_TIMEOUT, 1);
 
@@ -524,7 +530,7 @@ pgsql_open_connection(PGSQL *pgsql)
 	INSTR_TIME_SET_ZERO(pgsql->retryPolicy.connectTime);
 
 	/* Make a connection to the database */
-	pgsql->connection = PQconnectdb(pgsql->connectionString);
+	pgsql->connection = PQconnectdb(pgsql->safeURI.pguri);
 
 	/* Check to see that the backend connection was successfully made */
 	if (PQstatus(pgsql->connection) != CONNECTION_OK)
@@ -544,7 +550,7 @@ pgsql_open_connection(PGSQL *pgsql)
 			log_error("Failed to connect to %s database at \"%s\", "
 					  "see above for details",
 					  ConnectionTypeToString(pgsql->connectionType),
-					  pgsql->connectionString);
+					  pgsql->safeURI.pguri);
 
 			pgsql->status = PG_CONNECTION_BAD;
 
@@ -621,8 +627,6 @@ pgsql_retry_open_connection(PGSQL *pgsql)
 			INSTR_TIME_SUBTRACT(duration, pgsql->retryPolicy.startTime);
 
 			(void) log_connection_error(pgsql->connection, LOG_ERROR);
-			pgsql->status = PG_CONNECTION_BAD;
-			pgsql_finish(pgsql);
 
 			log_error("Failed to connect to \"%s\" "
 					  "after %d attempts in %d ms, "
@@ -630,6 +634,9 @@ pgsql_retry_open_connection(PGSQL *pgsql)
 					  pgsql->safeURI.pguri,
 					  pgsql->retryPolicy.attempts,
 					  (int) INSTR_TIME_GET_MILLISEC(duration));
+
+			pgsql->status = PG_CONNECTION_BAD;
+			pgsql_finish(pgsql);
 
 			return false;
 		}


### PR DESCRIPTION
Allow overriding at the command-line level, also set the parameters in the connection string so that they're effective even when connecting.