### PR TITLE
Fix copying blobs that are not included in snapshot.

### DIFF
--- a/src/bin/pgcopydb/blobs.c
+++ b/src/bin/pgcopydb/blobs.c
@@ -417,14 +417,14 @@ copydb_send_lo_stop(CopyDataSpec *specs)
 bool
 copydb_queue_largeobject_metadata(CopyDataSpec *specs, uint64_t *count)
 {
-	PGSQL *src = &(specs->sourceSnapshot.pgsql);
-
-	/* initialize our connection to the source database */
-	if (!pgsql_init(src, specs->connStrings.source_pguri, PGSQL_CONN_SOURCE))
+	/* connect to the source database and set snapshot */
+	if (!copydb_set_snapshot(specs))
 	{
 		/* errors have already been logged */
 		return false;
 	}
+
+	PGSQL *src = &(specs->sourceSnapshot.pgsql);
 
 	if (!pgsql_begin(src))
 	{


### PR DESCRIPTION
The issue was that we weren't setting the snapshot for the query that fetches the list of large object ids. This inconsistency led to errors when trying to access large objects that weren't restored on target.

Error:
```
15:30:11 108 ERROR  [SOURCE 85] ERROR:  large object 16390 does not exist
15:30:11 108 ERROR  [SOURCE 85] Context: Failed to open large object 16390
15:30:11 107 ERROR  [SOURCE 83] ERROR:  large object 16392 does not exist
15:30:11 107 ERROR  [SOURCE 83] Context: Failed to open large object 16392
```