### PR TITLE
Automate updating help messages for commands

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -65,3 +65,13 @@ jobs:
 
     - name: Check C style
       run: citus_indent --check
+
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Build docs
+        uses: ammaraskar/sphinx-action@master
+        with:
+          docs-folder: "docs/"

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ maintainer-clean: clean
 docs:
 	$(MAKE) -C docs clean man html
 
+update-docs: install
+	bash ./docs/update-help-messages.sh
+
 test: build
 	$(MAKE) -C tests all
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,7 +58,7 @@ html_theme = "sphinx_rtd_theme"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []
 
 latex_engine = 'xelatex'
 

--- a/docs/include/clone.rst
+++ b/docs/include/clone.rst
@@ -1,0 +1,39 @@
+::
+
+   pgcopydb clone: Clone an entire database from source to target
+   usage: pgcopydb clone  --source ... --target ... [ --table-jobs ... --index-jobs ... ] 
+   
+     --source                      Postgres URI to the source database
+     --target                      Postgres URI to the target database
+     --dir                         Work directory to use
+     --table-jobs                  Number of concurrent COPY jobs to run
+     --index-jobs                  Number of concurrent CREATE INDEX jobs to run
+     --restore-jobs                Number of concurrent jobs for pg_restore
+     --large-objects-jobs          Number of concurrent Large Objects jobs to run
+     --split-tables-larger-than    Same-table concurrency size threshold
+     --drop-if-exists              On the target database, clean-up from a previous run first
+     --roles                       Also copy roles found on source to target
+     --no-role-passwords           Do not dump passwords for roles
+     --no-owner                    Do not set ownership of objects to match the original database
+     --no-acl                      Prevent restoration of access privileges (grant/revoke commands).
+     --no-comments                 Do not output commands to restore comments
+     --skip-large-objects          Skip copying large objects (blobs)
+     --skip-extensions             Skip restoring extensions
+     --skip-ext-comments           Skip restoring COMMENT ON EXTENSION
+     --skip-collations             Skip restoring collations
+     --skip-vacuum                 Skip running VACUUM ANALYZE
+     --requirements <filename>     List extensions requirements
+     --filters <filename>          Use the filters defined in <filename>
+     --fail-fast                   Abort early in case of error
+     --restart                     Allow restarting when temp files exist already
+     --resume                      Allow resuming operations after a failure
+     --not-consistent              Allow taking a new snapshot on the source database
+     --snapshot                    Use snapshot obtained with pg_export_snapshot
+     --follow                      Implement logical decoding to replay changes
+     --plugin                      Output plugin to use (test_decoding, wal2json)
+     --wal2json-numeric-as-string  Print numeric data type as string when using wal2json output plugin
+     --slot-name                   Use this Postgres replication slot name
+     --create-slot                 Create the replication slot
+     --origin                      Use this Postgres replication origin node name
+     --endpos                      Stop replaying changes when reaching this LSN
+   

--- a/docs/include/compare-data.rst
+++ b/docs/include/compare-data.rst
@@ -1,0 +1,10 @@
+::
+
+   pgcopydb compare data: Compare source and target data
+   usage: pgcopydb compare data  --source ... 
+   
+     --source         Postgres URI to the source database
+     --target         Postgres URI to the target database
+     --dir            Work directory to use
+     --json           Format the output using JSON
+   

--- a/docs/include/compare-schema.rst
+++ b/docs/include/compare-schema.rst
@@ -1,0 +1,9 @@
+::
+
+   pgcopydb compare schema: Compare source and target schema
+   usage: pgcopydb compare schema  --source ... 
+   
+     --source         Postgres URI to the source database
+     --target         Postgres URI to the target database
+     --dir            Work directory to use
+   

--- a/docs/include/compare.rst
+++ b/docs/include/compare.rst
@@ -1,0 +1,9 @@
+::
+
+   pgcopydb compare: Compare source and target databases
+   
+   Available commands:
+     pgcopydb compare
+       schema  Compare source and target schema
+       data    Compare source and target data
+   

--- a/docs/include/copy-blobs.rst
+++ b/docs/include/copy-blobs.rst
@@ -1,0 +1,15 @@
+::
+
+   pgcopydb copy blobs: Copy the blob data from the source database to the target
+   usage: pgcopydb copy blobs  --source ... --target ... [ --table-jobs ... --index-jobs ... ] 
+   
+     --source             Postgres URI to the source database
+     --target             Postgres URI to the target database
+     --dir                Work directory to use
+     --large-objects-jobs Number of concurrent Large Objects jobs to run
+     --drop-if-exists     On the target database, drop and create large objects
+     --restart            Allow restarting when temp files exist already
+     --resume             Allow resuming operations after a failure
+     --not-consistent     Allow taking a new snapshot on the source database
+     --snapshot           Use snapshot obtained with pg_export_snapshot
+   

--- a/docs/include/copy-constraints.rst
+++ b/docs/include/copy-constraints.rst
@@ -1,0 +1,13 @@
+::
+
+   pgcopydb copy constraints: Create all the constraints found in the source database in the target
+   usage: pgcopydb copy constraints  --source ... --target ... [ --table-jobs ... --index-jobs ... ] 
+   
+     --source             Postgres URI to the source database
+     --target             Postgres URI to the target database
+     --dir                Work directory to use
+     --filters <filename> Use the filters defined in <filename>
+     --restart            Allow restarting when temp files exist already
+     --resume             Allow resuming operations after a failure
+     --not-consistent     Allow taking a new snapshot on the source database
+   

--- a/docs/include/copy-data.rst
+++ b/docs/include/copy-data.rst
@@ -1,0 +1,18 @@
+::
+
+   pgcopydb copy data: Copy the data section from source to target
+   usage: pgcopydb copy data  --source ... --target ... [ --table-jobs ... --index-jobs ... ] 
+   
+     --source              Postgres URI to the source database
+     --target              Postgres URI to the target database
+     --dir                 Work directory to use
+     --table-jobs          Number of concurrent COPY jobs to run
+     --index-jobs          Number of concurrent CREATE INDEX jobs to run
+     --restore-jobs        Number of concurrent jobs for pg_restore
+     --skip-large-objects  Skip copying large objects (blobs)
+     --filters <filename>  Use the filters defined in <filename>
+     --restart             Allow restarting when temp files exist already
+     --resume              Allow resuming operations after a failure
+     --not-consistent      Allow taking a new snapshot on the source database
+     --snapshot            Use snapshot obtained with pg_export_snapshot
+   

--- a/docs/include/copy-db.rst
+++ b/docs/include/copy-db.rst
@@ -1,0 +1,24 @@
+::
+
+   pgcopydb copy db: Copy an entire database from source to target
+   usage: pgcopydb copy db  --source ... --target ... [ --table-jobs ... --index-jobs ... ] 
+   
+     --source              Postgres URI to the source database
+     --target              Postgres URI to the target database
+     --dir                 Work directory to use
+     --table-jobs          Number of concurrent COPY jobs to run
+     --index-jobs          Number of concurrent CREATE INDEX jobs to run
+     --restore-jobs        Number of concurrent jobs for pg_restore
+     --drop-if-exists      On the target database, clean-up from a previous run first
+     --roles               Also copy roles found on source to target
+     --no-owner            Do not set ownership of objects to match the original database
+     --no-acl              Prevent restoration of access privileges (grant/revoke commands).
+     --no-comments         Do not output commands to restore comments
+     --skip-large-objects  Skip copying large objects (blobs)
+     --filters <filename>  Use the filters defined in <filename>
+     --fail-fast           Abort early in case of error
+     --restart             Allow restarting when temp files exist already
+     --resume              Allow resuming operations after a failure
+     --not-consistent      Allow taking a new snapshot on the source database
+     --snapshot            Use snapshot obtained with pg_export_snapshot
+   

--- a/docs/include/copy-extensions.rst
+++ b/docs/include/copy-extensions.rst
@@ -1,0 +1,10 @@
+::
+
+   pgcopydb copy extensions: Copy the extensions from the source instance to the target instance
+   usage: pgcopydb copy extensions  --source ... --target ... 
+   
+     --source              Postgres URI to the source database
+     --target              Postgres URI to the target database
+     --dir                 Work directory to use
+     --requirements        List extensions requirements
+   

--- a/docs/include/copy-indexes.rst
+++ b/docs/include/copy-indexes.rst
@@ -1,0 +1,15 @@
+::
+
+   pgcopydb copy indexes: Create all the indexes found in the source database in the target
+   usage: pgcopydb copy indexes  --source ... --target ... [ --table-jobs ... --index-jobs ... ] 
+   
+     --source             Postgres URI to the source database
+     --target             Postgres URI to the target database
+     --dir                Work directory to use
+     --index-jobs         Number of concurrent CREATE INDEX jobs to run
+     --restore-jobs       Number of concurrent jobs for pg_restore
+     --filters <filename> Use the filters defined in <filename>
+     --restart            Allow restarting when temp files exist already
+     --resume             Allow resuming operations after a failure
+     --not-consistent     Allow taking a new snapshot on the source database
+   

--- a/docs/include/copy-roles.rst
+++ b/docs/include/copy-roles.rst
@@ -1,0 +1,10 @@
+::
+
+   pgcopydb copy roles: Copy the roles from the source instance to the target instance
+   usage: pgcopydb copy roles  --source ... --target ... 
+   
+     --source              Postgres URI to the source database
+     --target              Postgres URI to the target database
+     --dir                 Work directory to use
+     --no-role-passwords   Do not dump passwords for roles
+   

--- a/docs/include/copy-schema.rst
+++ b/docs/include/copy-schema.rst
@@ -1,0 +1,14 @@
+::
+
+   pgcopydb copy schema: Copy the database schema from source to target
+   usage: pgcopydb copy schema  --source ... --target ... [ --table-jobs ... --index-jobs ... ] 
+   
+     --source              Postgres URI to the source database
+     --target              Postgres URI to the target database
+     --dir                 Work directory to use
+     --filters <filename>  Use the filters defined in <filename>
+     --restart             Allow restarting when temp files exist already
+     --resume              Allow resuming operations after a failure
+     --not-consistent      Allow taking a new snapshot on the source database
+     --snapshot            Use snapshot obtained with pg_export_snapshot
+   

--- a/docs/include/copy-sequences.rst
+++ b/docs/include/copy-sequences.rst
@@ -1,0 +1,14 @@
+::
+
+   pgcopydb copy sequences: Copy the current value from all sequences in database from source to target
+   usage: pgcopydb copy sequences  --source ... --target ... [ --table-jobs ... --index-jobs ... ] 
+   
+     --source             Postgres URI to the source database
+     --target             Postgres URI to the target database
+     --dir                Work directory to use
+     --filters <filename> Use the filters defined in <filename>
+     --restart            Allow restarting when temp files exist already
+     --resume             Allow resuming operations after a failure
+     --not-consistent     Allow taking a new snapshot on the source database
+     --snapshot           Use snapshot obtained with pg_export_snapshot
+   

