### PR TITLE
Fix data loss when reading large transaction bodies

### DIFF
--- a/src/bin/pgcopydb/file_utils.c
+++ b/src/bin/pgcopydb/file_utils.c
@@ -523,8 +523,9 @@ read_from_stream(FILE *stream, ReadFromStreamContext *context)
 			/* if the buffer doesn't terminate with \n it's a partial read */
 			bool partialRead = buf[bytes - 1] != '\n';
 
-			char *lines[BUFSIZE] = { 0 };
-			int lineCount = splitLines(buf, lines, BUFSIZE);
+			int count = countLines(buf);
+			char **lines = (char **) calloc(count, sizeof(char *));
+			int lineCount = splitLines(buf, lines, count);
 
 			log_trace("read_from_stream read %6zu bytes in %d lines %s[%lld]",
 					  bytes,
@@ -662,6 +663,7 @@ read_from_stream(FILE *stream, ReadFromStreamContext *context)
 				}
 			}
 
+			free(lines);
 			free(buf);
 		}
 


### PR DESCRIPTION
The `read_from_stream` function in pgcopydb was encountering a data loss issue when reading from a source system with transaction bodies containing more than `BUFSIZE(1024)` statements. The problem arose from the statically allocated array of size `BUFSIZE(1024)` used to split lines within the function. When the buffer held more than `BUFSIZE(1024)` lines, it caused subsequent lines to be ignored, resulting in data loss.

To resolve this issue, this commit introduces the following changes:
- We now count the number of lines in the buffer before splitting them.
- Dynamically allocate an array to hold the split lines, based on the line count.

Without the fix, pgcopydb used to abort with the following error message.
```
2023-10-12 12:13:47.381 480684 ERROR  ld_transform.c:963        BUG: logical message xid is 6522573, which is different from the current transaction xid 6522572
2023-10-12 12:13:47.381 480684 ERROR  ld_transform.c:390        Failed to parse JSON message: {"action":"I","xid":"6522573","lsn":"122/FF389FB8","timestamp":"2023-10-12 12:13:47.327968+0000","message":{"action":"I","xid":6522573,"schema":"public","table":"diagnostics","columns":[{"name":"time","type":"timestamp with time zone","value":"2016-01-24 13:00:10+00"},{"name":"tags_id","type":"integer","value":334},{"name":"fuel_state","type":"double precision","value":0.6},{"name":"current_load","type":"double precision","value":1849},{"name":"status","type":"double precision","value":0},{"name":"additional_tags","type":"jsonb","value":null}]}}
2023-10-12 12:13:47.381 480684 ERROR  ld_transform.c:111        Failed to transform JSON messages from input stream, see above for details
```