### PR TITLE
Close pipes created by follow after forking childs

### DIFF
--- a/src/bin/pgcopydb/ld_replay.c
+++ b/src/bin/pgcopydb/ld_replay.c
@@ -90,7 +90,7 @@ stream_apply_replay(StreamSpecs *specs)
 
 	if (!read_from_stream(specs->in, &readerContext))
 	{
-		log_error("Failed to transform JSON messages from input stream, "
+		log_error("Failed to read SQL lines from input stream, "
 				  "see above for details");
 		return false;
 	}


### PR DESCRIPTION
In the follow process, we create two Unix pipes for bidirectional communication between child processes (prefetch, transform, apply) during replay mode. Each child process closes its unused pipe descriptors upon startup. For example, the prefetch process, which only writes to the transform process, closes the read end of its pipe descriptors immediately.

However, the follow process (parent) itself, which initializes these pipes, does not utilize them for communication. Leaving these pipe descriptors open in the follow process leads to an issue where EOF is not sent, even after the child processes close their ends upon completion. This situation can result in a deadlock, especially when an interruption occurs through Ctrl+C or a SIGTERM signal.

Prior to the fix, the transform process would continuously loop within the select system calls in [read_from_stream](https://github.com/dimitri/pgcopydb/blob/e6d8628e30ddb1b9441f781bd4d38549e864bdc1/src/bin/pgcopydb/file_utils.c#L449-L505). This looping occurred because the process never received an EOF (End Of File) signal. The root cause was that the follow process did not close its end of the pipe, thereby preventing the EOF signal from being sent to the transform process.

```
#0  0x00007f5361c3774d in __GI___select (nfds=nfds@entry=20, readfds=readfds@entry=0x7ffd48641b30, writefds=writefds@entry=0x0, exceptfds=exceptfds@entry=0x0, 
    timeout=timeout@entry=0x7ffd48641b20) at ../sysdeps/unix/sysv/linux/select.c:69                                                                                                
#1  0x00005621a604681d in read_from_stream (stream=0x5621a7915860, context=context@entry=0x7ffd48643c10) at file_utils.c:445                                                       
#2  0x00005621a6058e9a in stream_transform_stream (specs=specs@entry=0x7ffd48643d90) at ld_transform.c:98                                                                          
#3  0x00005621a6049148 in follow_start_transform (specs=0x7ffd48643d90) at follow.c:667                                                                                            
#4  0x00005621a60492ae in follow_start_subprocess (specs=specs@entry=0x7ffd48643d90, subprocess=subprocess@entry=0x7ffd4874cad0) at follow.c:769                                   
#5  0x00005621a6049a8e in followDB (copySpecs=copySpecs@entry=0x7ffd4874f570, streamSpecs=streamSpecs@entry=0x7ffd48643d90) at follow.c:542                                        
#6  0x00005621a6049cce in follow_main_loop (copySpecs=copySpecs@entry=0x7ffd4874f570, streamSpecs=streamSpecs@entry=0x7ffd48643d90) at follow.c:286                                
#7  0x00005621a602c1f1 in start_follow_process (copySpecs=copySpecs@entry=0x7ffd4874f570, streamSpecs=streamSpecs@entry=0x7ffd48643d90, pid=pid@entry=0x7ffd48643d8c)
    at cli_clone_follow.c:674                                                                                                                                                      
#8  0x00005621a602ca68 in clone_and_follow (copySpecs=copySpecs@entry=0x7ffd4874f570) at cli_clone_follow.c:269                                                                    
#9  0x00005621a602cc61 in cli_clone (argc=<optimized out>, argv=<optimized out>) at cli_clone_follow.c:142                                                                         
#10 0x00005621a6078993 in commandline_run (command=0x5621a60ba0e0 <clone_command>, argc=0, argc@entry=14, argv=0x7ffd48862700, argv@entry=0x7ffd48862690)                          
    at /home/marco/pgcopydb/src/bin/pgcopydb/../lib/subcommands.c/commandline.c:71                                                                                                 
#11 0x00005621a6078a75 in commandline_run (command=command@entry=0x7ffd48862110, argc=14, argc@entry=15, argv=0x7ffd48862690, argv@entry=0x7ffd48862688)                           
    at /home/marco/pgcopydb/src/bin/pgcopydb/../lib/subcommands.c/commandline.c:94                                                                                                 
#12 0x00005621a605a7b5 in main (argc=15, argv=0x7ffd48862688) at main.c:167  
```

Fixes https://github.com/dimitri/pgcopydb/issues/427