--- a/docs/include/copy-table-data.rst
+++ b/docs/include/copy-table-data.rst
@@ -1,0 +1,15 @@
+::
+
+   pgcopydb copy table-data: Copy the data from all tables in database from source to target
+   usage: pgcopydb copy table-data  --source ... --target ... [ --table-jobs ... --index-jobs ... ] 
+   
+     --source             Postgres URI to the source database
+     --target             Postgres URI to the target database
+     --dir                Work directory to use
+     --table-jobs         Number of concurrent COPY jobs to run
+     --filters <filename> Use the filters defined in <filename>
+     --restart            Allow restarting when temp files exist already
+     --resume             Allow resuming operations after a failure
+     --not-consistent     Allow taking a new snapshot on the source database
+     --snapshot           Use snapshot obtained with pg_export_snapshot
+   

--- a/docs/include/copy.rst
+++ b/docs/include/copy.rst
@@ -1,0 +1,17 @@
+::
+
+   pgcopydb copy: Implement the data section of the database copy
+   
+   Available commands:
+     pgcopydb copy
+       db           Copy an entire database from source to target
+       roles        Copy the roles from the source instance to the target instance
+       extensions   Copy the extensions from the source instance to the target instance
+       schema       Copy the database schema from source to target
+       data         Copy the data section from source to target
+       table-data   Copy the data from all tables in database from source to target
+       blobs        Copy the blob data from the source database to the target
+       sequences    Copy the current value from all sequences in database from source to target
+       indexes      Create all the indexes found in the source database in the target
+       constraints  Create all the constraints found in the source database in the target
+   

--- a/docs/include/dump-post-data.rst
+++ b/docs/include/dump-post-data.rst
@@ -1,0 +1,10 @@
+::
+
+   pgcopydb dump post-data: Dump source database post-data schema as custom files in work directory
+   usage: pgcopydb dump post-data  --source <URI>
+   
+     --source          Postgres URI to the source database
+     --target          Directory where to save the dump files
+     --dir             Work directory to use
+     --snapshot        Use snapshot obtained with pg_export_snapshot
+   

--- a/docs/include/dump-pre-data.rst
+++ b/docs/include/dump-pre-data.rst
@@ -1,0 +1,11 @@
+::
+
+   pgcopydb dump pre-data: Dump source database pre-data schema as custom files in work directory
+   usage: pgcopydb dump pre-data  --source <URI> 
+   
+     --source          Postgres URI to the source database
+     --target          Directory where to save the dump files
+     --dir             Work directory to use
+     --skip-extensions Skip restoring extensions
+     --snapshot        Use snapshot obtained with pg_export_snapshot
+   

--- a/docs/include/dump-roles.rst
+++ b/docs/include/dump-roles.rst
@@ -1,0 +1,10 @@
+::
+
+   pgcopydb dump roles: Dump source database roles as custome file in work directory
+   usage: pgcopydb dump roles  --source <URI>
+   
+     --source            Postgres URI to the source database
+     --target            Directory where to save the dump files
+     --dir               Work directory to use
+     --no-role-passwords Do not dump passwords for roles
+   

--- a/docs/include/dump-schema.rst
+++ b/docs/include/dump-schema.rst
@@ -1,0 +1,11 @@
+::
+
+   pgcopydb dump schema: Dump source database schema as custom files in work directory
+   usage: pgcopydb dump schema  --source <URI> 
+   
+     --source          Postgres URI to the source database
+     --target          Directory where to save the dump files
+     --dir             Work directory to use
+     --skip-extensions Skip restoring extensions
+     --snapshot        Use snapshot obtained with pg_export_snapshot
+   

--- a/docs/include/dump.rst
+++ b/docs/include/dump.rst
@@ -1,0 +1,11 @@
+::
+
+   pgcopydb dump: Dump database objects from a Postgres instance
+   
+   Available commands:
+     pgcopydb dump
+       schema     Dump source database schema as custom files in work directory
+       pre-data   Dump source database pre-data schema as custom files in work directory
+       post-data  Dump source database post-data schema as custom files in work directory
+       roles      Dump source database roles as custome file in work directory
+   

--- a/docs/include/follow.rst
+++ b/docs/include/follow.rst
@@ -1,0 +1,20 @@
+::
+
+   pgcopydb follow: Replay changes from the source database to the target database
+   usage: pgcopydb follow  --source ... --target ...  
+   
+     --source                      Postgres URI to the source database
+     --target                      Postgres URI to the target database
+     --dir                         Work directory to use
+     --filters <filename>          Use the filters defined in <filename>
+     --restart                     Allow restarting when temp files exist already
+     --resume                      Allow resuming operations after a failure
+     --not-consistent              Allow taking a new snapshot on the source database
+     --snapshot                    Use snapshot obtained with pg_export_snapshot
+     --plugin                      Output plugin to use (test_decoding, wal2json)
+     --wal2json-numeric-as-string  Print numeric data type as string when using wal2json output plugin
+     --slot-name                   Use this Postgres replication slot name
+     --create-slot                 Create the replication slot
+     --origin                      Use this Postgres replication origin node name
+     --endpos                      Stop replaying changes when reaching this LSN
+   

--- a/docs/include/list-collations.rst
+++ b/docs/include/list-collations.rst
@@ -1,0 +1,7 @@
+::
+
+   pgcopydb list collations: List all the source collations to copy
+   usage: pgcopydb list collations  --source ... 
+   
+     --source            Postgres URI to the source database
+   

--- a/docs/include/list-databases.rst
+++ b/docs/include/list-databases.rst
@@ -1,0 +1,7 @@
+::
+
+   pgcopydb list databases: List databases
+   usage: pgcopydb list databases  --source ... 
+   
+     --source            Postgres URI to the source database
+   

--- a/docs/include/list-depends.rst
+++ b/docs/include/list-depends.rst
@@ -1,0 +1,12 @@
+::
+
+   pgcopydb list depends: List all the dependencies to filter-out
+   usage: pgcopydb list depends  --source ... [ --schema-name [ --table-name ] ]
+   
+     --source            Postgres URI to the source database
+     --force             Force fetching catalogs again
+     --schema-name       Name of the schema where to find the table
+     --table-name        Name of the target table
+     --filter <filename> Use the filters defined in <filename>
+     --list-skipped      List only tables that are setup to be skipped
+   

--- a/docs/include/list-extensions.rst
+++ b/docs/include/list-extensions.rst
@@ -1,0 +1,10 @@
+::
+
+   pgcopydb list extensions: List all the source extensions to copy
+   usage: pgcopydb list extensions  --source ... 
+   
+     --source              Postgres URI to the source database
+     --json                Format the output using JSON
+     --available-versions  List available extension versions
+     --requirements        List extensions requirements
+   

--- a/docs/include/list-indexes.rst
+++ b/docs/include/list-indexes.rst
@@ -1,0 +1,12 @@
+::
+
+   pgcopydb list indexes: List all the indexes to create again after copying the data
+   usage: pgcopydb list indexes  --source ... [ --schema-name [ --table-name ] ]
+   
+     --source            Postgres URI to the source database
+     --force             Force fetching catalogs again
+     --schema-name       Name of the schema where to find the table
+     --table-name        Name of the target table
+     --filter <filename> Use the filters defined in <filename>
+     --list-skipped      List only tables that are setup to be skipped
+   

--- a/docs/include/list-progress.rst
+++ b/docs/include/list-progress.rst
@@ -1,0 +1,10 @@
+::
+
+   pgcopydb list progress: List the progress
+   usage: pgcopydb list progress  --source ... 
+   
+     --source  Postgres URI to the source database
+     --summary List the summary, requires --json
+     --json    Format the output using JSON
+     --dir     Work directory to use
+   

--- a/docs/include/list-schema.rst
+++ b/docs/include/list-schema.rst
@@ -1,0 +1,9 @@
+::
+
+   pgcopydb list schema: List the schema to migrate, formatted in JSON
+   usage: pgcopydb list schema  --source ... 
+   
+     --source            Postgres URI to the source database
+     --force             Force fetching catalogs again
+     --filter <filename> Use the filters defined in <filename>
+   

--- a/docs/include/list-sequences.rst
+++ b/docs/include/list-sequences.rst
@@ -1,0 +1,10 @@
+::
+
+   pgcopydb list sequences: List all the source sequences to copy data from
+   usage: pgcopydb list sequences  --source ... 
+   
+     --source            Postgres URI to the source database
+     --force             Force fetching catalogs again
+     --filter <filename> Use the filters defined in <filename>
+     --list-skipped      List only tables that are setup to be skipped
+   

--- a/docs/include/list-table-parts.rst
+++ b/docs/include/list-table-parts.rst
@@ -1,0 +1,11 @@
+::
+
+   pgcopydb list table-parts: List a source table copy partitions
+   usage: pgcopydb list table-parts  --source ... 
+   
+     --source                    Postgres URI to the source database
+     --force                     Force fetching catalogs again
+     --schema-name               Name of the schema where to find the table
+     --table-name                Name of the target table
+     --split-tables-larger-than  Size threshold to consider partitioning
+   

--- a/docs/include/list-tables.rst
+++ b/docs/include/list-tables.rst
@@ -1,0 +1,13 @@
+::
+
+   pgcopydb list tables: List all the source tables to copy data from
+   usage: pgcopydb list tables  --source ... 
+   
+     --source            Postgres URI to the source database
+     --filter <filename> Use the filters defined in <filename>
+     --force             Force fetching catalogs again
+     --cache             Cache table size in relation pgcopydb.pgcopydb_table_size
+     --drop-cache        Drop relation pgcopydb.pgcopydb_table_size
+     --list-skipped      List only tables that are setup to be skipped
+     --without-pkey      List only tables that have no primary key
+   

--- a/docs/include/list.rst
+++ b/docs/include/list.rst
@@ -1,0 +1,17 @@
+::
+
+   pgcopydb list: List database objects from a Postgres instance
+   
+   Available commands:
+     pgcopydb list
+       databases    List databases
+       extensions   List all the source extensions to copy
+       collations   List all the source collations to copy
+       tables       List all the source tables to copy data from
+       table-parts  List a source table copy partitions
+       sequences    List all the source sequences to copy data from
+       indexes      List all the indexes to create again after copying the data
+       depends      List all the dependencies to filter-out
+       schema       List the schema to migrate, formatted in JSON
+       progress     List the progress
+   

--- a/docs/include/pgcopydb.rst
+++ b/docs/include/pgcopydb.rst
@@ -1,0 +1,22 @@
+::
+
+   pgcopydb: pgcopydb tool
+   usage: pgcopydb [ --verbose --quiet ]
+   
+   
+   Available commands:
+     pgcopydb
+       clone     Clone an entire database from source to target
+       fork      Clone an entire database from source to target
+       follow    Replay changes from the source database to the target database
+       snapshot  Create and export a snapshot on the source database
+     + compare   Compare source and target databases
+     + copy      Implement the data section of the database copy
+     + dump      Dump database objects from a Postgres instance
+     + restore   Restore database objects into a Postgres instance
+     + list      List database objects from a Postgres instance
+     + stream    Stream changes from the source database
+       ping      Attempt to connect to the source and target instances
+       help      Print help message
+       version   Print pgcopydb version
+   

