### PR TITLE
Add byte level details to list progress command

### DIFF
--- a/docs/ref/pgcopydb_clone.rst
+++ b/docs/ref/pgcopydb_clone.rst
@@ -891,15 +891,16 @@ Examples
    13:09:09 81991 INFO  STEP 7: restore the post-data section to the target database
    13:09:09 81991 INFO   /Applications/Postgres.app/Contents/Versions/12/bin/pg_restore --dbname 'postgres://@:/plop?' --single-transaction --clean --if-exists --use-list /var/folders/d7/zzxmgs9s16gdxxcm0hs0sssw0000gn/T//pgcopydb/schema/post.list /var/folders/d7/zzxmgs9s16gdxxcm0hs0sssw0000gn/T//pgcopydb/schema/post.dump
 
-                                             Step   Connection    Duration   Concurrency
-    ---------------------------------------------   ----------  ----------  ------------
-                                      Dump Schema       source       355ms             1
-                                   Prepare Schema       target       135ms             1
-    COPY, INDEX, CONSTRAINTS, VACUUM (wall clock)         both       641ms        8 + 12
-                                COPY (cumulative)         both       1s598             8
-                       Large Objects (cumulative)         both        29ms             1
-           CREATE INDEX, CONSTRAINTS (cumulative)       target       4s072            12
-                                  Finalize Schema       target       366ms             1
-    ---------------------------------------------   ----------  ----------  ------------
-                        Total Wall Clock Duration         both       1s499        8 + 12
-    ---------------------------------------------   ----------  ----------  ------------
+                                               Step   Connection    Duration    Transfer   Concurrency
+ --------------------------------------------------   ----------  ----------  ----------  ------------
+                                        Dump Schema       source       225ms                         1
+   Catalog Queries (table ordering, filtering, etc)       source       842ms                         1
+                                     Prepare Schema       target       694ms                         1
+      COPY, INDEX, CONSTRAINTS, VACUUM (wall clock)         both       1s538                    8 + 12
+                                  COPY (cumulative)         both       2s771     2955 kB             8
+                         Large Objects (cumulative)         both       242ms                         1
+             CREATE INDEX, CONSTRAINTS (cumulative)       target       3s489                        12
+                                    Finalize Schema       target       654ms                         1
+ --------------------------------------------------   ----------  ----------  ----------  ------------
+                          Total Wall Clock Duration         both       3s984                    8 + 12
+ --------------------------------------------------   ----------  ----------  ----------  ------------

--- a/docs/ref/pgcopydb_clone.rst
+++ b/docs/ref/pgcopydb_clone.rst
@@ -842,65 +842,87 @@ Examples
 --------
 
 ::
-
-   $ export PGCOPYDB_SOURCE_PGURI="port=54311 host=localhost dbname=pgloader"
-   $ export PGCOPYDB_TARGET_PGURI="port=54311 dbname=plop"
+   $ export PGCOPYDB_SOURCE_PGURI=postgres://pagila:0wn3d@source/pagila
+   $ export PGCOPYDB_TARGET_PGURI=postgres://pagila:0wn3d@target/pagila
    $ export PGCOPYDB_DROP_IF_EXISTS=on
 
    $ pgcopydb clone --table-jobs 8 --index-jobs 12
