### PR TITLE
Ensure transactions are not read only by default

### DIFF
--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -24,8 +24,8 @@
 #define COMMON_GUC_SETTINGS \
 	{ "client_encoding", "'UTF-8'" }, \
 	{ "extra_float_digits", "3" }, \
-	{ "statement_timeout", "0" }
-
+	{ "statement_timeout", "0" }, \
+	{ "default_transaction_read_only", "off" }
 /*
  * These parameters are added to the connection strings, unless the user has
  * added them, allowing user-defined values to be taken into account.


### PR DESCRIPTION
This change will make sure that pgcopydb can write to the database even if the user has set the default_transaction_read_only GUC.