### PR TITLE
Review static memory size of Postgres identifier names.

### DIFF
--- a/src/bin/pgcopydb/cli_list.c
+++ b/src/bin/pgcopydb/cli_list.c
@@ -269,7 +269,7 @@ cli_list_db_getopts(int argc, char **argv)
 
 			case 's':
 			{
-				strlcpy(options.schema_name, optarg, NAMEDATALEN);
+				strlcpy(options.schema_name, optarg, PG_NAMEDATALEN);
 				log_trace("--schema %s", options.schema_name);
 				break;
 			}
@@ -283,7 +283,7 @@ cli_list_db_getopts(int argc, char **argv)
 
 			case 't':
 			{
-				strlcpy(options.table_name, optarg, NAMEDATALEN);
+				strlcpy(options.table_name, optarg, PG_NAMEDATALEN);
 				log_trace("--table %s", options.table_name);
 				break;
 			}
@@ -1073,7 +1073,7 @@ cli_list_table_parts(int argc, char **argv)
 
 	if (IS_EMPTY_STRING_BUFFER(listDBoptions.schema_name))
 	{
-		strlcpy(listDBoptions.schema_name, "public", NAMEDATALEN);
+		strlcpy(listDBoptions.schema_name, "public", PG_NAMEDATALEN);
 	}
 
 	ConnStrings *dsn = &(listDBoptions.connStrings);
@@ -1103,8 +1103,8 @@ cli_list_table_parts(int argc, char **argv)
 	SourceFilterTable *tableFilter =
 		(SourceFilterTable *) malloc(1 * sizeof(SourceFilterTable));
 