-   13:09:08 81987 INFO  Running pgcopydb version 0.8.21.gacd2795.dirty from "/Applications/Postgres.app/Contents/Versions/12/bin/pgcopydb"
-   13:09:08 81987 INFO  [SOURCE] Copying database from "postgres://@:/pagila?"
-   13:09:08 81987 INFO  [TARGET] Copying database into "postgres://@:/plop?"
-   13:09:08 81987 INFO  Using work dir "/var/folders/d7/zzxmgs9s16gdxxcm0hs0sssw0000gn/T//pgcopydb"
-   13:09:08 81987 INFO  Exported snapshot "00000003-00076012-1" from the source database
-   13:09:08 81991 INFO  STEP 1: dump the source database schema (pre/post data)
-   13:09:08 81991 INFO   /Applications/Postgres.app/Contents/Versions/12/bin/pg_dump -Fc --snapshot 00000003-00076012-1 --section pre-data --file /var/folders/d7/zzxmgs9s16gdxxcm0hs0sssw0000gn/T//pgcopydb/schema/pre.dump 'postgres://@:/pagila?'
-   13:09:08 81991 INFO   /Applications/Postgres.app/Contents/Versions/12/bin/pg_dump -Fc --snapshot 00000003-00076012-1 --section post-data --file /var/folders/d7/zzxmgs9s16gdxxcm0hs0sssw0000gn/T//pgcopydb/schema/post.dump 'postgres://@:/pagila?'
-   13:09:08 81991 INFO  STEP 2: restore the pre-data section to the target database
-   13:09:09 81991 INFO  Listing ordinary tables in source database
-   13:09:09 81991 INFO  Fetched information for 21 tables, with an estimated total of 46 248 tuples and 3776 kB
-   13:09:09 81991 INFO  Fetching information for 13 sequences
-   13:09:09 81991 INFO   /Applications/Postgres.app/Contents/Versions/12/bin/pg_restore --dbname 'postgres://@:/plop?' --single-transaction --clean --if-exists --use-list /var/folders/d7/zzxmgs9s16gdxxcm0hs0sssw0000gn/T//pgcopydb/schema/pre.list /var/folders/d7/zzxmgs9s16gdxxcm0hs0sssw0000gn/T//pgcopydb/schema/pre.dump
-   13:09:09 81991 INFO  STEP 3: copy data from source to target in sub-processes
-   13:09:09 81991 INFO  STEP 4: create indexes and constraints in parallel
-   13:09:09 81991 INFO  STEP 5: vacuum analyze each table
-   13:09:09 81991 INFO  Now starting 8 processes
-   13:09:09 81991 INFO  Reset sequences values on the target database
-   13:09:09 82003 INFO  COPY "public"."rental"
-   13:09:09 82004 INFO  COPY "public"."film"
-   13:09:09 82009 INFO  COPY "public"."payment_p2020_04"
-   13:09:09 82002 INFO  Copying large objects
-   13:09:09 82007 INFO  COPY "public"."payment_p2020_03"
-   13:09:09 82010 INFO  COPY "public"."film_actor"
-   13:09:09 82005 INFO  COPY "public"."inventory"
-   13:09:09 82014 INFO  COPY "public"."payment_p2020_02"
-   13:09:09 82012 INFO  COPY "public"."customer"
-   13:09:09 82009 INFO  Creating 3 indexes for table "public"."payment_p2020_04"
-   13:09:09 82010 INFO  Creating 2 indexes for table "public"."film_actor"
-   13:09:09 82007 INFO  Creating 3 indexes for table "public"."payment_p2020_03"
-   13:09:09 82004 INFO  Creating 5 indexes for table "public"."film"
-   13:09:09 82005 INFO  Creating 2 indexes for table "public"."inventory"
-   13:09:09 82033 INFO  VACUUM ANALYZE "public"."payment_p2020_04";
-   13:09:09 82036 INFO  VACUUM ANALYZE "public"."film_actor";
-   13:09:09 82039 INFO  VACUUM ANALYZE "public"."payment_p2020_03";
-   13:09:09 82041 INFO  VACUUM ANALYZE "public"."film";
-   13:09:09 82043 INFO  VACUUM ANALYZE "public"."inventory";
-   ...
-   ...
-   ...
-   13:09:09 81991 INFO  STEP 7: restore the post-data section to the target database
-   13:09:09 81991 INFO   /Applications/Postgres.app/Contents/Versions/12/bin/pg_restore --dbname 'postgres://@:/plop?' --single-transaction --clean --if-exists --use-list /var/folders/d7/zzxmgs9s16gdxxcm0hs0sssw0000gn/T//pgcopydb/schema/post.list /var/folders/d7/zzxmgs9s16gdxxcm0hs0sssw0000gn/T//pgcopydb/schema/post.dump
+   14:49:01 22 INFO   Running pgcopydb version 0.13.38.g22e6544.dirty from "/usr/local/bin/pgcopydb"
+   14:49:01 22 INFO   [SOURCE] Copying database from "postgres://pagila@source/pagila?keepalives=1&keepalives_idle=10&keepalives_interval=10&keepalives_count=60"
+   14:49:01 22 INFO   [TARGET] Copying database into "postgres://pagila@target/pagila?keepalives=1&keepalives_idle=10&keepalives_interval=10&keepalives_count=60"
+   14:49:01 22 INFO   Exported snapshot "00000003-00000022-1" from the source database
+   14:49:01 24 INFO   STEP 1: fetch source database tables, indexes, and sequences
+   14:49:01 24 INFO   Fetched information for 3 extensions
+   14:49:01 24 INFO   Splitting source candidate tables larger than 200 kB
+   14:49:01 24 INFO   Table public.rental is 1224 kB large, 7 COPY processes will be used, partitioning on rental_id.
+   14:49:01 24 INFO   Table public.film is 472 kB large, 3 COPY processes will be used, partitioning on film_id.
+   14:49:01 24 INFO   Table public.film_actor is 264 kB large which is larger than --split-tables-larger-than 200 kB, and does not have a unique column of type integer: splitting by CTID
+   14:49:01 24 INFO   Table public.film_actor is 264 kB large, 2 COPY processes will be used, partitioning on ctid.
+   14:49:01 24 INFO   Table public.inventory is 264 kB large, 2 COPY processes will be used, partitioning on inventory_id.
+   14:49:01 24 INFO   Fetched information for 21 tables, with an estimated total of 0 tuples and 3816 kB
+   14:49:01 24 INFO   Fetched information for 54 indexes
+   14:49:01 24 INFO   Fetching information for 13 sequences
+   14:49:01 24 INFO   STEP 2: dump the source database schema (pre/post data)
+   14:49:01 24 INFO    /usr/bin/pg_dump -Fc --snapshot 00000003-00000022-1 --section pre-data --file /tmp/pgcopydb/schema/pre.dump 'postgres://pagila@source/pagila?keepalives=1&keepalives_idle=10&keepalives_interval=10&keepalives_count=60'
+   14:49:01 24 INFO    /usr/bin/pg_dump -Fc --snapshot 00000003-00000022-1 --section post-data --file /tmp/pgcopydb/schema/post.dump 'postgres://pagila@source/pagila?keepalives=1&keepalives_idle=10&keepalives_interval=10&keepalives_count=60'
+   14:49:02 24 INFO   STEP 3: restore the pre-data section to the target database
+   14:49:02 24 INFO    /usr/bin/pg_restore --dbname 'postgres://pagila@target/pagila?keepalives=1&keepalives_idle=10&keepalives_interval=10&keepalives_count=60' --single-transaction --use-list /tmp/pgcopydb/schema/pre-filtered.list /tmp/pgcopydb/schema/pre.dump
+   14:49:02 24 INFO   STEP 6: starting 12 CREATE INDEX processes
+   14:49:02 24 INFO   STEP 7: constraints are built by the CREATE INDEX processes
+   14:49:02 24 INFO   STEP 8: starting 8 VACUUM processes
+   14:49:02 24 INFO   STEP 9: reset sequences values
+   14:49:02 51 INFO   STEP 5: starting 4 Large Objects workers
+   14:49:02 30 INFO   STEP 4: starting 8 table data COPY processes
+   14:49:02 52 INFO   Reset sequences values on the target database
+   14:49:02 51 INFO   Added 0 large objects to the queue
+   14:49:04 24 INFO   STEP 10: restore the post-data section to the target database
+   14:49:04 24 INFO    /usr/bin/pg_restore --dbname 'postgres://pagila@target/pagila?keepalives=1&keepalives_idle=10&keepalives_interval=10&keepalives_count=60' --single-transaction --use-list /tmp/pgcopydb/schema/post-filtered.list /tmp/pgcopydb/schema/post.dump
 
