### PR TITLE
Optimize INSERT statements by translating them to COPY operations

### DIFF
--- a/src/bin/pgcopydb/ld_stream.h
+++ b/src/bin/pgcopydb/ld_stream.h
@@ -383,6 +383,8 @@ typedef struct StreamApplyContext
 	char sqlFileName[MAXPGPATH];
 
 	PreparedStmt *preparedStmt;
+
+	uint32_t currentCopyHash;
 } StreamApplyContext;
 
 

--- a/src/bin/pgcopydb/pgsql.h
+++ b/src/bin/pgcopydb/pgsql.h
@@ -312,6 +312,7 @@ bool pg_copy(PGSQL *src, PGSQL *dst,
 			 const char *srcQname, const char *dstQname, bool truncate);
 
 bool pg_copy_from_stdin(PGSQL *pgsql, const char *qname);
+bool pg_copy_put_row(PGSQL *pgsql, const char **array, size_t len);
 bool pg_copy_row_from_stdin(PGSQL *pgsql, char *fmt, ...);
 bool pg_copy_end(PGSQL *pgsql);
 


### PR DESCRIPTION
This commit optimizes INSERT statements by converting them into COPY operations, significantly enhancing insert throughput. The conversion begins when an INSERT statement is encountered and continues to push data to the COPY operation until a new table or other DML operations are encountered.

Performance tests were conducted using a timeseries benchmark suite[1]. Initially, pgcopydb provided approximately 2500 inserts per second. After implementing the COPY optimization, the insertion rate increased to nearly 26000 inserts per second, resulting in nearly a 10x improvement.

**Please note that this optimization is most effective when consecutive INSERT statements target the same table. Performance may not be as significant when INSERT statements are directed to different tables.**

[1] https://github.com/timescale/tsbs