### PR TITLE
Rollback incomplete txns on graceful exit

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -34,6 +34,7 @@ jobs:
           - follow-wal2json
           - follow-9.6
           - follow-data-only
+          - endpos-in-multi-wal-txn
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/src/bin/pgcopydb/ld_stream.c
+++ b/src/bin/pgcopydb/ld_stream.c
@@ -338,14 +338,12 @@ stream_init_context(StreamSpecs *specs)
 
 	privateContext->endpos = specs->endpos;
 	privateContext->startpos = specs->startpos;
-	privateContext->startposActionFromJSON = specs->startposActionFromJSON;
 
 	privateContext->mode = specs->mode;
 
 	privateContext->transformQueue = &(specs->transformQueue);
 
 	privateContext->paths = specs->paths;
-	privateContext->startpos = specs->startpos;
 
 	privateContext->connStrings = specs->connStrings;
 
@@ -378,20 +376,6 @@ stream_init_context(StreamSpecs *specs)
 	privateContext->previous.action = STREAM_ACTION_UNKNOWN;
 
 	privateContext->lastWriteTime = 0;
-
-	if (specs->startposComputedFromJSON &&
-		(specs->startposActionFromJSON == STREAM_ACTION_BEGIN ||
-		 specs->startposActionFromJSON == STREAM_ACTION_INSERT ||
-		 specs->startposActionFromJSON == STREAM_ACTION_UPDATE ||
-		 specs->startposActionFromJSON == STREAM_ACTION_DELETE ||
-		 specs->startposActionFromJSON == STREAM_ACTION_TRUNCATE))
-	{
-		privateContext->reachedStartPos = false;
-	}
-	else
-	{
-		privateContext->reachedStartPos = true;
-	}
 
 	/*
 	 * Initializing maxWrittenLSN as startpos at the beginning of migration or
@@ -660,45 +644,14 @@ streamCheckResumePosition(StreamSpecs *specs)
 		LogicalMessageMetadata *messages = latestStreamedContent.messages;
 		LogicalMessageMetadata *latest = &(messages[lastLineNb]);
 
-		/*
-		 * We could have several messages following each-other with the same
-		 * LSN, typically a sequence like:
-		 *
-		 *  {"action":"I","xid":"492","lsn":"0/244BEE0", ...}
-		 *  {"action":"K","lsn":"0/244BEE0", ...}
-		 *  {"action":"E","lsn":"0/244BEE0"}
-		 *
-		 * In that case we want to remember the latest message action as being
-		 * INSERT rather than ENDPOS.
-		 */
-		int lineNb = lastLineNb;
-
-		for (; lineNb > 0; lineNb--)
-		{
-			LogicalMessageMetadata *previous = &(messages[lineNb]);
-
-			if (previous->lsn == latest->lsn)
-			{
-				latest = previous;
-			}
-			else
-			{
-				break;
-			}
-		}
-
 		specs->startpos = latest->lsn;
-		specs->startposComputedFromJSON = true;
-		specs->startposActionFromJSON = latest->action;
 
 		log_info("Resuming streaming at LSN %X/%X "
-				 "from first message with that LSN read in JSON file \"%s\", "
-				 "line %d",
+				 "from JSON file \"%s\" ",
 				 LSN_FORMAT_ARGS(specs->startpos),
-				 latestStreamedContent.filename,
-				 lineNb);
+				 latestStreamedContent.filename);
 
-		char *latestMessage = latestStreamedContent.lines[lineNb];
+		char *latestMessage = latestStreamedContent.lines[lastLineNb];
 		log_notice("Resume replication from latest message: %s", latestMessage);
 	}
 
@@ -898,6 +851,29 @@ stream_write_json(LogicalStreamContext *context, bool previous)
 
 	destroyPQExpBuffer(buffer);
 	free(metadata->jsonBuffer);
+
+	/*
+	 * Maintain the transaction progress based on the BEGIN and COMMIT messages
+	 * received from replication slot. We don't care about the other messages.
+	 */
+	if (metadata->action == STREAM_ACTION_BEGIN)
+	{
+		privateContext->transactionInProgress = true;
+	}
+	else if (metadata->action == STREAM_ACTION_COMMIT)
+	{
+		privateContext->transactionInProgress = false;
+	}
+	/*
+	 * We are not expecting STREAM_ACTION_ROLLBACK here. It's a custom
+	 * message we write directly to the "latest" file using
+	 * stream_write_internal_message to abort the last incomplete transaction.
+	 */
+	else if (metadata->action == STREAM_ACTION_ROLLBACK)
+	{
+		log_error("BUG: STREAM_ACTION_ROLLBACK is not expected here");
+		return false;
+	}
 
 	return true;
 }
