### PR TITLE
Fix one error with formatting in docs

### DIFF
--- a/docs/ref/pgcopydb_clone.rst
+++ b/docs/ref/pgcopydb_clone.rst
@@ -842,6 +842,7 @@ Examples
 --------
 
 ::
+
    $ export PGCOPYDB_SOURCE_PGURI=postgres://pagila:0wn3d@source/pagila
    $ export PGCOPYDB_TARGET_PGURI=postgres://pagila:0wn3d@target/pagila
    $ export PGCOPYDB_DROP_IF_EXISTS=on


### PR DESCRIPTION
In .rst files, the first line of a code block must be empty.  This was causing a malformed code block that is hard to read.