### PR TITLE
Use an intermediate file on-disk for pg_restore --list output.

### DIFF
--- a/src/bin/pgcopydb/copydb.c
+++ b/src/bin/pgcopydb/copydb.c
@@ -614,14 +614,20 @@ copydb_prepare_dump_paths(CopyFilePaths *cfPaths, DumpPaths *dumpPaths)
 	sformat(dumpPaths->preFilename, MAXPGPATH, "%s/%s",
 			cfPaths->schemadir, "pre.dump");
 
+	sformat(dumpPaths->preListOutFilename, MAXPGPATH, "%s/%s",
+			cfPaths->schemadir, "pre-out.list");
+
+	sformat(dumpPaths->preListFilename, MAXPGPATH, "%s/%s",
+			cfPaths->schemadir, "pre-filtered.list");
+
 	sformat(dumpPaths->postFilename, MAXPGPATH, "%s/%s",
 			cfPaths->schemadir, "post.dump");
 
-	sformat(dumpPaths->preListFilename, MAXPGPATH, "%s/%s",
-			cfPaths->schemadir, "pre.list");
+	sformat(dumpPaths->postListOutFilename, MAXPGPATH, "%s/%s",
+			cfPaths->schemadir, "post-out.list");
 
 	sformat(dumpPaths->postListFilename, MAXPGPATH, "%s/%s",
-			cfPaths->schemadir, "post.list");
+			cfPaths->schemadir, "post-filtered.list");
 
 	return true;
 }

--- a/src/bin/pgcopydb/copydb_paths.h
+++ b/src/bin/pgcopydb/copydb_paths.h
@@ -94,10 +94,12 @@ typedef struct DumpPaths
 	char extnspFilename[MAXPGPATH];  /* pg_dump --schema-only -n ... */
 
 	char preFilename[MAXPGPATH];     /* pg_dump --section=pre-data */
-	char preListFilename[MAXPGPATH]; /* pg_restore --list */
+	char preListOutFilename[MAXPGPATH]; /* pg_restore --list */
+	char preListFilename[MAXPGPATH]; /* pg_restore --use-list */
 
 	char postFilename[MAXPGPATH];     /* pg_dump --section=post-data */
-	char postListFilename[MAXPGPATH]; /* pg_restore --list */
+	char postListOutFilename[MAXPGPATH]; /* pg_restore --list */
+	char postListFilename[MAXPGPATH];    /* pg_restore --use-list */
 } DumpPaths;
 
 

--- a/src/bin/pgcopydb/pgcmd.h
+++ b/src/bin/pgcopydb/pgcmd.h
@@ -133,10 +133,12 @@ bool pg_restore_db(PostgresPaths *pgPaths,
 				   const char *listFilename,
 				   RestoreOptions options);
 
-bool pg_restore_list(PostgresPaths *pgPaths, const char *filename,
+bool pg_restore_list(PostgresPaths *pgPaths,
+					 const char *restoreFilename,
+					 const char *listFilename,
 					 ArchiveContentArray *archive);
 
-bool parse_archive_list(char *list, ArchiveContentArray *archive);
+bool parse_archive_list(const char *filename, ArchiveContentArray *archive);
 
 bool parse_archive_acl_or_comment(char *ptr, ArchiveContentItem *item);
 


### PR DESCRIPTION
That way it's possible to review the pg_restore file separately from the filtered file that we process in pgcopydb, and because both the files are left around at the end of the command, it's also possible to diff them.