### PR TITLE
Fix SQL identifier quoting, generalize using format %I.

### DIFF
--- a/src/bin/pgcopydb/cli_list.c
+++ b/src/bin/pgcopydb/cli_list.c
@@ -1185,16 +1185,14 @@ cli_list_table_parts(int argc, char **argv)
 
 	if (table->partsArray.count <= 1)
 	{
-		log_info("Table \"%s\".\"%s\" (%s) will not be split",
-				 table->nspname,
-				 table->relname,
+		log_info("Table %s (%s) will not be split",
+				 table->qname,
 				 table->bytesPretty);
 		exit(EXIT_CODE_QUIT);
 	}
 
-	log_info("Table \"%s\".\"%s\" COPY will be split %d-ways",
-			 table->nspname,
-			 table->relname,
+	log_info("Table %s COPY will be split %d-ways",
+			 table->qname,
 			 table->partsArray.count);
 
 	fformat(stdout, "%12s | %12s | %12s | %12s\n",

--- a/src/bin/pgcopydb/compare.c
+++ b/src/bin/pgcopydb/compare.c
@@ -617,10 +617,9 @@ compare_schemas(CopyDataSpec *copySpecs)
 			if (targetIndexList == NULL)
 			{
 				++diffCount;
-				log_error("Table %s is missing index \"%s\".\"%s\" on target",
+				log_error("Table %s is missing index %s on target",
 						  qname,
-						  sourceIndex->indexNamespace,
-						  sourceIndex->indexRelname);
+						  sourceIndex->indexQname);
 
 				continue;
 			}
@@ -631,43 +630,35 @@ compare_schemas(CopyDataSpec *copySpecs)
 				!streq(sourceIndex->indexRelname, targetIndex->indexRelname))
 			{
 				++diffCount;
-				log_error("Table %s index mismatch: \"%s\".\"%s\" on source, "
-						  "\"%s\".\"%s\" on target",
+				log_error("Table %s index mismatch: %s on source, %s on target",
 						  qname,
-						  sourceIndex->indexNamespace,
-						  sourceIndex->indexRelname,
-						  targetIndex->indexNamespace,
-						  targetIndex->indexRelname);
+						  sourceIndex->indexQname,
+						  targetIndex->indexQname);
 			}
 
 			if (!streq(sourceIndex->indexDef, targetIndex->indexDef))
 			{
 				++diffCount;
-				log_error("Table %s index \"%s\".\"%s\" mismatch "
-						  "on index definition",
+				log_error("Table %s index %s mismatch on index definition",
 						  qname,
-						  sourceIndex->indexNamespace,
-						  sourceIndex->indexRelname);
+						  sourceIndex->indexQname);
 
-				log_info("Source index \"%s\".\"%s\": %s",
-						 sourceIndex->indexNamespace,
-						 sourceIndex->indexRelname,
+				log_info("Source index %s: %s",
+						 sourceIndex->indexQname,
 						 sourceIndex->indexDef);
 
-				log_info("Target index \"%s\".\"%s\": %s",
-						 targetIndex->indexNamespace,
-						 targetIndex->indexRelname,
+				log_info("Target index %s: %s",
+						 targetIndex->indexQname,
 						 targetIndex->indexDef);
 			}
 
 			if (sourceIndex->isPrimary != targetIndex->isPrimary)
 			{
 				++diffCount;
-				log_error("Table %s index \"%s\".\"%s\" is %s on source "
+				log_error("Table %s index %s is %s on source "
 						  "and %s on target",
 						  qname,
-						  sourceIndex->indexNamespace,
-						  sourceIndex->indexRelname,
+						  sourceIndex->indexQname,
 						  sourceIndex->isPrimary ? "primary" : "not primary",
 						  targetIndex->isPrimary ? "primary" : "not primary");
 			}
@@ -675,11 +666,10 @@ compare_schemas(CopyDataSpec *copySpecs)
 			if (sourceIndex->isUnique != targetIndex->isUnique)
 			{
 				++diffCount;
-				log_error("Table %s index \"%s\".\"%s\" is %s on source "
+				log_error("Table %s index %s is %s on source "
 						  "and %s on target",
 						  qname,
-						  sourceIndex->indexNamespace,
-						  sourceIndex->indexRelname,
+						  sourceIndex->indexQname,
 						  sourceIndex->isUnique ? "unique" : "not unique",
 						  targetIndex->isUnique ? "unique" : "not unique");
 			}
@@ -687,12 +677,11 @@ compare_schemas(CopyDataSpec *copySpecs)
 			if (!streq(sourceIndex->constraintName, targetIndex->constraintName))
 			{
 				++diffCount;
-				log_error("Table %s index \"%s\".\"%s\" is supporting "
-						  " constraint named \"%s\" on source "
-						  "and \"%s\" on target",
+				log_error("Table %s index %s is supporting "
+						  " constraint named %s on source "
+						  "and %s on target",
 						  qname,
-						  sourceIndex->indexNamespace,
-						  sourceIndex->indexRelname,
+						  sourceIndex->indexQname,
 						  sourceIndex->constraintName,
 						  targetIndex->constraintName);
 			}
@@ -702,22 +691,19 @@ compare_schemas(CopyDataSpec *copySpecs)
 				 !streq(sourceIndex->constraintDef, targetIndex->constraintDef)))
 			{
 				++diffCount;
-				log_error("Table %s index \"%s\".\"%s\" constraint \"%s\" "
+				log_error("Table %s index %s constraint %s "
 						  "definition mismatch.",
 						  qname,
-						  sourceIndex->indexNamespace,
-						  sourceIndex->indexRelname,
+						  sourceIndex->indexQname,
 						  sourceIndex->constraintName);
 
-				log_info("Source index \"%s\".\"%s\" constraint \"%s\": %s",
-						 sourceIndex->indexNamespace,
-						 sourceIndex->indexRelname,
+				log_info("Source index %s constraint %s: %s",
+						 sourceIndex->indexQname,
 						 sourceIndex->constraintName,
 						 sourceIndex->constraintDef);
 
-				log_info("Target index \"%s\".\"%s\" constraint \"%s\": %s",
-						 targetIndex->indexNamespace,
-						 targetIndex->indexRelname,
+				log_info("Target index %s constraint %s: %s",
+						 targetIndex->indexQname,
 						 targetIndex->constraintName,
 						 targetIndex->constraintDef);
 			}

--- a/src/bin/pgcopydb/copydb_schema.c
+++ b/src/bin/pgcopydb/copydb_schema.c
@@ -332,10 +332,9 @@ copydb_prepare_table_specs(CopyDataSpec *specs, PGSQL *pgsql)
 
 			if (source->partsArray.count > 1)
 			{
-				log_info("Table \"%s\".\"%s\" is %s large, "
-						 "%d COPY processes will be used, partitining on \"%s\".",
-						 source->nspname,
-						 source->relname,
+				log_info("Table %s is %s large, "
+						 "%d COPY processes will be used, partitioning on %s.",
+						 source->qname,
 						 source->bytesPretty,
 						 source->partsArray.count,
 						 source->partKey);
@@ -481,11 +480,10 @@ copydb_prepare_index_specs(CopyDataSpec *specs, PGSQL *pgsql)
 
 			if (table == NULL)
 			{
-				log_error("Failed to find table %u (\"%s\".\"%s\") "
+				log_error("Failed to find table %u (%s) "
 						  " in sourceTableHashByOid",
 						  oid,
-						  indexArray->array[i].tableNamespace,
-						  indexArray->array[i].tableRelname);
+						  indexArray->array[i].tableQname);
 				return false;
 			}
 

--- a/src/bin/pgcopydb/progress.c
+++ b/src/bin/pgcopydb/progress.c
@@ -429,6 +429,7 @@ copydb_index_array_as_json(SourceIndexArray *indexArray,
 		json_object_set_number(jsIndexObj, "oid", (double) index->indexOid);
 		json_object_set_string(jsIndexObj, "schema", index->indexNamespace);
 		json_object_set_string(jsIndexObj, "name", index->indexRelname);
+		json_object_set_string(jsIndexObj, "qname", index->indexQname);
 
 		json_object_set_boolean(jsIndexObj, "isPrimary", index->isPrimary);
 		json_object_set_boolean(jsIndexObj, "isUnique", index->isUnique);
@@ -447,6 +448,7 @@ copydb_index_array_as_json(SourceIndexArray *indexArray,
 		json_object_set_number(jsTableObj, "oid", (double) index->tableOid);
 		json_object_set_string(jsTableObj, "schema", index->tableNamespace);
 		json_object_set_string(jsTableObj, "name", index->tableRelname);
+		json_object_set_string(jsTableObj, "qname", index->tableQname);
 
 		json_object_set_value(jsIndexObj, "table", jsTable);
 
@@ -508,6 +510,7 @@ copydb_seq_array_as_json(SourceSequenceArray *sequenceArray,
 		json_object_set_number(jsSeqObj, "oid", (double) seq->oid);
 		json_object_set_string(jsSeqObj, "schema", seq->nspname);
 		json_object_set_string(jsSeqObj, "name", seq->relname);
+		json_object_set_string(jsSeqObj, "qname", seq->qname);
 
 		json_object_set_number(jsSeqObj, "last-value", (double) seq->lastValue);
 		json_object_set_boolean(jsSeqObj, "is-called", (double) seq->isCalled);
@@ -723,6 +726,7 @@ copydb_parse_schema_json_file(CopyDataSpec *copySpecs)
 
 		char *schema = (char *) json_object_get_string(jsIndex, "schema");
 		char *name = (char *) json_object_get_string(jsIndex, "name");
+		char *qname = (char *) json_object_get_string(jsIndex, "qname");
 		char *cols = (char *) json_object_get_string(jsIndex, "columns");
 		char *def = (char *) json_object_get_string(jsIndex, "sql");
 		char *listName =
@@ -730,6 +734,7 @@ copydb_parse_schema_json_file(CopyDataSpec *copySpecs)
 
 		strlcpy(index->indexNamespace, schema, sizeof(index->indexNamespace));
 		strlcpy(index->indexRelname, name, sizeof(index->indexRelname));
+		strlcpy(index->indexQname, qname, sizeof(index->indexQname));
 
 		int lenCols = strlen(cols) + 1;
 
@@ -766,9 +771,11 @@ copydb_parse_schema_json_file(CopyDataSpec *copySpecs)
 
 		schema = (char *) json_object_dotget_string(jsIndex, "table.schema");
 		name = (char *) json_object_dotget_string(jsIndex, "table.name");
+		qname = (char *) json_object_dotget_string(jsIndex, "table.qname");
 
 		strlcpy(index->tableNamespace, schema, sizeof(index->tableNamespace));
 		strlcpy(index->tableRelname, name, sizeof(index->tableRelname));
+		strlcpy(index->tableQname, name, sizeof(index->tableQname));
 
 		if (json_object_has_value(jsIndex, "constraint"))
 		{

--- a/src/bin/pgcopydb/schema.h
+++ b/src/bin/pgcopydb/schema.h
@@ -245,20 +245,26 @@ typedef struct SourceSequenceArray
 typedef struct SourceIndex
 {
 	uint32_t indexOid;
+	char indexQname[NAMEDATALEN * 2 + 5 + 1];
 	char indexNamespace[NAMEDATALEN];
 	char indexRelname[NAMEDATALEN];
+
 	uint32_t tableOid;
+	char tableQname[NAMEDATALEN * 2 + 5 + 1];
 	char tableNamespace[NAMEDATALEN];
 	char tableRelname[NAMEDATALEN];
+
 	bool isPrimary;
 	bool isUnique;
 	char *indexColumns;         /* malloc'ed area */
 	char *indexDef;             /* malloc'ed area */
+
 	uint32_t constraintOid;
 	bool condeferrable;
 	bool condeferred;
 	char constraintName[NAMEDATALEN];
 	char *constraintDef;        /* malloc'ed area */
+
 	char indexRestoreListName[RESTORE_LIST_NAMEDATALEN];
 	char constraintRestoreListName[RESTORE_LIST_NAMEDATALEN];
 

--- a/src/bin/pgcopydb/sequences.c
+++ b/src/bin/pgcopydb/sequences.c
@@ -49,10 +49,6 @@ copydb_prepare_sequence_specs(CopyDataSpec *specs, PGSQL *pgsql)
 		/* add the current sequence to the sequence Hash-by-OID */
 		HASH_ADD(hh, sourceSeqHashByOid, oid, sizeof(uint32_t), seq);
 
-		sformat(seq->qname, sizeof(seq->qname), "%s.%s",
-				seq->nspname,
-				seq->relname);
-
 		/*
 		 * In case of "permission denied" for SELECT on the sequence object, we
 		 * would then have a broken transaction and all the rest of the loop

--- a/src/bin/pgcopydb/table-data.c
+++ b/src/bin/pgcopydb/table-data.c
@@ -531,11 +531,10 @@ copydb_copy_data_by_oid(CopyDataSpec *specs, uint32_t oid, uint32_t part)
 
 	if (table->partsArray.count < part)
 	{
-		log_error("Failed to find part %d for table \"%s\".\"%s\" (%u), "
+		log_error("Failed to find part %d for table %s (%u), "
 				  "which has only %d parts",
 				  part,
-				  table->nspname,
-				  table->relname,
+				  table->qname,
 				  table->oid,
 				  table->partsArray.count);
 		return false;
@@ -549,10 +548,9 @@ copydb_copy_data_by_oid(CopyDataSpec *specs, uint32_t oid, uint32_t part)
 		return false;
 	}
 
-	log_trace("copydb_copy_data_by_oid: %u \"%s.%s\", part %d",
+	log_trace("copydb_copy_data_by_oid: %u %s, part %d",
 			  oid,
-			  table->nspname,
-			  table->relname,
+			  table->qname,
 			  part);
 
 	char psTitle[BUFSIZE] = { 0 };
@@ -654,9 +652,8 @@ copydb_copy_data_by_oid(CopyDataSpec *specs, uint32_t oid, uint32_t part)
 
 					if (!vacuum_add_table(specs, sourceTable->oid))
 					{
-						log_error("Failed to queue VACUUM ANALYZE \"%s\".\"%s\" [%u]",
-								  sourceTable->nspname,
-								  sourceTable->relname,
+						log_error("Failed to queue VACUUM ANALYZE %s [%u]",
+								  sourceTable->qname,
 								  sourceTable->oid);
 						return false;
 					}
@@ -1144,7 +1141,7 @@ copydb_prepare_copy_query(CopyTableDataSpec *tableSpecs,
 				appendPQExpBufferStr(query, ", ");
 			}
 
-			appendPQExpBuffer(query, "\"%s\"", attname);
+			appendPQExpBuffer(query, "%s", attname);
 		}
 
 		appendPQExpBuffer(query, " FROM %s ", tableSpecs->sourceTable->qname);
@@ -1180,7 +1177,7 @@ copydb_prepare_copy_query(CopyTableDataSpec *tableSpecs,
 			else
 			{
 				appendPQExpBuffer(query,
-								  " WHERE \"%s\" BETWEEN %lld AND %lld ",
+								  " WHERE %s BETWEEN %lld AND %lld ",
 								  tableSpecs->part.partKey,
 								  (long long) tableSpecs->part.min,
 								  (long long) tableSpecs->part.max);
@@ -1209,7 +1206,7 @@ copydb_prepare_copy_query(CopyTableDataSpec *tableSpecs,
 				appendPQExpBufferStr(query, ", ");
 			}
 
-			appendPQExpBuffer(query, "\"%s\"", attname);
+			appendPQExpBuffer(query, "%s", attname);
 		}
 
 		if (table->attributes.count > 0)

--- a/tests/unit/copydb.sh
+++ b/tests/unit/copydb.sh
@@ -25,6 +25,7 @@ create collation if not exists mycol
 EOF
 
 # pgcopydb fork uses the environment variables
+export PGCOPYDB_SPLIT_TABLES_LARGER_THAN="2MB"
 pgcopydb fork --skip-collations --fail-fast --notice
 
 # now compare the output of running the SQL command with what's expected

--- a/tests/unit/setup/4-list-table-split.sql
+++ b/tests/unit/setup/4-list-table-split.sql
@@ -68,3 +68,47 @@ select
     *
 from
     cache_table_size;
+
+--
+-- also create tables with names that needs double-quoting to see that our
+-- partitioning queries can cope with that
+--
+CREATE SCHEMA IF NOT EXISTS "Sp1eCial .Char";
+
+CREATE TABLE "Sp1eCial .Char"."source1testing"
+ (
+   "s0" int PRIMARY KEY,
+   "s1" int NOT NULL
+ );
+
+insert into "Sp1eCial .Char"."source1testing"("s0", "s1")
+select x, (x * 2) % 100000
+  from generate_series(1, 10000) AS t(x);
+
+
+CREATE TABLE "Sp1eCial .Char"."Tabl e.1testing"
+ (
+  "iD" int PRIMARY KEY,
+  "regId" int,
+  "status" int,
+  "nA M.e" character varying(20) NOT NULL,
+
+   CONSTRAINT "Tabl e_fk_1_testing"
+  FOREIGN KEY ("iD")
+   REFERENCES "Sp1eCial .Char"."source1testing"("s0")
+);
+
+insert into "Sp1eCial .Char"."Tabl e.1testing"("iD", "regId", "status", "nA M.e")
+select
+    "s0",
+    "s0",
+    random() * 100,
+    'Name ' || "s0"
+from
+    "Sp1eCial .Char"."source1testing";
+
+insert into pgcopydb.pgcopydb_table_size (oid, bytes)
+     select tname::regclass,
+            10 * 1024 * 1024
+       from (values ('"Sp1eCial .Char"."source1testing"'),
+                    ('"Sp1eCial .Char"."Tabl e.1testing"')) as t(tname);


### PR DESCRIPTION
Using the Postgres function format with the %I formatter allows our code to bypass any formatting internally when re-using the SQL object names, both in our logs and also in the SQL queries we then emit.

Generalize that approach to attribute names, index names, index table names, index constraint names, and sequences names.

Fixes #463.