### PR TITLE
Set application name to process title and pid

### DIFF
--- a/src/bin/pgcopydb/defaults.h
+++ b/src/bin/pgcopydb/defaults.h
@@ -40,8 +40,6 @@
 #define PGCOPYDB_FAIL_FAST "PGCOPYDB_FAIL_FAST"
 #define PGCOPYDB_SKIP_VACUUM "PGCOPYDB_SKIP_VACUUM"
 
-#define PGCOPYDB_PGAPPNAME "pgcopydb"
-
 /* default values for the command line options */
 #define DEFAULT_TABLE_JOBS 4
 #define DEFAULT_INDEX_JOBS 4

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -492,11 +492,14 @@ pgsql_open_connection(PGSQL *pgsql)
 				pgsql->safeURI.pguri);
 	}
 
-	/* use our own application_name, unless the environment already is set */
-	if (!env_exists("PGAPPNAME"))
-	{
-		setenv("PGAPPNAME", PGCOPYDB_PGAPPNAME, 1);
-	}
+	/*
+	 * set application_name to contain the process title and pid, so that it is
+	 * easier to identify our connections in pg_stat_activity.
+	 */
+	char app_name[BUFSIZE] = { 0 };
+
+	sformat(app_name, sizeof(app_name), "pgcopydb[%d] %s", getpid(), ps_buffer);
+	setenv("PGAPPNAME", app_name, 1);
 
 	/* we implement our own retry strategy */
 	if (!env_exists("PGCONNECT_TIMEOUT"))


### PR DESCRIPTION
This change makes it easier to identify the connections of pgcopydb in
pg_stat_activity. The process title contains information on the current
operation, and the pid of the process is also included in the
application name. This way we can easily identify the connections of
pgcopydb in pg_stat_activity even if the process title is truncated.

Fixes: https://github.com/dimitri/pgcopydb/issues/431