### PR TITLE
fix decoding in transform subprocess when following

### DIFF
--- a/src/bin/pgcopydb/follow.c
+++ b/src/bin/pgcopydb/follow.c
@@ -267,9 +267,10 @@ follow_main_loop(CopyDataSpec *copySpecs, StreamSpecs *streamSpecs)
 	}
 
 	/*
-	 * Read the catalogs from the source table from on-file disk.
+	 * Read the catalogs from the source table from on-file disk if
+	 * the schema dump has been done already.
 	 */
-	if (!copydb_parse_schema_json_file(copySpecs))
+	if (copySpecs->dirState.schemaDumpIsDone && !copydb_parse_schema_json_file(copySpecs))
 	{
 		/* errors have already been logged */
 		return false;

--- a/src/bin/pgcopydb/follow.c
+++ b/src/bin/pgcopydb/follow.c
@@ -14,6 +14,7 @@
 #include "cli_root.h"
 #include "ld_stream.h"
 #include "log.h"
+#include "progress.h"
 #include "signals.h"
 
 
@@ -260,6 +261,15 @@ follow_main_loop(CopyDataSpec *copySpecs, StreamSpecs *streamSpecs)
 	 * connection.
 	 */
 	if (!stream_cleanup_context(streamSpecs))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/*
+	 * Read the catalogs from the source table from on-file disk.
+	 */
+	if (!copydb_parse_schema_json_file(copySpecs))
 	{
 		/* errors have already been logged */
 		return false;


### PR DESCRIPTION
without this change `pgcopydb follow` would fail with e.g.:
> Failed to parse decoding message for UPDATE on table "public"."tablename" which is not in our catalogs

I suspect this PR fixes issue #350

how I have successfully used it with this change:
```
$ pgcopydb snapshot --follow &
$ pgcopydb clone --no-owner --no-role-passwords --no-acl --no-comments --drop-if-exists --verbose
```

and then (while the `pgcopydb clone` is still running) I ran `pgcopydb follow` in a second shell so it would prefetch the changes