### PR TITLE
Fix some copy paste errors

### DIFF
--- a/src/bin/pgcopydb/cli_clone_follow.c
+++ b/src/bin/pgcopydb/cli_clone_follow.c
@@ -1,5 +1,5 @@
 /*
- * src/bin/pgcopydb/cli_copy.c
+ * src/bin/pgcopydb/cli_clone_follow.c
  *     Implementation of a CLI which lets you run individual routines
  *     directly
  */

--- a/src/bin/pgcopydb/cli_ping.c
+++ b/src/bin/pgcopydb/cli_ping.c
@@ -224,7 +224,7 @@ cli_ping(int argc, char **argv)
 
 			if (!pgsql_set_gucs(&src, settings))
 			{
-				log_fatal("Failed to set our GUC settings on the target connection, "
+				log_fatal("Failed to set our GUC settings on the source connection, "
 						  "see above for details");
 				pgsql_finish(&src);
 				exit(EXIT_CODE_TARGET);


### PR DESCRIPTION
This is a small PR that aims to fix 2 small issues in the codebase.
1. A comment that has a wrong file name. Possibly a copy paste error.
2. A fatal log message that can misguide users into thinking that connections to target nodes have a problem where as the problem lies in setting some GUCs in connections to source postgres nodes.