### PR TITLE
Recover from crash using undo log

### DIFF
--- a/src/bin/pgcopydb/copydb.c
+++ b/src/bin/pgcopydb/copydb.c
@@ -572,6 +572,10 @@ copydb_prepare_filepaths(CopyFilePaths *cfPaths,
 			"%s/lsn.json",
 			cfPaths->cdc.dir);
 
+	sformat(cfPaths->cdc.undofile, MAXPGPATH,
+			"%s/undo",
+			cfPaths->cdc.dir);
+
 	/*
 	 * Now prepare the "compare" files we need to compare schema and data
 	 * between the source and target instance.

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -26,6 +26,7 @@
 	{ "extra_float_digits", "3" }, \
 	{ "statement_timeout", "0" }, \
 	{ "default_transaction_read_only", "off" }
+
 /*
  * These parameters are added to the connection strings, unless the user has
  * added them, allowing user-defined values to be taken into account.

--- a/src/bin/pgcopydb/copydb_paths.h
+++ b/src/bin/pgcopydb/copydb_paths.h
@@ -54,6 +54,7 @@ typedef struct CDCPaths
 	char tlifile[MAXPGPATH];          /* /tmp/pgcopydb/cdc/tli */
 	char tlihistfile[MAXPGPATH];      /* /tmp/pgcopydb/cdc/tli.history */
 	char lsntrackingfile[MAXPGPATH];  /* /tmp/pgcopydb/cdc/lsn.json */
+	char undofile[MAXPGPATH];         /* /tmp/pgcopydb/cdc/undo */
 } CDCPaths;
 
 

--- a/src/bin/pgcopydb/follow.c
+++ b/src/bin/pgcopydb/follow.c
@@ -258,6 +258,22 @@ bool
 follow_main_loop(CopyDataSpec *copySpecs, StreamSpecs *streamSpecs)
 {
 	/*
+	 * Incase of a crash, execute recovery actions before starting the
+	 * main loop.
+	 */
+	if (!recoverFromUndoLog(&streamSpecs->paths))
+	{
+		log_error("Failed to recover from undo log, see above for details");
+		return false;
+	}
+
+	if (!removeUndoLog(&streamSpecs->paths))
+	{
+		log_error("Failed to remove undo log, see above for details");
+		return false;
+	}
+
+	/*
 	 * Remove the possibly still existing stream context files from
 	 * previous round of operations (--resume, etc). We want to make
 	 * sure that the catchup process reads the files created on this

--- a/src/bin/pgcopydb/ld_stream.h
+++ b/src/bin/pgcopydb/ld_stream.h
@@ -317,6 +317,11 @@ typedef struct StreamContext
 	FILE *jsonFile;
 	FILE *sqlFile;
 
+	char wal[MAXPGPATH];
+	char lastUndoWal[MAXPGPATH];
+	FILE *undoFile;
+	bool undoInProgress;
+
 	StreamCounters counters;
 
 	bool transactionInProgress;
@@ -499,6 +504,9 @@ bool stream_init_context(StreamSpecs *specs);
 bool startLogicalStreaming(StreamSpecs *specs);
 bool streamCheckResumePosition(StreamSpecs *specs);
 
+bool recoverFromUndoLog(CDCPaths *path);
+bool removeUndoLog(CDCPaths *path);
+
 bool streamWrite(LogicalStreamContext *context);
 bool streamFlush(LogicalStreamContext *context);
 bool streamKeepalive(LogicalStreamContext *context);
@@ -529,7 +537,7 @@ bool stream_write_internal_message(LogicalStreamContext *context,
 
 bool stream_read_file(StreamContent *content);
 bool stream_read_latest(StreamSpecs *specs, StreamContent *content);
-bool stream_update_latest_symlink(StreamContext *privateContext,
+bool stream_update_latest_symlink(CDCPaths *paths,
 								  const char *filename);
 
 bool buildReplicationURI(const char *pguri, char **repl_pguri);


### PR DESCRIPTION
This commit remembers the file write position of a last successful transaction in
a undo file. If there's a crash and we need to restart, we use this undo file to get rid of any partial work from the last transaction that wasn't finished.

TODO: Can we use the undo log mechanism to even for graceful exit?
This would simplify the code and make it uniform for both graceful
and ungraceful exits/crashes. The idea is to undo the changes made
by the last incomplete transaction by reading the undo log file and
write other messages like ENDPOS.