-                                               Step   Connection    Duration    Transfer   Concurrency
- --------------------------------------------------   ----------  ----------  ----------  ------------
-                                        Dump Schema       source       225ms                         1
-   Catalog Queries (table ordering, filtering, etc)       source       842ms                         1
-                                     Prepare Schema       target       694ms                         1
-      COPY, INDEX, CONSTRAINTS, VACUUM (wall clock)         both       1s538                    8 + 12
-                                  COPY (cumulative)         both       2s771     2955 kB             8
-                         Large Objects (cumulative)         both       242ms                         1
-             CREATE INDEX, CONSTRAINTS (cumulative)       target       3s489                        12
-                                    Finalize Schema       target       654ms                         1
- --------------------------------------------------   ----------  ----------  ----------  ------------
-                          Total Wall Clock Duration         both       3s984                    8 + 12
- --------------------------------------------------   ----------  ----------  ----------  ------------
+     OID | Schema |             Name | copy duration | transmitted bytes | indexes | create index duration
+   ------+--------+------------------+---------------+-------------------+---------+----------------------
+   16880 | public |           rental |         160ms |            188 kB |       3 |                 230ms
+   16880 | public |           rental |          77ms |            189 kB |       0 |                   0ms
+   16880 | public |           rental |         105ms |            189 kB |       0 |                   0ms
+   16880 | public |           rental |         107ms |            189 kB |       0 |                   0ms
+   16880 | public |           rental |          97ms |            190 kB |       0 |                   0ms
+   16880 | public |           rental |          82ms |            189 kB |       0 |                   0ms
+   16880 | public |           rental |          81ms |            189 kB |       0 |                   0ms
+   16758 | public |             film |         136ms |            112 kB |       5 |                 462ms
+   16758 | public |             film |          52ms |            110 kB |       0 |                   0ms
+   16758 | public |             film |          74ms |            111 kB |       0 |                   0ms
+   16770 | public |       film_actor |          74ms |            5334 B |       0 |                   0ms
+   16770 | public |       film_actor |          77ms |            156 kB |       0 |                   0ms
+   16825 | public |        inventory |         106ms |             74 kB |       2 |                 586ms
+   16825 | public |        inventory |         107ms |             76 kB |       0 |                   0ms
+   16858 | public | payment_p2022_03 |          86ms |            137 kB |       4 |                 468ms
+   16866 | public | payment_p2022_05 |          98ms |            136 kB |       4 |                 663ms
+   16870 | public | payment_p2022_06 |         106ms |            134 kB |       4 |                 571ms
+   16862 | public | payment_p2022_04 |         125ms |            129 kB |       4 |                 775ms
+   16854 | public | payment_p2022_02 |         117ms |            121 kB |       4 |                 684ms
+   16874 | public | payment_p2022_07 |         255ms |            118 kB |       1 |                 270ms
+   16724 | public |         customer |         247ms |             55 kB |       4 |                 1s091
+   16785 | public |          address |         128ms |             47 kB |       2 |                 132ms
+   16795 | public |             city |         163ms |             23 kB |       2 |                 270ms
+   16774 | public |    film_category |         172ms |             28 kB |       1 |                  47ms
+   16850 | public | payment_p2022_01 |         166ms |             36 kB |       4 |                 679ms
+   16738 | public |            actor |         399ms |            7999 B |       2 |                 116ms
+   16748 | public |         category |         170ms |             526 B |       1 |                 200ms
+   16805 | public |          country |          63ms |            3918 B |       1 |                 226ms
+   16900 | public |            staff |         170ms |             272 B |       1 |                 114ms
+   16832 | public |         language |         115ms |             276 B |       1 |                  68ms
+   16911 | public |            store |          88ms |              58 B |       2 |                 185ms
+
+
+                                                  Step   Connection    Duration    Transfer   Concurrency
+    --------------------------------------------------   ----------  ----------  ----------  ------------
+                                           Dump Schema       source        98ms                         1
+      Catalog Queries (table ordering, filtering, etc)       source       687ms                         1
+                                        Prepare Schema       target       667ms                         1
+         COPY, INDEX, CONSTRAINTS, VACUUM (wall clock)         both       1s256                    8 + 20
+                                     COPY (cumulative)         both       4s003     2955 kB             8
+                            Large Objects (cumulative)         both       877ms                         4
+                CREATE INDEX, CONSTRAINTS (cumulative)       target       7s837                        12
+                                       Finalize Schema       target       487ms                         1
+    --------------------------------------------------   ----------  ----------  ----------  ------------
+                             Total Wall Clock Duration         both       3s208                    8 + 20
+    --------------------------------------------------   ----------  ----------  ----------  ------------

--- a/docs/ref/pgcopydb_copy.rst
+++ b/docs/ref/pgcopydb_copy.rst
@@ -613,17 +613,19 @@ Then copy the data over:
    15:24:36 75688 INFO  Listing ordinary tables in "port=54311 host=localhost dbname=pgloader"
    15:24:36 75688 INFO  Fetched information for 56 tables
    ...
-                                             Step   Connection    Duration   Concurrency
-    ---------------------------------------------   ----------  ----------  ------------
-                                      Dump Schema       source         0ms             1
-                                   Prepare Schema       target         0ms             1
-    COPY, INDEX, CONSTRAINTS, VACUUM (wall clock)         both         0ms         4 + 4
-                                COPY (cumulative)         both       1s140             4
-                        CREATE INDEX (cumulative)       target         0ms             4
-                                  Finalize Schema       target         0ms             1
-    ---------------------------------------------   ----------  ----------  ------------
-                        Total Wall Clock Duration         both       2s143         4 + 4
-    ---------------------------------------------   ----------  ----------  ------------
+                                               Step   Connection    Duration    Transfer   Concurrency
+ --------------------------------------------------   ----------  ----------  ----------  ------------
+                                        Dump Schema       source         0ms                         1
+   Catalog Queries (table ordering, filtering, etc)       source         0ms                         1
+                                     Prepare Schema       target         0ms                         1
+      COPY, INDEX, CONSTRAINTS, VACUUM (wall clock)         both         0ms                     4 + 4
+                                  COPY (cumulative)         both       1s140     2955 kB             4
+                         Large Objects (cumulative)         both         0ms                         1
+             CREATE INDEX, CONSTRAINTS (cumulative)       target         0ms                         4
+                                    Finalize Schema       target         0ms                         1
+ --------------------------------------------------   ----------  ----------  ----------  ------------
+                          Total Wall Clock Duration         both       2s143                     4 + 4
+ --------------------------------------------------   ----------  ----------  ----------  ------------
 
 
 And now create the indexes on the target database, using the index
@@ -662,17 +664,19 @@ definitions from the source database:
    15:24:40 76052 INFO  CREATE UNIQUE INDEX IF NOT EXISTS nullif_pkey ON public."nullif" USING btree (id);
    15:24:40 76050 INFO  CREATE UNIQUE INDEX IF NOT EXISTS serial_pkey ON public.serial USING btree (a);
 
-                                             Step   Connection    Duration   Concurrency
-    ---------------------------------------------   ----------  ----------  ------------
-                                      Dump Schema       source         0ms             1
-                                   Prepare Schema       target         0ms             1
-    COPY, INDEX, CONSTRAINTS, VACUUM (wall clock)         both         0ms         4 + 4
-                                COPY (cumulative)         both       619ms             4
-                        CREATE INDEX (cumulative)       target       1s023             4
-                                  Finalize Schema       target         0ms             1
-    ---------------------------------------------   ----------  ----------  ------------
-                        Total Wall Clock Duration         both       400ms         4 + 4
-    ---------------------------------------------   ----------  ----------  ------------
+                                                 Step   Connection    Duration    Transfer   Concurrency
+   --------------------------------------------------   ----------  ----------  ----------  ------------
+                                          Dump Schema       source         0ms                         1
+     Catalog Queries (table ordering, filtering, etc)       source         0ms                         1
+                                       Prepare Schema       target         0ms                         1
+        COPY, INDEX, CONSTRAINTS, VACUUM (wall clock)         both         0ms                     4 + 4
+                                    COPY (cumulative)         both       619ms     2955 kB             4
+                           Large Objects (cumulative)         both         0ms                         1
+               CREATE INDEX, CONSTRAINTS (cumulative)       target       1s023                         4
+                                      Finalize Schema       target         0ms                         1
+   --------------------------------------------------   ----------  ----------  ----------  ------------
+                            Total Wall Clock Duration         both       400ms                     4 + 4
+   --------------------------------------------------   ----------  ----------  ----------  ------------
 
 Now re-create the constraints (primary key, unique constraints) from the
 source database schema into the target database:
