### PR TITLE
Invalidate context state during cleanup

### DIFF
--- a/src/bin/pgcopydb/ld_stream.c
+++ b/src/bin/pgcopydb/ld_stream.c
@@ -2657,6 +2657,9 @@ stream_cleanup_context(StreamSpecs *specs)
 	success = success && unlink_file(specs->paths.tlifile);
 	success = success && unlink_file(specs->paths.tlihistfile);
 
+	/* reset the timeline, so that we always read from the disk */
+	specs->system.timeline = 0;
+
 	return success;
 }
 


### PR DESCRIPTION
Currently, when switching between modes, the follow process cleans up context files, which include details like WAL segment size and timeline. However, we haven't been resetting the in-memory state that decides whether the context should be read from these files. This can lead to the usage of outdated timeline information while retriving the context[1][2][3].

This commit addresses this issue by resetting the in-memory state during context cleanup. This ensures that the system will re-read the context from the files after any cleanup, leading to more accurate and reliable timeline information.

[1] https://github.com/dimitri/pgcopydb/blob/8d305a51f82a83bacac6a3fcce716c9450505e57/src/bin/pgcopydb/ld_transform.c#L201-L212
[2] https://github.com/dimitri/pgcopydb/blob/8d305a51f82a83bacac6a3fcce716c9450505e57/src/bin/pgcopydb/follow.c#L428-L438
[3] https://github.com/dimitri/pgcopydb/blob/8d305a51f82a83bacac6a3fcce716c9450505e57/src/bin/pgcopydb/ld_apply.c#L206-L216