@@ -1236,6 +1212,33 @@ streamCloseFile(LogicalStreamContext *context, bool time_to_abort)
 			return false;
 		}
 	}
+
+	/*
+	 * On graceful exit, ROLLBACK the last incomplete transaction.
+	 * As we resume from a consistent point, there's no concern about
+	 * the transaction being rolled back here.
+	 *
+	 * TODO: For process crashes (e.g., segmentation faults), this
+	 * method won't work, potentially leaving incomplete transactions.
+	 * To handle this, we should read the last message from the "latest"
+	 * file and rollback any incomplete transaction found.
+	 */
+	if (time_to_abort &&
+		privateContext->jsonFile != NULL &&
+		privateContext->transactionInProgress)
+	{
+		InternalMessage rollback = {
+			.action = STREAM_ACTION_ROLLBACK,
+			.lsn = context->cur_record_lsn
+		};
+
+		if (!stream_write_internal_message(context, &rollback))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+	}
+
 
 	/*
 	 * If we have a JSON file currently opened, then close it.
@@ -1606,40 +1609,6 @@ prepareMessageMetadataFromContext(LogicalStreamContext *context)
 	/* in case of filtering, early exit */
 	if (metadata->filterOut)
 	{
-		return true;
-	}
-
-	/*
-	 * When streaming resumed for a partially applied txn, have we reached a
-	 * message that wasn't flushed in the previous command?
-	 */
-	if (!privateContext->reachedStartPos)
-	{
-		/*
-		 * Also the same LSN might be assigned to a BEGIN message, a COMMIT
-		 * message, and a KEEPALIVE message. Avoid skipping what looks like the
-		 * same message as the latest flushed in our JSON file when it's
-		 * actually a new message.
-		 */
-		privateContext->reachedStartPos =
-			privateContext->startpos < metadata->lsn ||
-			(privateContext->startpos == metadata->lsn &&
-			 metadata->action != privateContext->startposActionFromJSON);
-	}
-
-	if (!privateContext->reachedStartPos)
-	{
-		metadata->filterOut = true;
-
-		log_debug("Skipping write for action %c for XID %u at LSN %X/%X: "
-				  "startpos %X/%X not been reached",
-				  metadata->action,
-				  metadata->xid,
-				  LSN_FORMAT_ARGS(metadata->lsn),
-				  LSN_FORMAT_ARGS(privateContext->startpos));
-
-		*previous = *metadata;
-
 		return true;
 	}
 
@@ -2206,6 +2175,11 @@ StreamActionFromChar(char action)
 			return STREAM_ACTION_ENDPOS;
 		}
 
