### PR TITLE
Set GUCs in the connection for COPY to target.

### DIFF
--- a/src/bin/pgcopydb/table-data.c
+++ b/src/bin/pgcopydb/table-data.c
@@ -1013,6 +1013,14 @@ copydb_copy_table(CopyDataSpec *specs, CopyTableDataSpec *tableSpecs)
 		return false;
 	}
 
+	/* set GUC values for the target connection */
+	if (!pgsql_set_gucs(&dst, dstSettings))
+	{
+		log_fatal("Failed to set our GUC settings on the target connection, "
+				  "see above for details");
+		return false;
+	}
+
 	/* when using `pgcopydb copy table-data`, we don't truncate */
 	bool truncate = tableSpecs->section != DATA_SECTION_TABLE_DATA;
 
@@ -1197,7 +1205,8 @@ copydb_prepare_copy_query(CopyTableDataSpec *tableSpecs,
 			{
 				appendPQExpBufferStr(query, ", ");
 			}
-			else {
+			else
+			{
 				isFirst = false;
 			}
 
@@ -1254,7 +1263,7 @@ copydb_prepare_copy_query(CopyTableDataSpec *tableSpecs,
 		appendPQExpBuffer(query, "%s", tableSpecs->sourceTable->qname);
 
 		for (int i = 0; i < table->attributes.count; i++)
-		{			
+		{
 			SourceTableAttribute *attribute = &(table->attributes.array[i]);
 			char *attname = attribute->attname;
 


### PR DESCRIPTION
If `statement_timeout` is set on the target COPY may get interrupted, hence this change.