### PR TITLE
compare: implement --snapshot option for source database

### DIFF
--- a/docs/ref/pgcopydb_compare.rst
+++ b/docs/ref/pgcopydb_compare.rst
@@ -45,6 +45,7 @@ of tables, indexes, constraints and sequences there.
      --source         Postgres URI to the source database
      --target         Postgres URI to the target database
      --dir            Work directory to use
+     --snapshot       Use snapshot obtained with pg_export_snapshot on the source database
 
 
 .. _pgcopydb_compare_data:
@@ -92,13 +93,14 @@ Running such a query on a large table can take a lot of time.
      --target         Postgres URI to the target database
      --dir            Work directory to use
      --json           Format the output using JSON
+     --snapshot       Use snapshot obtained with pg_export_snapshot on the source database
 
 
 Options
 -------
 
-The following options are available to ``pgcopydb create`` and ``pgcopydb
-drop`` subcommands:
+The following options are available to ``pgcopydb compare schema`` and ``pgcopydb
+compare data`` subcommands:
 
 --source
 
@@ -125,6 +127,11 @@ drop`` subcommands:
 
   The output of the command is formatted in JSON, when supported. Ignored
   otherwise.
+
+--snapshot
+
+  Instead of comparing the live data pgcopydb will use an already exported
+  snapshot on the source database for comparison.
 
 --verbose
 


### PR DESCRIPTION
to compare a source snapshot to the target

usecase: to check and make sure that data on source and target has not diverged when CDC has been ongoing for a while

1. pause the ongoing CDC
2. create new snapshot on source:
```
$ pgcopydb snapshot --follow --slot pgcopydbcompare --dir /tmp/pgcopydb-cmpsnap &
INFO   Created logical replication slot "pgcopydbcompare" with plugin "test_decoding" at 11/11111110 and exported snapshot 00000000-00000000-0
```
4. `pgcopydb follow --resume` with endpos set to the position the snapshot is at (e.g. 11/11111110)
5. wait until the target has been caught up to that position
6. now `pgcopydb compare --snapshot 00000000-00000000-0` can be used to compare