### PR TITLE
Use dynamically allocated QMessage for msgrcv.

### DIFF
--- a/src/bin/pgcopydb/blobs.c
+++ b/src/bin/pgcopydb/blobs.c
@@ -299,11 +299,11 @@ copydb_blob_worker(CopyDataSpec *specs)
 			{
 				stop = true;
 				log_debug("Stop message received by Large Objects worker");
-				free(mesg);
 
 				if (!pgsql_commit(&dst))
 				{
 					/* errors have already been logged */
+					free(mesg);
 					return false;
 				}
 
@@ -338,6 +338,8 @@ copydb_blob_worker(CopyDataSpec *specs)
 				break;
 			}
 		}
+
+		free(mesg);
 	}
 
 	/* terminate our connection to the source database now */

--- a/src/bin/pgcopydb/indexes.c
+++ b/src/bin/pgcopydb/indexes.c
@@ -92,22 +92,24 @@ copydb_index_worker(CopyDataSpec *specs)
 
 	while (!stop)
 	{
-		QMessage mesg = { 0 };
-		bool recv_ok = queue_receive(&(specs->indexQueue), &mesg);
+		QMessage *mesg = (QMessage *) calloc(1, sizeof(QMessage));
+		bool recv_ok = queue_receive(&(specs->indexQueue), mesg);
 
 		if (asked_to_stop || asked_to_stop_fast || asked_to_quit)
 		{
 			log_error("CREATE INDEX worker has been interrupted");
+			free(mesg);
 			return false;
 		}
 
 		if (!recv_ok)
 		{
 			/* errors have already been logged */
+			free(mesg);
 			return false;
 		}
 
-		switch (mesg.type)
+		switch (mesg->type)
 		{
 			case QMSG_TYPE_STOP:
 			{
@@ -118,16 +120,17 @@ copydb_index_worker(CopyDataSpec *specs)
 
 			case QMSG_TYPE_INDEXOID:
 			{
-				if (!copydb_create_index_by_oid(specs, mesg.data.oid))
+				if (!copydb_create_index_by_oid(specs, mesg->data.oid))
 				{
 					++errors;
 
 					log_error("Failed to create index with oid %u, "
 							  "see above for details",
-							  mesg.data.oid);
+							  mesg->data.oid);
 
 					if (specs->failFast)
 					{
+						free(mesg);
 						return false;
 					}
 				}
@@ -137,11 +140,12 @@ copydb_index_worker(CopyDataSpec *specs)
 			default:
 			{
 				log_error("Received unknown message type %ld on index queue %d",
-						  mesg.type,
+						  mesg->type,
 						  specs->indexQueue.qId);
 				break;
 			}
 		}
+		free(mesg);
 	}
 
 	bool success = (stop == true && errors == 0);

--- a/src/bin/pgcopydb/table-data.c
+++ b/src/bin/pgcopydb/table-data.c
@@ -486,8 +486,8 @@ copydb_table_data_worker(CopyDataSpec *specs)
 
 	while (true)
 	{
-		QMessage mesg = { 0 };
-		bool recv_ok = queue_receive(&(specs->copyQueue), &mesg);
+		QMessage *mesg = (QMessage *) calloc(1, sizeof(QMessage));
+		bool recv_ok = queue_receive(&(specs->copyQueue), mesg);
 
 		if (asked_to_stop || asked_to_stop_fast || asked_to_quit)
 		{
@@ -501,30 +501,32 @@ copydb_table_data_worker(CopyDataSpec *specs)
 			break;
 		}
 
-		switch (mesg.type)
+		switch (mesg->type)
 		{
 			case QMSG_TYPE_STOP:
 			{
 				log_debug("Stop message received by COPY worker");
 				(void) copydb_close_snapshot(specs);
+				free(mesg);
 				return true;
 			}
 
 			case QMSG_TYPE_TABLEPOID:
 			{
 				if (!copydb_copy_data_by_oid(specs,
-											 mesg.data.tp.oid,
-											 mesg.data.tp.part))
+											 mesg->data.tp.oid,
+											 mesg->data.tp.part))
 				{
 					log_error("Failed to copy data for table with oid %u "
 							  "and part number %u, see above for details",
-							  mesg.data.tp.oid,
-							  mesg.data.tp.part);
+							  mesg->data.tp.oid,
+							  mesg->data.tp.part);
 
 					++errors;
 
 					if (specs->failFast)
 					{
+						free(mesg);
 						return false;
 					}
 
@@ -534,6 +536,7 @@ copydb_table_data_worker(CopyDataSpec *specs)
 					if (!copydb_set_snapshot(specs))
 					{
 						/* errors have already been logged */
+						free(mesg);
 						return false;
 					}
 				}
@@ -543,11 +546,13 @@ copydb_table_data_worker(CopyDataSpec *specs)
 			default:
 			{
 				log_error("Received unknown message type %ld on table queue %d",
-						  mesg.type,
+						  mesg->type,
 						  specs->copyQueue.qId);
 				break;
 			}
 		}