--- a/docs/include/ping.rst
+++ b/docs/include/ping.rst
@@ -1,0 +1,8 @@
+::
+
+   pgcopydb ping: Attempt to connect to the source and target instances
+   usage: pgcopydb ping  --source ... --target ... 
+   
+     --source              Postgres URI to the source database
+     --target              Postgres URI to the target database
+   

--- a/docs/include/restore-parse-list.rst
+++ b/docs/include/restore-parse-list.rst
@@ -1,0 +1,15 @@
+::
+
+   pgcopydb restore parse-list: Parse pg_restore --list output from custom file
+   usage: pgcopydb restore parse-list  [ <pre.list> ] 
+   
+     --source             Postgres URI to the source database
+     --target             Postgres URI to the target database
+     --dir                Work directory to use
+     --filters <filename> Use the filters defined in <filename>
+     --skip-extensions    Skip restoring extensions
+     --skip-ext-comments  Skip restoring COMMENT ON EXTENSION
+     --restart            Allow restarting when temp files exist already
+     --resume             Allow resuming operations after a failure
+     --not-consistent     Allow taking a new snapshot on the source database
+   

--- a/docs/include/restore-post-data.rst
+++ b/docs/include/restore-post-data.rst
@@ -1,0 +1,19 @@
+::
+
+   pgcopydb restore post-data: Restore a database post-data schema from custom file to target database
+   usage: pgcopydb restore post-data  --dir <dir> [ --source <URI> ] --target <URI> 
+   
+     --source             Postgres URI to the source database
+     --target             Postgres URI to the target database
+     --dir                Work directory to use
+     --restore-jobs       Number of concurrent jobs for pg_restore
+     --no-owner           Do not set ownership of objects to match the original database
+     --no-acl             Prevent restoration of access privileges (grant/revoke commands).
+     --no-comments        Do not output commands to restore comments
+     --skip-extensions    Skip restoring extensions
+     --skip-ext-comments  Skip restoring COMMENT ON EXTENSION
+     --filters <filename> Use the filters defined in <filename>
+     --restart            Allow restarting when temp files exist already
+     --resume             Allow resuming operations after a failure
+     --not-consistent     Allow taking a new snapshot on the source database
+   

--- a/docs/include/restore-pre-data.rst
+++ b/docs/include/restore-pre-data.rst
@@ -1,0 +1,20 @@
+::
+
+   pgcopydb restore pre-data: Restore a database pre-data schema from custom file to target database
+   usage: pgcopydb restore pre-data  --dir <dir> [ --source <URI> ] --target <URI> 
+   
+     --source             Postgres URI to the source database
+     --target             Postgres URI to the target database
+     --dir                Work directory to use
+     --restore-jobs       Number of concurrent jobs for pg_restore
+     --drop-if-exists     On the target database, clean-up from a previous run first
+     --no-owner           Do not set ownership of objects to match the original database
+     --no-acl             Prevent restoration of access privileges (grant/revoke commands).
+     --no-comments        Do not output commands to restore comments
+     --skip-extensions    Skip restoring extensions
+     --skip-ext-comments  Skip restoring COMMENT ON EXTENSION
+     --filters <filename> Use the filters defined in <filename>
+     --restart            Allow restarting when temp files exist already
+     --resume             Allow resuming operations after a failure
+     --not-consistent     Allow taking a new snapshot on the source database
+   

--- a/docs/include/restore-roles.rst
+++ b/docs/include/restore-roles.rst
@@ -1,0 +1,10 @@
+::
+
+   pgcopydb restore roles: Restore database roles from SQL file to target database
+   usage: pgcopydb restore roles  --dir <dir> [ --source <URI> ] --target <URI> 
+   
+     --source             Postgres URI to the source database
+     --target             Postgres URI to the target database
+     --dir                Work directory to use
+     --restore-jobs       Number of concurrent jobs for pg_restore
+   

--- a/docs/include/restore-schema.rst
+++ b/docs/include/restore-schema.rst
@@ -1,0 +1,18 @@
+::
+
+   pgcopydb restore schema: Restore a database schema from custom files to target database
+   usage: pgcopydb restore schema  --dir <dir> [ --source <URI> ] --target <URI> 
+   
+     --source             Postgres URI to the source database
+     --target             Postgres URI to the target database
+     --dir                Work directory to use
+     --restore-jobs       Number of concurrent jobs for pg_restore
+     --drop-if-exists     On the target database, clean-up from a previous run first
+     --no-owner           Do not set ownership of objects to match the original database
+     --no-acl             Prevent restoration of access privileges (grant/revoke commands).
+     --no-comments        Do not output commands to restore comments
+     --filters <filename> Use the filters defined in <filename>
+     --restart            Allow restarting when temp files exist already
+     --resume             Allow resuming operations after a failure
+     --not-consistent     Allow taking a new snapshot on the source database
+   

--- a/docs/include/restore.rst
+++ b/docs/include/restore.rst
@@ -1,0 +1,12 @@
+::
+
+   pgcopydb restore: Restore database objects into a Postgres instance
+   
+   Available commands:
+     pgcopydb restore
+       schema      Restore a database schema from custom files to target database
+       pre-data    Restore a database pre-data schema from custom file to target database
+       post-data   Restore a database post-data schema from custom file to target database
+       roles       Restore database roles from SQL file to target database
+       parse-list  Parse pg_restore --list output from custom file
+   

--- a/docs/include/snapshot.rst
+++ b/docs/include/snapshot.rst
@@ -1,0 +1,12 @@
+::
+
+   pgcopydb snapshot: Create and export a snapshot on the source database
+   usage: pgcopydb snapshot  --source ... 
+   
+     --source                      Postgres URI to the source database
+     --dir                         Work directory to use
+     --follow                      Implement logical decoding to replay changes
+     --plugin                      Output plugin to use (test_decoding, wal2json)
+     --wal2json-numeric-as-string  Print numeric data type as string when using wal2json output plugin
+     --slot-name                   Use this Postgres replication slot name
+   

--- a/docs/include/stream-apply.rst
+++ b/docs/include/stream-apply.rst
@@ -1,0 +1,12 @@
+::
+
+   pgcopydb stream apply: Apply changes from the source database into the target database
+   usage: pgcopydb stream apply  <sql filename> 
+   
+     --target         Postgres URI to the target database
+     --dir            Work directory to use
+     --restart        Allow restarting when temp files exist already
+     --resume         Allow resuming operations after a failure
+     --not-consistent Allow taking a new snapshot on the source database
+     --origin         Name of the Postgres replication origin
+   

--- a/docs/include/stream-catchup.rst
+++ b/docs/include/stream-catchup.rst
@@ -1,0 +1,15 @@
+::
+
+   pgcopydb stream catchup: Apply prefetched changes from SQL files to the target database
+   usage: pgcopydb stream catchup 
+   
+     --source         Postgres URI to the source database
+     --target         Postgres URI to the target database
+     --dir            Work directory to use
+     --restart        Allow restarting when temp files exist already
+     --resume         Allow resuming operations after a failure
+     --not-consistent Allow taking a new snapshot on the source database
+     --slot-name      Stream changes recorded by this slot
+     --endpos         LSN position where to stop receiving changes
+     --origin         Name of the Postgres replication origin
+   

--- a/docs/include/stream-cleanup.rst
+++ b/docs/include/stream-cleanup.rst
@@ -1,0 +1,14 @@
+::
+
+   pgcopydb stream cleanup: cleanup source and target systems for logical decoding
+   usage: pgcopydb stream cleanup 
+   
+     --source         Postgres URI to the source database
+     --target         Postgres URI to the target database
+     --restart        Allow restarting when temp files exist already
+     --resume         Allow resuming operations after a failure
+     --not-consistent Allow taking a new snapshot on the source database
+     --snapshot       Use snapshot obtained with pg_export_snapshot
+     --slot-name      Stream changes recorded by this slot
+     --origin         Name of the Postgres replication origin
+   

--- a/docs/include/stream-prefetch.rst
+++ b/docs/include/stream-prefetch.rst
@@ -1,0 +1,12 @@
+::
+
+   pgcopydb stream prefetch: Stream JSON changes from the source database and transform them to SQL
+   usage: pgcopydb stream prefetch 
+   
+     --source         Postgres URI to the source database
+     --dir            Work directory to use
+     --restart        Allow restarting when temp files exist already
+     --resume         Allow resuming operations after a failure
+     --not-consistent Allow taking a new snapshot on the source database
+     --slot-name      Stream changes recorded by this slot
+     --endpos         LSN position where to stop receiving changes

--- a/docs/include/stream-receive.rst
+++ b/docs/include/stream-receive.rst
@@ -1,0 +1,13 @@
+::
+
+   pgcopydb stream receive: Stream changes from the source database
+   usage: pgcopydb stream receive 
+   
+     --source         Postgres URI to the source database
+     --dir            Work directory to use
+     --to-stdout      Stream logical decoding messages to stdout
+     --restart        Allow restarting when temp files exist already
+     --resume         Allow resuming operations after a failure
+     --not-consistent Allow taking a new snapshot on the source database
+     --slot-name      Stream changes recorded by this slot
+     --endpos         LSN position where to stop receiving changes

--- a/docs/include/stream-replay.rst
+++ b/docs/include/stream-replay.rst
@@ -1,0 +1,15 @@
+::
+
+   pgcopydb stream replay: Replay changes from the source to the target database, live
+   usage: pgcopydb stream replay 
+   
+     --source         Postgres URI to the source database
+     --target         Postgres URI to the target database
+     --dir            Work directory to use
+     --restart        Allow restarting when temp files exist already
+     --resume         Allow resuming operations after a failure
+     --not-consistent Allow taking a new snapshot on the source database
+     --slot-name      Stream changes recorded by this slot
+     --endpos         LSN position where to stop receiving changes
+     --origin         Name of the Postgres replication origin
+   

--- a/docs/include/stream-sentinel-get.rst
+++ b/docs/include/stream-sentinel-get.rst
@@ -1,0 +1,8 @@
+::
+
+   pgcopydb stream sentinel get: Get the sentinel table values on the source database
+   usage: pgcopydb stream sentinel get  --source ... 
+   
+     --source      Postgres URI to the source database
+     --json        Format the output using JSON
+   

--- a/docs/include/stream-sentinel-set-apply.rst
+++ b/docs/include/stream-sentinel-set-apply.rst
@@ -1,0 +1,7 @@
+::
+
+   pgcopydb stream sentinel set apply: Set the sentinel apply mode on the source database
+   usage: pgcopydb stream sentinel set apply 
+   
+     --source      Postgres URI to the source database
+   

--- a/docs/include/stream-sentinel-set-endpos.rst
+++ b/docs/include/stream-sentinel-set-endpos.rst
@@ -1,0 +1,8 @@
+::
+
+   pgcopydb stream sentinel set endpos: Set the sentinel end position LSN on the source database
+   usage: pgcopydb stream sentinel set endpos  --source ... <end LSN>
+   
+     --source      Postgres URI to the source database
+     --current     Use pg_current_wal_flush_lsn() as the endpos
+   