@@ -697,17 +701,19 @@ source database schema into the target database:
    15:24:43 76159 INFO  ALTER TABLE "public"."udc" ADD CONSTRAINT "udc_pkey" PRIMARY KEY USING INDEX "udc_pkey";
    15:24:43 76108 INFO  ALTER TABLE "err"."errors" ADD CONSTRAINT "errors_pkey" PRIMARY KEY USING INDEX "errors_pkey";
 
-                                             Step   Connection    Duration   Concurrency
-    ---------------------------------------------   ----------  ----------  ------------
-                                      Dump Schema       source         0ms             1
-                                   Prepare Schema       target         0ms             1
-    COPY, INDEX, CONSTRAINTS, VACUUM (wall clock)         both         0ms         4 + 4
-                                COPY (cumulative)         both       605ms             4
-                        CREATE INDEX (cumulative)       target       1s023             4
-                                  Finalize Schema       target         0ms             1
-    ---------------------------------------------   ----------  ----------  ------------
-                        Total Wall Clock Duration         both       415ms         4 + 4
-    ---------------------------------------------   ----------  ----------  ------------
+                                                 Step   Connection    Duration    Transfer   Concurrency
+   --------------------------------------------------   ----------  ----------  ----------  ------------
+                                          Dump Schema       source         0ms                         1
+     Catalog Queries (table ordering, filtering, etc)       source         0ms                         1
+                                       Prepare Schema       target         0ms                         1
+        COPY, INDEX, CONSTRAINTS, VACUUM (wall clock)         both         0ms                     4 + 4
+                                    COPY (cumulative)         both       605ms     2955 kB             4
+                           Large Objects (cumulative)         both         0ms                         1
+               CREATE INDEX, CONSTRAINTS (cumulative)       target       1s023                         4
+                                      Finalize Schema       target         0ms                         1
+   --------------------------------------------------   ----------  ----------  ----------  ------------
+                            Total Wall Clock Duration         both       415ms                     4 + 4
+   --------------------------------------------------   ----------  ----------  ----------  ------------
 
 The next step is a VACUUM ANALYZE on each table that's been just filled-in
 with the data, and for that we can just use the `vacuumdb`__ command from

--- a/docs/ref/pgcopydb_copy.rst
+++ b/docs/ref/pgcopydb_copy.rst
@@ -570,21 +570,21 @@ re-use them all along:
 
 ::
 
-   $ export PGCOPYDB_SOURCE_PGURI="port=54311 host=localhost dbname=pgloader"
-   $ export PGCOPYDB_TARGET_PGURI="port=54311 dbname=plop"
+   $ export PGCOPYDB_SOURCE_PGURI=postgres://pagila:0wn3d@source/pagila
+   $ export PGCOPYDB_TARGET_PGURI=postgres://pagila:0wn3d@target/pagila
 
 Now, first dump the schema:
 
 ::
 
    $ pgcopydb dump schema
-   15:24:24 75511 INFO  Removing the stale pid file "/tmp/pgcopydb/pgcopydb.pid"
-   15:24:24 75511 WARN  Directory "/tmp/pgcopydb" already exists: removing it entirely
-   15:24:24 75511 INFO  Dumping database from "port=54311 host=localhost dbname=pgloader"
-   15:24:24 75511 INFO  Dumping database into directory "/tmp/pgcopydb"
-   15:24:24 75511 INFO  Using pg_dump for Postgres "12.9" at "/Applications/Postgres.app/Contents/Versions/12/bin/pg_dump"
-   15:24:24 75511 INFO   /Applications/Postgres.app/Contents/Versions/12/bin/pg_dump -Fc --section pre-data --file /tmp/pgcopydb/schema/pre.dump 'port=54311 host=localhost dbname=pgloader'
-   15:24:25 75511 INFO   /Applications/Postgres.app/Contents/Versions/12/bin/pg_dump -Fc --section post-data --file /tmp/pgcopydb/schema/post.dump 'port=54311 host=localhost dbname=pgloader'
+   14:28:50 22 INFO   Running pgcopydb version 0.13.38.g22e6544.dirty from "/usr/local/bin/pgcopydb"
+   14:28:50 22 INFO   Dumping database from "postgres://pagila@source/pagila?keepalives=1&keepalives_idle=10&keepalives_interval=10&keepalives_count=60"
+   14:28:50 22 INFO   Dumping database into directory "/tmp/pgcopydb"
+   14:28:50 22 INFO   Using pg_dump for Postgres "16.1" at "/usr/bin/pg_dumpall"
+   14:28:50 22 INFO   Exported snapshot "00000003-00000022-1" from the source database
+   14:28:50 22 INFO    /usr/bin/pg_dump -Fc --snapshot 00000003-00000022-1 --section pre-data --file /tmp/pgcopydb/schema/pre.dump 'postgres://pagila@source/pagila?keepalives=1&keepalives_idle=10&keepalives_interval=10&keepalives_count=60'
+   14:28:51 22 INFO    /usr/bin/pg_dump -Fc --snapshot 00000003-00000022-1 --section post-data --file /tmp/pgcopydb/schema/post.dump 'postgres://pagila@source/pagila?keepalives=1&keepalives_idle=10&keepalives_interval=10&keepalives_count=60'
 
 Now restore the pre-data schema on the target database, cleaning up the
 already existing objects if any, which allows running this test scenario
@@ -593,12 +593,15 @@ target instance though!
 
 ::
 
-   PGCOPYDB_DROP_IF_EXISTS=on pgcopydb restore pre-data --no-owner
-   15:24:29 75591 INFO  Removing the stale pid file "/tmp/pgcopydb/pgcopydb.pid"
-   15:24:29 75591 INFO  Restoring database from "/tmp/pgcopydb"
-   15:24:29 75591 INFO  Restoring database into "port=54311 dbname=plop"
-   15:24:29 75591 INFO  Using pg_restore for Postgres "12.9" at "/Applications/Postgres.app/Contents/Versions/12/bin/pg_restore"
-   15:24:29 75591 INFO   /Applications/Postgres.app/Contents/Versions/12/bin/pg_restore --dbname 'port=54311 dbname=plop' --clean --if-exists --no-owner /tmp/pgcopydb/schema/pre.dump
+   $ PGCOPYDB_DROP_IF_EXISTS=on pgcopydb restore pre-data --no-owner --resume --not-consistent
+   14:28:51 26 INFO   Running pgcopydb version 0.13.38.g22e6544.dirty from "/usr/local/bin/pgcopydb"
+   14:28:51 26 INFO   Schema dump for pre-data and post-data section have been done
+   14:28:51 26 INFO   Restoring database from existing files at "/tmp/pgcopydb"
+   14:28:51 26 INFO   Using pg_restore for Postgres "16.1" at "/usr/bin/pg_restore"
+   14:28:51 26 INFO   [TARGET] Restoring database into "postgres://pagila@target/pagila?keepalives=1&keepalives_idle=10&keepalives_interval=10&keepalives_count=60"
+   14:28:51 26 INFO   Drop tables on the target database, per --drop-if-exists
+   14:28:51 26 INFO   No tables to migrate, skipping drop tables on the target database
+   14:28:51 26 INFO    /usr/bin/pg_restore --dbname 'postgres://pagila@target/pagila?keepalives=1&keepalives_idle=10&keepalives_interval=10&keepalives_count=60' --single-transaction --clean --
 
 
 Then copy the data over:
@@ -606,26 +609,26 @@ Then copy the data over:
 ::
 
    $ pgcopydb copy table-data --resume --not-consistent
-   15:24:36 75688 INFO  [SOURCE] Copying database from "port=54311 host=localhost dbname=pgloader"
-   15:24:36 75688 INFO  [TARGET] Copying database into "port=54311 dbname=plop"
-   15:24:36 75688 INFO  Removing the stale pid file "/tmp/pgcopydb/pgcopydb.pid"
-   15:24:36 75688 INFO  STEP 3: copy data from source to target in sub-processes
-   15:24:36 75688 INFO  Listing ordinary tables in "port=54311 host=localhost dbname=pgloader"
-   15:24:36 75688 INFO  Fetched information for 56 tables
+    14:28:52 30 INFO   Running pgcopydb version 0.13.38.g22e6544.dirty from "/usr/local/bin/pgcopydb"
+    14:28:52 30 INFO   [SOURCE] Copying database from "postgres://pagila@source/pagila?keepalives=1&keepalives_idle=10&keepalives_interval=10&keepalives_count=60"
+    14:28:52 30 INFO   [TARGET] Copying database into "postgres://pagila@target/pagila?keepalives=1&keepalives_idle=10&keepalives_interval=10&keepalives_count=60"
+    14:28:52 30 INFO   Schema dump for pre-data and post-data section have been done
+    14:28:52 30 INFO   Pre-data schema has been restored on the target instance
+    14:28:52 30 INFO   Copy data from source to target in sub-processes
    ...
-                                               Step   Connection    Duration    Transfer   Concurrency
- --------------------------------------------------   ----------  ----------  ----------  ------------
-                                        Dump Schema       source         0ms                         1
-   Catalog Queries (table ordering, filtering, etc)       source         0ms                         1
-                                     Prepare Schema       target         0ms                         1
-      COPY, INDEX, CONSTRAINTS, VACUUM (wall clock)         both         0ms                     4 + 4
-                                  COPY (cumulative)         both       1s140     2955 kB             4
-                         Large Objects (cumulative)         both         0ms                         1
-             CREATE INDEX, CONSTRAINTS (cumulative)       target         0ms                         4
-                                    Finalize Schema       target         0ms                         1
- --------------------------------------------------   ----------  ----------  ----------  ------------
-                          Total Wall Clock Duration         both       2s143                     4 + 4
- --------------------------------------------------   ----------  ----------  ----------  ------------
+                                                  Step   Connection    Duration    Transfer   Concurrency
+    --------------------------------------------------   ----------  ----------  ----------  ------------
+                                           Dump Schema       source         0ms                         1
+      Catalog Queries (table ordering, filtering, etc)       source         0ms                         1
+                                        Prepare Schema       target         0ms                         1
+         COPY, INDEX, CONSTRAINTS, VACUUM (wall clock)         both         0ms                     4 + 8
+                                     COPY (cumulative)         both       1s671     2955 kB             4
+                            Large Objects (cumulative)         both                                     4
+                CREATE INDEX, CONSTRAINTS (cumulative)       target         0ms                         4
+                                       Finalize Schema       target         0ms                         1
+    --------------------------------------------------   ----------  ----------  ----------  ------------
+                             Total Wall Clock Duration         both       753ms                     4 + 8
+    --------------------------------------------------   ----------  ----------  ----------  ------------
 
 
 And now create the indexes on the target database, using the index
@@ -634,49 +637,30 @@ definitions from the source database:
 ::
 
    $ pgcopydb copy indexes --resume --not-consistent
-   15:24:40 75918 INFO  [SOURCE] Copying database from "port=54311 host=localhost dbname=pgloader"
-   15:24:40 75918 INFO  [TARGET] Copying database into "port=54311 dbname=plop"
-   15:24:40 75918 INFO  Removing the stale pid file "/tmp/pgcopydb/pgcopydb.pid"
-   15:24:40 75918 INFO  STEP 4: create indexes in parallel
-   15:24:40 75918 INFO  Listing ordinary tables in "port=54311 host=localhost dbname=pgloader"
-   15:24:40 75918 INFO  Fetched information for 56 tables
-   15:24:40 75930 INFO  Creating 2 indexes for table "csv"."partial"
-   15:24:40 75922 INFO  Creating 1 index for table "csv"."track"
-   15:24:40 75931 INFO  Creating 1 index for table "err"."errors"
-   15:24:40 75928 INFO  Creating 1 index for table "csv"."blocks"
-   15:24:40 75925 INFO  Creating 1 index for table "public"."track_full"
-   15:24:40 76037 INFO  CREATE INDEX IF NOT EXISTS partial_b_idx ON csv.partial USING btree (b);
-   15:24:40 76036 INFO  CREATE UNIQUE INDEX IF NOT EXISTS track_pkey ON csv.track USING btree (trackid);
-   15:24:40 76035 INFO  CREATE UNIQUE INDEX IF NOT EXISTS partial_a_key ON csv.partial USING btree (a);
-   15:24:40 76038 INFO  CREATE UNIQUE INDEX IF NOT EXISTS errors_pkey ON err.errors USING btree (a);
-   15:24:40 75987 INFO  Creating 1 index for table "public"."xzero"
-   15:24:40 75969 INFO  Creating 1 index for table "public"."csv_escape_mode"
-   15:24:40 75985 INFO  Creating 1 index for table "public"."udc"
-   15:24:40 75965 INFO  Creating 1 index for table "public"."allcols"
-   15:24:40 75981 INFO  Creating 1 index for table "public"."serial"
-   15:24:40 76039 INFO  CREATE INDEX IF NOT EXISTS blocks_ip4r_idx ON csv.blocks USING gist (iprange);
-   15:24:40 76040 INFO  CREATE UNIQUE INDEX IF NOT EXISTS track_full_pkey ON public.track_full USING btree (trackid);
-   15:24:40 75975 INFO  Creating 1 index for table "public"."nullif"
-   15:24:40 76046 INFO  CREATE UNIQUE INDEX IF NOT EXISTS xzero_pkey ON public.xzero USING btree (a);
-   15:24:40 76048 INFO  CREATE UNIQUE INDEX IF NOT EXISTS udc_pkey ON public.udc USING btree (b);
-   15:24:40 76047 INFO  CREATE UNIQUE INDEX IF NOT EXISTS csv_escape_mode_pkey ON public.csv_escape_mode USING btree (id);
-   15:24:40 76049 INFO  CREATE UNIQUE INDEX IF NOT EXISTS allcols_pkey ON public.allcols USING btree (a);
-   15:24:40 76052 INFO  CREATE UNIQUE INDEX IF NOT EXISTS nullif_pkey ON public."nullif" USING btree (id);
-   15:24:40 76050 INFO  CREATE UNIQUE INDEX IF NOT EXISTS serial_pkey ON public.serial USING btree (a);
+   14:28:53 47 INFO   Running pgcopydb version 0.13.38.g22e6544.dirty from "/usr/local/bin/pgcopydb"
+   14:28:53 47 INFO   [SOURCE] Copying database from "postgres://pagila@source/pagila?keepalives=1&keepalives_idle=10&keepalives_interval=10&keepalives_count=60"
+   14:28:53 47 INFO   [TARGET] Copying database into "postgres://pagila@target/pagila?keepalives=1&keepalives_idle=10&keepalives_interval=10&keepalives_count=60"
+   14:28:53 47 INFO   Schema dump for pre-data and post-data section have been done
+   14:28:53 47 INFO   Pre-data schema has been restored on the target instance
+   14:28:53 47 INFO   All the table data has been copied to the target instance
+   14:28:53 47 INFO   All the indexes have been copied to the target instance
+   14:28:53 47 INFO   Fetched information for 54 indexes
+   14:28:53 47 INFO   Creating 54 indexes in the target database using 4 processes
 
