### PR TITLE
Fix various issues with docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ $ pgcopydb help
     schema       Copy the database schema from source to target
     data         Copy the data section from source to target
     table-data   Copy the data from all tables in database from source to target
-    blobs        Copy the blob data from ther source database to the target
+    blobs        Copy the blob data from the source database to the target
     sequences    Copy the current value from all sequences in database from source to target
     indexes      Create all the indexes found in the source database in the target
     constraints  Create all the constraints found in the source database in the target

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ $ pgcopydb help
   + list      List database objects from a Postgres instance
   + stream    Stream changes from the source database
     ping      Attempt to connect to the source and target instances
-    help      print help message
-    version   print pgcopydb version
+    help      Print help message
+    version   Print pgcopydb version
 
   pgcopydb compare
     schema  Compare source and target schema
@@ -104,7 +104,7 @@ $ pgcopydb help
 
   pgcopydb stream
     setup      Setup source and target systems for logical decoding
-    cleanup    cleanup source and target systems for logical decoding
+    cleanup    Cleanup source and target systems for logical decoding
     prefetch   Stream JSON changes from the source database and transform them to SQL
     catchup    Apply prefetched changes from SQL files to the target database
     replay     Replay changes from the source to the target database, live

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ $ pgcopydb help
     fork      Clone an entire database from source to target
     follow    Replay changes from the source database to the target database
     copy-db   Clone an entire database from source to target
-    snapshot  Create and exports a snapshot on the source database
+    snapshot  Create and export a snapshot on the source database
   + compare   Compare source and target databases
   + copy      Implement the data section of the database copy
   + dump      Dump database objects from a Postgres instance

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Several distributions are available for pgcopydb:
      version currently in debian stable.
 
 	 ```
-	 $ docker run --rm -it dimitri/pgcopydb:v0.11 pgcopydb --version
+	 $ docker run --rm -it dimitri/pgcopydb:v0.13 pgcopydb --version
 	 ```
 
 	 Or you can use the CI/CD integration that publishes packages from the

--- a/docs/design.rst
+++ b/docs/design.rst
@@ -53,7 +53,7 @@ sub-processes that each handle a part of the work.
 
 The process tree then looks like the following:
 
- * pgcopydb clone --follow --table-jobs 4 --index-jobs 4
+ * pgcopydb clone --follow --table-jobs 4 --index-jobs 4 --large-objects-jobs 4
 
    * pgcopydb clone worker
 
@@ -69,13 +69,13 @@ The process tree then looks like the following:
 
      * pgcopydb blob metadata worker (``--large-objects-jobs 4``)
 
-       #. pgcopydb blob worker
+       #. pgcopydb blob data worker
 
-       #. pgcopydb blob worker
+       #. pgcopydb blob data worker
 
-       #. pgcopydb blob worker
+       #. pgcopydb blob data worker
 
-       #. pgcopydb blob worker
+       #. pgcopydb blob data worker
 
      1. pgcopydb index/constraints worker (``--index-jobs 4``)
 
@@ -104,14 +104,14 @@ The process tree then looks like the following:
      * pgcopydb stream catchup
 
 We see that when using ``pgcopydb clone --follow --table-jobs 4 --index-jobs
-4 --large-objects-jobs`` then pgcopydb creates 24 sub-processes, including
+4 --large-objects-jobs 4`` then pgcopydb creates 24 sub-processes, including
 one transient sub-process each time a JSON file is to be converted to a SQL
 file for replay.
 
 The 24 total is counted from:
 
- - 1 clone worker + 1 copy supervisor + 4 copy workers + 1 blob worker + 4
-   blob data workers + 4 index workers + 4 vacuum workers + 1 sequence reset
+ - 1 clone worker + 1 copy supervisor + 4 copy workers + 1 blob metadata worker
+   + 4 blob data workers + 4 index workers + 4 vacuum workers + 1 sequence reset
    worker
 
    that's 1 + 1 + 4 + 1 + 4 + 4 + 4 + 1 = 20

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -29,8 +29,9 @@ After following the instructions for installing the repository, in this
 example in a Docker image for Rocky Linux (``docker run --rm -it
 rockylinux:9``), then we get the following::
 