--- a/docs/include/stream-sentinel-set-prefetch.rst
+++ b/docs/include/stream-sentinel-set-prefetch.rst
@@ -1,0 +1,7 @@
+::
+
+   pgcopydb stream sentinel set prefetch: Set the sentinel prefetch mode on the source database
+   usage: pgcopydb stream sentinel set prefetch 
+   
+     --source      Postgres URI to the source database
+   

--- a/docs/include/stream-sentinel-set-startpos.rst
+++ b/docs/include/stream-sentinel-set-startpos.rst
@@ -1,0 +1,7 @@
+::
+
+   pgcopydb stream sentinel set startpos: Set the sentinel start position LSN on the source database
+   usage: pgcopydb stream sentinel set startpos  --source ... <start LSN>
+   
+     --source      Postgres URI to the source database
+   

--- a/docs/include/stream-sentinel-set.rst
+++ b/docs/include/stream-sentinel-set.rst
@@ -1,0 +1,11 @@
+::
+
+   pgcopydb stream sentinel set: Maintain a sentinel table on the source database
+   
+   Available commands:
+     pgcopydb stream sentinel set
+       startpos  Set the sentinel start position LSN on the source database
+       endpos    Set the sentinel end position LSN on the source database
+       apply     Set the sentinel apply mode on the source database
+       prefetch  Set the sentinel prefetch mode on the source database
+   

--- a/docs/include/stream-sentinel-setup.rst
+++ b/docs/include/stream-sentinel-setup.rst
@@ -1,0 +1,8 @@
+::
+
+   pgcopydb stream sentinel setup: Setup the sentinel table
+   usage: pgcopydb stream sentinel setup 
+   
+     --startpos    Start replaying changes when reaching this LSN
+     --endpos      Stop replaying changes when reaching this LSN
+   

--- a/docs/include/stream-sentinel.rst
+++ b/docs/include/stream-sentinel.rst
@@ -1,0 +1,10 @@
+::
+
+   pgcopydb stream sentinel: Maintain a sentinel table on the source database
+   
+   Available commands:
+     pgcopydb stream sentinel
+       setup  Setup the sentinel table
+       get    Get the sentinel table values on the source database
+     + set    Maintain a sentinel table on the source database
+   

--- a/docs/include/stream-setup.rst
+++ b/docs/include/stream-setup.rst
@@ -1,0 +1,17 @@
+::
+
+   pgcopydb stream setup: Setup source and target systems for logical decoding
+   usage: pgcopydb stream setup 
+   
+     --source                      Postgres URI to the source database
+     --target                      Postgres URI to the target database
+     --dir                         Work directory to use
+     --restart                     Allow restarting when temp files exist already
+     --resume                      Allow resuming operations after a failure
+     --not-consistent              Allow taking a new snapshot on the source database
+     --snapshot                    Use snapshot obtained with pg_export_snapshot
+     --plugin                      Output plugin to use (test_decoding, wal2json)
+     --wal2json-numeric-as-string  Print numeric data type as string when using wal2json output plugin
+     --slot-name                   Stream changes recorded by this slot
+     --origin                      Name of the Postgres replication origin
+   

--- a/docs/include/stream-transform.rst
+++ b/docs/include/stream-transform.rst
@@ -1,0 +1,11 @@
+::
+
+   pgcopydb stream transform: Transform changes from the source database into SQL commands
+   usage: pgcopydb stream transform  <json filename> <sql filename> 
+   
+     --target         Postgres URI to the target database
+     --dir            Work directory to use
+     --restart        Allow restarting when temp files exist already
+     --resume         Allow resuming operations after a failure
+     --not-consistent Allow taking a new snapshot on the source database
+   

--- a/docs/include/stream.rst
+++ b/docs/include/stream.rst
@@ -1,0 +1,16 @@
+::
+
+   pgcopydb stream: Stream changes from the source database
+   
+   Available commands:
+     pgcopydb stream
+       setup      Setup source and target systems for logical decoding
+       cleanup    cleanup source and target systems for logical decoding
+       prefetch   Stream JSON changes from the source database and transform them to SQL
+       catchup    Apply prefetched changes from SQL files to the target database
+       replay     Replay changes from the source to the target database, live
+     + sentinel   Maintain a sentinel table on the source database
+       receive    Stream changes from the source database
+       transform  Transform changes from the source database into SQL commands
+       apply      Apply changes from the source database into the target database
+   

--- a/docs/ref/pgcopydb.rst
+++ b/docs/ref/pgcopydb.rst
@@ -8,20 +8,9 @@ pgcopydb - copy an entire Postgres database from source to target
 Synopsis
 --------
 
-pgcopydb provides the following commands::
+pgcopydb provides the following commands
 
-  pgcopydb
-    clone     Clone an entire database from source to target
-    fork      Clone an entire database from source to target
-    follow    Replay changes from the source database to the target database
-    snapshot  Create and export a snapshot on the source database
-  + copy      Implement the data section of the database copy
-  + dump      Dump database objects from a Postgres instance
-  + restore   Restore database objects into a Postgres instance
-  + list      List database objects from a Postgres instance
-  + stream    Stream changes from the source database
-    help      Print help message
-    version   Print pgcopydb version
+.. include:: ../include/pgcopydb.rst
 
 Description
 -----------
@@ -53,6 +42,7 @@ The ``pgcopydb help`` command lists all the supported sub-commands:
       fork      Clone an entire database from source to target
       follow    Replay changes from the source database to the target database
       snapshot  Create and export a snapshot on the source database
+    + compare   Compare source and target databases
     + copy      Implement the data section of the database copy
     + dump      Dump database objects from a Postgres instance
     + restore   Restore database objects into a Postgres instance
@@ -61,6 +51,10 @@ The ``pgcopydb help`` command lists all the supported sub-commands:
       ping      Attempt to connect to the source and target instances
       help      Print help message
       version   Print pgcopydb version
+
+    pgcopydb compare
+      schema  Compare source and target schema
+      data    Compare source and target data
 
     pgcopydb copy
       db           Copy an entire database from source to target
@@ -111,8 +105,7 @@ The ``pgcopydb help`` command lists all the supported sub-commands:
       apply      Apply changes from the source database into the target database
 
     pgcopydb stream sentinel
-      create  Create the sentinel table on the source database
-      drop    Drop the sentinel table on the source database
+      setup   Setup the sentinel table
       get     Get the sentinel table values on the source database
     + set     Maintain a sentinel table on the source database
 
@@ -160,13 +153,7 @@ pgcopydb ping
 The ``pgcopydb ping`` command attempts to connect to both the source and the
 target Postgres databases, concurrently.
 
-::
-
-   pgcopydb ping: Attempt to connect to the source and target instances
-   usage: pgcopydb ping  --source ... --target ...
-
-     --source              Postgres URI to the source database
-     --target              Postgres URI to the target database
+.. include:: ../include/ping.rst
 
 An example output looks like the following:
 

--- a/docs/ref/pgcopydb_clone.rst
+++ b/docs/ref/pgcopydb_clone.rst
@@ -19,44 +19,7 @@ pgcopydb clone
 The command ``pgcopydb clone`` copies a database from the given source
 Postgres instance to the target Postgres instance.
 
-::
-
-   pgcopydb clone: Clone an entire database from source to target
-   usage: pgcopydb clone  --source ... --target ... [ --table-jobs ... --index-jobs ... ]
-
-     --source                      Postgres URI to the source database
-     --target                      Postgres URI to the target database
-     --dir                         Work directory to use
-     --table-jobs                  Number of concurrent COPY jobs to run
-     --index-jobs                  Number of concurrent CREATE INDEX jobs to run
-     --restore-jobs                Number of concurrent jobs for pg_restore
-     --large-objects-jobs          Number of concurrent Large Objects jobs to run
-     --split-tables-larger-than    Same-table concurrency size threshold
-     --drop-if-exists              On the target database, clean-up from a previous run first
-     --roles                       Also copy roles found on source to target
-     --no-role-passwords           Do not dump passwords for roles
-     --no-owner                    Do not set ownership of objects to match the original database
-     --no-acl                      Prevent restoration of access privileges (grant/revoke commands).
-     --no-comments                 Do not output commands to restore comments
-     --skip-large-objects          Skip copying large objects (blobs)
-     --skip-extensions             Skip restoring extensions
-     --skip-ext-comments           Skip restoring COMMENT ON EXTENSION
-     --skip-collations             Skip restoring collations
-     --skip-vacuum                 Skip running VACUUM ANALYZE
-     --requirements <filename>     List extensions requirements
-     --filters <filename>          Use the filters defined in <filename>
-     --fail-fast                   Abort early in case of error
-     --restart                     Allow restarting when temp files exist already
-     --resume                      Allow resuming operations after a failure
-     --not-consistent              Allow taking a new snapshot on the source database
-     --snapshot                    Use snapshot obtained with pg_export_snapshot
-     --follow                      Implement logical decoding to replay changes
-     --plugin                      Output plugin to use (test_decoding, wal2json)
-     --wal2json-numeric-as-string  Print numeric data type as string when using wal2json output plugin
-     --slot-name                   Use this Postgres replication slot name
-     --create-slot                 Create the replication slot
-     --origin                      Use this Postgres replication origin node name
-     --endpos                      Stop replaying changes when reaching this LSN
+.. include:: ../include/clone.rst
 
 .. _pgcopydb_fork:
 

--- a/docs/ref/pgcopydb_compare.rst
+++ b/docs/ref/pgcopydb_compare.rst
@@ -17,14 +17,7 @@ At the moment, the ``pgcopydb compare`` tool is pretty limited in terms of
 schema support: it only covers what pgcopydb needs to know about the
 database schema, which isn't much.
 
-::
-
-   pgcopydb compare: Compare source and target databases
-
-   Available commands:
-     pgcopydb compare
-       schema  Compare source and target schema
-       data    Compare source and target data
+.. include:: ../include/compare.rst
 
 .. _pgcopydb_compare_schema:
 
@@ -37,15 +30,7 @@ The command ``pgcopydb compare schema`` connects to the source and target
 databases and executes SQL queries using the Postgres catalogs to get a list
 of tables, indexes, constraints and sequences there.
 
-::
-
-   pgcopydb compare schema: Compare source and target schema
-   usage: pgcopydb compare schema  --source ...
-
-     --source         Postgres URI to the source database
-     --target         Postgres URI to the target database
-     --dir            Work directory to use
-
+.. include:: ../include/compare-schema.rst
 
 .. _pgcopydb_compare_data:
 
@@ -83,16 +68,7 @@ count and a checksum for each table::
 
 Running such a query on a large table can take a lot of time.
 
-::
-
-   pgcopydb compare data: Compare source and target data
-   usage: pgcopydb compare data  --source ...
-
-     --source         Postgres URI to the source database
-     --target         Postgres URI to the target database
-     --dir            Work directory to use
-     --json           Format the output using JSON
-
+.. include:: ../include/compare-data.rst
 
 Options
 -------

