### PR TITLE
Buffer transaction statements to disk to prevent replay deadlock

### DIFF
--- a/src/bin/pgcopydb/copydb.c
+++ b/src/bin/pgcopydb/copydb.c
@@ -572,6 +572,10 @@ copydb_prepare_filepaths(CopyFilePaths *cfPaths,
 			"%s/lsn.json",
 			cfPaths->cdc.dir);
 
+	sformat(cfPaths->cdc.txnlatestfile, MAXPGPATH,
+			"%s/txn.latest.sql",
+			cfPaths->cdc.dir);
+
 	/*
 	 * Now prepare the "compare" files we need to compare schema and data
 	 * between the source and target instance.

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -26,6 +26,7 @@
 	{ "extra_float_digits", "3" }, \
 	{ "statement_timeout", "0" }, \
 	{ "default_transaction_read_only", "off" }
+
 /*
  * These parameters are added to the connection strings, unless the user has
  * added them, allowing user-defined values to be taken into account.

--- a/src/bin/pgcopydb/copydb_paths.h
+++ b/src/bin/pgcopydb/copydb_paths.h
@@ -54,6 +54,7 @@ typedef struct CDCPaths
 	char tlifile[MAXPGPATH];          /* /tmp/pgcopydb/cdc/tli */
 	char tlihistfile[MAXPGPATH];      /* /tmp/pgcopydb/cdc/tli.history */
 	char lsntrackingfile[MAXPGPATH];  /* /tmp/pgcopydb/cdc/lsn.json */
+	char txnlatestfile[MAXPGPATH];    /* /tmp/pgcopydb/cdc/txn.latest.sql */
 } CDCPaths;
 
 

--- a/src/bin/pgcopydb/ld_transform.c
+++ b/src/bin/pgcopydb/ld_transform.c
@@ -360,6 +360,18 @@ stream_transform_write_message(StreamContext *privateContext,
 		txn->commit = true;
 	}
 
+	/*
+	 * If we're in a continued transaction, it means that the earlier write
+	 * of this txn's BEGIN statement didn't have the COMMIT LSN. Therefore,
+	 * we need to maintain that LSN as a separate metadata file. This is
+	 * necessary because the COMMIT LSN is required later in the apply
+	 * process.
+	 */
+	if (txn->continued && txn->commit)
+	{
+		writeTxnMetadataFile(txn, privateContext->paths.dir);
+	}
+
 	/* now write the transaction out */
 	if (privateContext->out != NULL)
 	{
@@ -375,18 +387,6 @@ stream_transform_write_message(StreamContext *privateContext,
 	{
 		/* errors have already been logged */
 		return false;
-	}
-
-	/*
-	 * If we're in a continued transaction, it means that the earlier write
-	 * of this txn's BEGIN statement didn't have the COMMIT LSN. Therefore,
-	 * we need to maintain that LSN as a separate metadata file. This is
-	 * necessary because the COMMIT LSN is required later in the apply
-	 * process.
-	 */
-	if (txn->continued && txn->commit)
-	{
-		writeTxnMetadataFile(txn, privateContext->paths.dir);
 	}
 
 	(void) FreeLogicalMessage(currentMsg);


### PR DESCRIPTION
This commit buffers transactions being replayed into a separate file until
the entire transaction body is received. It addresses potential deadlocks
that can occur when the BEGIN message arrives before the creation of the
transaction metadata file by the transform process.

Signed-off-by: Arunprasad Rajkumar <ar.arunprasad@gmail.com>