### PR TITLE
Use same connection in table copy worker.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,5 +7,7 @@ docs/_build
 **/*.so*
 **/.deps/
 
+/Debug/
+
 # ignore the git version number in release builds
 src/bin/pgcopydb/git-version.h

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -26,6 +26,7 @@
 	{ "extra_float_digits", "3" }, \
 	{ "statement_timeout", "0" }, \
 	{ "default_transaction_read_only", "off" }
+
 /*
  * These parameters are added to the connection strings, unless the user has
  * added them, allowing user-defined values to be taken into account.
@@ -498,13 +499,15 @@ bool copydb_start_table_data_workers(CopyDataSpec *specs);
 bool copydb_table_data_worker(CopyDataSpec *specs);
 
 bool copydb_add_copy(CopyDataSpec *specs, uint32_t oid, uint32_t part);
-bool copydb_copy_data_by_oid(CopyDataSpec *specs, uint32_t oid, uint32_t part);
+bool copydb_copy_data_by_oid(CopyDataSpec *specs, PGSQL *src,
+							 PGSQL *dst, uint32_t oid, uint32_t part);
 
 bool copydb_process_table_data_worker(CopyDataSpec *specs);
 
 bool copydb_process_table_data_with_workers(CopyDataSpec *specs);
 
-bool copydb_copy_table(CopyDataSpec *specs, CopyTableDataSpec *tableSpecs);
+bool copydb_copy_table(CopyDataSpec *specs, PGSQL *src, PGSQL *dst,
+					   CopyTableDataSpec *tableSpecs);
 
 
 bool copydb_table_create_lockfile(CopyDataSpec *specs,

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -52,7 +52,9 @@ static bool build_parameters_list(PQExpBuffer buffer,
 
 static void parseIdentifySystemResult(void *ctx, PGresult *result);
 static void parseTimelineHistoryResult(void *ctx, PGresult *result);
-
+static bool pg_copy_data(PGSQL *src, PGSQL *dst, const char *srcQname,
+						 const char *dstQname, bool truncate,
+						 uint64_t *bytesTransmitted);
 static bool pg_copy_send_query(PGSQL *pgsql,
 							   const char *qname,
 							   ExecStatusType status,
@@ -2254,16 +2256,13 @@ pg_copy(PGSQL *src, PGSQL *dst, const char *srcQname, const char *dstQname,
 		bool truncate, uint64_t *bytesTransmitted)
 {
 	bool srcConnIsOurs = src->connection == NULL;
-	PGconn *srcConn = pgsql_open_connection(src);
-
-	if (srcConn == NULL)
+	if (!pgsql_open_connection(src))
 	{
 		return false;
 	}
 
-	PGconn *dstConn = pgsql_open_connection(dst);
-
-	if (dstConn == NULL)
+	bool dstConnIsOurs = dst->connection == NULL;
+	if (!pgsql_open_connection(dst))
 	{
 		/* errors have already been logged */
 		if (srcConnIsOurs)
@@ -2272,14 +2271,38 @@ pg_copy(PGSQL *src, PGSQL *dst, const char *srcQname, const char *dstQname,
 		}
 		return false;
 	}
+
+	bool result = pg_copy_data(src, dst, srcQname, dstQname,
+							   truncate, bytesTransmitted);
+
+	if (srcConnIsOurs)
+	{
+		pgsql_finish(src);
+	}
+
+	if (dstConnIsOurs)
+	{
+		pgsql_finish(dst);
+	}
+
+	return result;
+}
+
+
+/*
+ * pg_copy_data implements the core of pg_copy. That is, COPY operation from a
+ * source Postgres instance (src) to a target Postgres instance (dst). It
+ * expects src and dst are opened connection and doesn't manage their lifetime.
+ */
+static bool
+pg_copy_data(PGSQL *src, PGSQL *dst, const char *srcQname, const char *dstQname,
+			 bool truncate, uint64_t *bytesTransmitted)
+{
+	PGconn *srcConn = src->connection;
+	PGconn *dstConn = dst->connection;
 
 	if (!pgsql_begin(dst))
 	{
-		/* errors have already been logged */
-		if (srcConnIsOurs)
-		{
-			pgsql_finish(src);
-		}
 		return false;
 	}
 
@@ -2288,13 +2311,6 @@ pg_copy(PGSQL *src, PGSQL *dst, const char *srcQname, const char *dstQname,
 	{
 		if (!pgsql_truncate(dst, dstQname))
 		{
-			/* errors have already been logged */
-			if (srcConnIsOurs)
-			{
-				pgsql_finish(src);
-			}
-			pgsql_finish(dst);
-
 			return false;
 		}
 	}
@@ -2302,24 +2318,12 @@ pg_copy(PGSQL *src, PGSQL *dst, const char *srcQname, const char *dstQname,
 	/* SRC: COPY schema.table TO STDOUT */
 	if (!pg_copy_send_query(src, srcQname, PGRES_COPY_OUT, false))
 	{
-		if (srcConnIsOurs)
-		{
-			pgsql_finish(src);
-		}
-		pgsql_finish(dst);
-
 		return false;
 	}
 
 	/* DST: COPY schema.table FROM STDIN WITH (FREEZE) */
 	if (!pg_copy_send_query(dst, dstQname, PGRES_COPY_IN, truncate))
 	{
-		if (srcConnIsOurs)
-		{
-			pgsql_finish(src);
-		}
-		pgsql_finish(dst);
-
 		return false;
 	}
 
@@ -2335,13 +2339,6 @@ pg_copy(PGSQL *src, PGSQL *dst, const char *srcQname, const char *dstQname,
 		if (asked_to_quit || asked_to_stop || asked_to_stop_fast)
 		{
 			log_debug("COPY was asked to stop");
-
-			if (srcConnIsOurs)
-			{
-				pgsql_finish(src);
-			}
-			(void) pgsql_finish(dst);
-
 			return false;
 		}
 
@@ -2376,11 +2373,6 @@ pg_copy(PGSQL *src, PGSQL *dst, const char *srcQname, const char *dstQname,
 
 			/* we're done here */
 			clear_results(src);
-
-			if (srcConnIsOurs)
-			{
-				pgsql_finish(src);
-			}
 
 			/* make sure to pass through and send this last COPY buffer */
 		}
@@ -2466,11 +2458,6 @@ pg_copy(PGSQL *src, PGSQL *dst, const char *srcQname, const char *dstQname,
 
 				clear_results(src);
 
-				if (srcConnIsOurs)
-				{
-					pgsql_finish(src);
-				}
-
 				break;
 			}
 		}
@@ -2509,15 +2496,12 @@ pg_copy(PGSQL *src, PGSQL *dst, const char *srcQname, const char *dstQname,
 
 		if (!failedOnDst)
 		{
-			if (!pgsql_commit(dst))
+			if (!pgsql_execute(dst, "COMMIT"))
 			{
 				failedOnDst = true;
 			}
 		}
 	}
-
-	/* always close the target connection, that we opened in this function */
-	(void) pgsql_finish(dst);
 
 	return !failedOnSrc && !failedOnDst;
 }


### PR DESCRIPTION
Currently for each table we are creating and closing a new connection to
the target. Using a same connection would save us some time and resource,
both at pgcopydb and target side.

Also, seting GUCs only once for a given target connection session would
again save us resources. This would also reduce 8 extra log lines that are
currently produced for each table which otherwise would produce noise if we
have say, 10K tables.

Follow-up: Use the same connection for `INDEX` worker where same connection is even more useful.