--- a/docs/ref/pgcopydb_copy.rst
+++ b/docs/ref/pgcopydb_copy.rst
@@ -7,19 +7,7 @@ pgcopydb copy - Implement the data section of the database copy
 
 This command prefixes the following sub-commands:
 
-::
-
-  pgcopydb copy
-    db           Copy an entire database from source to target
-    roles        Copy the roles from the source instance to the target instance
-    extensions   Copy the extensions from the source instance to the target instance
-    schema       Copy the database schema from source to target
-    data         Copy the data section from source to target
-    table-data   Copy the data from all tables in database from source to target
-    blobs        Copy the blob data from the source database to the target
-    sequences    Copy the current value from all sequences in database from source to target
-    indexes      Create all the indexes found in the source database in the target
-    constraints  Create all the constraints found in the source database in the target
+.. include:: ../include/copy.rst
 
 Those commands implement a part of the whole database copy operation as
 detailed in section :ref:`pgcopydb_clone`. Only use those commands to debug
@@ -42,28 +30,7 @@ pgcopydb copy db - Copy an entire database from source to target
 The command ``pgcopydb copy db`` is an alias for ``pgcopydb clone``. See
 also :ref:`pgcopydb_clone`.
 
-::
-
-   pgcopydb copy db: Copy an entire database from source to target
-   usage: pgcopydb copy db  --source ... --target ... [ --table-jobs ... --index-jobs ... ]
-
-     --source              Postgres URI to the source database
-     --target              Postgres URI to the target database
-     --dir                 Work directory to use
-     --table-jobs          Number of concurrent COPY jobs to run
-     --index-jobs          Number of concurrent CREATE INDEX jobs to run
-     --restore-jobs        Number of concurrent jobs for pg_restore
-     --drop-if-exists      On the target database, clean-up from a previous run first
-     --roles               Also copy roles found on source to target
-     --no-owner            Do not set ownership of objects to match the original database
-     --no-acl              Prevent restoration of access privileges (grant/revoke commands).
-     --no-comments         Do not output commands to restore comments
-     --skip-large-objects  Skip copying large objects (blobs)
-     --filters <filename>  Use the filters defined in <filename>
-     --restart             Allow restarting when temp files exist already
-     --resume              Allow resuming operations after a failure
-     --not-consistent      Allow taking a new snapshot on the source database
-     --snapshot            Use snapshot obtained with pg_export_snapshot
+.. include:: ../include/copy-db.rst
 
 .. _pgcopydb_copy_roles:
 
@@ -75,15 +42,7 @@ pgcopydb copy roles - Copy the roles from the source instance to the target inst
 The command ``pgcopydb copy roles`` implements both
 :ref:`pgcopydb_dump_roles` and then :ref:`pgcopydb_restore_roles`.
 
-::
-
-   pgcopydb copy roles: Copy the roles from the source instance to the target instance
-   usage: pgcopydb copy roles  --source ... --target ...
-
-     --source              Postgres URI to the source database
-     --target              Postgres URI to the target database
-     --dir                 Work directory to use
-     --no-role-passwords   Do not dump passwords for roles
+.. include:: ../include/copy-roles.rst
 
 .. note::
 
@@ -111,14 +70,7 @@ The command ``pgcopydb copy extensions`` gets a list of the extensions
 installed on the source database, and for each of them run the SQL command
 CREATE EXTENSION IF NOT EXISTS.
 
-::
-
-   pgcopydb copy extensions: Copy the extensions from the source instance to the target instance
-   usage: pgcopydb copy extensions  --source ... --target ...
-
-     --source              Postgres URI to the source database
-     --target              Postgres URI to the target database
-     --dir                 Work directory to use
+.. include:: ../include/copy-extensions.rst
 
 When copying extensions, this command also takes care of copying any
 `Extension Configuration Tables`__ user-data to the target database.
@@ -135,20 +87,7 @@ pgcopydb copy schema - Copy the database schema from source to target
 The command ``pgcopydb copy schema`` implements the schema only section of
 the clone steps.
 
-::
-
-   pgcopydb copy schema: Copy the database schema from source to target
-   usage: pgcopydb copy schema  --source ... --target ... [ --table-jobs ... --index-jobs ... ]
-
-     --source              Postgres URI to the source database
-     --target              Postgres URI to the target database
-     --dir                 Work directory to use
-     --filters <filename>  Use the filters defined in <filename>
-     --restart             Allow restarting when temp files exist already
-     --resume              Allow resuming operations after a failure
-     --not-consistent      Allow taking a new snapshot on the source database
-     --snapshot            Use snapshot obtained with pg_export_snapshot
-
+.. include:: ../include/copy-schema.rst
 
 .. _pgcopydb_copy_data:
 
@@ -160,24 +99,7 @@ pgcopydb copy data - Copy the data section from source to target
 The command ``pgcopydb copy data`` implements the data section of the clone
 steps.
 
-::
-
-   pgcopydb copy data: Copy the data section from source to target
-   usage: pgcopydb copy data  --source ... --target ... [ --table-jobs ... --index-jobs ... ]
-
-     --source              Postgres URI to the source database
-     --target              Postgres URI to the target database
-     --dir                 Work directory to use
-     --table-jobs          Number of concurrent COPY jobs to run
-     --index-jobs          Number of concurrent CREATE INDEX jobs to run
-     --restore-jobs        Number of concurrent jobs for pg_restore
-     --drop-if-exists      On the target database, clean-up from a previous run first
-     --no-owner            Do not set ownership of objects to match the original database
-     --skip-large-objects  Skip copying large objects (blobs)
-     --restart             Allow restarting when temp files exist already
-     --resume              Allow resuming operations after a failure
-     --not-consistent      Allow taking a new snapshot on the source database
-     --snapshot            Use snapshot obtained with pg_export_snapshot
+.. include:: ../include/copy-data.rst
 
 .. note::
 
@@ -213,19 +135,7 @@ source database and runs a COPY TO command on the source database and sends
 the result to the target database using a COPY FROM command directly,
 avoiding disks entirely.
 
-::
-
-   pgcopydb copy table-data: Copy the data from all tables in database from source to target
-   usage: pgcopydb copy table-data  --source ... --target ... [ --table-jobs ... --index-jobs ... ]
-
-     --source          Postgres URI to the source database
-     --target          Postgres URI to the target database
-     --dir             Work directory to use
-     --table-jobs      Number of concurrent COPY jobs to run
-     --restart         Allow restarting when temp files exist already
-     --resume          Allow resuming operations after a failure
-     --not-consistent  Allow taking a new snapshot on the source database
-     --snapshot        Use snapshot obtained with pg_export_snapshot
+.. include:: ../include/copy-table-data.rst
 
 .. _pgcopydb_copy_blobs:
 
@@ -240,20 +150,7 @@ database. By default the command assumes that the large objects metadata
 have already been taken care of, because of the behaviour of
 ``pg_dump --section=pre-data``.
 
-::
-
-   pgcopydb copy blobs: Copy the blob data from the source database to the target
-   usage: pgcopydb copy blobs  --source ... --target ...
-
-     --source             Postgres URI to the source database
-     --target             Postgres URI to the target database
-     --dir                Work directory to use
-     --large-objects-jobs Number of concurrent Large Objects jobs to run
-     --drop-if-exists     On the target database, drop and create large objects
-     --restart            Allow restarting when temp files exist already
-     --resume             Allow resuming operations after a failure
-     --not-consistent     Allow taking a new snapshot on the source database
-     --snapshot           Use snapshot obtained with pg_export_snapshot
+.. include:: ../include/copy-blobs.rst
 
 .. _pgcopydb_copy_sequences:
 
@@ -268,17 +165,7 @@ the source database, then for each sequence fetches the ``last_value`` and
 and then for each sequence call ``pg_catalog.setval()`` on the target
 database.
 
-::
-
-   pgcopydb copy sequences: Copy the current value from all sequences in database from source to target
-   usage: pgcopydb copy sequences  --source ... --target ... [ --table-jobs ... --index-jobs ... ]
-
-     --source          Postgres URI to the source database
-     --target          Postgres URI to the target database
-     --dir             Work directory to use
-     --restart         Allow restarting when temp files exist already
-     --resume          Allow resuming operations after a failure
-     --not-consistent  Allow taking a new snapshot on the source database
+.. include:: ../include/copy-sequences.rst
 
 .. _pgcopydb_copy_indexes:
 
@@ -293,19 +180,7 @@ database. The statements for the index definitions are modified to include
 IF NOT EXISTS and allow for skipping indexes that already exist on the
 target database.
 
-::
-
-   pgcopydb copy indexes: Create all the indexes found in the source database in the target
-   usage: pgcopydb copy indexes  --source ... --target ... [ --table-jobs ... --index-jobs ... ]
-
-     --source          Postgres URI to the source database
-     --target          Postgres URI to the target database
-     --dir             Work directory to use
-	 --index-jobs      Number of concurrent CREATE INDEX jobs to run
-     --restore-jobs    Number of concurrent jobs for pg_restore
-     --restart         Allow restarting when temp files exist already
-     --resume          Allow resuming operations after a failure
-     --not-consistent  Allow taking a new snapshot on the source database
+.. include:: ../include/copy-indexes.rst
 
 .. _pgcopydb_copy_constraints:
 
@@ -321,17 +196,7 @@ USING INDEX statement on the target database.
 The indexes must already exist, and the command will fail if any constraint
 is found existing already on the target database.
 
-::
-
-   pgcopydb copy constraints: Create all the constraints found in the source database in the target
-   usage: pgcopydb copy constraints  --source ... --target ... [ --table-jobs ... --index-jobs ... ]
-
-     --source          Postgres URI to the source database
-     --target          Postgres URI to the target database
-     --dir             Work directory to use
-     --restart         Allow restarting when temp files exist already
-     --resume          Allow resuming operations after a failure
-     --not-consistent  Allow taking a new snapshot on the source data
+.. include:: ../include/copy-constraints.rst
 
 Description
 -----------

--- a/docs/ref/pgcopydb_dump.rst
+++ b/docs/ref/pgcopydb_dump.rst
@@ -7,14 +7,7 @@ pgcopydb dump - Dump database objects from a Postgres instance
 
 This command prefixes the following sub-commands:
 
-::
-
-   pgcopydb dump
-     schema     Dump source database schema as custom files in target directory
-     pre-data   Dump source database pre-data schema as custom files in target directory
-     post-data  Dump source database post-data schema as custom files in target directory
-     roles      Dump source database roles as custome file in work directory
-
+.. include:: ../include/dump.rst
 
 .. _pgcopydb_dump_schema:
 
@@ -26,15 +19,7 @@ pgcopydb dump schema - Dump source database schema as custom files in target dir
 The command ``pgcopydb dump schema`` uses pg_dump to export SQL schema
 definitions from the given source Postgres instance.
 
-::
-
-   pgcopydb dump schema: Dump source database schema as custom files in target directory
-   usage: pgcopydb dump schema  --source <URI> --target <dir>
-
-     --source          Postgres URI to the source database
-     --target          Directory where to save the dump files
-     --dir             Work directory to use
-     --snapshot        Use snapshot obtained with pg_export_snapshot
+.. include:: ../include/dump-schema.rst
 
 .. _pgcopydb_dump_pre_data:
 
