### PR TITLE
Review logical decoding client tracking of LSNs.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,9 @@ RUN apt-get update \
     tmux \
     watch \
     lsof \
-    psutils \
+	psutils \
+	gdb \
+    strace \
 	valgrind \
     postgresql-common \
     libpq5 \
@@ -60,7 +62,7 @@ RUN apt-get update \
     tmux \
     watch \
     lsof \
-    psutils \
+	psutils \
     libpq5 \
     postgresql-client-common \
     postgresql-client-13 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
     tmux \
     watch \
     lsof \
-	psutils \
+	psmisc \
 	gdb \
     strace \
 	valgrind \
@@ -62,7 +62,7 @@ RUN apt-get update \
     tmux \
     watch \
     lsof \
-	psutils \
+	psmisc \
     libpq5 \
     postgresql-client-common \
     postgresql-client-13 \

--- a/src/bin/pgcopydb/follow.c
+++ b/src/bin/pgcopydb/follow.c
@@ -596,7 +596,9 @@ follow_start_prefetch(StreamSpecs *specs)
 	if (specs->mode == STREAM_MODE_REPLAY)
 	{
 		/* arrange to write to the receive-transform pipe */
+		specs->stdIn = false;
 		specs->stdOut = true;
+
 		specs->out = fdopen(specs->pipe_rt[1], "a");
 
 		/* close pipe ends we're not using */
@@ -621,6 +623,7 @@ follow_start_prefetch(StreamSpecs *specs)
 	}
 	else
 	{
+		specs->stdIn = false;
 		specs->stdOut = false;
 
 		bool success = startLogicalStreaming(specs);
@@ -709,6 +712,8 @@ follow_start_catchup(StreamSpecs *specs)
 	{
 		/* arrange to read from the transform-apply pipe */
 		specs->stdIn = true;
+		specs->stdOut = false;
+
 		specs->in = fdopen(specs->pipe_ta[0], "r");
 
 		/* close pipe ends we're not using */
@@ -731,6 +736,7 @@ follow_start_catchup(StreamSpecs *specs)
 		 * open the right SQL file and apply statements from there.
 		 */
 		specs->stdIn = false;
+		specs->stdOut = false;
 
 		return stream_apply_catchup(specs);
 	}

--- a/src/bin/pgcopydb/follow.c
+++ b/src/bin/pgcopydb/follow.c
@@ -615,13 +615,19 @@ follow_start_prefetch(StreamSpecs *specs)
 
 		close_fd_or_exit(specs->pipe_rt[1]);
 
+		log_info("Prefetch process has terminated");
+
 		return success;
 	}
 	else
 	{
 		specs->stdOut = false;
 
-		return startLogicalStreaming(specs);
+		bool success = startLogicalStreaming(specs);
+
+		log_info("Prefetch process has terminated");
+
+		return success;
 	}
 
 	return true;

--- a/src/bin/pgcopydb/ld_apply.c
+++ b/src/bin/pgcopydb/ld_apply.c
@@ -108,13 +108,6 @@ stream_apply_catchup(StreamSpecs *specs)
 		}
 
 		/*
-		 * Each time we are done applying a file, we update our progress and
-		 * fetch new values from the pgcopydb sentinel. Errors are warning
-		 * here, we'll update next time.
-		 */
-		(void) stream_apply_sync_sentinel(&context);
-
-		/*
 		 * When syncing with the pgcopydb sentinel we might receive a new
 		 * endpos, and it might mean we're done already.
 		 */
@@ -146,8 +139,6 @@ stream_apply_catchup(StreamSpecs *specs)
 			return false;
 		}
 
-		log_info("Apply new filename: \"%s\"", context.sqlFileName);
-
 		/*
 		 * If we reached the end of the file and the current LSN still belongs
 		 * to the same file (a SWITCH did not occur), then we exit so that the
@@ -163,13 +154,8 @@ stream_apply_catchup(StreamSpecs *specs)
 			(void) pgsql_finish(&(context.pgsql));
 			return true;
 		}
-	}
 
-	if (!stream_apply_sync_sentinel(&context))
-	{
-		log_error("Failed to sync replay_lsn %X/%X",
-				  LSN_FORMAT_ARGS(context.previousLSN));
-		return false;
+		log_notice("Apply new filename: \"%s\"", context.sqlFileName);
 	}
 
 	/* make sure we close the connection on the way out */
