### PR TITLE
Update pgcopydb sentinel in the main follow process.

### DIFF
--- a/src/bin/pgcopydb/file_utils.c
+++ b/src/bin/pgcopydb/file_utils.c
@@ -449,8 +449,13 @@ read_from_stream(FILE *stream, ReadFromStreamContext *context)
 		{
 			if (errno == EINTR || errno == EAGAIN)
 			{
-				if (asked_to_stop || asked_to_stop_fast || asked_to_quit)
+				if (asked_to_quit)
 				{
+					/*
+					 * When asked_to_stop || asked_to_stop_fast still continue
+					 * reading through EOF on the input stream, then quit
+					 * normally. Here when
+					 */
 					doneReading = true;
 				}
 
@@ -472,7 +477,7 @@ read_from_stream(FILE *stream, ReadFromStreamContext *context)
 		 */
 		if (countFdsReadyToRead == 0)
 		{
-			if (asked_to_stop || asked_to_stop_fast || asked_to_quit)
+			if (asked_to_quit)
 			{
 				doneReading = true;
 				log_notice("read_from_stream was asked to stop or quit");

--- a/src/bin/pgcopydb/ld_apply.c
+++ b/src/bin/pgcopydb/ld_apply.c
@@ -830,7 +830,8 @@ stream_apply_sql(StreamApplyContext *context,
 													 lsn,
 													 metadata->timestamp))
 			{
-				/* errors have already been logged */
+				log_error("Failed to setup apply transaction, "
+						  "see above for details");
 				return false;
 			}
 
@@ -1750,8 +1751,8 @@ stream_apply_read_lsn_tracking(StreamApplyContext *context)
 	/* it's okay if the file does not exists, just skip the operation */
 	if (!file_exists(filename))
 	{
-		log_warn("Failed to parse JSON file \"%s\": file does not exists",
-				 filename);
+		log_notice("Failed to parse JSON file \"%s\": file does not exists",
+				   filename);
 		return true;
 	}
 

--- a/src/bin/pgcopydb/ld_stream.h
+++ b/src/bin/pgcopydb/ld_stream.h
@@ -691,7 +691,9 @@ bool follow_setup_databases(CopyDataSpec *copySpecs, StreamSpecs *streamSpecs);
 bool follow_reset_sequences(CopyDataSpec *copySpecs, StreamSpecs *streamSpecs);
 
 bool follow_init_sentinel(StreamSpecs *specs, CopyDBSentinel *sentinel);
-bool follow_get_sentinel(StreamSpecs *specs, CopyDBSentinel *sentinel);
+bool follow_get_sentinel(StreamSpecs *specs,
+						 CopyDBSentinel *sentinel,
+						 bool verbose);
 bool follow_main_loop(CopyDataSpec *copySpecs, StreamSpecs *streamSpecs);
 
 bool followDB(CopyDataSpec *copySpecs, StreamSpecs *streamSpecs);


### PR DESCRIPTION
To avoid infinite looping when endpos has been reached it's important to update our endpos value to the sentinel's one even in the main follow process.

In passing, review some error messages.

Also refrain from stopping early from reading data from a PIPE when a terminating signal is received, we should finish reading as per the comments in the code.