+
+		free(mesg);
 	}
 
 	/* terminate our connection to the source database now */
@@ -1197,7 +1202,8 @@ copydb_prepare_copy_query(CopyTableDataSpec *tableSpecs,
 			{
 				appendPQExpBufferStr(query, ", ");
 			}
-			else {
+			else
+			{
 				isFirst = false;
 			}
 
@@ -1254,7 +1260,7 @@ copydb_prepare_copy_query(CopyTableDataSpec *tableSpecs,
 		appendPQExpBuffer(query, "%s", tableSpecs->sourceTable->qname);
 
 		for (int i = 0; i < table->attributes.count; i++)
-		{			
+		{
 			SourceTableAttribute *attribute = &(table->attributes.array[i]);
 			char *attname = attribute->attname;
 

--- a/src/bin/pgcopydb/vacuum.c
+++ b/src/bin/pgcopydb/vacuum.c
@@ -95,22 +95,24 @@ vacuum_worker(CopyDataSpec *specs)
 
 	while (!stop)
 	{
-		QMessage mesg = { 0 };
-		bool recv_ok = queue_receive(&(specs->vacuumQueue), &mesg);
+		QMessage *mesg = (QMessage *) calloc(1, sizeof(QMessage));
+		bool recv_ok = queue_receive(&(specs->vacuumQueue), mesg);
 
 		if (asked_to_stop || asked_to_stop_fast || asked_to_quit)
 		{
 			log_error("VACUUM worker has been interrupted");
+			free(mesg);
 			return false;
 		}
 
 		if (!recv_ok)
 		{
 			/* errors have already been logged */
+			free(mesg);
 			return false;
 		}
 
-		switch (mesg.type)
+		switch (mesg->type)
 		{
 			case QMSG_TYPE_STOP:
 			{
@@ -121,16 +123,17 @@ vacuum_worker(CopyDataSpec *specs)
 
 			case QMSG_TYPE_TABLEOID:
 			{
-				if (!vacuum_analyze_table_by_oid(specs, mesg.data.oid))
+				if (!vacuum_analyze_table_by_oid(specs, mesg->data.oid))
 				{
 					++errors;
 
 					log_error("Failed to vacuum table with oid %u, "
 							  "see above for details",
-							  mesg.data.oid);
+							  mesg->data.oid);
 
 					if (specs->failFast)
 					{
+						free(mesg);
 						return false;
 					}
 				}
@@ -140,11 +143,13 @@ vacuum_worker(CopyDataSpec *specs)
 			default:
 			{
 				log_error("Received unknown message type %ld on vacuum queue %d",
-						  mesg.type,
+						  mesg->type,
 						  specs->vacuumQueue.qId);
 				break;
 			}
 		}
+
+		free(mesg);
 	}
 
 	bool success = (stop == true && errors == 0);


### PR DESCRIPTION
Follow up of https://github.com/dimitri/pgcopydb/pull/533#pullrequestreview-1720295497. Context is sometimes msgrcv acts weird and corrupts the value of other stack allocated variables. Using heap allocated queue message as the workaround until its root cause is known.