-	strlcpy(tableFilter[0].nspname, listDBoptions.schema_name, NAMEDATALEN);
-	strlcpy(tableFilter[0].relname, listDBoptions.table_name, NAMEDATALEN);
+	strlcpy(tableFilter[0].nspname, listDBoptions.schema_name, PG_NAMEDATALEN);
+	strlcpy(tableFilter[0].relname, listDBoptions.table_name, PG_NAMEDATALEN);
 
 	SourceFilters filter =
 	{

--- a/src/bin/pgcopydb/cli_list.h
+++ b/src/bin/pgcopydb/cli_list.h
@@ -14,6 +14,7 @@
 #include "cli_common.h"
 #include "cli_root.h"
 #include "pgsql.h"
+#include "schema.h"
 
 typedef struct ListDBOptions
 {
@@ -21,8 +22,8 @@ typedef struct ListDBOptions
 
 	ConnStrings connStrings;
 
-	char schema_name[NAMEDATALEN];
-	char table_name[NAMEDATALEN];
+	char schema_name[PG_NAMEDATALEN];
+	char table_name[PG_NAMEDATALEN];
 	char filterFileName[MAXPGPATH];
 
 	bool listSkipped;

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -133,7 +133,7 @@ typedef struct CopyTableDataPartSpec
 	int64_t min;                /* WHERE partKey >= min */
 	int64_t max;                /*   AND partKey  < max */
 
-	char partKey[NAMEDATALEN];
+	char partKey[PG_NAMEDATALEN];
 } CopyTableDataPartSpec;
 
 
@@ -226,7 +226,7 @@ typedef struct SourceFilterItem
  */
 typedef struct ExtensionReqs
 {
-	char extname[NAMEDATALEN];
+	char extname[PG_NAMEDATALEN];
 	char version[BUFSIZE];
 
 	UT_hash_handle hh;          /* makes this structure hashable */

--- a/src/bin/pgcopydb/extensions.c
+++ b/src/bin/pgcopydb/extensions.c
@@ -148,7 +148,7 @@ copydb_copy_extensions(CopyDataSpec *copySpecs, bool createExtensions)
 						 config->relname);
 
 				/* apply extcondition to the source table */
-				char qname[NAMEDATALEN * 2 + 5] = { 0 };
+				char qname[PG_NAMEDATALEN_FQ] = { 0 };
 
 				sformat(qname, sizeof(qname), "%s.%s",
 						config->nspname,

--- a/src/bin/pgcopydb/filtering.h
+++ b/src/bin/pgcopydb/filtering.h
@@ -27,7 +27,7 @@ typedef enum
 
 typedef struct SourceFilterSchema
 {
-	char nspname[NAMEDATALEN];
+	char nspname[PG_NAMEDATALEN];
 } SourceFilterSchema;
 
 typedef struct SourceFilterSchemaList
@@ -39,8 +39,8 @@ typedef struct SourceFilterSchemaList
 
 typedef struct SourceFilterTable
 {
-	char nspname[NAMEDATALEN];
-	char relname[NAMEDATALEN];
+	char nspname[PG_NAMEDATALEN];
+	char relname[PG_NAMEDATALEN];
 } SourceFilterTable;
 
 typedef struct SourceFilterTableList

--- a/src/bin/pgcopydb/ld_stream.h
+++ b/src/bin/pgcopydb/ld_stream.h
@@ -13,6 +13,7 @@
 #include "copydb.h"
 #include "queue_utils.h"
 #include "pgsql.h"
+#include "schema.h"
 
 #define OUTPUT_BEGIN "BEGIN; -- "
 #define OUTPUT_COMMIT "COMMIT; -- "
@@ -134,30 +135,30 @@ typedef struct LogicalMessageTupleArray
 
 typedef struct LogicalMessageInsert
 {
-	char nspname[NAMEDATALEN];
-	char relname[NAMEDATALEN];
+	char nspname[PG_NAMEDATALEN];
+	char relname[PG_NAMEDATALEN];
 	LogicalMessageTupleArray new;   /* {"columns": ...} */
 } LogicalMessageInsert;
 
 typedef struct LogicalMessageUpdate
 {
-	char nspname[NAMEDATALEN];
-	char relname[NAMEDATALEN];
+	char nspname[PG_NAMEDATALEN];
+	char relname[PG_NAMEDATALEN];
 	LogicalMessageTupleArray old;   /* {"identity": ...} */
 	LogicalMessageTupleArray new;   /* {"columns": ...} */
 } LogicalMessageUpdate;
 
 typedef struct LogicalMessageDelete
 {
-	char nspname[NAMEDATALEN];
-	char relname[NAMEDATALEN];
+	char nspname[PG_NAMEDATALEN];
+	char relname[PG_NAMEDATALEN];
 	LogicalMessageTupleArray old;   /* {"identity": ...} */
 } LogicalMessageDelete;
 
 typedef struct LogicalMessageTruncate
 {
-	char nspname[NAMEDATALEN];
-	char relname[NAMEDATALEN];
+	char nspname[PG_NAMEDATALEN];
+	char relname[PG_NAMEDATALEN];
 } LogicalMessageTruncate;
 
 typedef struct LogicalMessageSwitchWAL

--- a/src/bin/pgcopydb/ld_test_decoding.c
+++ b/src/bin/pgcopydb/ld_test_decoding.c
@@ -35,9 +35,9 @@
 typedef struct TestDecodingHeader
 {
 	const char *message;
-	char qname[NAMEDATALEN * 2 + 5 + 1];
-	char nspname[NAMEDATALEN];
-	char relname[NAMEDATALEN];
+	char qname[PG_NAMEDATALEN_FQ];
+	char nspname[PG_NAMEDATALEN];
+	char relname[PG_NAMEDATALEN];
 	StreamAction action;
 	int offset;                 /* end of metadata section */
 	int pos;
@@ -247,8 +247,8 @@ parseTestDecodingMessage(StreamContext *privateContext,
 
 		case STREAM_ACTION_TRUNCATE:
 		{
-			strlcpy(stmt->stmt.truncate.nspname, header.nspname, NAMEDATALEN);
-			strlcpy(stmt->stmt.truncate.relname, header.relname, NAMEDATALEN);
+			strlcpy(stmt->stmt.truncate.nspname, header.nspname, PG_NAMEDATALEN);
+			strlcpy(stmt->stmt.truncate.relname, header.relname, PG_NAMEDATALEN);
 
 			break;
 		}
@@ -388,8 +388,8 @@ parseTestDecodingInsertMessage(StreamContext *privateContext,
 {
 	LogicalTransactionStatement *stmt = privateContext->stmt;
 
-	strlcpy(stmt->stmt.insert.nspname, header->nspname, NAMEDATALEN);
-	strlcpy(stmt->stmt.insert.relname, header->relname, NAMEDATALEN);
+	strlcpy(stmt->stmt.insert.nspname, header->nspname, PG_NAMEDATALEN);
+	strlcpy(stmt->stmt.insert.relname, header->relname, PG_NAMEDATALEN);
 
 	stmt->stmt.insert.new.count = 1;
 	stmt->stmt.insert.new.array =
@@ -427,8 +427,8 @@ parseTestDecodingUpdateMessage(StreamContext *privateContext,
 {
 	LogicalTransactionStatement *stmt = privateContext->stmt;
 
-	strlcpy(stmt->stmt.update.nspname, header->nspname, NAMEDATALEN);
-	strlcpy(stmt->stmt.update.relname, header->relname, NAMEDATALEN);
+	strlcpy(stmt->stmt.update.nspname, header->nspname, PG_NAMEDATALEN);
+	strlcpy(stmt->stmt.update.relname, header->relname, PG_NAMEDATALEN);
 
 	stmt->stmt.update.old.count = 1;
 	stmt->stmt.update.new.count = 1;
@@ -521,8 +521,8 @@ parseTestDecodingDeleteMessage(StreamContext *privateContext,
 {
 	LogicalTransactionStatement *stmt = privateContext->stmt;
 
-	strlcpy(stmt->stmt.delete.nspname, header->nspname, NAMEDATALEN);
-	strlcpy(stmt->stmt.delete.relname, header->relname, NAMEDATALEN);
+	strlcpy(stmt->stmt.delete.nspname, header->nspname, PG_NAMEDATALEN);
+	strlcpy(stmt->stmt.delete.relname, header->relname, PG_NAMEDATALEN);
 
 	stmt->stmt.delete.old.count = 1;
 	stmt->stmt.delete.old.array =
@@ -703,7 +703,7 @@ parseNextColumn(TestDecodingColumns *cols,
 	 */
 	char *typStart = typA + 1;
 	int typLen = (int) ((typB - typA) - 1);
-	char typname[NAMEDATALEN] = { 0 };
+	char typname[PG_NAMEDATALEN] = { 0 };
 
 	sformat(typname, sizeof(typname), "%.*s", typLen, typStart);
 

--- a/src/bin/pgcopydb/ld_wal2json.c
+++ b/src/bin/pgcopydb/ld_wal2json.c
@@ -148,8 +148,8 @@ parseWal2jsonMessage(StreamContext *privateContext,
 
 		case STREAM_ACTION_TRUNCATE:
 		{
-			strlcpy(stmt->stmt.truncate.nspname, schema, NAMEDATALEN);
-			strlcpy(stmt->stmt.truncate.relname, table, NAMEDATALEN);
+			strlcpy(stmt->stmt.truncate.nspname, schema, PG_NAMEDATALEN);
+			strlcpy(stmt->stmt.truncate.relname, table, PG_NAMEDATALEN);
 
 			break;
 		}
@@ -159,8 +159,8 @@ parseWal2jsonMessage(StreamContext *privateContext,
 			JSON_Array *jscols =
 				json_object_dotget_array(jsobj, "message.columns");
 
-			strlcpy(stmt->stmt.insert.nspname, schema, NAMEDATALEN);
-			strlcpy(stmt->stmt.insert.relname, table, NAMEDATALEN);
+			strlcpy(stmt->stmt.insert.nspname, schema, PG_NAMEDATALEN);
+			strlcpy(stmt->stmt.insert.relname, table, PG_NAMEDATALEN);
 
 			stmt->stmt.insert.new.count = 1;
 			stmt->stmt.insert.new.array =
@@ -187,8 +187,8 @@ parseWal2jsonMessage(StreamContext *privateContext,
 
 		case STREAM_ACTION_UPDATE:
 		{
-			strlcpy(stmt->stmt.update.nspname, schema, NAMEDATALEN);
-			strlcpy(stmt->stmt.update.relname, table, NAMEDATALEN);
+			strlcpy(stmt->stmt.update.nspname, schema, PG_NAMEDATALEN);
+			strlcpy(stmt->stmt.update.relname, table, PG_NAMEDATALEN);
 
 			stmt->stmt.update.old.count = 1;
 			stmt->stmt.update.new.count = 1;
@@ -235,8 +235,8 @@ parseWal2jsonMessage(StreamContext *privateContext,
 
 		case STREAM_ACTION_DELETE:
 		{
-			strlcpy(stmt->stmt.delete.nspname, schema, NAMEDATALEN);
-			strlcpy(stmt->stmt.delete.relname, table, NAMEDATALEN);
+			strlcpy(stmt->stmt.delete.nspname, schema, PG_NAMEDATALEN);
+			strlcpy(stmt->stmt.delete.relname, table, PG_NAMEDATALEN);
 
 			stmt->stmt.delete.old.count = 1;
 			stmt->stmt.delete.old.array =
@@ -319,7 +319,7 @@ SetColumnNamesAndValues(LogicalMessageTuple *tuple,
 			return false;
 		}
 
-		tuple->columns[i] = strndup(colname, NAMEDATALEN);
+		tuple->columns[i] = strndup(colname, PG_NAMEDATALEN);
 
 		if (tuple->columns[i] == NULL)
 		{

--- a/src/bin/pgcopydb/pg_utils.h
+++ b/src/bin/pgcopydb/pg_utils.h
@@ -26,6 +26,20 @@
 
 
 /*
+ * We use format('%I') to grab identifier names, so we need to account for the
+ * quotes around the names (2 more bytes) and also the quotes within the names
+ * are going to be doubled, in the worst case that's twice the size + 2.
+ */
+#define PG_NAMEDATALEN (NAMEDATALEN * 2 + 2)
+
+/* the pg_restore -l output uses "schema name owner" */
+#define RESTORE_LIST_NAMEDATALEN (3 * PG_NAMEDATALEN + 3)
+
+/* Fully Qualified Postgres name: "nspname"."relname" */
+#define PG_NAMEDATALEN_FQ (PG_NAMEDATALEN * 2 + 1)
+
+
+/*
  * OID values from PostgreSQL src/include/catalog/pg_type.h
  */
 #define BOOLOID 16

--- a/src/bin/pgcopydb/progress.c
+++ b/src/bin/pgcopydb/progress.c
@@ -230,7 +230,7 @@ copydb_filtering_as_json(CopyDataSpec *copySpecs,
 	/* exclude table lists */
 	struct section
 	{
-		char name[NAMEDATALEN];
+		char name[PG_NAMEDATALEN];
 		SourceFilterTableList *list;
 	};
 

--- a/src/bin/pgcopydb/schema.c
+++ b/src/bin/pgcopydb/schema.c
@@ -3644,13 +3644,13 @@ getSchemaList(void *ctx, PGresult *result)
 
 		/* 2. nspname */
 		value = PQgetvalue(result, rowNumber, 1);
-		int length = strlcpy(schema->nspname, value, NAMEDATALEN);
+		int length = strlcpy(schema->nspname, value, PG_NAMEDATALEN);
 
-		if (length >= NAMEDATALEN)
+		if (length >= PG_NAMEDATALEN)
 		{
 			log_error("Schema name \"%s\" is %d bytes long, "
-					  "the maximum expected is %d (NAMEDATALEN - 1)",
-					  value, length, NAMEDATALEN - 1);
+					  "the maximum expected is %d (PG_NAMEDATALEN - 1)",
+					  value, length, PG_NAMEDATALEN - 1);
 			++errors;
 		}
 
@@ -3732,13 +3732,13 @@ getDatabaseList(void *ctx, PGresult *result)
 
 		/* 2. datname */
 		value = PQgetvalue(result, rowNumber, 1);
-		int length = strlcpy(database->datname, value, NAMEDATALEN);
+		int length = strlcpy(database->datname, value, PG_NAMEDATALEN);
 
-		if (length >= NAMEDATALEN)
+		if (length >= PG_NAMEDATALEN)
 		{
 			log_error("Database name \"%s\" is %d bytes long, "
-					  "the maximum expected is %d (NAMEDATALEN - 1)",
-					  value, length, NAMEDATALEN - 1);
+					  "the maximum expected is %d (PG_NAMEDATALEN - 1)",
+					  value, length, PG_NAMEDATALEN - 1);
 			++errors;
 		}
 
@@ -3765,13 +3765,13 @@ getDatabaseList(void *ctx, PGresult *result)
 
 		/* 4. pg_size_pretty */
 		value = PQgetvalue(result, rowNumber, 3);
-		length = strlcpy(database->bytesPretty, value, NAMEDATALEN);
+		length = strlcpy(database->bytesPretty, value, PG_NAMEDATALEN);
 
-		if (length >= NAMEDATALEN)
+		if (length >= PG_NAMEDATALEN)
 		{
 			log_error("Pretty printed byte size \"%s\" is %d bytes long, "
-					  "the maximum expected is %d (NAMEDATALEN - 1)",
-					  value, length, NAMEDATALEN - 1);
+					  "the maximum expected is %d (PG_NAMEDATALEN - 1)",
+					  value, length, PG_NAMEDATALEN - 1);
 			++errors;
 		}
 	}
@@ -3928,25 +3928,25 @@ parseCurrentExtension(PGresult *result,
 
 	/* 2. extname */
 	value = PQgetvalue(result, rowNumber, 1);
-	int length = strlcpy(extension->extname, value, NAMEDATALEN);
+	int length = strlcpy(extension->extname, value, PG_NAMEDATALEN);
 
-	if (length >= NAMEDATALEN)
+	if (length >= PG_NAMEDATALEN)
 	{
 		log_error("Extension name \"%s\" is %d bytes long, "
-				  "the maximum expected is %d (NAMEDATALEN - 1)",
-				  value, length, NAMEDATALEN - 1);
+				  "the maximum expected is %d (PG_NAMEDATALEN - 1)",
+				  value, length, PG_NAMEDATALEN - 1);
 		++errors;
 	}
 
 	/* 3. extnamespace */
 	value = PQgetvalue(result, rowNumber, 2);
-	length = strlcpy(extension->extnamespace, value, NAMEDATALEN);
+	length = strlcpy(extension->extnamespace, value, PG_NAMEDATALEN);
 
-	if (length >= NAMEDATALEN)
+	if (length >= PG_NAMEDATALEN)
 	{
 		log_error("Extension extnamespace \"%s\" is %d bytes long, "
-				  "the maximum expected is %d (NAMEDATALEN - 1)",
-				  value, length, NAMEDATALEN - 1);
+				  "the maximum expected is %d (PG_NAMEDATALEN - 1)",
+				  value, length, PG_NAMEDATALEN - 1);
 		++errors;
 	}
 
@@ -4013,25 +4013,25 @@ parseCurrentExtensionConfig(PGresult *result,
 
 	/* 8. n.nspname */
 	value = PQgetvalue(result, rowNumber, 7);
-	int length = strlcpy(extConfig->nspname, value, NAMEDATALEN);
+	int length = strlcpy(extConfig->nspname, value, PG_NAMEDATALEN);
 
-	if (length >= NAMEDATALEN)
+	if (length >= PG_NAMEDATALEN)
 	{
 		log_error("Schema name \"%s\" is %d bytes long, "
-				  "the maximum expected is %d (NAMEDATALEN - 1)",
-				  value, length, NAMEDATALEN - 1);
+				  "the maximum expected is %d (PG_NAMEDATALEN - 1)",
+				  value, length, PG_NAMEDATALEN - 1);
 		++errors;
 	}
 
 	/* 9. c.relname */
 	value = PQgetvalue(result, rowNumber, 8);
-	length = strlcpy(extConfig->relname, value, NAMEDATALEN);
+	length = strlcpy(extConfig->relname, value, PG_NAMEDATALEN);
 
-	if (length >= NAMEDATALEN)
+	if (length >= PG_NAMEDATALEN)
 	{
 		log_error("Extension configuration table name \"%s\" is %d bytes long, "
-				  "the maximum expected is %d (NAMEDATALEN - 1)",
-				  value, length, NAMEDATALEN - 1);
+				  "the maximum expected is %d (PG_NAMEDATALEN - 1)",
+				  value, length, PG_NAMEDATALEN - 1);
 		++errors;
 	}
 
@@ -4098,37 +4098,37 @@ getExtensionsVersions(void *ctx, PGresult *result)
 
 		/* 1. name */
 		char *value = PQgetvalue(result, rowNumber, 0);
-		int length = strlcpy(ev->name, value, NAMEDATALEN);
+		int length = strlcpy(ev->name, value, PG_NAMEDATALEN);
 
-		if (length >= NAMEDATALEN)
+		if (length >= PG_NAMEDATALEN)
 		{
 			log_error("Extension name \"%s\" is %d bytes long, "
-					  "the maximum expected is %d (NAMEDATALEN - 1)",
-					  value, length, NAMEDATALEN - 1);
+					  "the maximum expected is %d (PG_NAMEDATALEN - 1)",
+					  value, length, PG_NAMEDATALEN - 1);
 			++errors;
 		}
 
 		/* 2. defaultVersion */
 		value = PQgetvalue(result, rowNumber, 1);
-		length = strlcpy(ev->defaultVersion, value, NAMEDATALEN);
+		length = strlcpy(ev->defaultVersion, value, PG_NAMEDATALEN);
 
-		if (length >= NAMEDATALEN)
+		if (length >= PG_NAMEDATALEN)
 		{
 			log_error("Extension version \"%s\" is %d bytes long, "
-					  "the maximum expected is %d (NAMEDATALEN - 1)",
-					  value, length, NAMEDATALEN - 1);
+					  "the maximum expected is %d (PG_NAMEDATALEN - 1)",
+					  value, length, PG_NAMEDATALEN - 1);
 			++errors;
 		}
 
 		/* 3. installedVersion */
 		value = PQgetvalue(result, rowNumber, 2);
-		length = strlcpy(ev->installedVersion, value, NAMEDATALEN);
+		length = strlcpy(ev->installedVersion, value, PG_NAMEDATALEN);
 
-		if (length >= NAMEDATALEN)
+		if (length >= PG_NAMEDATALEN)
 		{
 			log_error("Extension version \"%s\" is %d bytes long, "
-					  "the maximum expected is %d (NAMEDATALEN - 1)",
-					  value, length, NAMEDATALEN - 1);
+					  "the maximum expected is %d (PG_NAMEDATALEN - 1)",
+					  value, length, PG_NAMEDATALEN - 1);
 			++errors;
 		}
 
@@ -4208,13 +4208,13 @@ getCollationList(void *ctx, PGresult *result)
 
 		/* 2. collname */
 		value = PQgetvalue(result, rowNumber, 1);
-		int length = strlcpy(collation->collname, value, NAMEDATALEN);
+		int length = strlcpy(collation->collname, value, PG_NAMEDATALEN);
 
-		if (length >= NAMEDATALEN)
+		if (length >= PG_NAMEDATALEN)
 		{
 			log_error("Collation name \"%s\" is %d bytes long, "
-					  "the maximum expected is %d (NAMEDATALEN - 1)",
-					  value, length, NAMEDATALEN - 1);
+					  "the maximum expected is %d (PG_NAMEDATALEN - 1)",
+					  value, length, PG_NAMEDATALEN - 1);
 			++errors;
 		}
 
@@ -4343,25 +4343,25 @@ parseCurrentSourceTable(PGresult *result, int rowNumber, SourceTable *table)
 
 	/* n.nspname */
 	value = PQgetvalue(result, rowNumber, fnnspname);
-	int length = strlcpy(table->nspname, value, NAMEDATALEN);
+	int length = strlcpy(table->nspname, value, PG_NAMEDATALEN);
 
-	if (length >= NAMEDATALEN)
+	if (length >= PG_NAMEDATALEN)
 	{
 		log_error("Schema name \"%s\" is %d bytes long, "
-				  "the maximum expected is %d (NAMEDATALEN - 1)",
-				  value, length, NAMEDATALEN - 1);
+				  "the maximum expected is %d (PG_NAMEDATALEN - 1)",
+				  value, length, PG_NAMEDATALEN - 1);
 		++errors;
 	}
 
 	/* c.relname */
 	value = PQgetvalue(result, rowNumber, fnrelname);
-	length = strlcpy(table->relname, value, NAMEDATALEN);
+	length = strlcpy(table->relname, value, PG_NAMEDATALEN);
 
-	if (length >= NAMEDATALEN)
+	if (length >= PG_NAMEDATALEN)
 	{
 		log_error("Table name \"%s\" is %d bytes long, "
-				  "the maximum expected is %d (NAMEDATALEN - 1)",
-				  value, length, NAMEDATALEN - 1);
+				  "the maximum expected is %d (PG_NAMEDATALEN - 1)",
+				  value, length, PG_NAMEDATALEN - 1);
 		++errors;
 	}
 
@@ -4373,7 +4373,7 @@ parseCurrentSourceTable(PGresult *result, int rowNumber, SourceTable *table)
 	if (length >= sizeof(table->qname))
 	{
 		log_error("Qualified table name \"%s\".\"%s\" is %d bytes long, "
-				  "the maximum expected is %lld (NAMEDATALEN * 2 + 5)",
+				  "the maximum expected is %lld",
 				  table->nspname,
 				  table->relname,
 				  length,
@@ -4385,18 +4385,18 @@ parseCurrentSourceTable(PGresult *result, int rowNumber, SourceTable *table)
 	if (PQgetisnull(result, rowNumber, fnamname))
 	{
 		/* table started having an amname in Postgres 12 */
-		strlcpy(table->amname, "heap", NAMEDATALEN);
+		strlcpy(table->amname, "heap", PG_NAMEDATALEN);
 	}
 	else
 	{
 		value = PQgetvalue(result, rowNumber, fnamname);
-		length = strlcpy(table->amname, value, NAMEDATALEN);
+		length = strlcpy(table->amname, value, PG_NAMEDATALEN);
 
-		if (length >= NAMEDATALEN)
+		if (length >= PG_NAMEDATALEN)
 		{
 			log_error("Access Method name \"%s\" is %d bytes long, "
-					  "the maximum expected is %d (NAMEDATALEN - 1)",
-					  value, length, NAMEDATALEN - 1);
+					  "the maximum expected is %d (PG_NAMEDATALEN - 1)",
+					  value, length, PG_NAMEDATALEN - 1);
 			++errors;
 		}
 	}
@@ -4463,13 +4463,13 @@ parseCurrentSourceTable(PGresult *result, int rowNumber, SourceTable *table)
 
 	/* pg_size_pretty(c.oid) */
 	value = PQgetvalue(result, rowNumber, fnbytespretty);
-	length = strlcpy(table->bytesPretty, value, NAMEDATALEN);
+	length = strlcpy(table->bytesPretty, value, PG_NAMEDATALEN);
 
-	if (length >= NAMEDATALEN)
+	if (length >= PG_NAMEDATALEN)
 	{
 		log_error("Pretty printed byte size \"%s\" is %d bytes long, "
-				  "the maximum expected is %d (NAMEDATALEN - 1)",
-				  value, length, NAMEDATALEN - 1);
+				  "the maximum expected is %d (PG_NAMEDATALEN - 1)",
+				  value, length, PG_NAMEDATALEN - 1);
 		++errors;
 	}
 
@@ -4499,13 +4499,13 @@ parseCurrentSourceTable(PGresult *result, int rowNumber, SourceTable *table)
 	else
 	{
 		value = PQgetvalue(result, rowNumber, fnpartkey);
-		length = strlcpy(table->partKey, value, NAMEDATALEN);
+		length = strlcpy(table->partKey, value, PG_NAMEDATALEN);
 
-		if (length >= NAMEDATALEN)
+		if (length >= PG_NAMEDATALEN)
 		{
 			log_error("Partition key column name %s is %d bytes long, "
-					  "the maximum expected is %d (NAMEDATALEN - 1)",
-					  value, length, NAMEDATALEN - 1);
+					  "the maximum expected is %d (PG_NAMEDATALEN - 1)",
+					  value, length, PG_NAMEDATALEN - 1);
 			++errors;
 		}
 	}
@@ -4663,25 +4663,25 @@ parseCurrentSourceSequence(PGresult *result, int rowNumber, SourceSequence *seq)
 
 	/* 2. n.nspname */
 	value = PQgetvalue(result, rowNumber, 1);
-	int length = strlcpy(seq->nspname, value, NAMEDATALEN);
+	int length = strlcpy(seq->nspname, value, PG_NAMEDATALEN);
 
-	if (length >= NAMEDATALEN)
+	if (length >= PG_NAMEDATALEN)
 	{
 		log_error("Schema name \"%s\" is %d bytes long, "
-				  "the maximum expected is %d (NAMEDATALEN - 1)",
-				  value, length, NAMEDATALEN - 1);
+				  "the maximum expected is %d (PG_NAMEDATALEN - 1)",
+				  value, length, PG_NAMEDATALEN - 1);
 		++errors;
 	}
 
 	/* 3. c.relname */
 	value = PQgetvalue(result, rowNumber, 2);
-	length = strlcpy(seq->relname, value, NAMEDATALEN);
+	length = strlcpy(seq->relname, value, PG_NAMEDATALEN);
 
-	if (length >= NAMEDATALEN)
+	if (length >= PG_NAMEDATALEN)
 	{
 		log_error("Sequence name \"%s\" is %d bytes long, "
-				  "the maximum expected is %d (NAMEDATALEN - 1)",
-				  value, length, NAMEDATALEN - 1);
+				  "the maximum expected is %d (PG_NAMEDATALEN - 1)",
+				  value, length, PG_NAMEDATALEN - 1);
 		++errors;
 	}
 
@@ -4693,7 +4693,7 @@ parseCurrentSourceSequence(PGresult *result, int rowNumber, SourceSequence *seq)
 	if (length >= sizeof(seq->qname))
 	{
 		log_error("Qualified seq name \"%s\".\"%s\" is %d bytes long, "
-				  "the maximum expected is %lld (NAMEDATALEN * 2 + 5)",
+				  "the maximum expected is %lld",
 				  seq->nspname,
 				  seq->relname,
 				  length,
@@ -4844,25 +4844,25 @@ parseCurrentSourceIndex(PGresult *result, int rowNumber, SourceIndex *index)
 
 	/* 2. n.nspname */
 	value = PQgetvalue(result, rowNumber, 1);
-	int length = strlcpy(index->indexNamespace, value, NAMEDATALEN);
+	int length = strlcpy(index->indexNamespace, value, PG_NAMEDATALEN);
 
-	if (length >= NAMEDATALEN)
+	if (length >= PG_NAMEDATALEN)
 	{
 		log_error("Schema name \"%s\" is %d bytes long, "
-				  "the maximum expected is %d (NAMEDATALEN - 1)",
-				  value, length, NAMEDATALEN - 1);
+				  "the maximum expected is %d (PG_NAMEDATALEN - 1)",
+				  value, length, PG_NAMEDATALEN - 1);
 		++errors;
 	}
 
 	/* 3. i.relname */
 	value = PQgetvalue(result, rowNumber, 2);
-	length = strlcpy(index->indexRelname, value, NAMEDATALEN);
+	length = strlcpy(index->indexRelname, value, PG_NAMEDATALEN);
 
-	if (length >= NAMEDATALEN)
+	if (length >= PG_NAMEDATALEN)
 	{
 		log_error("Index name \"%s\" is %d bytes long, "
-				  "the maximum expected is %d (NAMEDATALEN - 1)",
-				  value, length, NAMEDATALEN - 1);
+				  "the maximum expected is %d (PG_NAMEDATALEN - 1)",
+				  value, length, PG_NAMEDATALEN - 1);
 		++errors;
 	}
 
@@ -4874,7 +4874,7 @@ parseCurrentSourceIndex(PGresult *result, int rowNumber, SourceIndex *index)
 	if (length >= sizeof(index->tableQname))
 	{
 		log_error("Qualified index name \"%s\".\"%s\" is %d bytes long, "
-				  "the maximum expected is %lld (NAMEDATALEN * 2 + 5)",
+				  "the maximum expected is %lld",
 				  index->indexNamespace,
 				  index->indexRelname,
 				  length,
@@ -4893,25 +4893,25 @@ parseCurrentSourceIndex(PGresult *result, int rowNumber, SourceIndex *index)
 
 	/* 5. rn.nspname */
 	value = PQgetvalue(result, rowNumber, 4);
-	length = strlcpy(index->tableNamespace, value, NAMEDATALEN);
+	length = strlcpy(index->tableNamespace, value, PG_NAMEDATALEN);
 
-	if (length >= NAMEDATALEN)
+	if (length >= PG_NAMEDATALEN)
 	{
 		log_error("Schema name \"%s\" is %d bytes long, "
-				  "the maximum expected is %d (NAMEDATALEN - 1)",
-				  value, length, NAMEDATALEN - 1);
+				  "the maximum expected is %d (PG_NAMEDATALEN - 1)",
+				  value, length, PG_NAMEDATALEN - 1);
 		++errors;
 	}
 
 	/* 6. r.relname */
 	value = PQgetvalue(result, rowNumber, 5);
-	length = strlcpy(index->tableRelname, value, NAMEDATALEN);
+	length = strlcpy(index->tableRelname, value, PG_NAMEDATALEN);
 
-	if (length >= NAMEDATALEN)
+	if (length >= PG_NAMEDATALEN)
 	{
 		log_error("Index name \"%s\" is %d bytes long, "
-				  "the maximum expected is %d (NAMEDATALEN - 1)",
-				  value, length, NAMEDATALEN - 1);
+				  "the maximum expected is %d (PG_NAMEDATALEN - 1)",
+				  value, length, PG_NAMEDATALEN - 1);
 		++errors;
 	}
 
@@ -4923,7 +4923,7 @@ parseCurrentSourceIndex(PGresult *result, int rowNumber, SourceIndex *index)
 	if (length >= sizeof(index->tableQname))
 	{
 		log_error("Qualified table name \"%s\".\"%s\" is %d bytes long, "
-				  "the maximum expected is %lld (NAMEDATALEN * 2 + 5)",
+				  "the maximum expected is %lld",
 				  index->tableNamespace,
 				  index->tableRelname,
 				  length,
@@ -5032,13 +5032,13 @@ parseCurrentSourceIndex(PGresult *result, int rowNumber, SourceIndex *index)
 	if (!PQgetisnull(result, rowNumber, 13))
 	{
 		value = PQgetvalue(result, rowNumber, 13);
-		length = strlcpy(index->constraintName, value, NAMEDATALEN);
+		length = strlcpy(index->constraintName, value, PG_NAMEDATALEN);
 
-		if (length >= NAMEDATALEN)
+		if (length >= PG_NAMEDATALEN)
 		{
 			log_error("Index name \"%s\" is %d bytes long, "
-					  "the maximum expected is %d (NAMEDATALEN - 1)",
-					  value, length, NAMEDATALEN - 1);
+					  "the maximum expected is %d (PG_NAMEDATALEN - 1)",
+					  value, length, PG_NAMEDATALEN - 1);
 			++errors;
 		}
 	}
@@ -5147,25 +5147,25 @@ parseCurrentSourceDepend(PGresult *result, int rowNumber, SourceDepend *depend)
 
 	/* 1. n.nspname */
 	char *value = PQgetvalue(result, rowNumber, 0);
-	int length = strlcpy(depend->nspname, value, NAMEDATALEN);
+	int length = strlcpy(depend->nspname, value, PG_NAMEDATALEN);
 
-	if (length >= NAMEDATALEN)
+	if (length >= PG_NAMEDATALEN)
 	{
 		log_error("Schema name \"%s\" is %d bytes long, "
-				  "the maximum expected is %d (NAMEDATALEN - 1)",
-				  value, length, NAMEDATALEN - 1);
+				  "the maximum expected is %d (PG_NAMEDATALEN - 1)",
+				  value, length, PG_NAMEDATALEN - 1);
 		++errors;
 	}
 
 	/* 2. c.relname */
 	value = PQgetvalue(result, rowNumber, 1);
-	length = strlcpy(depend->relname, value, NAMEDATALEN);
+	length = strlcpy(depend->relname, value, PG_NAMEDATALEN);
 
-	if (length >= NAMEDATALEN)
+	if (length >= PG_NAMEDATALEN)
 	{
 		log_error("Table name \"%s\" is %d bytes long, "
-				  "the maximum expected is %d (NAMEDATALEN - 1)",
-				  value, length, NAMEDATALEN - 1);
+				  "the maximum expected is %d (PG_NAMEDATALEN - 1)",
+				  value, length, PG_NAMEDATALEN - 1);
 		++errors;
 	}
 

--- a/src/bin/pgcopydb/summary.h
+++ b/src/bin/pgcopydb/summary.h
@@ -92,8 +92,8 @@ typedef struct SummaryIndexEntry
 {
 	uint32_t oid;
 	char oidStr[INTSTRING_MAX_DIGITS];
-	char nspname[NAMEDATALEN];
-	char relname[NAMEDATALEN];
+	char nspname[PG_NAMEDATALEN];
+	char relname[PG_NAMEDATALEN];
 	char *sql;                  /* malloc'ed area */
 	char indexMs[INTERVAL_MAXLEN];
 	uint64_t durationMs;
@@ -109,8 +109,8 @@ typedef struct SummaryTableEntry
 {
 	uint32_t oid;
 	char oidStr[INTSTRING_MAX_DIGITS];
-	char nspname[NAMEDATALEN];
-	char relname[NAMEDATALEN];
+	char nspname[PG_NAMEDATALEN];
+	char relname[PG_NAMEDATALEN];
 	char tableMs[INTERVAL_MAXLEN];
 	char indexCount[INTSTRING_MAX_DIGITS];
 	char indexMs[INTERVAL_MAXLEN];

--- a/tests/unit/setup/6-multiline-table-name.sql
+++ b/tests/unit/setup/6-multiline-table-name.sql
@@ -16,3 +16,16 @@ CREATE TABLE IF NOT EXISTS public."""dqname"""
 (
     id integer
 );
+
+
+--
+-- See https://github.com/dimitri/pgcopydb/issues/483
+--
+-- Migrations fails when the column name of a table is very long
+--
+CREATE TABLE """long"""
+(
+    """aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa""" INT
+);
+
+INSERT INTO """long""" VALUES (1);


### PR DESCRIPTION
Now that we grab the Postgres identifier names already quoted, we need to expand our internal structures memory to handle more bytes: the quotes around the names, and also any double-quote char within the name is going to be doubled by the quoting rules.

Fixes #483 