### PR TITLE
fix password handling in safeURI

### DIFF
--- a/src/bin/pgcopydb/defaults.h
+++ b/src/bin/pgcopydb/defaults.h
@@ -58,9 +58,6 @@
 
 #define POSTGRES_PORT 5432
 
-/* masqurade  passwords with that value in logs */
-#define PASSWORD_MASK "****"
-
 /* default replication slot and origin for logical replication */
 #define REPLICATION_ORIGIN "pgcopydb"
 #define REPLICATION_PLUGIN "test_decoding"

--- a/src/bin/pgcopydb/parsing_utils.c
+++ b/src/bin/pgcopydb/parsing_utils.c
@@ -936,9 +936,9 @@ escapeWithPercentEncoding(const char *str, char **dst)
 
 
 /*
- * uri_contains_password takes a Postgres connection string and checks to see
- * if it contains a parameter called password. Returns true if a password
- * keyword is present in the connection string.
+ * uri_grab_password takes a Postgres connection string and checks to see
+ * if it contains a parameter called password and if so stores a copy of it
+ * in safeURI->password.
  */
 static bool
 uri_grab_password(const char *pguri, SafeURI *safeURI)
@@ -984,8 +984,8 @@ uri_grab_password(const char *pguri, SafeURI *safeURI)
 
 /*
  * parse_and_scrub_connection_string takes a Postgres connection string and
- * populates scrubbedPguri with the password replaced with **** for logging.
- * The scrubbedPguri parameter should point to a memory area that has been
+ * populates safeURI without the password for logging purposes.
+ * The safeURI parameter should point to a memory area that has been
  * allocated by the caller and has at least MAXCONNINFO bytes.
  */
 bool

--- a/src/bin/pgcopydb/pgcmd.c
+++ b/src/bin/pgcopydb/pgcmd.c
@@ -793,7 +793,7 @@ pg_restore_db(PostgresPaths *pgPaths,
 	setenv("PGCONNECT_TIMEOUT", POSTGRES_CONNECT_TIMEOUT, 1);
 
 	/* override PGPASSWORD environment variable if the pguri contains one */
-	if (connStrings->safeSourcePGURI.password != NULL)
+	if (connStrings->safeTargetPGURI.password != NULL)
 	{
 		if (pgpassword_found_in_env && !get_env_dup("PGPASSWORD", &PGPASSWORD))
 		{
@@ -892,7 +892,7 @@ pg_restore_db(PostgresPaths *pgPaths,
 
 	/* make sure to reset the environment PGPASSWORD if we edited it */
 	if (pgpassword_found_in_env &&
-		connStrings->safeSourcePGURI.password != NULL)
+		connStrings->safeTargetPGURI.password != NULL)
 	{
 		setenv("PGPASSWORD", PGPASSWORD, 1);
 	}

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -516,9 +516,16 @@ pgsql_open_connection(PGSQL *pgsql)
 		setenv("PGAPPNAME", PGCOPYDB_PGAPPNAME, 1);
 	}
 
-	/* use the parsed password, unless the environment already is set */
-	if (!env_exists("PGPASSWORD") && pgsql->safeURI.password != NULL)
+	char *PGPASSWORD = NULL;
+	bool pgpassword_found_in_env = env_exists("PGPASSWORD");
+
+	/* override PGPASSWORD environment variable if the pguri contains one */
+	if (pgsql->safeURI.password != NULL)
 	{
+		if (pgpassword_found_in_env)
+		{
+			get_env_dup("PGPASSWORD", &PGPASSWORD);
+		}
 		setenv("PGPASSWORD", pgsql->safeURI.password, 1);
 	}
 
@@ -531,6 +538,12 @@ pgsql_open_connection(PGSQL *pgsql)
 
 	/* Make a connection to the database */
 	pgsql->connection = PQconnectdb(pgsql->safeURI.pguri);
+
+	/* make sure to reset the environment PGPASSWORD if we edited it */
+	if (pgpassword_found_in_env && pgsql->safeURI.password != NULL)
+	{
+		setenv("PGPASSWORD", PGPASSWORD, 1);
+	}
 
 	/* Check to see that the backend connection was successfully made */
 	if (PQstatus(pgsql->connection) != CONNECTION_OK)


### PR DESCRIPTION
when the passwords of source and target differ it will always fail on the first connection attempt because it tries to log in with the password for the other DB:

reproducible test case:
```
$ git switch main && make -s bin
Already on 'main'
Your branch is up to date with 'origin/main'.
$ env|grep PGCOPYDB_
PGCOPYDB_SOURCE_PGURI=postgres://testuser1:testPassword@localhost/testdb1
PGCOPYDB_TARGET_PGURI=postgres://testuser2:testPassword@localhost/testdb2
$ ./src/bin/pgcopydb/pgcopydb clone --restart |& grep connect
$ psql -e postgres://postgres@localhost --command="ALTER ROLE testuser2 PASSWORD 'a_different_password';"
ALTER ROLE testuser2 PASSWORD 'a_different_password';
ALTER ROLE
Time: 12.275 ms
$ export PGCOPYDB_TARGET_PGURI="postgres://testuser2:a_different_password@localhost/testdb2"
$ ./src/bin/pgcopydb/pgcopydb clone --restart |& grep connect
2023-10-31 16:21:24 2172643 WARN   pgsql.c:608               Failed to connect to "postgres://testuser2@localhost/testdb2?keepalives=1&keepalives_idle=10&keepalives_interval=10&keepalives_count=60", retrying until the server is ready
2023-10-31 16:21:24 2172643 INFO   pgsql.c:693               Successfully connected to "postgres://testuser2@localhost/testdb2?keepalives=1&keepalives_idle=10&keepalives_interval=10&keepalives_count=60" after 2 attempts in 88 ms.
2023-10-31 16:21:25 2172643 WARN   pgsql.c:608               Failed to connect to "postgres://testuser2@localhost/testdb2?keepalives=1&keepalives_idle=10&keepalives_interval=10&keepalives_count=60", retrying until the server is ready
2023-10-31 16:21:25 2172643 INFO   pgsql.c:693               Successfully connected to "postgres://testuser2@localhost/testdb2?keepalives=1&keepalives_idle=10&keepalives_interval=10&keepalives_count=60" after 2 attempts in 92 ms.
2023-10-31 16:21:25 2172662 WARN   pgsql.c:608               Failed to connect to "postgres://testuser2@localhost/testdb2?keepalives=1&keepalives_idle=10&keepalives_interval=10&keepalives_count=60", retrying until the server is ready
2023-10-31 16:21:25 2172662 INFO   pgsql.c:693               Successfully connected to "postgres://testuser2@localhost/testdb2?keepalives=1&keepalives_idle=10&keepalives_interval=10&keepalives_count=60" after 2 attempts in 102 ms.
$ git switch fix_different_passwords; make -s bin
Switched to branch 'fix_different_passwords'
Your branch is up to date with 'origin/fix_different_passwords'.
$ ./src/bin/pgcopydb/pgcopydb clone --restart |& grep connect
$ 
```

no output from grep = no issue, therefore this commit fixes the bug