-   # dnf search pgcopydb
-   ...
+   # dnf search --all --quiet pgcopydb
+   ======================== Name & Description & URL Matched: pgcopydb ========================
+   pgcopydb.x86_64 : Automate pg_dump | pg_restore between two running Postgres servers
    pgcopydb_11.x86_64 : Automate pg_dump | pg_restore between two running Postgres servers
    pgcopydb_12.x86_64 : Automate pg_dump | pg_restore between two running Postgres servers
    pgcopydb_13.x86_64 : Automate pg_dump | pg_restore between two running Postgres servers

--- a/docs/ref/pgcopydb.rst
+++ b/docs/ref/pgcopydb.rst
@@ -11,17 +11,17 @@ Synopsis
 pgcopydb provides the following commands::
 
   pgcopydb
-    clone    Clone an entire database from source to target
-    fork     Clone an entire database from source to target
-    follow   Replay changes from the source database to the target database
+    clone     Clone an entire database from source to target
+    fork      Clone an entire database from source to target
+    follow    Replay changes from the source database to the target database
     snapshot  Create and exports a snapshot on the source database
-  + copy     Implement the data section of the database copy
-  + dump     Dump database objects from a Postgres instance
-  + restore  Restore database objects into a Postgres instance
-  + list     List database objects from a Postgres instance
-  + stream   Stream changes from the source database
-    help     Print help message
-    version  Print pgcopydb version
+  + copy      Implement the data section of the database copy
+  + dump      Dump database objects from a Postgres instance
+  + restore   Restore database objects into a Postgres instance
+  + list      List database objects from a Postgres instance
+  + stream    Stream changes from the source database
+    help      Print help message
+    version   Print pgcopydb version
 
 Description
 -----------

--- a/docs/ref/pgcopydb.rst
+++ b/docs/ref/pgcopydb.rst
@@ -70,7 +70,7 @@ The ``pgcopydb help`` command lists all the supported sub-commands:
       schema       Copy the database schema from source to target
       data         Copy the data section from source to target
       table-data   Copy the data from all tables in database from source to target
-      blobs        Copy the blob data from ther source database to the target
+      blobs        Copy the blob data from the source database to the target
       sequences    Copy the current value from all sequences in database from source to target
       indexes      Create all the indexes found in the source database in the target
       constraints  Create all the constraints found in the source database in the target

--- a/docs/ref/pgcopydb.rst
+++ b/docs/ref/pgcopydb.rst
@@ -133,9 +133,9 @@ of pgcopydb used, and can do that in the JSON format when using the
 ::
 
    $ pgcopydb version
-   pgcopydb version 0.8
-   compiled with PostgreSQL 12.12 on x86_64-apple-darwin16.7.0, compiled by Apple LLVM version 8.1.0 (clang-802.0.42), 64-bit
-   compatible with Postgres 10, 11, 12, 13, and 14
+   pgcopydb version 0.13.31.g17a317d
+   compiled with PostgreSQL 15.1 on x86_64-pc-linux-gnu, compiled by gcc (Debian 8.3.0-6) 8.3.0, 64-bit
+   compatible with Postgres 10, 11, 12, 13, 14, and 15
 
 In JSON:
 
@@ -143,11 +143,11 @@ In JSON:
 
    $ pgcopydb version --json
    {
-       "pgcopydb": "0.8",
-       "pg_major": "12",
-       "pg_version": "12.12",
-       "pg_version_str": "PostgreSQL 12.12 on x86_64-apple-darwin16.7.0, compiled by Apple LLVM version 8.1.0 (clang-802.0.42), 64-bit",
-       "pg_version_num": 120012
+       "pgcopydb": "0.13.31.g17a317d",
+       "pg_major": "15",
+       "pg_version": "15.1",
+       "pg_version_str": "PostgreSQL 15.1 on x86_64-pc-linux-gnu, compiled by gcc (Debian 8.3.0-6) 8.3.0, 64-bit",
+       "pg_version_num": 150001
    }
 
 The details about the Postgres version applies to the version that's been