@@ -324,12 +310,17 @@ stream_apply_wait_for_sentinel(StreamSpecs *specs, StreamApplyContext *context)
 		context->apply = sentinel.apply;
 
 		/* TODO: find more about this */
-		/* context->previousLSN = sentinel.replay_lsn; */
-
-		log_debug("stream_apply_wait_for_sentinel: "
-				  "previous lsn %X/%X, replay_lsn %X/%X",
-				  LSN_FORMAT_ARGS(context->previousLSN),
-				  LSN_FORMAT_ARGS(sentinel.replay_lsn));
+		if (context->previousLSN == InvalidXLogRecPtr)
+		{
+			context->previousLSN = sentinel.replay_lsn;
+		}
+		else
+		{
+			log_warn("stream_apply_wait_for_sentinel: "
+					 "previous lsn %X/%X, replay_lsn %X/%X",
+					 LSN_FORMAT_ARGS(context->previousLSN),
+					 LSN_FORMAT_ARGS(sentinel.replay_lsn));
+		}
 
 		log_debug("startpos %X/%X endpos %X/%X apply %s",
 				  LSN_FORMAT_ARGS(context->startpos),
@@ -368,7 +359,7 @@ stream_apply_wait_for_sentinel(StreamSpecs *specs, StreamApplyContext *context)
  * values.
  */
 bool
-stream_apply_sync_sentinel(StreamApplyContext *context)
+stream_apply_sync_sentinel(StreamApplyContext *context, bool findDurableLSN)
 {
 	PGSQL src = { 0 };
 	CopyDBSentinel sentinel = { 0 };
@@ -394,7 +385,7 @@ stream_apply_sync_sentinel(StreamApplyContext *context)
 	/*
 	 * If we know we reached endpos, then publish that as the replay_lsn.
 	 */
-	if (context->reachedEndPos)
+	if (context->reachedEndPos || !findDurableLSN)
 	{
 		durableLSN = context->previousLSN;
 	}
@@ -402,8 +393,8 @@ stream_apply_sync_sentinel(StreamApplyContext *context)
 	{
 		if (!stream_apply_find_durable_lsn(context, &durableLSN))
 		{
-			log_debug("Skipping sentinel replay_lsn: "
-					  "failed to find a durable LSN matching current flushLSN");
+			log_warn("Skipping sentinel replay_lsn udpate: "
+					 "failed to find a durable LSN matching current flushLSN");
 			return true;
 		}
 	}
@@ -536,14 +527,19 @@ stream_apply_file(StreamApplyContext *context)
 			  content.count,
 			  content.filename);
 
-	/* replay the SQL commands from the SQL file */
+	LogicalMessageMetadata *mArray =
+		(LogicalMessageMetadata *) calloc(content.count,
+										  sizeof(LogicalMessageMetadata));
+
+	LogicalMessageMetadata *lastCommit = NULL;
+
+	/* parse the SQL commands metadata from the SQL file */
 	for (int i = 0; i < content.count && !context->reachedEndPos; i++)
 	{
 		const char *sql = content.lines[i];
+		LogicalMessageMetadata *metadata = &(mArray[i]);
 
-		LogicalMessageMetadata metadata = { 0 };
-
-		if (!parseSQLAction(sql, &metadata))
+		if (!parseSQLAction(sql, metadata))
 		{
 			/* errors have already been logged */
 			free(content.buffer);
@@ -555,12 +551,12 @@ stream_apply_file(StreamApplyContext *context)
 		/*
 		 * The SWITCH WAL command should always be the last line of the file.
 		 */
-		if (metadata.action == STREAM_ACTION_SWITCH &&
+		if (metadata->action == STREAM_ACTION_SWITCH &&
 			i != (content.count - 1))
 		{
 			log_error("SWITCH command for LSN %X/%X found in \"%s\" line %d, "
 					  "before last line %d",
-					  LSN_FORMAT_ARGS(metadata.lsn),
+					  LSN_FORMAT_ARGS(metadata->lsn),
 					  content.filename,
 					  i + 1,
 					  content.count);
@@ -571,7 +567,22 @@ stream_apply_file(StreamApplyContext *context)
 			return false;
 		}
 
-		if (!stream_apply_sql(context, &metadata, sql))
+		if (metadata->action == STREAM_ACTION_COMMIT)
+		{
+			lastCommit = metadata;
+		}
+	}
+
+	/* replay the SQL commands from the SQL file */
+	for (int i = 0; i < content.count && !context->reachedEndPos; i++)
+	{
+		const char *sql = content.lines[i];
+		LogicalMessageMetadata *metadata = &(mArray[i]);
+
+		/* last commit of a file requires synchronous_commit on */
+		context->reachedEOF = metadata == lastCommit;
+
+		if (!stream_apply_sql(context, metadata, sql))
 		{
 			log_error("Failed to apply SQL from file \"%s\", "
 					  "see above for details",
@@ -587,6 +598,20 @@ stream_apply_file(StreamApplyContext *context)
 	/* free dynamic memory that's not needed anymore */
 	free(content.buffer);
 	free(content.lines);
+
+	/*
+	 * Each time we are done applying a file, we update our progress and
+	 * fetch new values from the pgcopydb sentinel. Errors are warning
+	 * here, we'll update next time.
+	 */
+	bool findDurableLSN = false;
+
+	if (!stream_apply_sync_sentinel(context, findDurableLSN))
+	{
+		log_error("Failed to sync replay_lsn %X/%X",
+				  LSN_FORMAT_ARGS(context->previousLSN));
+		return false;
+	}
 
 	return true;
 }
@@ -669,7 +694,12 @@ stream_apply_sql(StreamApplyContext *context,
 				context->endpos <= metadata->lsn)
 			{
 				context->reachedEndPos = true;
-				break;
+
+				log_notice("Apply reached end position %X/%X at BEGIN %X/%X",
+						   LSN_FORMAT_ARGS(context->endpos),
+						   LSN_FORMAT_ARGS(metadata->lsn));
+
+				return true;
 			}
 
 			/* actually skip this one if we didn't reach start pos yet */
@@ -700,7 +730,9 @@ stream_apply_sql(StreamApplyContext *context,
 				context->endpos <= metadata->txnCommitLSN;
 
 			GUC *settings =
-				commitLSNreachesEndPos ? applySettingsSync : applySettings;
+				commitLSNreachesEndPos || context->reachedEOF
+				? applySettingsSync
+				: applySettings;
 
 			if (commitLSNreachesEndPos)
 			{
@@ -772,10 +804,10 @@ stream_apply_sql(StreamApplyContext *context,
 			{
 				context->reachedEndPos = true;
 
-				log_notice("Apply reached end position %X/%X at %X/%X",
+				log_notice("Apply reached end position %X/%X at COMMIT %X/%X",
 						   LSN_FORMAT_ARGS(context->endpos),
 						   LSN_FORMAT_ARGS(context->previousLSN));
-				break;
+				return true;
 			}
 
 			if (!stream_apply_track_insert_lsn(context, metadata->lsn))
@@ -810,7 +842,7 @@ stream_apply_sql(StreamApplyContext *context,
 			{
 				context->reachedEndPos = true;
 
-				log_notice("Apply reached end position %X/%X at %X/%X",
+				log_notice("Apply reached end position %X/%X at ENDPOS %X/%X",
 						   LSN_FORMAT_ARGS(context->endpos),
 						   LSN_FORMAT_ARGS(context->previousLSN));
 
@@ -825,7 +857,7 @@ stream_apply_sql(StreamApplyContext *context,
 					context->transactionInProgress = false;
 				}
 
-				break;
+				return true;
 			}
 
 			break;
@@ -874,7 +906,13 @@ stream_apply_sql(StreamApplyContext *context,
 				context->endpos < metadata->lsn)
 			{
 				context->reachedEndPos = true;
-				break;
+				context->previousLSN = metadata->lsn;
+
+				log_notice("Apply reached end position %X/%X at KEEPALIVE %X/%X",
+						   LSN_FORMAT_ARGS(context->endpos),
+						   LSN_FORMAT_ARGS(context->previousLSN));
+
+				return true;
 			}
 
 			/* actually skip this one if we didn't reach start pos yet */
@@ -928,7 +966,7 @@ stream_apply_sql(StreamApplyContext *context,
 			{
 				context->reachedEndPos = true;
 
-				log_notice("Apply reached end position %X/%X at %X/%X",
+				log_notice("Apply reached end position %X/%X at KEEPALIVE %X/%X",
 						   LSN_FORMAT_ARGS(context->endpos),
 						   LSN_FORMAT_ARGS(context->previousLSN));
 				break;
@@ -1125,13 +1163,39 @@ setupReplicationOrigin(StreamApplyContext *context, bool logSQL)
 		return false;
 	}
 
-	if (!pgsql_replication_origin_progress(pgsql,
-										   nodeName,
-										   true,
-										   &(context->previousLSN)))
+	/*
+	 * Fetch the replication origin LSN tracking, which is maintained in a
+	 * transactional fashion with the SQL that's been replayed. It's the
+	 * authoritative value for progress at reconnect, given that we use
+	 * synchronous_commit off.
+	 */
+	uint64_t originLSN = InvalidXLogRecPtr;
+
+	if (!pgsql_replication_origin_progress(pgsql, nodeName, true, &originLSN))
 	{
 		/* errors have already been logged */
 		return false;
+	}
+
+	if (context->previousLSN == InvalidXLogRecPtr)
+	{
+		log_info("Setting up previous LSN from "
+				 "replication origin \"%s\" progress at %X/%X",
+				 nodeName,
+				 LSN_FORMAT_ARGS(originLSN));
+
+		context->previousLSN = originLSN;
+	}
+	else if (context->previousLSN != originLSN)
+	{
+		log_info("Setting up previous LSN from "
+				 "replication origin \"%s\" progress at %X/%X, "
+				 "overriding previous value %X/%X",
+				 nodeName,
+				 LSN_FORMAT_ARGS(originLSN),
+				 LSN_FORMAT_ARGS(context->previousLSN));
+
+		context->previousLSN = originLSN;
 	}
 
 	if (IS_EMPTY_STRING_BUFFER(context->sqlFileName))
@@ -1194,6 +1258,7 @@ stream_apply_init_context(StreamApplyContext *context,
 	}
 
 	context->reachedStartPos = false;
+	context->reachedEOF = false;
 
 	context->connStrings = connStrings;
 
@@ -1709,8 +1774,8 @@ stream_apply_read_lsn_tracking(StreamApplyContext *context)
 	/* it's okay if the file does not exists, just skip the operation */
 	if (!file_exists(filename))
 	{
-		log_debug("Failed to parse JSON file \"%s\": file does not exists",
-				  filename);
+		log_warn("Failed to parse JSON file \"%s\": file does not exists",
+				 filename);
 		return true;
 	}
 

--- a/src/bin/pgcopydb/ld_stream.c
+++ b/src/bin/pgcopydb/ld_stream.c
@@ -452,9 +452,11 @@ startLogicalStreaming(StreamSpecs *specs)
 
 		if (cleanExit)
 		{
-			log_info("Streamed up to write_lsn %X/%X, flush_lsn %X/%X, stopping",
+			log_info("Streamed up to write_lsn %X/%X, flush_lsn %X/%X, stopping: "
+					 "endpos is %X/%X",
 					 LSN_FORMAT_ARGS(context.tracking->written_lsn),
-					 LSN_FORMAT_ARGS(context.tracking->flushed_lsn));
+					 LSN_FORMAT_ARGS(context.tracking->flushed_lsn),
+					 LSN_FORMAT_ARGS(context.endpos));
 		}
 		else if (!(asked_to_stop || asked_to_stop_fast || asked_to_quit))
 		{

--- a/src/bin/pgcopydb/ld_stream.c
+++ b/src/bin/pgcopydb/ld_stream.c
@@ -225,8 +225,10 @@ stream_init_for_mode(StreamSpecs *specs, LogicalStreamMode mode)
 	}
 	else if (specs->mode == STREAM_MODE_REPLAY && mode == STREAM_MODE_CATCHUP)
 	{
+		specs->stdIn = false;
+		specs->stdOut = false;
+
 		/* we keep the transform queue around */
-		(void) 0;
 	}
 	else
 	{

--- a/src/bin/pgcopydb/ld_stream.h
+++ b/src/bin/pgcopydb/ld_stream.h
@@ -378,6 +378,7 @@ typedef struct StreamApplyContext
 
 	bool reachedStartPos;
 	bool reachedEndPos;
+	bool reachedEOF;
 	bool transactionInProgress;
 	bool logSQL;
 
@@ -645,7 +646,9 @@ bool stream_apply_setup(StreamSpecs *specs, StreamApplyContext *context);
 bool stream_apply_wait_for_sentinel(StreamSpecs *specs,
 									StreamApplyContext *context);
 
-bool stream_apply_sync_sentinel(StreamApplyContext *context);
+bool stream_apply_sync_sentinel(StreamApplyContext *context,
+								bool findDurableLSN);
+
 bool stream_apply_send_sync_sentinel(StreamApplyContext *context);
 bool stream_apply_fetch_sync_sentinel(StreamApplyContext *context);
 
@@ -683,6 +686,9 @@ bool stream_apply_read_lsn_tracking(StreamApplyContext *context);
 bool stream_replay(StreamSpecs *specs);
 bool stream_apply_replay(StreamSpecs *specs);
 bool stream_replay_line(void *ctx, const char *line, bool *stop);
+bool stream_replay_reached_endpos(StreamSpecs *specs,
+								  StreamApplyContext *context,
+								  bool stop);
 
 /* follow.c */
 bool follow_export_snapshot(CopyDataSpec *copySpecs, StreamSpecs *streamSpecs);

--- a/src/bin/pgcopydb/ld_stream.h
+++ b/src/bin/pgcopydb/ld_stream.h
@@ -491,6 +491,7 @@ bool stream_init_for_mode(StreamSpecs *specs, LogicalStreamMode mode);
 
 char * LogicalStreamModeToString(LogicalStreamMode mode);
 
+bool stream_check_in_out(StreamSpecs *specs);
 bool stream_init_context(StreamSpecs *specs);
 
 bool startLogicalStreaming(StreamSpecs *specs);

--- a/tests/Dockerfile.pagila
+++ b/tests/Dockerfile.pagila
@@ -13,7 +13,9 @@ RUN apt-get update \
     tmux \
     watch \
     lsof \
-    psutils \
+	psutils \
+	strace \
+	gdb \
     libpq5 \
     postgresql-client-common \
     curl \
@@ -34,8 +36,10 @@ RUN apt-get update \
 WORKDIR /usr/src/
 RUN git clone --depth 1 https://github.com/devrimgunduz/pagila.git
 
-RUN adduser --disabled-password --gecos '' --home /var/lib/postgres docker
-RUN adduser docker sudo
+#RUN adduser --disabled-password --gecos '' --home /var/lib/postgres docker
+#RUN adduser docker sudo
+RUN useradd -rm -d /var/lib/postgres -s /bin/bash -g postgres -G sudo docker
+RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 COPY --from=pgcopydb /usr/local/bin/pgcopydb /usr/local/bin
 COPY .psqlrc /var/lib/postgres

--- a/tests/Dockerfile.pagila
+++ b/tests/Dockerfile.pagila
@@ -13,7 +13,8 @@ RUN apt-get update \
     tmux \
     watch \
     lsof \
-	psutils \
+	psmisc \
+    htop \
 	strace \
 	gdb \
     libpq5 \

--- a/tests/cdc-low-level/docker-compose.yml
+++ b/tests/cdc-low-level/docker-compose.yml
@@ -29,6 +29,9 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    cap_add:
+      - SYS_ADMIN
+      - SYS_PTRACE
     environment:
       PGSSLMODE: "require"
       PGCOPYDB_SOURCE_PGURI: postgres://postgres:h4ckm3@source/postgres

--- a/tests/follow-wal2json/docker-compose.yml
+++ b/tests/follow-wal2json/docker-compose.yml
@@ -37,6 +37,9 @@ services:
       PGCOPYDB_TARGET_PGURI: postgres://postgres:h4ckm3@target/postgres
   test:
     build: .
+    cap_add:
+      - SYS_ADMIN
+      - SYS_PTRACE
     environment:
       PGSSLMODE: "require"
       PGCOPYDB_SOURCE_PGURI: postgres://postgres:h4ckm3@source/postgres


### PR DESCRIPTION
When replaying from file, ensure that the last transaction of a file is commited with synchronous_commit on, allowing better tracking of replication progress.

Also, improve our way to keep track of the previousLSN and log when we reach endpos (KEEPALIVE, COMMIT, ENDPOS) to help get a sense of what's happening.

By setting previousLSN to the proper value even when reaching endpos at a KEEPALIVE message that we skip, we allow the overall system to exit properly in case when there is no activity on the source server.

Fixes #500 
See #427 
See #493 