@@ -46,15 +31,7 @@ pgcopydb dump pre-data - Dump source database pre-data schema as custom files in
 The command ``pgcopydb dump pre-data`` uses pg_dump to export SQL schema
 *pre-data* definitions from the given source Postgres instance.
 
-::
-
-   pgcopydb dump pre-data: Dump source database pre-data schema as custom files in target directory
-   usage: pgcopydb dump schema  --source <URI> --target <dir>
-
-     --source          Postgres URI to the source database
-     --target          Directory where to save the dump files
-     --dir             Work directory to use
-     --snapshot        Use snapshot obtained with pg_export_snapshot
+.. include:: ../include/dump-pre-data.rst
 
 .. _pgcopydb_dump_post_data:
 
@@ -66,16 +43,7 @@ pgcopydb dump post-data - Dump source database post-data schema as custom files 
 The command ``pgcopydb dump post-data`` uses pg_dump to export SQL schema
 *post-data* definitions from the given source Postgres instance.
 
-::
-
-   pgcopydb dump post-data: Dump source database post-data schema as custom files in target directory
-   usage: pgcopydb dump schema  --source <URI> --target <dir>
-
-     --source          Postgres URI to the source database
-     --target          Directory where to save the dump files
-     --dir             Work directory to use
-     --snapshot        Use snapshot obtained with pg_export_snapshot
-
+.. include:: ../include/dump-post-data.rst
 
 .. _pgcopydb_dump_roles:
 
@@ -87,15 +55,7 @@ pgcopydb dump roles - Dump source database roles as custome file in work directo
 The command ``pgcopydb dump roles`` uses pg_dumpall --roles-only to export
 SQL definitions of the roles found on the source Postgres instance.
 
-::
-
-   pgcopydb dump roles: Dump source database roles as custome file in work directory
-   usage: pgcopydb dump roles  --source <URI>
-
-     --source            Postgres URI to the source database
-     --target            Directory where to save the dump files
-     --dir               Work directory to use
-     --no-role-passwords Do not dump passwords for roles
+.. include:: ../include/dump-roles.rst
 
 The ``pg_dumpall --roles-only`` is used to fetch the list of roles from the
 source database, and this command includes support for passwords. As a

--- a/docs/ref/pgcopydb_follow.rst
+++ b/docs/ref/pgcopydb_follow.rst
@@ -52,25 +52,7 @@ __ https://www.postgresql.org/docs/current/logical-replication-restrictions.html
 pgcopydb follow
 ---------------
 
-::
-
-   pgcopydb follow: Replay changes from the source database to the target database
-   usage: pgcopydb follow  --source ... --target ...
-
-     --source                      Postgres URI to the source database
-     --target                      Postgres URI to the target database
-     --dir                         Work directory to use
-     --filters <filename>          Use the filters defined in <filename>
-     --restart                     Allow restarting when temp files exist already
-     --resume                      Allow resuming operations after a failure
-     --not-consistent              Allow taking a new snapshot on the source database
-     --snapshot                    Use snapshot obtained with pg_export_snapshot
-     --plugin                      Output plugin to use (test_decoding, wal2json)
-     --wal2json-numeric-as-string  Print numeric data type as string when using wal2json output plugin
-     --slot-name                   Use this Postgres replication slot name
-     --create-slot                 Create the replication slot
-     --origin                      Use this Postgres replication origin node name
-     --endpos                      Stop replaying changes when reaching this LSN
+.. include:: ../include/follow.rst
 
 Description
 -----------

--- a/docs/ref/pgcopydb_list.rst
+++ b/docs/ref/pgcopydb_list.rst
@@ -7,20 +7,7 @@ pgcopydb list - List database objects from a Postgres instance
 
 This command prefixes the following sub-commands:
 
-::
-
-  pgcopydb list
-    databases    List databases
-    extensions   List all the source extensions to copy
-    collations   List all the source collations to copy
-    tables       List all the source tables to copy data from
-    table-parts  List a source table copy partitions
-    sequences    List all the source sequences to copy data from
-    indexes      List all the indexes to create again after copying the data
-    depends      List all the dependencies to filter-out
-    schema       List the schema to migrate, formatted in JSON
-    progress     List the progress
-
+.. include:: ../include/list.rst
 
 .. _pgcopydb_list_databases:
 
@@ -33,12 +20,7 @@ The command ``pgcopydb list databases`` connects to the source database and
 executes a SQL query using the Postgres catalogs to get a list of all the
 databases there.
 
-::
-
-   pgcopydb list databases: List databases
-   usage: pgcopydb list databases  --source ...
-
-     --source            Postgres URI to the source database
+.. include:: ../include/list-databases.rst
 
 .. _pgcopydb_list_extensions:
 
@@ -51,15 +33,7 @@ The command ``pgcopydb list extensions`` connects to the source database and
 executes a SQL query using the Postgres catalogs to get a list of all the
 extensions to COPY to the target database.
 
-::
-
-   pgcopydb list extensions: List all the source extensions to copy
-   usage: pgcopydb list extensions  --source ...
-
-     --source              Postgres URI to the source database
-     --json                Format the output using JSON
-     --available-versions  List available extension versions
-     --requirements        List extensions requirements
+.. include:: ../include/list-extensions.rst
 
 The command ``pgcopydb list extensions --available-versions`` is typically
 used with the target database. If you're using the connection string
@@ -78,12 +52,7 @@ The command ``pgcopydb list collations`` connects to the source database and
 executes a SQL query using the Postgres catalogs to get a list of all the
 collations to COPY to the target database.
 
-::
-
-   pgcopydb list collations: List all the source collations to copy
-   usage: pgcopydb list collations  --source ...
-
-     --source            Postgres URI to the source database
+.. include:: ../include/list-collations.rst
 
 The SQL query that is used lists the database collation, and then any
 non-default collation that's used in a user column or a user index.
@@ -99,17 +68,7 @@ The command ``pgcopydb list tables`` connects to the source database and
 executes a SQL query using the Postgres catalogs to get a list of all the
 tables to COPY the data from.
 
-::
-
-   pgcopydb list tables: List all the source tables to copy data from
-   usage: pgcopydb list tables  --source ...
-
-     --source            Postgres URI to the source database
-     --filter <filename> Use the filters defined in <filename>
-     --cache             Cache table size in relation pgcopydb.pgcopydb_table_size
-     --drop-cache        Drop relation pgcopydb.pgcopydb_table_size
-     --list-skipped      List only tables that are setup to be skipped
-     --without-pkey      List only tables that have no primary key
+.. include:: ../include/list-tables.rst
 
 The ``--cache`` option allows caching the `pg_table_size()`__ result in the
 newly created table ``pgcopydb.pgcopydb_table_size``. This is only useful in
@@ -130,15 +89,7 @@ and executes a SQL query using the Postgres catalogs to get detailed
 information about the given source table, and then another SQL query to
 compute how to split this source table given the size threshold argument.
 
-::
-
-   pgcopydb list table-parts: List a source table copy partitions
-   usage: pgcopydb list table-parts  --source ...
-
-     --source                    Postgres URI to the source database
-     --schema-name               Name of the schema where to find the table
-     --table-name                Name of the target table
-     --split-tables-larger-than  Size threshold to consider partitioning
+.. include:: ../include/list-table-parts.rst
 
 .. _pgcopydb_list_sequences:
 
@@ -151,14 +102,7 @@ The command ``pgcopydb list sequences`` connects to the source database and
 executes a SQL query using the Postgres catalogs to get a list of all the
 sequences to COPY the data from.
 
-::
-
-   pgcopydb list sequences: List all the source sequences to copy data from
-   usage: pgcopydb list sequences  --source ...
-
-     --source            Postgres URI to the source database
-     --filter <filename> Use the filters defined in <filename>
-     --list-skipped      List only tables that are setup to be skipped
+.. include:: ../include/list-sequences.rst
 
 .. _pgcopydb_list_indexes:
 
@@ -171,16 +115,7 @@ The command ``pgcopydb list indexes`` connects to the source database and
 executes a SQL query using the Postgres catalogs to get a list of all the
 indexes to COPY the data from.
 
-::
-
-  pgcopydb list indexes: List all the indexes to create again after copying the data
-  usage: pgcopydb list indexes  --source ... [ --schema-name [ --table-name ] ]
-
-    --source            Postgres URI to the source database
-    --schema-name       Name of the schema where to find the table
-    --table-name        Name of the target table
-    --filter <filename> Use the filters defined in <filename>
-    --list-skipped      List only tables that are setup to be skipped
+.. include:: ../include/list-indexes.rst
 
 .. _pgcopydb_list_depends:
 
@@ -193,17 +128,7 @@ The command ``pgcopydb list depends`` connects to the source database and
 executes a SQL query using the Postgres catalogs to get a list of all the
 objects that depend on excluded objects from the filtering rules.
 
-::
-
-   pgcopydb list depends: List all the dependencies to filter-out
-   usage: pgcopydb list depends  --source ... [ --schema-name [ --table-name ] ]
-
-     --source            Postgres URI to the source database
-     --schema-name       Name of the schema where to find the table
-     --table-name        Name of the target table
-     --filter <filename> Use the filters defined in <filename>
-     --list-skipped      List only tables that are setup to be skipped
-
+.. include:: ../include/list-depends.rst
 
 .. _pgcopydb_list_schema:
 
@@ -217,14 +142,7 @@ executes a SQL queries using the Postgres catalogs to get a list of the
 tables, indexes, and sequences to migrate. The command then outputs a JSON
 formatted string that contains detailed information about all those objects.
 
-::
-
-   pgcopydb list schema: List the schema to migrate, formatted in JSON
-   usage: pgcopydb list schema  --source ...
-
-     --source            Postgres URI to the source database
-     --filter <filename> Use the filters defined in <filename>
-
+.. include:: ../include/list-schema.rst
 
 .. _pgcopydb_list_progress:
 
@@ -241,16 +159,7 @@ done already, and how many are in-progress.
 When using the option ``--json`` the JSON formatted output also includes a
 list of all the tables and indexes that are currently being processed.
 
-::
-
-    pgcopydb list progress: List the progress
-    usage: pgcopydb list progress  --source ...
-
-      --source  Postgres URI to the source database
-      --summary List the summary, requires --json
-      --json    Format the output using JSON
-      --dir     Work directory to use
-
+.. include:: ../include/list-progress.rst
 
 Options
 -------

--- a/docs/ref/pgcopydb_restore.rst
+++ b/docs/ref/pgcopydb_restore.rst
@@ -7,15 +7,7 @@ pgcopydb restore - Restore database objects into a Postgres instance
 
 This command prefixes the following sub-commands:
 
-::
-
-  pgcopydb restore
-    schema      Restore a database schema from custom files to target database
-    pre-data    Restore a database pre-data schema from custom file to target database
-    post-data   Restore a database post-data schema from custom file to target database
-    roles       Restore database roles from SQL file to target database
-    parse-list  Parse pg_restore --list output from custom file
-
+.. include:: ../include/restore.rst
 
 .. _pgcopydb_restore_schema:
 
