### PR TITLE
Improve error handling when COPY fails.

### DIFF
--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -492,6 +492,7 @@ bool copydb_process_table_data(CopyDataSpec *specs);
 
 bool copydb_start_copy_supervisor(CopyDataSpec *specs);
 bool copydb_copy_supervisor(CopyDataSpec *specs);
+bool copydb_copy_supervisor_send_stop(CopyDataSpec *specs);
 bool copydb_start_table_data_workers(CopyDataSpec *specs);
 bool copydb_table_data_worker(CopyDataSpec *specs);
 

--- a/src/bin/pgcopydb/indexes.c
+++ b/src/bin/pgcopydb/indexes.c
@@ -120,15 +120,16 @@ copydb_index_worker(CopyDataSpec *specs)
 			{
 				if (!copydb_create_index_by_oid(specs, mesg.data.oid))
 				{
+					++errors;
+
+					log_error("Failed to create index with oid %u, "
+							  "see above for details",
+							  mesg.data.oid);
+
 					if (specs->failFast)
 					{
-						log_error("Failed to create index with oid %u, "
-								  "see above for details",
-								  mesg.data.oid);
 						return false;
 					}
-
-					++errors;
 				}
 				break;
 			}

--- a/src/bin/pgcopydb/vacuum.c
+++ b/src/bin/pgcopydb/vacuum.c
@@ -123,15 +123,16 @@ vacuum_worker(CopyDataSpec *specs)
 			{
 				if (!vacuum_analyze_table_by_oid(specs, mesg.data.oid))
 				{
+					++errors;
+
+					log_error("Failed to vacuum table with oid %u, "
+							  "see above for details",
+							  mesg.data.oid);
+
 					if (specs->failFast)
 					{
-						log_error("Failed to vacuum table with oid %u, "
-								  "see above for details",
-								  mesg.data.oid);
 						return false;
 					}
-
-					++errors;
 				}
 				break;
 			}
@@ -227,7 +228,7 @@ vacuum_analyze_table_by_oid(CopyDataSpec *specs, uint32_t oid)
 
 	if (!pgsql_execute(&dst, vacuum))
 	{
-		/* errors have already been logged */
+		log_error("Failed to run command, see above for details: %s", vacuum);
 		return false;
 	}
 


### PR DESCRIPTION
In the normal case we want the COPY process to continue with the rest of the tables in the queue, and in the fail-fast case we want to bubble-up the problem as fast as possible for a quick total failure.

The partial failure in the normal case can be resumed with the existing option such as --resume, as long as the snapshot still is held, or when using the option --not-consistent.

Also, ensure that when errors happen mid-flight in the COPY processes we still send the STOP messages in the queues, or signal all the other processes to terminate.

See #477 