### PR TITLE
Fix error handling of fork() calls.

### DIFF
--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -524,6 +524,7 @@ bool copydb_prepare_copy_query(CopyTableDataSpec *tableSpecs,
 /* blobs.c */
 bool copydb_start_blob_process(CopyDataSpec *specs);
 
+bool copydb_blob_supervisor(CopyDataSpec *specs);
 bool copydb_start_blob_workers(CopyDataSpec *specs);
 bool copydb_blob_worker(CopyDataSpec *specs);
 bool copydb_queue_largeobject_metadata(CopyDataSpec *specs, uint64_t *count);

--- a/src/bin/pgcopydb/indexes.c
+++ b/src/bin/pgcopydb/indexes.c
@@ -45,7 +45,7 @@ copydb_start_index_workers(CopyDataSpec *specs)
 		{
 			case -1:
 			{
-				log_error("Failed to fork a worker process: %m");
+				log_error("Failed to fork a create index worker process: %m");
 				return false;
 			}
 

--- a/src/bin/pgcopydb/vacuum.c
+++ b/src/bin/pgcopydb/vacuum.c
@@ -47,7 +47,7 @@ vacuum_start_workers(CopyDataSpec *specs)
 		{
 			case -1:
 			{
-				log_error("Failed to fork a worker process: %m");
+				log_error("Failed to fork a vacuum worker process: %m");
 				return false;
 			}
 


### PR DESCRIPTION
When failing to start a sub-process (out-of-memory can be reported when calling the fork() system call), properly handle the error rather than continue trying the migration.

In order to cancel the other sub-processes that were succesfully started we then send a TERM signal to all processes in our process group.

Fixes #458 