@@ -29,24 +21,7 @@ schema definitions from the given ``pgcopydb dump schema`` export directory.
 This command is not compatible with using Postgres files directly, it must
 be fed with the directory output from the ``pgcopydb dump ...`` commands.
 
-::
-
-   pgcopydb restore schema: Restore a database schema from custom files to target database
-   usage: pgcopydb restore schema  --dir <dir> [ --source <URI> ] --target <URI>
-
-     --source             Postgres URI to the source database
-     --target             Postgres URI to the target database
-     --dir                Work directory to use
-     --restore-jobs       Number of concurrent jobs for pg_restore
-     --drop-if-exists     On the target database, clean-up from a previous run first
-     --no-owner           Do not set ownership of objects to match the original database
-     --no-acl             Prevent restoration of access privileges (grant/revoke commands).
-     --no-comments        Do not output commands to restore comments
-     --filters <filename> Use the filters defined in <filename>
-     --restart            Allow restarting when temp files exist already
-     --resume             Allow resuming operations after a failure
-     --not-consistent     Allow taking a new snapshot on the source database
-
+.. include:: ../include/restore-schema.rst
 
 .. _pgcopydb_restore_pre_data:
 
@@ -60,23 +35,7 @@ schema definitions from the given ``pgcopydb dump schema`` export directory.
 This command is not compatible with using Postgres files directly, it must
 be fed with the directory output from the ``pgcopydb dump ...`` commands.
 
-::
-
-   pgcopydb restore pre-data: Restore a database pre-data schema from custom file to target database
-   usage: pgcopydb restore pre-data  --dir <dir> [ --source <URI> ] --target <URI>
-
-     --source             Postgres URI to the source database
-     --target             Postgres URI to the target database
-     --dir                Work directory to use
-     --restore-jobs       Number of concurrent jobs for pg_restore
-     --drop-if-exists     On the target database, clean-up from a previous run first
-     --no-owner           Do not set ownership of objects to match the original database
-     --no-acl             Prevent restoration of access privileges (grant/revoke commands).
-     --no-comments        Do not output commands to restore comments
-     --filters <filename> Use the filters defined in <filename>
-     --restart            Allow restarting when temp files exist already
-     --resume             Allow resuming operations after a failure
-     --not-consistent     Allow taking a new snapshot on the source database
+.. include:: ../include/restore-pre-data.rst
 
 .. _pgcopydb_restore_post_data:
 
@@ -90,23 +49,7 @@ schema definitions from the given ``pgcopydb dump schema`` export directory.
 This command is not compatible with using Postgres files directly, it must
 be fed with the directory output from the ``pgcopydb dump ...`` commands.
 
-::
-
-   pgcopydb restore post-data: Restore a database post-data schema from custom file to target database
-   usage: pgcopydb restore post-data  --dir <dir> [ --source <URI> ] --target <URI>
-
-     --source             Postgres URI to the source database
-     --target             Postgres URI to the target database
-     --dir                Work directory to use
-     --restore-jobs       Number of concurrent jobs for pg_restore
-     --no-owner           Do not set ownership of objects to match the original database
-     --no-acl             Prevent restoration of access privileges (grant/revoke commands).
-     --no-comments        Do not output commands to restore comments
-     --filters <filename> Use the filters defined in <filename>
-     --restart            Allow restarting when temp files exist already
-     --resume             Allow resuming operations after a failure
-     --not-consistent     Allow taking a new snapshot on the source database
-
+.. include:: ../include/restore-post-data.rst
 
 .. _pgcopydb_restore_roles:
 
@@ -124,16 +67,7 @@ The ``pg_dumpall`` command issues two lines per role, the first one is a
 command. Both those lines are skipped when the role already exists on the
 target database.
 
-::
-
-   pgcopydb restore roles: Restore database roles from SQL file to target database
-   usage: pgcopydb restore roles  --dir <dir> [ --source <URI> ] --target <URI>
-
-     --source             Postgres URI to the source database
-     --target             Postgres URI to the target database
-     --dir                Work directory to use
-     --restore-jobs       Number of concurrent jobs for pg_restore
-
+.. include:: ../include/restore-roles.rst
 
 .. _pgcopydb_restore_parse_list:
 
@@ -153,21 +87,7 @@ output of the command shows those pg_restore catalog entries commented out.
 A pg_restore archive catalog entry is commented out when its line starts
 with a semi-colon character (`;`).
 
-::
-
-   pgcopydb restore parse-list: Parse pg_restore --list output from custom file
-   usage: pgcopydb restore parse-list  --dir <dir> [ --source <URI> ] --target <URI>
-
-     --source             Postgres URI to the source database
-     --target             Postgres URI to the target database
-     --dir                Work directory to use
-     --filters <filename> Use the filters defined in <filename>
-     --skip-extensions    Skip restoring extensions
-     --skip-ext-comments  Skip restoring COMMENT ON EXTENSION
-     --restart            Allow restarting when temp files exist already
-     --resume             Allow resuming operations after a failure
-     --not-consistent     Allow taking a new snapshot on the source database
-
+.. include:: ../include/restore-parse-list.rst
 
 Description
 -----------

--- a/docs/ref/pgcopydb_snapshot.rst
+++ b/docs/ref/pgcopydb_snapshot.rst
@@ -10,17 +10,7 @@ executes a SQL query to export a snapshot. The obtained snapshot is both
 printed on stdout and also in a file where other pgcopydb commands might
 expect to find it.
 
-::
-
-   pgcopydb snapshot: Create and export a snapshot on the source database
-   usage: pgcopydb snapshot  --source ...
-
-     --source                      Postgres URI to the source database
-     --dir                         Work directory to use
-     --follow                      Implement logical decoding to replay changes
-     --plugin                      Output plugin to use (test_decoding, wal2json)
-     --wal2json-numeric-as-string  Print numeric data type as string when using wal2json output plugin
-     --slot-name                   Use this Postgres replication slot name
+.. include:: ../include/snapshot.rst
 
 Options
 -------

--- a/docs/ref/pgcopydb_stream.rst
+++ b/docs/ref/pgcopydb_stream.rst
@@ -32,36 +32,10 @@ pgcopydb stream - Stream changes from source database
 
 This command prefixes the following sub-commands:
 
-::
-
-  pgcopydb stream
-    setup      Setup source and target systems for logical decoding
-    cleanup    cleanup source and target systems for logical decoding
-    prefetch   Stream JSON changes from the source database and transform them to SQL
-    catchup    Apply prefetched changes from SQL files to the target database
-    replay     Replay changes from the source to the target database, live
-  + sentinel   Maintain a sentinel table on the source database
-    receive    Stream changes from the source database
-    transform  Transform changes from the source database into SQL commands
-    apply      Apply changes from the source database into the target database
-
-  pgcopydb stream create
-    slot    Create a replication slot in the source database
-    origin  Create a replication origin in the target database
-
-  pgcopydb stream drop
-    slot    Drop a replication slot in the source database
-    origin  Drop a replication origin in the target database
-
-  pgcopydb stream sentinel
-    get     Get the sentinel table values on the source database
-  + set     Maintain a sentinel table on the source database
-
-  pgcopydb stream sentinel set
-    startpos  Set the sentinel start position LSN on the source database
-    endpos    Set the sentinel end position LSN on the source database
-    apply     Set the sentinel apply mode on the source database
-    prefetch  Set the sentinel prefetch mode on the source database
+.. include:: ../include/stream.rst
+.. include:: ../include/stream-sentinel.rst
+.. include:: ../include/stream-sentinel-set.rst
+.. include:: ../include/stream-sentinel-setup.rst
 
 Those commands implement a part of the whole database replay operation as
 detailed in section :ref:`pgcopydb_follow`. Only use those commands to debug
@@ -93,22 +67,7 @@ decoding replication slot that must have been created already. See
 :ref:`pgcopydb_snapshot` to create the replication slot and export a
 snapshot.
 
-::
-
-   pgcopydb stream setup: Setup source and target systems for logical decoding
-   usage: pgcopydb stream setup
-
-     --source                      Postgres URI to the source database
-     --target                      Postgres URI to the target database
-     --dir                         Work directory to use
-     --restart                     Allow restarting when temp files exist already
-     --resume                      Allow resuming operations after a failure
-     --not-consistent              Allow taking a new snapshot on the source database
-     --snapshot                    Use snapshot obtained with pg_export_snapshot
-     --plugin                      Output plugin to use (test_decoding, wal2json)
-     --wal2json-numeric-as-string  Print numeric data type as string when using wal2json output plugin
-     --slot-name                   Stream changes recorded by this slot
-     --origin                      Name of the Postgres replication origin
+.. include:: ../include/stream-setup.rst
 
 .. _pgcopydb_stream_cleanup:
 
@@ -121,19 +80,7 @@ The command ``pgcopydb stream cleanup`` connects to the source and target
 databases to delete the objects created in the ``pgcopydb stream setup``
 step.
 
-::
-
-   pgcopydb stream cleanup: cleanup source and target systems for logical decoding
-   usage: pgcopydb stream cleanup
-
-     --source         Postgres URI to the source database
-     --target         Postgres URI to the target database
-     --restart        Allow restarting when temp files exist already
-     --resume         Allow resuming operations after a failure
-     --not-consistent Allow taking a new snapshot on the source database
-     --snapshot       Use snapshot obtained with pg_export_snapshot
-     --slot-name      Stream changes recorded by this slot
-     --origin         Name of the Postgres replication origin
+.. include:: ../include/stream-cleanup.rst
 
 .. _pgcopydb_stream_prefetch:
 
@@ -151,19 +98,7 @@ as their origin WAL filename (with the ``.json`` extension). Each time a
 JSON file is closed, a subprocess is started to transform the JSON into an
 SQL file.
 
-
-::
-
-   pgcopydb stream prefetch: Stream JSON changes from the source database and transform them to SQL
-   usage: pgcopydb stream prefetch
-
-     --source         Postgres URI to the source database
-     --dir            Work directory to use
-     --restart        Allow restarting when temp files exist already
-     --resume         Allow resuming operations after a failure
-     --not-consistent Allow taking a new snapshot on the source database
-     --slot-name      Stream changes recorded by this slot
-     --endpos         LSN position where to stop receiving changes
+.. include:: ../include/stream-prefetch.rst
 
 .. _pgcopydb_stream_catchup:
 
@@ -176,21 +111,7 @@ The command ``pgcopydb stream catchup`` connects to the target database and
 applies changes from the SQL files that have been prepared with the
 ``pgcopydb stream prefetch`` command.
 
-
-::
-
-   pgcopydb stream catchup: Apply prefetched changes from SQL files to the target database
-   usage: pgcopydb stream catchup
-
-     --source         Postgres URI to the source database
-     --target         Postgres URI to the target database
-     --dir            Work directory to use
-     --restart        Allow restarting when temp files exist already
-     --resume         Allow resuming operations after a failure
-     --not-consistent Allow taking a new snapshot on the source database
-     --slot-name      Stream changes recorded by this slot
-     --endpos         LSN position where to stop receiving changes
-	 --origin         Name of the Postgres replication origin
+.. include:: ../include/stream-catchup.rst
 
 .. _pgcopydb_stream_replay:
 