+		case 'R':
+		{
+			return STREAM_ACTION_ROLLBACK;
+		}
+
 		default:
 		{
 			log_error("Failed to parse JSON message action: \"%c\"", action);
@@ -2279,6 +2253,11 @@ StreamActionToString(StreamAction action)
 		case STREAM_ACTION_ENDPOS:
 		{
 			return "ENDPOS";
+		}
+
+		case STREAM_ACTION_ROLLBACK:
+		{
+			return "ROLLBACK";
 		}
 
 		default:

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -4,7 +4,7 @@
 PGVERSION ?= 16
 BUILD_ARGS = --build-arg PGVERSION=$(PGVERSION)
 
-all: pagila pagila-multi-steps blobs unit filtering cdc follow extensions cdc-endpos-between-transaction;
+all: pagila pagila-multi-steps blobs unit filtering cdc follow extensions cdc-endpos-between-transaction endpos-in-multi-wal-txn;
 
 pagila: build
 	$(MAKE) -C $@
@@ -45,6 +45,9 @@ extensions: build
 follow-data-only: build
 	$(MAKE) -C $@
 
+endpos-in-multi-wal-txn: build
+	$(MAKE) -C $@
+
 build:
 	docker build $(BUILD_ARGS) -t pagila -f Dockerfile.pagila .
 
@@ -52,3 +55,4 @@ build:
 .PHONY: pagila pagila-multi-steps blobs unit filtering extensions
 .PHONY: cdc-wal2json cdc-test-decoding cdc-low-level
 .PHONY: follow-wal2json follow-9.6
+.PHONY: endpos-in-multi-wal-txn

--- a/tests/cdc-endpos-between-transaction/000000010000000000000002.json
+++ b/tests/cdc-endpos-between-transaction/000000010000000000000002.json
@@ -12,3 +12,4 @@
 {"action":"I","xid":"492","lsn":"0/244A978","timestamp":"2023-06-14 11:17:51.979475+0000","message":{"action":"I","xid":492,"schema":"public","table":"category","columns":[{"name":"category_id","type":"integer","value":1008},{"name":"name","type":"text","value":"Thriller"},{"name":"last_update","type":"timestamp with time zone","value":"2022-12-15 00:00:01+00"}]}}
 {"action":"K","lsn":"0/244A978","timestamp":"2023-06-14 11:17:51.979481+0000"}
 {"action":"E","lsn":"0/244A978"}
+{"action":"R","lsn":"0/244A978"}

--- a/tests/cdc-endpos-between-transaction/000000010000000000000002.sql
+++ b/tests/cdc-endpos-between-transaction/000000010000000000000002.sql
@@ -8,3 +8,4 @@ PREPARE 6a9e34e7 AS INSERT INTO public.category ("category_id", "name", "last_up
 EXECUTE 6a9e34e7["1005","Mystery","2022-12-13 00:00:01+00","1006","Historical drama","2022-12-14 00:00:01+00","1008","Thriller","2022-12-15 00:00:01+00"];
 -- KEEPALIVE {"lsn":"0/244B9A8","timestamp":"2023-09-17 07:04:04.9770+0000"}
 -- ENDPOS {"lsn":"0/244B9A8"}
+ROLLBACK; -- {"xid":492,"lsn":"0/244BF28","timestamp":"2023-11-21 05:43:00.647523+0000"}

--- a/tests/cdc-endpos-between-transaction/copydb.sh
+++ b/tests/cdc-endpos-between-transaction/copydb.sh
@@ -85,7 +85,7 @@ pgcopydb stream transform --trace ${SHAREDIR}/${WALFILE} /tmp/${SQLFILENAME}
 diff ${SHAREDIR}/${SQLFILE} /tmp/${SQLFILENAME}
 
 # we should also get the same result as expected (discarding LSN numbers)
-DIFFOPTS='-I BEGIN -I COMMIT -I KEEPALIVE -I SWITCH -I ENDPOS'
+DIFFOPTS='-I BEGIN -I COMMIT -I KEEPALIVE -I SWITCH -I ENDPOS -I ROLLBACK'
 
 diff ${DIFFOPTS} /usr/src/pgcopydb/${SQLFILE} ${SHAREDIR}/${SQLFILENAME}
 
@@ -99,7 +99,7 @@ timeout 5s pgcopydb stream catchup --resume --endpos "${lsn}" --trace
 pgcopydb stream sentinel set endpos --current
 
 # and replay the available changes, including the transaction in dml2.sql now
-pgcopydb follow --resume
+pgcopydb follow --resume --trace
 
 # now check that all the new rows made it
 sql="select count(*) from category"

--- a/tests/endpos-in-multi-wal-txn/Dockerfile
+++ b/tests/endpos-in-multi-wal-txn/Dockerfile
@@ -1,0 +1,9 @@
+FROM pagila
+
+WORKDIR /usr/src/pgcopydb
+COPY ./copydb.sh copydb.sh
+COPY ./ddl.sql ddl.sql
+COPY ./multi-wal-txn.sql multi-wal-txn.sql
+
+USER docker
+CMD /usr/src/pgcopydb/copydb.sh

--- a/tests/endpos-in-multi-wal-txn/Dockerfile.pg
+++ b/tests/endpos-in-multi-wal-txn/Dockerfile.pg
@@ -1,0 +1,5 @@
+FROM postgres:13-bullseye
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends postgresql-13-wal2json \
+    && rm -rf /var/lib/apt/lists/*

--- a/tests/endpos-in-multi-wal-txn/Makefile
+++ b/tests/endpos-in-multi-wal-txn/Makefile
@@ -1,0 +1,15 @@
+# Copyright (c) 2021 The PostgreSQL Global Development Group.
+# Licensed under the PostgreSQL License.
+
+test: down run down ;
+
+run: build
+	docker-compose run test
+
+down:
+	docker-compose down
+
+build:
+	docker-compose build --quiet
+
+.PHONY: run down build test

--- a/tests/endpos-in-multi-wal-txn/copydb.sh
+++ b/tests/endpos-in-multi-wal-txn/copydb.sh
@@ -1,0 +1,121 @@
+#! /bin/bash
+
+set -x
+set -e
+
+# This script expects the following environment variables to be set:
+#
+#  - PGCOPYDB_SOURCE_PGURI
+#  - PGCOPYDB_TARGET_PGURI
+#  - PGCOPYDB_TABLE_JOBS
+#  - PGCOPYDB_INDEX_JOBS
+#  - PGCOPYDB_OUTPUT_PLUGIN
+
+env | grep ^PGCOPYDB
+
+# make sure source and target databases are ready
+pgcopydb ping
+
+psql -o /tmp/s.out -d ${PGCOPYDB_SOURCE_PGURI} -1 -f /usr/src/pagila/pagila-schema.sql
+psql -o /tmp/d.out -d ${PGCOPYDB_SOURCE_PGURI} -1 -f /usr/src/pagila/pagila-data.sql
+
+# alter the pagila schema to allow capturing DDLs without pkey
+psql -d ${PGCOPYDB_SOURCE_PGURI} -f /usr/src/pgcopydb/ddl.sql
+
+slot=pgcopydb
+
+# create the replication slot that captures all the changes
+# PGCOPYDB_OUTPUT_PLUGIN is set to wal2json in docker-compose.yml
+coproc ( pgcopydb snapshot --follow --slot-name ${slot})
+
+sleep 1
+
+# now setup the replication origin (target) and the pgcopydb.sentinel (source)
+pgcopydb stream setup
+
+# pgcopydb copy db uses the environment variables
+pgcopydb clone
+
+kill -TERM ${COPROC_PID}
+wait ${COPROC_PID}
+
+# now that the copying is done, inject some SQL DML changes to the source
+psql -d ${PGCOPYDB_SOURCE_PGURI} -f /usr/src/pgcopydb/multi-wal-txn.sql
+
+SLOT_PEEK_FILE=/tmp/repl-peek.json
+
+# peek into the replication messages
+psql -t -d ${PGCOPYDB_SOURCE_PGURI} \
+    -c "SELECT data FROM pg_logical_slot_peek_changes('${slot}', NULL, NULL, 'format-version', '2', 'pretty-print', '1', 'include-lsn', '1');" \
+    -o ${SLOT_PEEK_FILE}
+
+# LSN of first insert in a new WAL segement.
+lsn_a=`jq -r 'select((.columns // empty) | .[] | ((.name == "f1") and (.value == 10001001))) | .lsn' ${SLOT_PEEK_FILE} | tail -1`
+
+# and prefetch the changes captured in our replication slot
+pgcopydb stream prefetch --resume --endpos "${lsn_a}" --trace
+
+# now prefetch the changes again, which should be a noop
+pgcopydb stream prefetch --resume --endpos "${lsn_a}" --trace
+
+# now allow for replaying/catching-up changes
+pgcopydb stream sentinel set apply
+
+# now apply the SQL file to the target database shouldn't take more than 5s
+timeout 5s pgcopydb stream catchup --resume --endpos "${lsn_a}" --trace
+
+psql -d ${PGCOPYDB_SOURCE_PGURI} -f /usr/src/pgcopydb/multi-wal-txn.sql
+psql -t -d ${PGCOPYDB_SOURCE_PGURI} \
+    -c "SELECT data FROM pg_logical_slot_peek_changes('${slot}', NULL, NULL, 'format-version', '2', 'pretty-print', '1', 'include-lsn', '1');" \
+    -o ${SLOT_PEEK_FILE}
+# LSN of middle insert in a WAL segement.
+lsn_b=`jq -r 'select((.columns // empty) | .[] | ((.name == "f1") and (.value == 10001002))) | .lsn' ${SLOT_PEEK_FILE} | tail -1`
+
+# adjust the endpos LSN to the lsn_b in the WAL
+pgcopydb stream sentinel set endpos "${lsn_b}"
+
+# and replay the available changes
+pgcopydb follow --resume --trace
+
+# now check that all the new rows made it
+sql="select count(*) from table_a"
+test 8 -eq `psql -AtqX -d ${PGCOPYDB_TARGET_PGURI} -c "${sql}"`
+
+# adjust the endpos LSN to the current position in the WAL
+pgcopydb stream sentinel set endpos --current
+
+# and replay the available changes, including the second txn.
+pgcopydb follow --resume --trace
+
+# now check that all the new rows made it
+sql="select count(*) from table_a"
+test 16 -eq `psql -AtqX -d ${PGCOPYDB_TARGET_PGURI} -c "${sql}"`
+
+psql -d ${PGCOPYDB_SOURCE_PGURI} -f /usr/src/pgcopydb/multi-wal-txn.sql
+psql -t -d ${PGCOPYDB_SOURCE_PGURI} \
+    -c "SELECT data FROM pg_logical_slot_peek_changes('${slot}', NULL, NULL, 'format-version', '2', 'pretty-print', '1', 'include-lsn', '1');" \
+    -o ${SLOT_PEEK_FILE}
+
+# LSN of the last insert in a WAL segement.
+lsn_c=`jq -r 'select((.columns // empty) | .[] | ((.name == "f1") and (.value == 10001003))) | .lsn' ${SLOT_PEEK_FILE} | tail -1`
+
+# adjust the endpos LSN to the current position in the WAL
+pgcopydb stream sentinel set endpos "${lsn_c}"
+
+# and replay the available changes, including the 3rd txn.
+pgcopydb follow --resume --trace
+
+# new txn should not have made it yet
+sql="select count(*) from table_a"
+test 16 -eq `psql -AtqX -d ${PGCOPYDB_TARGET_PGURI} -c "${sql}"`
+
+pgcopydb stream sentinel set endpos --current
+# and replay the available changes, including the 3rd txn.
+pgcopydb follow --resume --trace
+#
+# now check that all the new rows made it
+sql="select count(*) from table_a"
+test 24 -eq `psql -AtqX -d ${PGCOPYDB_TARGET_PGURI} -c "${sql}"`
+
+# cleanup
+pgcopydb stream cleanup

--- a/tests/endpos-in-multi-wal-txn/ddl.sql
+++ b/tests/endpos-in-multi-wal-txn/ddl.sql
@@ -1,0 +1,11 @@
+---
+--- pgcopydb test/cdc/ddl.sql
+---
+--- This file implements DDL changes in the pagila database.
+
+begin;
+
+CREATE TABLE table_a (id serial PRIMARY KEY, f1 int4, f2 text);
+CREATE TABLE table_b (id serial PRIMARY KEY, f1 int4, f2 text[]);
+
+commit;

--- a/tests/endpos-in-multi-wal-txn/docker-compose.yml
+++ b/tests/endpos-in-multi-wal-txn/docker-compose.yml
@@ -1,0 +1,43 @@
+version: "3.9"  # optional since v1.27.0
+services:
+  source:
+    build:
+      context: .
+      dockerfile: Dockerfile.pg
+    expose:
+      - 5432
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: h4ckm3
+      POSTGRES_HOST_AUTH_METHOD: trust
+    command: >
+      -c wal_level=logical
+      -c ssl=on
+      -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
+      -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
+  target:
+    image: postgres:13-bullseye
+    expose:
+      - 5432
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: h4ckm3
+      POSTGRES_HOST_AUTH_METHOD: trust
+    command: >
+      -c ssl=on
+      -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
+      -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
+  test:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      PGSSLMODE: "require"
+      PGCOPYDB_SOURCE_PGURI: postgres://postgres:h4ckm3@source/postgres
+      PGCOPYDB_TARGET_PGURI: postgres://postgres:h4ckm3@target/postgres
+      PGCOPYDB_TABLE_JOBS: 4
+      PGCOPYDB_INDEX_JOBS: 2
+      PGCOPYDB_OUTPUT_PLUGIN: wal2json
+    depends_on:
+      - source
+      - target

--- a/tests/endpos-in-multi-wal-txn/multi-wal-txn.sql
+++ b/tests/endpos-in-multi-wal-txn/multi-wal-txn.sql
@@ -1,0 +1,25 @@
+-- transaction that spans multiple WAL files
+
+BEGIN;
+
+INSERT INTO table_a(f1) VALUES ((random() * 100 + 1)::int);
+
+SELECT
+    pg_switch_wal();
+
+INSERT INTO table_a(f1) VALUES ((random() * 100 + 1)::int);
+
+SELECT
+    pg_switch_wal();
+
+INSERT INTO table_a(f1) VALUES (10001001), (101), (10001002), (104), (10001003);
+
+SELECT
+    pg_switch_wal();
+
+INSERT INTO table_a(f1) VALUES ((random() * 100 + 1)::int);
+
+SELECT
+    pg_switch_wal();
+
+COMMIT;


### PR DESCRIPTION
Before this update, exiting the process (either reaching ENDPOS or user-initiated abort like Ctrl-C) could leave us in the midst of an unfinished transaction. Upon resumption, PostgreSQL begins streaming from a consistent point, which might be the start of this incomplete transaction or from an earlier one. Our previous method tried to bypass all earlier messages until hitting the final message of the incomplete transaction, but this approach had its shortcomings, especially when the messages originated from several transactions back.

This commit introduces a more straightforward solution. Now, if the process is aborted and the last transaction is not complete, we'll issue a rollback command for that transaction. This ensures a clean and consistent state for a graceful exit and subsequent resumption.

Signed-off-by: Arunprasad Rajkumar <ar.arunprasad@gmail.com>