### PR TITLE
Documentation and Naming Improvements

### DIFF
--- a/docs/ref/pgcopydb_compare.rst
+++ b/docs/ref/pgcopydb_compare.rst
@@ -97,8 +97,8 @@ Running such a query on a large table can take a lot of time.
 Options
 -------
 
-The following options are available to ``pgcopydb create`` and ``pgcopydb
-drop`` subcommands:
+The following options are available to ``pgcopydb compare schema`` and ``pgcopydb
+compare data`` subcommands:
 
 --source
 

--- a/docs/ref/pgcopydb_dump.rst
+++ b/docs/ref/pgcopydb_dump.rst
@@ -127,7 +127,8 @@ pg_dump.
 Options
 -------
 
-The following options are available to ``pgcopydb dump schema``:
+The following options are available to ``pgcopydb dump schema``, ``pgcopydb dump pre-data``
+and ``pgcopydb dump post-data`` subcommands:
 
 --source
 

--- a/docs/ref/pgcopydb_snapshot.rst
+++ b/docs/ref/pgcopydb_snapshot.rst
@@ -24,8 +24,7 @@ expect to find it.
 Options
 -------
 
-The following options are available to ``pgcopydb create`` and ``pgcopydb
-drop`` subcommands:
+The following options are available to ``pgcopydb snapshot``:
 
 --source
 

--- a/src/bin/pgcopydb/cli_root.c
+++ b/src/bin/pgcopydb/cli_root.c
@@ -26,7 +26,7 @@ CommandLine *root_subcommands_with_debug[] = {
 	&fork_command,
 	&follow_command,
 	&copy__db_command,          /* backward compat */
-	&create_snapshot_command,
+	&snapshot_command,
 	&compare_commands,
 	&copy_commands,
 	&dump_commands,
@@ -53,7 +53,7 @@ CommandLine *root_subcommands[] = {
 	&fork_command,
 	&follow_command,
 	&copy__db_command,          /* backward compat */
-	&create_snapshot_command,
+	&snapshot_command,
 	&compare_commands,
 	&copy_commands,
 	&dump_commands,

--- a/src/bin/pgcopydb/cli_root.c
+++ b/src/bin/pgcopydb/cli_root.c
@@ -11,10 +11,10 @@
 
 /* local bindings for all the commands */
 CommandLine help =
-	make_command("help", "print help message", "", "", NULL, cli_help);
+	make_command("help", "Print help message", "", "", NULL, cli_help);
 
 CommandLine version =
-	make_command("version", "print pgcopydb version", "", "",
+	make_command("version", "Print pgcopydb version", "", "",
 				 cli_print_version_getopts,
 				 cli_print_version);
 

--- a/src/bin/pgcopydb/cli_root.h
+++ b/src/bin/pgcopydb/cli_root.h
@@ -43,7 +43,7 @@ extern CommandLine follow_command;
 extern CommandLine copy_commands;
 
 /* cli_snapshot.c */
-extern CommandLine create_snapshot_command;
+extern CommandLine snapshot_command;
 
 /* cli_dump.c */
 extern CommandLine dump_commands;

--- a/src/bin/pgcopydb/cli_snapshot.c
+++ b/src/bin/pgcopydb/cli_snapshot.c
@@ -24,7 +24,7 @@
 static int cli_create_snapshot_getopts(int argc, char **argv);
 static void cli_create_snapshot(int argc, char **argv);
 
-CommandLine create_snapshot_command =
+CommandLine snapshot_command =
 	make_command(
 		"snapshot",
 		"Create and export a snapshot on the source database",


### PR DESCRIPTION
This pull request addresses minor documentation errors for the following `pgcopydb` commands:

- `pgcopydb snapshot`
- `pgcopydb compare`
- `pgcopydb dump`

Additionally, it capitalizes the first letters of `version` and `help` command descriptions.

Furthermore, it renames `create_snapshot_command` to `snapshot_command` for consistency with the existing naming convention. I'm unsure whether it's valuable to introduce this change in the same PR. Please let me know if you'd like me to revert it or create another PR.