--- a/docs/ref/pgcopydb.rst
+++ b/docs/ref/pgcopydb.rst
@@ -176,7 +176,7 @@ An example output looks like the following:
    $ pgcopydb ping
    18:04:48 84679 INFO   Running pgcopydb version 0.10.31.g7e5fbb8.dirty from "/Users/dim/dev/PostgreSQL/pgcopydb/src/bin/pgcopydb/pgcopydb"
    18:04:48 84683 INFO   Successfully could connect to target database at "postgres://@:/plop?"
-   18:04:48 84682 INFO   Successfully could connect t source database at "postgres://@:/pagila?"
+   18:04:48 84682 INFO   Successfully could connect to source database at "postgres://@:/pagila?"
 
 This command implements a retry policy (named *Decorrelated Jitter*) and can
 be used in automation to make sure that the databases are ready to accept

--- a/docs/ref/pgcopydb.rst
+++ b/docs/ref/pgcopydb.rst
@@ -133,8 +133,8 @@ of pgcopydb used, and can do that in the JSON format when using the
 ::
 
    $ pgcopydb version
-   pgcopydb version 0.13.31.g17a317d
-   compiled with PostgreSQL 15.1 on x86_64-pc-linux-gnu, compiled by gcc (Debian 8.3.0-6) 8.3.0, 64-bit
+   pgcopydb version 0.13.1.g868ad77
+   compiled with PostgreSQL 13.11 (Debian 13.11-0+deb11u1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1 20210110, 64-bit
    compatible with Postgres 10, 11, 12, 13, 14, and 15
 
 In JSON:
@@ -143,11 +143,11 @@ In JSON:
 
    $ pgcopydb version --json
    {
-       "pgcopydb": "0.13.31.g17a317d",
-       "pg_major": "15",
-       "pg_version": "15.1",
-       "pg_version_str": "PostgreSQL 15.1 on x86_64-pc-linux-gnu, compiled by gcc (Debian 8.3.0-6) 8.3.0, 64-bit",
-       "pg_version_num": 150001
+       "pgcopydb": "0.13.1.g868ad77",
+       "pg_major": "13",
+       "pg_version": "13.11 (Debian 13.11-0+deb11u1)",
+       "pg_version_str": "PostgreSQL 13.11 (Debian 13.11-0+deb11u1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1 20210110, 64-bit",
+       "pg_version_num": 130011
    }
 
 The details about the Postgres version applies to the version that's been

--- a/docs/ref/pgcopydb.rst
+++ b/docs/ref/pgcopydb.rst
@@ -14,7 +14,7 @@ pgcopydb provides the following commands::
     clone     Clone an entire database from source to target
     fork      Clone an entire database from source to target
     follow    Replay changes from the source database to the target database
-    snapshot  Create and exports a snapshot on the source database
+    snapshot  Create and export a snapshot on the source database
   + copy      Implement the data section of the database copy
   + dump      Dump database objects from a Postgres instance
   + restore   Restore database objects into a Postgres instance
@@ -53,7 +53,7 @@ The ``pgcopydb help`` command lists all the supported sub-commands:
       fork      Clone an entire database from source to target
       follow    Replay changes from the source database to the target database
       copy-db   Clone an entire database from source to target
-      snapshot  Create and exports a snapshot on the source database
+      snapshot  Create and export a snapshot on the source database
     + copy      Implement the data section of the database copy
     + dump      Dump database objects from a Postgres instance
     + restore   Restore database objects into a Postgres instance

--- a/docs/ref/pgcopydb.rst
+++ b/docs/ref/pgcopydb.rst
@@ -20,8 +20,8 @@ pgcopydb provides the following commands::
   + restore  Restore database objects into a Postgres instance
   + list     List database objects from a Postgres instance
   + stream   Stream changes from the source database
-    help     print help message
-    version  print pgcopydb version
+    help     Print help message
+    version  Print pgcopydb version
 
 Description
 -----------
@@ -60,8 +60,8 @@ The ``pgcopydb help`` command lists all the supported sub-commands:
     + list      List database objects from a Postgres instance
     + stream    Stream changes from the source database
       ping      Attempt to connect to the source and target instances
-      help      print help message
-      version   print pgcopydb version
+      help      Print help message
+      version   Print pgcopydb version
 
     pgcopydb copy
       db           Copy an entire database from source to target
@@ -102,7 +102,7 @@ The ``pgcopydb help`` command lists all the supported sub-commands:
 
     pgcopydb stream
       setup      Setup source and target systems for logical decoding
-      cleanup    cleanup source and target systems for logical decoding
+      cleanup    Cleanup source and target systems for logical decoding
       prefetch   Stream JSON changes from the source database and transform them to SQL
       catchup    Apply prefetched changes from SQL files to the target database
       replay     Replay changes from the source to the target database, live

--- a/docs/ref/pgcopydb_copy.rst
+++ b/docs/ref/pgcopydb_copy.rst
@@ -230,7 +230,7 @@ avoiding disks entirely.
 pgcopydb copy blobs
 -------------------
 
-pgcopydb copy blobs - Copy the blob data from ther source database to the target
+pgcopydb copy blobs - Copy the blob data from the source database to the target
 
 The command ``pgcopydb copy blobs`` fetches list of large objects (aka
 blobs) from the source database and copies their data parts to the target
@@ -240,7 +240,7 @@ have already been taken care of, because of the behaviour of
 
 ::
 
-   pgcopydb copy blobs: Copy the blob data from ther source database to the target
+   pgcopydb copy blobs: Copy the blob data from the source database to the target
    usage: pgcopydb copy blobs  --source ... --target ...
 
      --source             Postgres URI to the source database

--- a/docs/ref/pgcopydb_snapshot.rst
+++ b/docs/ref/pgcopydb_snapshot.rst
@@ -3,7 +3,7 @@
 pgcopydb snapshot
 =================
 
-pgcopydb snapshot - Create and exports a snapshot on the source database
+pgcopydb snapshot - Create and export a snapshot on the source database
 
 The command ``pgcopydb snapshot`` connects to the source database and
 executes a SQL query to export a snapshot. The obtained snapshot is both
@@ -12,7 +12,7 @@ expect to find it.
 
 ::
 
-   pgcopydb snapshot: Create and exports a snapshot on the source database
+   pgcopydb snapshot: Create and export a snapshot on the source database
    usage: pgcopydb snapshot  --source ...
 
      --source         Postgres URI to the source database

--- a/src/bin/pgcopydb/cli_copy.c
+++ b/src/bin/pgcopydb/cli_copy.c
@@ -137,7 +137,7 @@ static CommandLine copy_table_data_command =
 static CommandLine copy_blobs_command =
 	make_command(
 		"blobs",
-		"Copy the blob data from ther source database to the target",
+		"Copy the blob data from the source database to the target",
 		" --source ... --target ... [ --table-jobs ... --index-jobs ... ] ",
 		"  --source             Postgres URI to the source database\n"
 		"  --target             Postgres URI to the target database\n"

--- a/src/bin/pgcopydb/cli_snapshot.c
+++ b/src/bin/pgcopydb/cli_snapshot.c
@@ -27,7 +27,7 @@ static void cli_create_snapshot(int argc, char **argv);
 CommandLine create_snapshot_command =
 	make_command(
 		"snapshot",
-		"Create and exports a snapshot on the source database",
+		"Create and export a snapshot on the source database",
 		" --source ... ",
 		"  --source         Postgres URI to the source database\n"
 		"  --dir            Work directory to use\n"


### PR DESCRIPTION
Changes include:
- typos
- spacing issues
- inconsistent casing
- using earlier versions instead of the latest in the docs
- not listing all available packages for yum based distros. i.e. missing PG16 packages
- inconsistent naming for processes. I decided on having 1 blob metadata worker + N blob data workers. It is up to discussion if this naming makes sense.