-                                                 Step   Connection    Duration    Transfer   Concurrency
-   --------------------------------------------------   ----------  ----------  ----------  ------------
-                                          Dump Schema       source         0ms                         1
-     Catalog Queries (table ordering, filtering, etc)       source         0ms                         1
-                                       Prepare Schema       target         0ms                         1
-        COPY, INDEX, CONSTRAINTS, VACUUM (wall clock)         both         0ms                     4 + 4
-                                    COPY (cumulative)         both       619ms     2955 kB             4
-                           Large Objects (cumulative)         both         0ms                         1
-               CREATE INDEX, CONSTRAINTS (cumulative)       target       1s023                         4
-                                      Finalize Schema       target         0ms                         1
-   --------------------------------------------------   ----------  ----------  ----------  ------------
-                            Total Wall Clock Duration         both       400ms                     4 + 4
-   --------------------------------------------------   ----------  ----------  ----------  ------------
+                                                  Step   Connection    Duration    Transfer   Concurrency
+    --------------------------------------------------   ----------  ----------  ----------  ------------
+                                           Dump Schema       source         0ms                         1
+      Catalog Queries (table ordering, filtering, etc)       source         0ms                         1
+                                        Prepare Schema       target         0ms                         1
+         COPY, INDEX, CONSTRAINTS, VACUUM (wall clock)         both         0ms                     4 + 8
+                                     COPY (cumulative)         both         0ms         0 B             4
+                            Large Objects (cumulative)         both                                     4
+                CREATE INDEX, CONSTRAINTS (cumulative)       target         0ms                         4
+                                       Finalize Schema       target         0ms                         1
+    --------------------------------------------------   ----------  ----------  ----------  ------------
+                             Total Wall Clock Duration         both       696ms                     4 + 8
+    --------------------------------------------------   ----------  ----------  ----------  ------------
+
 
 Now re-create the constraints (primary key, unique constraints) from the
 source database schema into the target database:
@@ -684,36 +668,31 @@ source database schema into the target database:
 ::
 
    $ pgcopydb copy constraints --resume --not-consistent
-   15:24:43 76095 INFO  [SOURCE] Copying database from "port=54311 host=localhost dbname=pgloader"
-   15:24:43 76095 INFO  [TARGET] Copying database into "port=54311 dbname=plop"
-   15:24:43 76095 INFO  Removing the stale pid file "/tmp/pgcopydb/pgcopydb.pid"
-   15:24:43 76095 INFO  STEP 4: create constraints
-   15:24:43 76095 INFO  Listing ordinary tables in "port=54311 host=localhost dbname=pgloader"
-   15:24:43 76095 INFO  Fetched information for 56 tables
-   15:24:43 76099 INFO  ALTER TABLE "csv"."track" ADD CONSTRAINT "track_pkey" PRIMARY KEY USING INDEX "track_pkey";
-   15:24:43 76107 INFO  ALTER TABLE "csv"."partial" ADD CONSTRAINT "partial_a_key" UNIQUE USING INDEX "partial_a_key";
-   15:24:43 76102 INFO  ALTER TABLE "public"."track_full" ADD CONSTRAINT "track_full_pkey" PRIMARY KEY USING INDEX "track_full_pkey";
-   15:24:43 76142 INFO  ALTER TABLE "public"."allcols" ADD CONSTRAINT "allcols_pkey" PRIMARY KEY USING INDEX "allcols_pkey";
-   15:24:43 76157 INFO  ALTER TABLE "public"."serial" ADD CONSTRAINT "serial_pkey" PRIMARY KEY USING INDEX "serial_pkey";
-   15:24:43 76161 INFO  ALTER TABLE "public"."xzero" ADD CONSTRAINT "xzero_pkey" PRIMARY KEY USING INDEX "xzero_pkey";
-   15:24:43 76146 INFO  ALTER TABLE "public"."csv_escape_mode" ADD CONSTRAINT "csv_escape_mode_pkey" PRIMARY KEY USING INDEX "csv_escape_mode_pkey";
-   15:24:43 76154 INFO  ALTER TABLE "public"."nullif" ADD CONSTRAINT "nullif_pkey" PRIMARY KEY USING INDEX "nullif_pkey";
-   15:24:43 76159 INFO  ALTER TABLE "public"."udc" ADD CONSTRAINT "udc_pkey" PRIMARY KEY USING INDEX "udc_pkey";
-   15:24:43 76108 INFO  ALTER TABLE "err"."errors" ADD CONSTRAINT "errors_pkey" PRIMARY KEY USING INDEX "errors_pkey";
+   14:28:54 53 INFO   Running pgcopydb version 0.13.38.g22e6544.dirty from "/usr/local/bin/pgcopydb"
+   14:28:54 53 INFO   [SOURCE] Copying database from "postgres://pagila@source/pagila?keepalives=1&keepalives_idle=10&keepalives_interval=10&keepalives_count=60"
+   14:28:54 53 INFO   [TARGET] Copying database into "postgres://pagila@target/pagila?keepalives=1&keepalives_idle=10&keepalives_interval=10&keepalives_count=60"
+   14:28:54 53 INFO   Schema dump for pre-data and post-data section have been done
+   14:28:54 53 INFO   Pre-data schema has been restored on the target instance
+   14:28:54 53 INFO   All the table data has been copied to the target instance
+   14:28:54 53 INFO   All the indexes have been copied to the target instance
+   14:28:54 53 INFO   Create constraints
+   14:28:54 53 INFO   Fetched information for 54 indexes
+   14:28:54 53 INFO   Creating 54 indexes in the target database using 4 processes
 
