### PR TITLE
Fix duplicate key errors on resuming continued txn

### DIFF
--- a/tests/endpos-in-multi-wal-txn/copydb.sh
+++ b/tests/endpos-in-multi-wal-txn/copydb.sh
@@ -112,7 +112,12 @@ test 16 -eq `psql -AtqX -d ${PGCOPYDB_TARGET_PGURI} -c "${sql}"`
 pgcopydb stream sentinel set endpos --current
 # and replay the available changes, including the 3rd txn.
 pgcopydb follow --resume --trace
-#
+
+# This operation is expected to be a no-op. It tests the scenario where,
+# upon resuming, we skip a transaction that lacks a commitLSN in its
+# BEGIN message but has already been applied.
+pgcopydb stream apply --trace --resume /var/lib/postgres/.local/share/pgcopydb/000000010000000000000004.sql
+
 # now check that all the new rows made it
 sql="select count(*) from table_a"
 test 24 -eq `psql -AtqX -d ${PGCOPYDB_TARGET_PGURI} -c "${sql}"`


### PR DESCRIPTION
This commit addresses and resolves the issue of duplicate key errors when resuming partially executed transactions (continuedTxn) in pgcopydb. We have reintroduced the transaction metadata file, which is essential for identifying the commitLSN of a partial transaction.

Unlike our previous approach, which led to a deadlock between the transform and apply phases, this update brings a more efficient process. Now, the apply phase creates metadata for any partial (continued) transactions during the commit. This metadata is then used to accurately skip the already applied partial transaction if a resume is needed.

This fix is crucial, particularly for tables with unique constraints, where executing the same continued transaction twice previously resulted in duplicate key errors. With this update, pgcopydb ensures smooth and error-free handling of transaction resumes.