@@ -204,21 +125,7 @@ streams changes using the logical decoding protocol, and internally streams
 those changes to a transform process and then a replay process, which
 connects to the target database and applies SQL changes.
 
-::
-
-   pgcopydb stream replay: Replay changes from the source to the target database, live
-   usage: pgcopydb stream replay
-
-     --source         Postgres URI to the source database
-     --target         Postgres URI to the target database
-     --dir            Work directory to use
-     --restart        Allow restarting when temp files exist already
-     --resume         Allow resuming operations after a failure
-     --not-consistent Allow taking a new snapshot on the source database
-     --slot-name      Stream changes recorded by this slot
-     --endpos         LSN position where to stop receiving changes
-     --origin         Name of the Postgres replication origin
-
+.. include:: ../include/stream-replay.rst
 
 This command is equivalent to running the following script::
 
@@ -233,13 +140,7 @@ pgcopydb stream sentinel get
 
 pgcopydb stream sentinel get - Get the sentinel table values on the source database
 
-::
-
-   pgcopydb stream sentinel get: Get the sentinel table values on the source database
-   usage: pgcopydb stream sentinel get
-
-     --source      Postgres URI to the source database
-     --json        Format the output using JSON
+.. include:: ../include/stream-sentinel-get.rst
 
 .. _pgcopydb_stream_sentinel_set_startpos:
 
@@ -248,12 +149,7 @@ pgcopydb stream sentinel set startpos
 
 pgcopydb stream sentinel set startpos - Set the sentinel start position LSN on the source database
 
-::
-
-   pgcopydb stream sentinel set startpos: Set the sentinel start position LSN on the source database
-   usage: pgcopydb stream sentinel set startpos <start LSN>
-
-     --source      Postgres URI to the source database
+.. include:: ../include/stream-sentinel-set-startpos.rst
 
 .. _pgcopydb_stream_sentinel_set_endpos:
 
@@ -262,14 +158,7 @@ pgcopydb stream sentinel set endpos
 
 pgcopydb stream sentinel set endpos - Set the sentinel end position LSN on the source database
 
-::
-
-   pgcopydb stream sentinel set endpos: Set the sentinel end position LSN on the source database
-   usage: pgcopydb stream sentinel set endpos <end LSN>
-
-     --source      Postgres URI to the source database
-     --current     Use pg_current_wal_flush_lsn() as the endpos
-
+.. include:: ../include/stream-sentinel-set-endpos.rst
 
 .. _pgcopydb_stream_sentinel_set_apply:
 
@@ -278,13 +167,7 @@ pgcopydb stream sentinel set apply
 
 pgcopydb stream sentinel set apply - Set the sentinel apply mode on the source database
 
-::
-
-   pgcopydb stream sentinel set apply: Set the sentinel apply mode on the source database
-   usage: pgcopydb stream sentinel set apply
-
-     --source      Postgres URI to the source database
-
+.. include:: ../include/stream-sentinel-set-apply.rst
 
 .. _pgcopydb_stream_sentinel_set_prefetch:
 
@@ -293,13 +176,7 @@ pgcopydb stream sentinel set prefetch
 
 pgcopydb stream sentinel set prefetch - Set the sentinel prefetch mode on the source database
 
-::
-
-   pgcopydb stream sentinel set prefetch: Set the sentinel prefetch mode on the source database
-   usage: pgcopydb stream sentinel set prefetch
-
-     --source      Postgres URI to the source database
-
+.. include:: ../include/stream-sentinel-set-prefetch.rst
 
 .. _pgcopydb_stream_receive:
 
@@ -315,20 +192,7 @@ The receive command receives the changes from the source database in a
 streaming fashion, and writes them in a series of JSON files named the same
 as their origin WAL filename (with the ``.json`` extension).
 
-::
-
-   pgcopydb stream receive: Stream changes from the source database
-   usage: pgcopydb stream receive  --source ...
-
-     --source         Postgres URI to the source database
-     --dir            Work directory to use
-     --to-stdout      Stream logical decoding messages to stdout
-     --restart        Allow restarting when temp files exist already
-     --resume         Allow resuming operations after a failure
-     --not-consistent Allow taking a new snapshot on the source database
-     --slot-name      Stream changes recorded by this slot
-     --endpos         LSN position where to stop receiving changes
-
+.. include:: ../include/stream-receive.rst
 
 .. _pgcopydb_stream_transform:
 
@@ -341,16 +205,7 @@ The command ``pgcopydb stream transform`` transforms a JSON file as received
 by the ``pgcopydb stream receive`` command into an SQL file with one query
 per line.
 
-::
-
-   pgcopydb stream transform: Transform changes from the source database into SQL commands
-   usage: pgcopydb stream transform  <json filename> <sql filename>
-
-     --target         Postgres URI to the target database
-     --dir            Work directory to use
-     --restart        Allow restarting when temp files exist already
-     --resume         Allow resuming operations after a failure
-     --not-consistent Allow taking a new snapshot on the source database
+.. include:: ../include/stream-transform.rst
 
 The command supports using ``-`` as the filename for either the JSON input
 or the SQL output, or both. In that case reading from standard input and/or
@@ -369,17 +224,7 @@ Tracking`__.
 
 __ https://www.postgresql.org/docs/current/replication-origins.html
 
-::
-
-   pgcopydb stream apply: Apply changes from the source database into the target database
-   usage: pgcopydb stream apply <sql filename>
-
-     --target         Postgres URI to the target database
-     --dir            Work directory to use
-     --restart        Allow restarting when temp files exist already
-     --resume         Allow resuming operations after a failure
-     --not-consistent Allow taking a new snapshot on the source database
-     --origin         Name of the Postgres replication origin
+.. include:: ../include/stream-apply.rst
 
 This command supports using ``-`` as the filename to read from, and in that
 case reads from the standard input in a streaming fashion instead.

--- a/docs/update-help-messages.sh
+++ b/docs/update-help-messages.sh
@@ -1,0 +1,128 @@
+#! /bin/bash
+
+set -e
+set -u
+set -o pipefail
+
+# This script is used to update the help messages in the docs.
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+INCLUDE_DIR="$SCRIPT_DIR/include"
+
+# Given a single command, print the help text, and wrap the output in rst style
+# code block format in a file under include directory
+function print_help_to_file() {
+
+
+    # expand all positional parameters and trim whitespace at the end
+    local cmd
+    cmd=$(echo "$*" | sed -E "s/^ +//")
+
+    # Replace spaces in the file name with dashes We print the output of
+    # `pgcopydb --help` to `pgcopydb.rst`
+    # `pgcopydb compare --help` to `compare.rst`
+    # `pgcopydb compare data --help` to `compare-data.rst`
+    local file_path
+    local help_cmd
+    if [ "${cmd}" = "" ]; then
+        help_cmd="pgcopydb --help 2>&1"
+        file_path="${INCLUDE_DIR}/pgcopydb.rst"
+    else
+        help_cmd="pgcopydb ${cmd} --help 2>&1"
+        file_path="${INCLUDE_DIR}/${cmd// /-}.rst"
+    fi
+
+    # Generate help text by running the command, removing the line with version
+    # information and adding 3 spaces at the beginning of each line
+    local help_text
+    help_text="$( eval "${help_cmd}"  |
+        sed -e '/.*Running pgcopydb version.*/d' -e 's/^/   /'
+    )"
+
+
+    # Wrao the help text in a rst code block and print to file
+    {
+        echo "::"
+        echo
+        echo "${help_text}"
+    } >"${file_path}"
+}
+
+# Parse the output of `pgcopydb help` and call print_help_to_file for each command
+function parse_help_output() {
+
+    # Loop over all the lines of the help text, parse commands and subcommands,
+    # and call print_help_to_file for each command.
+    #
+    # Currently the output of `pgcopydb help` starts with:
+    #
+    #   pgcopydb
+    #     clone     Clone an entire database from source to target
+    #     fork      Clone an entire database from source to target
+    #     follow    Replay changes from the source database to the target database
+    #     ...
+    #     ...
+    #     ping      Attempt to connect to the source and target instances
+    #     help      Print help message
+    #     version   Print pgcopydb version
+    #
+    #   pgcopydb compare
+    #     schema  Compare source and target schema
+    #     data    Compare source and target data
+    #
+    # We parse these lines one by one, and store portions of the commands in
+    # variables cmd and subcmd. For example, for the line that corresponds to
+    # `pgcopydb compare schema`, we set cmd to `compare` and subcmd to `schema`
+    while read -r l; do
+        subcmd=""
+        # Parse first section of the help text:
+        #   pgcopydb
+        if [[ ${l} =~ ^pgcopydb$ ]]; then
+            cmd=""
+
+        # Parse other section headers of the help text that contain `pgcopydb <cmd>`
+        #
+        # For example:
+        #   pgcopydb compare
+        #   pgcopydb copy
+        #   pgcopydb dump
+        #
+        # These commands should already be printed in an earlier section.
+        # Therefore we store the command name in a variable and move on to the
+        # next line for parsing subcommands
+        elif [[ ${l} =~ ^pgcopydb\ (.+) ]]; then
+            cmd="${BASH_REMATCH[1]}"
+            continue;
+
+        # Parse subcommands that are followed by a section header. For example,
+        # there are the subcommands under pgcopydb strem sentinel section:
+        #     create  Create the sentinel table on the source database
+        #     drop    Drop the sentinel table on the source database
+        #     get     Get the sentinel table values on the source database
+        #   + set     Maintain a sentinel table on the source database
+        #
+        # Here we have an optional + character followed by the subcommand name.
+        # The subcommand may contain lowercase alphabetical characters or dashes
+        # (e.g. table-parts).
+        elif [[ ${l} =~ ^(\+ )?([a-z-]+) ]]; then
+            subcmd="${BASH_REMATCH[2]}"
+
+        # Skip all other lines that does not match. (e.g. empty lines)
+        else
+            continue
+        fi
+
+        # print the help message for the subcommand to file
+        print_help_to_file "${cmd} ${subcmd}"
+
+    done < <(pgcopydb help 2>&1)
+}
+
+# Delete all the existing help files and recreate them
+rm -f "${INCLUDE_DIR}/*"
+parse_help_output
+
+# Remove the help messages for the commands that are not covered in docs
+rm -rf "${INCLUDE_DIR}/fork.rst" \
+       "${INCLUDE_DIR}/help.rst" \
+       "${INCLUDE_DIR}/version.rst"


### PR DESCRIPTION
This commit is the first phase of a plan to automate updating our documentation. It adds a script that can be used to update the help messages for commands. Instead of copy pasting `--help` output into the documentation, we can now use this script to generate these messages for us. All that is left is to include relevant parts of these generated output in the documentation.

In the near future, I plan to run this script as part of the build process to make sure that the documentation is always up to date.

Closes: #588 