-                                                 Step   Connection    Duration    Transfer   Concurrency
-   --------------------------------------------------   ----------  ----------  ----------  ------------
-                                          Dump Schema       source         0ms                         1
-     Catalog Queries (table ordering, filtering, etc)       source         0ms                         1
-                                       Prepare Schema       target         0ms                         1
-        COPY, INDEX, CONSTRAINTS, VACUUM (wall clock)         both         0ms                     4 + 4
-                                    COPY (cumulative)         both       605ms     2955 kB             4
-                           Large Objects (cumulative)         both         0ms                         1
-               CREATE INDEX, CONSTRAINTS (cumulative)       target       1s023                         4
-                                      Finalize Schema       target         0ms                         1
-   --------------------------------------------------   ----------  ----------  ----------  ------------
-                            Total Wall Clock Duration         both       415ms                     4 + 4
-   --------------------------------------------------   ----------  ----------  ----------  ------------
+                                                  Step   Connection    Duration    Transfer   Concurrency
+    --------------------------------------------------   ----------  ----------  ----------  ------------
+                                           Dump Schema       source         0ms                         1
+      Catalog Queries (table ordering, filtering, etc)       source         0ms                         1
+                                        Prepare Schema       target         0ms                         1
+         COPY, INDEX, CONSTRAINTS, VACUUM (wall clock)         both         0ms                     4 + 8
+                                     COPY (cumulative)         both         0ms         0 B             4
+                            Large Objects (cumulative)         both                                     4
+                CREATE INDEX, CONSTRAINTS (cumulative)       target         0ms                         4
+                                       Finalize Schema       target         0ms                         1
+    --------------------------------------------------   ----------  ----------  ----------  ------------
+                             Total Wall Clock Duration         both       283ms                     4 + 8
+    --------------------------------------------------   ----------  ----------  ----------  ------------
+
 
 The next step is a VACUUM ANALYZE on each table that's been just filled-in
 with the data, and for that we can just use the `vacuumdb`__ command from
@@ -724,15 +703,19 @@ __ https://www.postgresql.org/docs/current/app-vacuumdb.html
 ::
 
    $ vacuumdb --analyze --dbname "$PGCOPYDB_TARGET_PGURI" --jobs 4
-   vacuumdb: vacuuming database "plop"
+   vacuumdb: vacuuming database "pagila"
 
 Finally we can restore the post-data section of the schema:
 
 ::
 
    $ pgcopydb restore post-data --resume --not-consistent
-   15:24:50 76328 INFO  Removing the stale pid file "/tmp/pgcopydb/pgcopydb.pid"
-   15:24:50 76328 INFO  Restoring database from "/tmp/pgcopydb"
-   15:24:50 76328 INFO  Restoring database into "port=54311 dbname=plop"
-   15:24:50 76328 INFO  Using pg_restore for Postgres "12.9" at "/Applications/Postgres.app/Contents/Versions/12/bin/pg_restore"
-   15:24:50 76328 INFO   /Applications/Postgres.app/Contents/Versions/12/bin/pg_restore --dbname 'port=54311 dbname=plop' --use-list /tmp/pgcopydb/schema/post.list /tmp/pgcopydb/schema/post.dump
+   14:28:54 60 INFO   Running pgcopydb version 0.13.38.g22e6544.dirty from "/usr/local/bin/pgcopydb"
+   14:28:54 60 INFO   Schema dump for pre-data and post-data section have been done
+   14:28:54 60 INFO   Pre-data schema has been restored on the target instance
+   14:28:54 60 INFO   All the table data has been copied to the target instance
+   14:28:54 60 INFO   All the indexes have been copied to the target instance
+   14:28:54 60 INFO   Restoring database from existing files at "/tmp/pgcopydb"
+   14:28:54 60 INFO   Using pg_restore for Postgres "16.1" at "/usr/bin/pg_restore"
+   14:28:54 60 INFO   [TARGET] Restoring database into "postgres://pagila@target/pagila?keepalives=1&keepalives_idle=10&keepalives_interval=10&keepalives_count=60"
+   14:28:55 60 INFO    /usr/bin/pg_restore --dbname 'postgres://pagila@target/pagila?keepalives=1&keepalives_idle=10&keepalives_interval=10&keepalives_count=60' --single-transaction --use-list /tmp/pgcopydb/schema/post-filtered.list /tmp/pgcopydb/schema/post.dump

--- a/src/bin/pgcopydb/extensions.c
+++ b/src/bin/pgcopydb/extensions.c
@@ -168,8 +168,9 @@ copydb_copy_extensions(CopyDataSpec *copySpecs, bool createExtensions)
 
 				bool truncate = false;
 				PGSQL *src = &(copySpecs->sourceSnapshot.pgsql);
+				uint64_t bytesTransmitted = 0;
 
-				if (!pg_copy(src, &dst, sql, qname, truncate))
+				if (!pg_copy(src, &dst, sql, qname, truncate, &bytesTransmitted))
 				{
 					/* errors have already been logged */
 					return false;

--- a/src/bin/pgcopydb/pgsql.h
+++ b/src/bin/pgcopydb/pgsql.h
@@ -308,7 +308,8 @@ bool validate_connection_string(const char *connectionString);
 bool pgsql_truncate(PGSQL *pgsql, const char *qname);
 
 bool pg_copy(PGSQL *src, PGSQL *dst,
-			 const char *srcQname, const char *dstQname, bool truncate);
+			 const char *srcQname, const char *dstQname,
+			 bool truncate, uint64_t *bytesTransmitted);
 
 bool pg_copy_from_stdin(PGSQL *pgsql, const char *qname);
 bool pg_copy_row_from_stdin(PGSQL *pgsql, char *fmt, ...);

--- a/src/bin/pgcopydb/string_utils.c
+++ b/src/bin/pgcopydb/string_utils.c
@@ -645,7 +645,7 @@ processBufferCallback(const char *buffer, bool error)
 	for (lineNumber = 0; lineNumber < lineCount; lineNumber++)
 	{
 		if (strneq(outLines[lineNumber], ""))
-		{	
+		{
 			char *match = regexp_first_match(outLines[lineNumber], warningPattern);
 			int logLevel = match != NULL ? LOG_WARN : (error ? LOG_ERROR : LOG_INFO);
 			log_level(logLevel, "%s", outLines[lineNumber]);
@@ -683,10 +683,34 @@ pretty_print_bytes(char *buffer, size_t size, uint64_t bytes)
 	sformat(buffer, size, "%d %s", (int) count, suffixes[sIndex]);
 }
 
+/*
+ * pretty_print_bytes_per_second pretty prints bytes transmitted per second in
+ * a human readable form. Given 17179869184 it places the string
+ * "16 GBPS" in the given buffer.
+ */
+void
+pretty_print_bytes_per_second(char *buffer, size_t size, uint64_t bytes,
+							  uint64_t durationMs)
+{
+	/* avoid division by zero */
+	if (durationMs == 0)
+	{
+		sformat(buffer, size, "0 BPS");
+	}
+	else
+	{
+		char bytesPretty[BUFSIZE] = { 0 };
+		uint64_t bytesPerSecond = bytes * 1000 / durationMs;
+
+		pretty_print_bytes(bytesPretty, size-2, bytesPerSecond);
+		sformat(buffer, size, "%sPS", bytesPretty);
+	}
+}
+
 
 /*
  * pretty_print_bytes pretty prints bytes in a human readable form. Given
- * 17179869184 it places the string "16 GB" in the given buffer.
+ * 17179869184 it places the string "17 billion" in the given buffer.
  */
 void
 pretty_print_count(char *buffer, size_t size, uint64_t number)

--- a/src/bin/pgcopydb/string_utils.c
+++ b/src/bin/pgcopydb/string_utils.c
@@ -689,7 +689,7 @@ pretty_print_bytes(char *buffer, size_t size, uint64_t bytes)
  * "17 GB/s" in the given buffer.
  *
  * Unlike pretty_print_bytes function that uses powers of 2, this function uses
- * powers of 10. So 1 GB/s is 1,000,000,000 bytes per second.
+ * powers of 10. So 1 GBit/s is 1,000,000,000 bits per second.
  */
 void
 pretty_print_bytes_per_second(char *buffer, size_t size, uint64_t bytes,
@@ -703,17 +703,17 @@ pretty_print_bytes_per_second(char *buffer, size_t size, uint64_t bytes,
 	}
 
 	const char *suffixes[7] = {
-		"B/s",                    /* Bytes per second */
-		"kB/s",                   /* Kilobytes per second */
-		"MB/s",                   /* Megabytes per second */
-		"GB/s",                   /* Gigabytes per second */
-		"TB/s",                   /* Terabytes per second */
-		"PB/s",                   /* Petabytes per second */
-		"EB/s"                    /* Exabytes per second */
+		"Bit/s",                    /* Bits per second */
+		"kBit/s",                   /* Kilobits per second */
+		"MBit/s",                   /* Megabits per second */
+		"GBit/s",                   /* Gigabits per second */
+		"TBit/s",                   /* Terabits per second */
+		"PBit/s",                   /* Petabits per second */
+		"EBit/s"                    /* Exabits per second */
 	};
 
 	uint sIndex = 0;
-	long double count = ((long double) bytes) / durationMs * 1000;
+	long double count = ((long double) bytes) * 1000 * 8 / durationMs ;
 
 	while (count >= 10000 && sIndex < 7)
 	{

--- a/src/bin/pgcopydb/string_utils.h
+++ b/src/bin/pgcopydb/string_utils.h
@@ -49,6 +49,8 @@ int splitLines(char *buffer, char **linesArray, int size);
 void processBufferCallback(const char *buffer, bool error);
 
 void pretty_print_bytes(char *buffer, size_t size, uint64_t bytes);
+void pretty_print_bytes_per_second(char *buffer, size_t size, uint64_t bytes,
+								   uint64_t durationMs);
 void pretty_print_count(char *buffer, size_t size, uint64_t count);
 
 #endif /* STRING_UTILS_h */

--- a/src/bin/pgcopydb/summary.h
+++ b/src/bin/pgcopydb/summary.h
@@ -32,6 +32,7 @@ typedef struct CopyTableSummary
 	uint64_t durationMs;        /* instr_time duration in milliseconds */
 	instr_time startTimeInstr;  /* internal instr_time tracker */
 	instr_time durationInstr;   /* internal instr_time tracker */
+	uint64_t bytesTransmitted;  /* total number of bytes copied */
 	char *command;              /* malloc'ed area */
 } CopyTableSummary;
 
@@ -74,6 +75,7 @@ typedef struct SummaryTableHeaders
 	int maxNspnameSize;
 	int maxRelnameSize;
 	int maxTableMsSize;
+	int maxBytesSize;
 	int maxIndexCountSize;
 	int maxIndexMsSize;
 
@@ -81,6 +83,7 @@ typedef struct SummaryTableHeaders
 	char nspnameSeparator[NAMEDATALEN];
 	char relnameSeparator[NAMEDATALEN];
 	char tableMsSeparator[NAMEDATALEN];
+	char bytesSeparator[NAMEDATALEN];
 	char indexCountSeparator[NAMEDATALEN];
 	char indexMsSeparator[NAMEDATALEN];
 } SummaryTableHeaders;
@@ -112,6 +115,9 @@ typedef struct SummaryTableEntry
 	char nspname[PG_NAMEDATALEN];
 	char relname[PG_NAMEDATALEN];
 	char tableMs[INTERVAL_MAXLEN];
+	uint64_t bytes;
+	char bytesStr[INTSTRING_MAX_DIGITS];
+	char transmitRate[INTSTRING_MAX_DIGITS];
 	char indexCount[INTSTRING_MAX_DIGITS];
 	char indexMs[INTERVAL_MAXLEN];
 	uint64_t durationTableMs;
@@ -124,7 +130,9 @@ typedef struct SummaryTable
 {
 	int count;
 	SummaryTableHeaders headers;
-	SummaryTableEntry *array;   /* malloc'ed area */
+	uint64_t totalBytes;
+	char totalBytesStr[INTSTRING_MAX_DIGITS];
+	SummaryTableEntry *array;   /* calloc'ed area */
 } SummaryTable;
 
 

--- a/src/bin/pgcopydb/table-data.c
+++ b/src/bin/pgcopydb/table-data.c
@@ -1109,7 +1109,8 @@ copydb_copy_table(CopyDataSpec *specs, CopyTableDataSpec *tableSpecs)
 		++attempts;
 
 		/* ignore previous attempts, we need only one success here */
-		success = pg_copy(src, &dst, copySrc->data, copyDst->data, truncate);
+		success = pg_copy(src, &dst, copySrc->data, copyDst->data, truncate,
+						  &(summary->bytesTransmitted));
 
 		if (success)
 		{


### PR DESCRIPTION
This patch allows reporting the total number of bytes transferred during
a copy operation. However, it has a limitation that the reported value
is only updated after each table is copied. This is because we do not
update table summary files while the copy is in progress.

Changes include:
- 3 new fields in table summary structures:
  - network.bytes: total number of bytes transmitted
  - network.bytes-pretty: pretty printed form of network.bytes
  - network.transmit-rate: pretty printed bytes transmitted per second
- Some new fields on the `pgcopydb list progress --json --summary`
  command:
  - steps[].network is a new field that exists for COPY step and has
    the following fields:
	- bytes: total number of bytes transmitted for all tables
	- bytes-pretty: pretty printed form of bytes
  - tables[].network is a new json value with the following fields:
	- bytes: total number of bytes transmitted for table
	- bytes-pretty: pretty printed form of bytes
	- transmit-rate: pretty printed bytes transmitted per second
- A new column on top level summary that shows total number of bytes
  copied.