### PR TITLE
Use SQLite to store our internal copy of the source catalogs.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN dpkg --add-architecture ${TARGETARCH:-arm64} && apt update \
     libpq5 \
     libreadline-dev \
     libselinux1-dev \
+    libsqlite3-dev \
     libssl-dev \
     libxslt1-dev \
     lsof \
@@ -65,7 +66,8 @@ RUN dpkg --add-architecture ${TARGETARCH:-arm64} && apt update \
 	passwd \
     ca-certificates \
     libpq5 \
-    lsof \
+	libsqlite3-0 \
+	lsof \
     tmux \
     watch \
     psmisc \

--- a/src/bin/lib/log/src/log.c
+++ b/src/bin/lib/log/src/log.c
@@ -54,6 +54,7 @@ static struct {
 
 static const char *level_names[] = {
 	"TRACE",
+	"SQLite",
 	"DEBUG",
 	"SQL",
 	"NOTICE",
@@ -65,6 +66,7 @@ static const char *level_names[] = {
 
 static const char *level_colors[] = {
   "\x1b[90m",					/* TRACE:  bright black (light gray) */
+  "\x1b[30m",					/* SQLite: black */
   "\x1b[34m",					/* DEBUG:  blue */
   "\x1b[30m",					/* SQL:    black */
   "\x1b[36m",					/* NOTICE: cyan */
@@ -210,7 +212,7 @@ void log_log(int level, const char *file, int line, const char *fmt, ...)
   }
 
   /* max source filename is 20 chars long, max file lines is < 10000 (5) */
-  int showLineNumber = L.showLineNumber || L.level <= 1;
+  int showLineNumber = L.showLineNumber || L.level <= LOG_DEBUG;
   char fileLine[25] = { 0 };
 
   if (showLineNumber || (L.fp && L.fpFmt == LOG_FORMAT_TEXT))

--- a/src/bin/lib/log/src/log.h
+++ b/src/bin/lib/log/src/log.h
@@ -23,6 +23,7 @@ typedef void (*log_LockFn)(void *udata, int lock);
 
 enum {
 	LOG_TRACE,
+	LOG_SQLITE,
 	LOG_DEBUG,
 	LOG_SQL,
 	LOG_NOTICE,
@@ -33,6 +34,7 @@ enum {
 };
 
 #define log_trace(...) log_log(LOG_TRACE, __FILE__, __LINE__, __VA_ARGS__)
+#define log_sqlite(...) log_log(LOG_SQLITE, __FILE__, __LINE__, __VA_ARGS__)
 #define log_debug(...) log_log(LOG_DEBUG, __FILE__, __LINE__, __VA_ARGS__)
 #define log_sql(...) log_log(LOG_SQL, __FILE__, __LINE__, __VA_ARGS__)
 #define log_notice(...)  log_log(LOG_NOTICE,  __FILE__, __LINE__, __VA_ARGS__)

--- a/src/bin/pgcopydb/Makefile
+++ b/src/bin/pgcopydb/Makefile
@@ -72,6 +72,7 @@ LIBS += $(shell $(PG_CONFIG) --ldflags)
 LIBS += $(shell $(PG_CONFIG) --libs)
 LIBS += -lpq
 LIBS += -lncurses
+LIBS += -lsqlite3
 
 all: $(PGCOPYDB) ;
 

--- a/src/bin/pgcopydb/catalog.c
+++ b/src/bin/pgcopydb/catalog.c
@@ -1,0 +1,6887 @@
+/*
+ * src/bin/pgcopydb/catalog.c
+ *	 Catalog management as a SQLite internal file
+ */
+
+#include <inttypes.h>
+#include <limits.h>
+#include <sys/select.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <sqlite3.h>
+
+#include "catalog.h"
+#include "copydb.h"
+#include "defaults.h"
+#include "log.h"
+#include "parsing_utils.h"
+#include "schema.h"
+#include "signals.h"
+#include "string_utils.h"
+
+
+/*
+ * pgcopydb catalog cache is a SQLite database with the following schema:
+ */
+static char *sourceDBcreateDDLs[] = {
+	"create table setup("
+	"  id integer primary key check (id = 1), "
+	"  source_pg_uri text, "
+	"  target_pg_uri text, "
+	"  snapshot text, "
+	"  split_tables_larger_than integer, "
+	"  filters text, "
+	"  plugin text, "
+	"  slot_name text "
+	")",
+
+	"create table section("
+	"  name text primary key, fetched boolean "
+	")",
+
+	"create table s_database("
+	"  oid integer primary key, datname text, bytes integer, bytes_pretty text"
+	")",
+
+	"create table s_database_property("
+	"  role_in_database boolean, rolname text, datname text, setconfig text"
+	")",
+
+	"create index s_d_p_oid on s_database_property(datname)",
+
+	"create table s_table("
+	"  oid integer primary key, "
+	"  datname text, qname text, nspname text, relname text, amname text, "
+	"  restore_list_name text, "
+	"  relpages integer, reltuples integer, bytes integer, bytes_pretty text, "
+	"  exclude_data boolean, "
+	"  part_key text"
+	")",
+
+	"create unique index s_t_qname on s_table(qname)",
+	"create unique index s_t_rlname on s_table(restore_list_name)",
+
+	"create table s_attr("
+	"  oid integer references s_table(oid), "
+	"  attnum integer, attypid integer, attname text, "
+	"  attisprimary bool, attisgenerated bool, "
+	"  primary key(oid, attnum) "
+	")",
+
+	"create index s_a_oid_attname on s_attr(oid, attname)",
+
+	"create table s_table_part("
+	"  oid integer references s_table(oid), "
+	"  partnum integer, partcount integer, "
+	"  min integer, max integer, count integer, "
+	"  primary key(oid, partnum) "
+	")",
+
+	"create table s_table_chksum("
+	"  oid integer primary key references s_table(oid), "
+	"  srcrowcount integer, srcsum text, dstrowcount integer, dstsum text "
+	")",
+
+	"create table s_index("
+	"  oid integer primary key, "
+	"  qname text, nspname text, relname text, restore_list_name text, "
+	"  tableoid references s_table(oid), "
+	"  isprimary bool, isunique bool, columns text, sql text "
+	")",
+
+	"create unique index s_i_rlname on s_index(restore_list_name)",
+
+	"create table s_constraint("
+	"  oid integer primary key, conname text, "
+	"  indexoid references s_index(oid), "
+	"  condeferrable bool, condeferred bool, sql text "
+	")",
+
+	"create table s_seq("
+	"  oid integer, "
+	"  ownedby integer, attrelid integer, attroid integer, "
+	"  datname text, qname text, nspname text, relname text, "
+	"  restore_list_name text, "
+	"  last_value integer, isCalled bool, "
+	"  primary key(oid, ownedby, attrelid, attroid)"
+	")",
+
+	"create index s_s_rlname on s_seq(restore_list_name)",
+
+	/* internal activity tracking / completion / statistics */
+	"create table process("
+	"  pid integer primary key, "
+	"  ps_type text, ps_title text, "
+	"  tableoid integer references s_table(oid), "
+	"  partnum integer, "
+	"  indexoid integer references s_index(oid) "
+	")",
+
+	"create table summary("
+	"  pid integer, "
+	"  tableoid integer references s_table(oid), "
+	"  indexoid integer references s_table(oid), "
+	"  start_time_epoch integer, done_time_epoch integer, duration integer, "
+	"  command text"
+	")"
+};
+
+
+/*
+ * pgcopydb implements filtering which needs to be implement by editin the
+ * `pg_restore --list` archive TOC. The TOC contains OIDs "restore list names",
+ * and some TOC entries do not have an OID.
+ *
+ * pgcopydb catalog cache needs to enable matching TOC entries by either OID
+ * for restore list names for the main SQL objects (tables, indexes,
+ * constraints, dependencies).
+ *
+ * The schema definition used for those objects is the same as in the previous
+ * section, but the data is different and the points in the code where the
+ * filters are used are limited in scope, in such a way that it makes sense to
+ * maintain a separate SQLite database for the filters catalog cache.
+ *
+ */
+static char *filterDBcreateDDLs[] = {
+	"create table section("
+	"  name text primary key, fetched boolean "
+	")",
+
+	"create table s_coll("
+	"  oid integer primary key, collname text, description text, "
+	"  restore_list_name text"
+	")",
+
+	"create unique index s_coll_rlname on s_coll(restore_list_name)",
+
+	"create table s_extension("
+	"  oid integer primary key, extname text, extnamespace text, "
+	"  extrelocatable integer "
+	")",
+
+	"create table s_extension_config("
+	"  extoid integer references s_extension(oid), "
+	"  reloid integer, nspname text, relname text, condition text"
+	")",
+
+	"create index s_ec_oid on s_extension_config(extoid)",
+
+	"create table s_extension_versions("
+	"  oid integer, name text, default_version text, installed_version text, "
+	"  versions_array text, "
+	"  primary key (oid, name)"
+	")",
+
+	"create table s_namespace("
+	"  oid integer primary key, nspname text, restore_list_name text "
+	")",
+
+	"create index s_n_rlname on s_namespace(restore_list_name)",
+
+	"create table s_table("
+	"  oid integer primary key, "
+	"  datname text, qname text, nspname text, relname text, amname text, "
+	"  restore_list_name text, "
+	"  relpages integer, reltuples integer, bytes integer, bytes_pretty text, "
+	"  exclude_data boolean, "
+	"  srcrowcount integer, srcsum text, dstrowcount integer, dstsum text, "
+	"  part_key text"
+	")",
+
+	"create unique index s_t_qname on s_table(qname)",
+	"create unique index s_t_rlname on s_table(restore_list_name)",
+
+	"create table s_attr("
+	"  oid integer references s_table(oid), "
+	"  attnum integer, attypid integer, attname text, "
+	"  attisprimary bool, attisgenerated bool, "
+	"  primary key(oid, attnum) "
+	")",
+
+	"create table s_table_part("
+	"  oid integer references s_table(oid), "
+	"  partnum integer, partcount integer, "
+	"  min integer, max integer, count integer, "
+	"  primary key(oid, partnum) "
+	")",
+
+	"create table s_table_chksum("
+	"  oid integer primary key references s_table(oid), "
+	"  srcrowcount integer, srcsum text, dstrowcount integer, dstsum text "
+	")",
+
+	"create table s_index("
+	"  oid integer primary key, "
+	"  qname text, nspname text, relname text, restore_list_name text, "
+	"  tableoid references s_table(oid), "
+	"  isprimary bool, isunique bool, columns text, sql text "
+	")",
+
+	"create unique index s_i_rlname on s_index(restore_list_name)",
+
+	"create table s_constraint("
+	"  oid integer primary key, conname text, "
+	"  indexoid references s_index(oid), "
+	"  condeferrable bool, condeferred bool, sql text "
+	")",
+
+	"create table s_seq("
+	"  oid integer, "
+	"  ownedby integer, attrelid integer, attroid integer, "
+	"  datname text, qname text, nspname text, relname text, "
+	"  restore_list_name text, "
+	"  last_value integer, isCalled bool, "
+	"  primary key(oid, ownedby, attrelid, attroid)"
+	")",
+
+	"create index s_s_rlname on s_seq(restore_list_name)",
+
+	"create table s_depend("
+	"  nspname text, relname text, "
+	"  refclassid integer, refobjid integer, classid integer, objid integer, "
+	"  deptype text, type text, identity text "
+	")",
+
+	"create index s_d_refobjid on s_depend(refobjid)",
+	"create index s_d_objid on s_depend(objid)",
+
+	/* the filter table is our hash-table */
+	"create table filter(oid integer, restore_list_name text, kind text)",
+	"create unique index filter_oid on filter(oid)",
+	"create index filter_rlname on filter(restore_list_name)",
+};
+
+
+/*
+ * Target schema objects, allowing to skip pre-existing entries.
+ */
+static char *targetDBcreateDDLs[] = {
+	"create table section("
+	"  name text primary key, fetched boolean "
+	")",
+
+	"create table s_role("
+	"  oid integer primary key, rolname text"
+	")",
+
+	"create table s_namespace("
+	"  nspname text primary key, restore_list_name text"
+	")",
+
+	"create index s_n_rlname on s_namespace(restore_list_name)",
+
+	"create table s_table("
+	"  oid integer primary key, "
+	"  datname text, qname text, nspname text, relname text, amname text, "
+	"  restore_list_name text, "
+	"  relpages integer, reltuples integer, bytes integer, bytes_pretty text, "
+	"  exclude_data boolean, "
+	"  srcrowcount integer, srcsum text, dstrowcount integer, dstsum text, "
+	"  part_key text"
+	")",
+
+	"create unique index s_t_qname on s_table(qname)",
+	"create unique index s_t_rlname on s_table(restore_list_name)",
+
+	"create table s_attr("
+	"  oid integer references s_table(oid), "
+	"  attnum integer, attypid integer, attname text, "
+	"  attisprimary bool, attisgenerated bool, "
+	"  primary key(oid, attnum) "
+	")",
+
+	"create table s_index("
+	"  oid integer primary key, "
+	"  qname text, nspname text, relname text, restore_list_name text, "
+	"  tableoid integer references s_table(oid), "
+	"  isprimary bool, isunique bool, columns text, sql text "
+	")",
+
+	"create unique index s_i_rlname on s_index(restore_list_name)",
+
+	"create table s_constraint("
+	"  oid integer primary key, conname text, "
+	"  indexoid references s_index(oid), "
+	"  condeferrable bool, condeferred bool, sql text "
+	")"
+};
+
+
+static char *sourceDBdropDDLs[] = {
+	"drop table if exists setup",
+	"drop table if exists section",
+
+	"drop table if exists s_database",
+	"drop table if exists s_database_property",
+	"drop table if exists s_table",
+	"drop table if exists s_attr",
+	"drop table if exists s_table_part",
+	"drop table if exists s_table_chksum",
+	"drop table if exists s_index",
+	"drop table if exists s_constraint",
+	"drop table if exists s_seq",
+	"drop table if exists s_depend",
+
+	"drop table if exists t_roles",
+	"drop table if exists t_schema",
+	"drop table if exists t_index",
+	"drop table if exists t_constraint",
+
+	"drop table if exists process",
+	"drop table if exists summary"
+};
+
+
+static char *filterDBdropDDLs[] = {
+	"drop table if exists section",
+
+	"drop table if exists s_coll",
+	"drop table if exists s_extension",
+	"drop table if exists s_extension_config",
+	"drop table if exists s_extension_versions",
+	"drop table if exists s_namespace",
+	"drop table if exists s_table",
+	"drop table if exists s_attr",
+	"drop table if exists s_table_part",
+	"drop table if exists s_table_chksum",
+	"drop table if exists s_index",
+	"drop table if exists s_constraint",
+	"drop table if exists s_seq",
+	"drop table if exists s_depend",
+	"drop table if exists filter"
+};
+
+
+static char *targetDBdropDDLs[] = {
+	"drop table if exists section",
+
+	"drop table if exists s_role",
+	"drop table if exists s_namespace",
+	"drop table if exists s_table",
+	"drop table if exists s_attr",
+	"drop table if exists s_index",
+	"drop table if exists s_constraint"
+};
+
+
+/*
+ * catalog_init_from_specs initializes our internal catalog database file from
+ * a specification.
+ */
+bool
+catalog_init_from_specs(CopyDataSpec *copySpecs)
+{
+	DatabaseCatalog *sourceDB = &(copySpecs->catalogs.source);
+	DatabaseCatalog *filtersDB = &(copySpecs->catalogs.filter);
+	DatabaseCatalog *targetDB = &(copySpecs->catalogs.target);
+
+	if (!catalog_init(sourceDB) ||
+		!catalog_init(filtersDB) ||
+		!catalog_init(targetDB))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/*
+	 * Fetch and register the catalog setup.
+	 *
+	 * Because commands such as `pgcopydb list tables` and all might have
+	 * fetched parts of the catalogs already, we need to make sure there is no
+	 * mismatch between the on-disk catalog setup and the current catalog
+	 * setup.
+	 *
+	 * In case of a mismatch:
+	 *
+	 *  - if we're running for DATA_SECTION_ALL we can implement cache
+	 *    invalidation (drop everything, create everything again, register
+	 *    current setup).
+	 *
+	 * - if we have specs->fetchCatalogs set to true (meaning --force was used)
+	 *   we can also implement cache invalidation.
+	 *
+	 * - in all other cases, we error out with the mismatch information.
+	 *
+	 * So first prepare the setup information:
+	 */
+	SafeURI spguri = { 0 };
+	SafeURI tpguri = { 0 };
+
+	if (!bareConnectionString(copySpecs->connStrings.source_pguri, &spguri))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	if (!bareConnectionString(copySpecs->connStrings.target_pguri, &tpguri))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	SourceFilters *filters = &(copySpecs->filters);
+	JSON_Value *jsFilters = json_value_init_object();
+
+	if (!filters_as_json(filters, jsFilters))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	char *json = json_serialize_to_string(jsFilters);
+
+	/*
+	 * Now see if the catalog already have been setup.
+	 */
+	if (!catalog_setup(sourceDB))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	if (sourceDB->setup.id == 0)
+	{
+		/* catalogs unregistered, register current setup */
+		log_notice("Registering catalog setup for "
+				   "source \"%s\", target \"%s\", snapshot \"%s\"",
+				   spguri.pguri,
+				   tpguri.pguri,
+				   copySpecs->sourceSnapshot.snapshot);
+
+		if (!catalog_register_setup(sourceDB,
+									spguri.pguri,
+									tpguri.pguri,
+									copySpecs->sourceSnapshot.snapshot,
+									copySpecs->splitTablesLargerThan.bytes,
+									json))
+		{
+			/* errors have already been logged */
+			json_free_serialized_string(json);
+			json_value_free(jsFilters);
+			return false;
+		}
+	}
+	else
+	{
+		CatalogSetup *setup = &(sourceDB->setup);
+
+		log_debug("Catalog has been setup for "
+				  "source \"%s\", target \"%s\", snapshot \"%s\"",
+				  setup->source_pguri,
+				  setup->target_pguri,
+				  setup->snapshot);
+
+		if (!streq(spguri.pguri, setup->source_pguri))
+		{
+			log_error("Catalogs at \"%s\" have been setup for "
+					  "Postgres source \"%s\" and current source is \"%s\"",
+					  sourceDB->dbfile,
+					  setup->source_pguri,
+					  spguri.pguri);
+			return false;
+		}
+
+		/*
+		 * Not all commands need a target pguri, so we might have registered a
+		 * previous setup for the same context but without a target pguri,
+		 * which would be NULL in our catalogs at this point.
+		 */
+		if (setup->target_pguri != NULL && tpguri.pguri != NULL &&
+			!streq(tpguri.pguri, setup->target_pguri))
+		{
+			log_error("Catalogs at \"%s\" have been setup for "
+					  "Postgres target \"%s\" and current target is \"%s\"",
+					  sourceDB->dbfile,
+					  setup->target_pguri,
+					  tpguri.pguri);
+			return false;
+		}
+
+		/* skip comparing snapshots when --not-consistent is used */
+		if (copySpecs->consistent)
+		{
+			if (!streq(copySpecs->sourceSnapshot.snapshot, setup->snapshot))
+			{
+				log_error("Catalogs at \"%s\" have been setup for "
+						  "snapshot \"%s\" and current snapshot is \"%s\"",
+						  sourceDB->dbfile,
+						  setup->snapshot,
+						  copySpecs->sourceSnapshot.snapshot);
+				return false;
+			}
+		}
+
+		/* skip comparing --split-tables-larger-than values unless needed */
+		if (copySpecs->section == DATA_SECTION_ALL ||
+			copySpecs->section == DATA_SECTION_TABLE_DATA_PARTS)
+		{
+			if (copySpecs->splitTablesLargerThan.bytes !=
+				setup->splitTablesLargerThanBytes)
+			{
+				char bytesPretty[BUFSIZE] = { 0 };
+
+				pretty_print_bytes(bytesPretty,
+								   BUFSIZE,
+								   setup->splitTablesLargerThanBytes);
+
+				log_info("setup: %lld (%s)",
+						 (long long) setup->splitTablesLargerThanBytes,
+						 bytesPretty);
+
+				log_info("specs: %lld (%s)",
+						 (long long) copySpecs->splitTablesLargerThan.bytes,
+						 copySpecs->splitTablesLargerThan.bytesPretty);
+
+				log_error("Catalogs at \"%s\" have been setup for "
+						  "--split-tables-larger-than \"%s\" "
+						  "and current value is \"%s\"",
+						  sourceDB->dbfile,
+						  bytesPretty,
+						  copySpecs->splitTablesLargerThan.bytesPretty);
+
+				return false;
+			}
+		}
+
+		if (!streq(json, setup->filters))
+		{
+			log_info("Current filtering setup is: %s", json);
+			log_info("Catalog filtering setup is: %s", setup->filters);
+			log_error("Catalogs at \"%s\" have been setup for a different "
+					  "filtering than the current command, "
+					  "see above for details",
+					  sourceDB->dbfile);
+
+			return false;
+		}
+	}
+
+	json_free_serialized_string(json);
+	json_value_free(jsFilters);
+
+	return true;
+}
+
+
+/*
+ * catalog_close_from_specs closes our SQLite databases for internal catalogs.
+ */
+bool
+catalog_close_from_specs(CopyDataSpec *copySpecs)
+{
+	DatabaseCatalog *source = &(copySpecs->catalogs.source);
+	DatabaseCatalog *filter = &(copySpecs->catalogs.filter);
+	DatabaseCatalog *target = &(copySpecs->catalogs.target);
+
+	return catalog_close(source) &&
+		   catalog_close(filter) &&
+		   catalog_close(target);
+}
+
+
+/*
+ * catalog_open opens an already initialized catalog database file.
+ */
+bool
+catalog_open(DatabaseCatalog *catalog)
+{
+	if (!file_exists(catalog->dbfile))
+	{
+		log_error("Failed to open catalog \"%s\", file does not exists",
+				  catalog->dbfile);
+		return false;
+	}
+
+	return catalog_init(catalog);
+}
+
+
+/*
+ * source_catalog_init initializes our internal catalog database file.
+ */
+bool
+catalog_init(DatabaseCatalog *catalog)
+{
+	log_debug("Opening SQLite database \"%s\" with lib version %s",
+			  catalog->dbfile,
+			  sqlite3_libversion());
+
+	bool createSchema = !file_exists(catalog->dbfile);
+
+	if (sqlite3_open(catalog->dbfile, &(catalog->db)) != SQLITE_OK)
+	{
+		log_error("Failed to open \"%s\": %s",
+				  catalog->dbfile,
+				  sqlite3_errmsg(catalog->db));
+		return false;
+	}
+
+	if (createSchema)
+	{
+		return catalog_create_schema(catalog);
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_attach runs the ATTACH SQLite command to attach a catalog b in the
+ * already open catalog a, in such a way that it's then possible to query e.g.
+ * source.s_table from the filters database.
+ */
+bool
+catalog_attach(DatabaseCatalog *a, DatabaseCatalog *b, const char *name)
+{
+	char *sqlTmpl = "attach '%s' as %s";
+	char buf[BUFSIZE + MAXPGPATH] = { 0 };
+
+	sformat(buf, sizeof(buf), sqlTmpl, b->dbfile, name);
+
+	int rc = sqlite3_exec(a->db, buf, NULL, NULL, NULL);
+
+	if (rc != SQLITE_OK)
+	{
+		log_error("Failed to attach '%s' as %s", b->dbfile, name);
+		log_error("%s", sqlite3_errmsg(a->db));
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_close closes our internal catalog database file.
+ */
+bool
+catalog_close(DatabaseCatalog *catalog)
+{
+	/* it's okay to try and close the same catalog twice */
+	if (catalog->db == NULL)
+	{
+		return true;
+	}
+
+	if (sqlite3_close(catalog->db) != SQLITE_OK)
+	{
+		log_error("Failed to close \"%s\":", catalog->dbfile);
+		log_error("[SQLite]: %s", sqlite3_errmsg(catalog->db));
+		return false;
+	}
+
+	catalog->db = NULL;
+
+	return true;
+}
+
+
+/*
+ * catalog_create_schema creates the expected schema in the given catalog.
+ */
+bool
+catalog_create_schema(DatabaseCatalog *catalog)
+{
+	char **createDDLs = NULL;
+	int count = 0;
+
+	switch (catalog->type)
+	{
+		case DATABASE_CATALOG_TYPE_SOURCE:
+		{
+			createDDLs = sourceDBcreateDDLs;
+			count = sizeof(sourceDBcreateDDLs) / sizeof(sourceDBcreateDDLs[0]);
+			break;
+		}
+
+		case DATABASE_CATALOG_TYPE_FILTER:
+		{
+			createDDLs = filterDBcreateDDLs;
+			count = sizeof(filterDBcreateDDLs) / sizeof(filterDBcreateDDLs[0]);
+			break;
+		}
+
+		case DATABASE_CATALOG_TYPE_TARGET:
+		{
+			createDDLs = targetDBcreateDDLs;
+			count = sizeof(targetDBcreateDDLs) / sizeof(targetDBcreateDDLs[0]);
+			break;
+		}
+
+		default:
+		{
+			log_error("BUG: called catalog_init for unknown type %d",
+					  catalog->type);
+			return false;
+		}
+	}
+
+	for (int i = 0; i < count; i++)
+	{
+		char *ddl = createDDLs[i];
+
+		log_sqlite("catalog_init: %s", ddl);
+
+		int rc = sqlite3_exec(catalog->db, ddl, NULL, NULL, NULL);
+
+		if (rc != SQLITE_OK)
+		{
+			log_error("Failed to init catalogs: %s", ddl);
+			log_error("%s", sqlite3_errmsg(catalog->db));
+			return false;
+		}
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_drop_schema drops all the catalog schema and data.
+ */
+bool
+catalog_drop_schema(DatabaseCatalog *catalog)
+{
+	char **dropDDLs = NULL;
+	int count = 0;
+
+	switch (catalog->type)
+	{
+		case DATABASE_CATALOG_TYPE_SOURCE:
+		{
+			dropDDLs = sourceDBdropDDLs;
+			count = sizeof(sourceDBdropDDLs) / sizeof(sourceDBdropDDLs[0]);
+			break;
+		}
+
+		case DATABASE_CATALOG_TYPE_FILTER:
+		{
+			dropDDLs = filterDBdropDDLs;
+			count = sizeof(filterDBdropDDLs) / sizeof(filterDBdropDDLs[0]);
+			break;
+		}
+
+		case DATABASE_CATALOG_TYPE_TARGET:
+		{
+			dropDDLs = targetDBdropDDLs;
+			count = sizeof(targetDBdropDDLs) / sizeof(targetDBdropDDLs[0]);
+			break;
+		}
+
+		default:
+		{
+			log_error("BUG: called catalog_init for unknown type %d",
+					  catalog->type);
+			return false;
+		}
+	}
+
+	for (int i = 0; i < count; i++)
+	{
+		char *ddl = dropDDLs[i];
+
+		log_sqlite("catalog_init: %s", ddl);
+
+		int rc = sqlite3_exec(catalog->db, ddl, NULL, NULL, NULL);
+
+		if (rc != SQLITE_OK)
+		{
+			log_error("Failed to init catalogs: %s", ddl);
+			log_error("%s", sqlite3_errmsg(catalog->db));
+			return false;
+		}
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_begin explicitely begins a SQLite transaction.
+ */
+bool
+catalog_begin(DatabaseCatalog *catalog)
+{
+	int rc = sqlite3_exec(catalog->db, "BEGIN", NULL, NULL, NULL);
+
+	if (rc != SQLITE_OK)
+	{
+		log_error("[SQLite]: BEGIN failed: %s", sqlite3_errmsg(catalog->db));
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_commit explicitely commits a SQLite transaction.
+ */
+bool
+catalog_commit(DatabaseCatalog *catalog)
+{
+	int rc = sqlite3_exec(catalog->db, "COMMIT", NULL, NULL, NULL);
+
+	if (rc != SQLITE_OK)
+	{
+		log_error("[SQLite]: COMMIT failed: %s", sqlite3_errmsg(catalog->db));
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_register_setup registers the setup metadata for this catalog.
+ */
+bool
+catalog_register_setup(DatabaseCatalog *catalog,
+					   const char *source_pg_uri,
+					   const char *target_pg_uri,
+					   const char *snapshot,
+					   uint64_t splitTablesLargerThanBytes,
+					   const char *filters)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_register_setup: db is NULL");
+		return false;
+	}
+
+	char *sql =
+		"insert into setup("
+		"  id, source_pg_uri, target_pg_uri, snapshot, "
+		"  split_tables_larger_than, filters) "
+		"values($1, $2, $3, $4, $5, $6)";
+
+	SQLiteQuery query = { 0 };
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_INT64, "id", 1, NULL },
+		{ BIND_PARAMETER_TYPE_TEXT, "source_pg_uri", 0, (char *) source_pg_uri },
+		{ BIND_PARAMETER_TYPE_TEXT, "target_pg_uri", 0, (char *) target_pg_uri },
+		{ BIND_PARAMETER_TYPE_TEXT, "snapshot", 0, (char *) snapshot },
+
+		{ BIND_PARAMETER_TYPE_INT64, "split_tables_larger_than",
+		  splitTablesLargerThanBytes, NULL },
+
+		{ BIND_PARAMETER_TYPE_TEXT, "filters", 0, (char *) filters }
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(&query, params, count))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which does not return any row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_setup fetches the registered catalog setup metadata.
+ */
+bool
+catalog_setup(DatabaseCatalog *catalog)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_setup: db is NULL");
+		return false;
+	}
+
+	SQLiteQuery query = {
+		.context = &(catalog->setup),
+		.fetchFunction = &catalog_setup_fetch
+	};
+
+	char *sql =
+		"select id, source_pg_uri, target_pg_uri, snapshot, "
+		"       split_tables_larger_than, filters "
+		"  from setup";
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which return exactly one row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_section_fetch is a SQLiteQuery callback.
+ */
+bool
+catalog_setup_fetch(SQLiteQuery *query)
+{
+	CatalogSetup *setup = (CatalogSetup *) query->context;
+
+	/*
+	 * id
+	 */
+	setup->id = sqlite3_column_int64(query->ppStmt, 0);
+
+	/*
+	 * source_pguri
+	 */
+	int len = sqlite3_column_bytes(query->ppStmt, 1);
+	int bytes = len + 1;
+
+	setup->source_pguri = (char *) calloc(bytes, sizeof(char));
+
+	if (setup->source_pguri == NULL)
+	{
+		log_fatal(ALLOCATION_FAILED_ERROR);
+		return false;
+	}
+
+	strlcpy(setup->source_pguri,
+			(char *) sqlite3_column_text(query->ppStmt, 1),
+			bytes);
+
+	/*
+	 * target_pguri
+	 */
+	if (sqlite3_column_type(query->ppStmt, 2) == SQLITE_NULL)
+	{
+		setup->target_pguri = NULL;
+	}
+	else
+	{
+		int len = sqlite3_column_bytes(query->ppStmt, 2);
+		int bytes = len + 1;
+
+		setup->target_pguri = (char *) calloc(bytes, sizeof(char));
+
+		if (setup->target_pguri == NULL)
+		{
+			log_fatal(ALLOCATION_FAILED_ERROR);
+			return false;
+		}
+
+		strlcpy(setup->target_pguri,
+				(char *) sqlite3_column_text(query->ppStmt, 2),
+				bytes);
+	}
+
+	/*
+	 * snapshot (a string buffer)
+	 */
+	if (sqlite3_column_type(query->ppStmt, 3) != SQLITE_NULL)
+	{
+		strlcpy(setup->snapshot,
+				(char *) sqlite3_column_text(query->ppStmt, 3),
+				sizeof(setup->snapshot));
+	}
+
+	/*
+	 * split-tables-larger-than
+	 */
+	setup->splitTablesLargerThanBytes = sqlite3_column_int64(query->ppStmt, 4);
+
+	/*
+	 * filters
+	 */
+	if (sqlite3_column_type(query->ppStmt, 5) == SQLITE_NULL)
+	{
+		setup->filters = NULL;
+	}
+	else
+	{
+		int len = sqlite3_column_bytes(query->ppStmt, 5);
+		int bytes = len + 1;
+
+		setup->filters = (char *) calloc(bytes, sizeof(char));
+
+		if (setup->filters == NULL)
+		{
+			log_fatal(ALLOCATION_FAILED_ERROR);
+			return false;
+		}
+
+		strlcpy(setup->filters,
+				(char *) sqlite3_column_text(query->ppStmt, 5),
+				bytes);
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_register_section registers that a section has been cached to the
+ * internal catalogs.
+ */
+bool
+catalog_register_section(DatabaseCatalog *catalog, CopyDataSection section)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_register_section: db is NULL");
+		return false;
+	}
+
+	char *sql = "insert into section(name, fetched) values($1, 1)";
+
+	SQLiteQuery query = { 0 };
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_TEXT, "section", 0,
+		  CopyDataSectionToString(section) }
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(&query, params, count))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which does not return any row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_section_state sets the fetched boolean to the catalog value.
+ */
+bool
+catalog_section_state(DatabaseCatalog *catalog, CatalogSection *section)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_section_state: db is NULL");
+		return false;
+	}
+
+	SQLiteQuery query = {
+		.context = section,
+		.fetchFunction = &catalog_section_fetch
+	};
+
+	char *sql = "select name, fetched from section where name = $1";
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_TEXT, "name", 0,
+		  CopyDataSectionToString(section->section) }
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(&query, params, count))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which return exactly one row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_section_fetch is a SQLiteQuery callback.
+ */
+bool
+catalog_section_fetch(SQLiteQuery *query)
+{
+	CatalogSection *section = (CatalogSection *) query->context;
+
+	strlcpy(section->name,
+			(char *) sqlite3_column_text(query->ppStmt, 1),
+			sizeof(section->name));
+
+	section->fetched = sqlite3_column_int(query->ppStmt, 1) == 1;
+
+	return true;
+}
+
+
+/*
+ * CopyDataSectionToString returns a string representation of a section.
+ */
+char *
+CopyDataSectionToString(CopyDataSection section)
+{
+	switch (section)
+	{
+		case DATA_SECTION_DATABASE_PROPERTIES:
+		{
+			return "database-properties";
+		}
+
+		case DATA_SECTION_COLLATIONS:
+		{
+			return "collations";
+		}
+
+		case DATA_SECTION_EXTENSIONS:
+		{
+			return "extension";
+		}
+
+		case DATA_SECTION_SCHEMA:
+		{
+			return "schema";
+		}
+
+		case DATA_SECTION_TABLE_DATA:
+		{
+			return "table-data";
+		}
+
+		case DATA_SECTION_TABLE_DATA_PARTS:
+		{
+			return "table-data-parts";
+		}
+
+		case DATA_SECTION_SET_SEQUENCES:
+		{
+			return "set-sequences";
+		}
+
+		case DATA_SECTION_INDEXES:
+		{
+			return "indexes";
+		}
+
+		case DATA_SECTION_CONSTRAINTS:
+		{
+			return "constraints";
+		}
+
+		case DATA_SECTION_DEPENDS:
+		{
+			return "pg_depend";
+		}
+
+		case DATA_SECTION_FILTERS:
+		{
+			return "filters";
+		}
+
+		case DATA_SECTION_BLOBS:
+		{
+			return "large-objects";
+		}
+
+		case DATA_SECTION_VACUUM:
+		{
+			return "vacuum";
+		}
+
+		case DATA_SECTION_ALL:
+		{
+			return "all";
+		}
+
+		case DATA_SECTION_NONE:
+		default:
+		{
+			log_error("BUG: CopyDataSectionToString unknown section %d", section);
+			return NULL;
+		}
+	}
+
+	/* keep compiler happy */
+	return "unknown";
+}
+
+
+/*
+ * catalog_add_s_table INSERTs a SourceTable to our internal catalogs database.
+ */
+bool
+catalog_add_s_table(DatabaseCatalog *catalog, SourceTable *table)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_add_s_table: db is NULL");
+		return false;
+	}
+
+	char *sql =
+		"insert into s_table("
+		"  oid, qname, nspname, relname, amname, restore_list_name, "
+		"  relpages, reltuples, bytes, bytes_pretty, exclude_data, part_key) "
+		"values($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)";
+
+	SQLiteQuery query = { 0 };
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_INT64, "oid", table->oid, NULL },
+		{ BIND_PARAMETER_TYPE_TEXT, "qname", 0, table->qname },
+		{ BIND_PARAMETER_TYPE_TEXT, "nspname", 0, table->nspname },
+		{ BIND_PARAMETER_TYPE_TEXT, "relname", 0, table->relname },
+		{ BIND_PARAMETER_TYPE_TEXT, "amname", 0, table->amname },
+
+		{ BIND_PARAMETER_TYPE_TEXT, "restore_list_name", 0,
+		  table->restoreListName },
+
+		{ BIND_PARAMETER_TYPE_INT64, "relpages", table->relpages, NULL },
+		{ BIND_PARAMETER_TYPE_INT64, "reltuples", table->reltuples, NULL },
+		{ BIND_PARAMETER_TYPE_INT64, "bytes", table->bytes, NULL },
+		{ BIND_PARAMETER_TYPE_TEXT, "bytes_pretty", 0, table->bytesPretty },
+
+		{ BIND_PARAMETER_TYPE_INT, "exclude_data",
+		  table->excludeData ? 1 : 0, NULL },
+
+		{ BIND_PARAMETER_TYPE_TEXT, "part_key", 0, table->partKey }
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(&query, params, count))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which does not return any row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now add the attributes */
+	if (!catalog_add_attributes(catalog, table))
+	{
+		log_error("Failed to add table %s attributes, see above for details",
+				  table->qname);
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_add_attributes INSERTs a SourceTable attributes array to our
+ * internal catalogs database (s_attr).
+ */
+bool
+catalog_add_attributes(DatabaseCatalog *catalog, SourceTable *table)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_add_attributes: db is NULL");
+		return false;
+	}
+
+	char *sql =
+		"insert into s_attr("
+		"oid, attnum, attypid, attname, attisprimary, attisgenerated)"
+		"values($1, $2, $3, $4, $5, $6)";
+
+	SQLiteQuery query = { 0 };
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	for (int i = 0; i < table->attributes.count; i++)
+	{
+		SourceTableAttribute *attr = &(table->attributes.array[i]);
+
+		BindParam params[] = {
+			{ BIND_PARAMETER_TYPE_INT64, "oid", table->oid, NULL },
+			{ BIND_PARAMETER_TYPE_INT64, "attnum", attr->attnum, NULL },
+			{ BIND_PARAMETER_TYPE_INT64, "atttypid", attr->atttypid, NULL },
+			{ BIND_PARAMETER_TYPE_TEXT, "attname", 0, attr->attname },
+
+			{ BIND_PARAMETER_TYPE_INT, "attisprimary",
+			  attr->attisprimary ? 1 : 0, NULL },
+
+			{ BIND_PARAMETER_TYPE_INT, "attisgenerated",
+			  attr->attisgenerated ? 1 : 0, NULL }
+		};
+
+		int count = sizeof(params) / sizeof(params[0]);
+
+		if (!catalog_sql_bind(&query, params, count))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+
+		/* now execute the query, which does not return any row */
+		if (!catalog_sql_execute(&query))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+	}
+
+	/* and finalize the query */
+	if (!catalog_sql_finalize(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_add_s_table_parts INSERTs a SourceTableParts array to our internal
+ * catalogs database (s_table_parts).
+ */
+bool
+catalog_add_s_table_parts(DatabaseCatalog *catalog, SourceTable *table)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_add_s_table_part: db is NULL");
+		return false;
+	}
+
+	char *sql =
+		"insert into s_table_part(oid, partnum, partcount, min, max, count)"
+		"values($1, $2, $3, $4, $5, $6)";
+
+	SQLiteQuery query = { 0 };
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	for (int i = 0; i < table->partsArray.count; i++)
+	{
+		SourceTableParts *part = &(table->partsArray.array[i]);
+
+		BindParam params[] = {
+			{ BIND_PARAMETER_TYPE_INT64, "oid", table->oid, NULL },
+			{ BIND_PARAMETER_TYPE_INT64, "partnum", part->partNumber, NULL },
+			{ BIND_PARAMETER_TYPE_INT64, "partcount", part->partCount, NULL },
+			{ BIND_PARAMETER_TYPE_INT64, "min", part->min, NULL },
+			{ BIND_PARAMETER_TYPE_INT64, "max", part->max, NULL },
+			{ BIND_PARAMETER_TYPE_INT64, "count", part->count, NULL },
+		};
+
+		int count = sizeof(params) / sizeof(params[0]);
+
+		if (!catalog_sql_bind(&query, params, count))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+
+		/* now execute the query, which does not return any row */
+		if (!catalog_sql_execute(&query))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+	}
+
+	/* and finalize the query */
+	if (!catalog_sql_finalize(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_add_s_table INSERTs a SourceTable to our internal catalogs database.
+ */
+bool
+catalog_add_s_table_chksum(DatabaseCatalog *catalog,
+						   SourceTable *table,
+						   TableChecksum *srcChk,
+						   TableChecksum *dstChk)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_add_s_table_chksum: db is NULL");
+		return false;
+	}
+
+	char *sql =
+		"insert into s_table_chksum("
+		"  oid, srcrowcount, srcsum, dstrowcount, dstsum)"
+		"values($1, $2, $3, $4, $5)";
+
+	SQLiteQuery query = { 0 };
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_INT64, "oid", table->oid, NULL },
+		{ BIND_PARAMETER_TYPE_INT64, "srcrowcount", srcChk->rowcount, NULL },
+		{ BIND_PARAMETER_TYPE_TEXT, "srcsum", 0, srcChk->checksum },
+		{ BIND_PARAMETER_TYPE_INT64, "dstrowcount", dstChk->rowcount, NULL },
+		{ BIND_PARAMETER_TYPE_TEXT, "dstsum", 0, dstChk->checksum }
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(&query, params, count))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which does not return any row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_delete_s_table_chksum_all implements cache invalidation for pgcopydb
+ * compare data.
+ */
+bool
+catalog_delete_s_table_chksum_all(DatabaseCatalog *catalog)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_delete_s_table_chksum_all: db is NULL");
+		return false;
+	}
+
+	char *sql = "delete from s_table_chksum";
+
+	SQLiteQuery query = { 0 };
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which does not return any row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_stats fetches statistics about the objects we have in our catalog.
+ */
+bool
+catalog_stats(DatabaseCatalog *catalog, CatalogStats *stats)
+{
+	if (!catalog_s_table_stats(catalog, &(stats->table)))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	if (!catalog_count_objects(catalog, &(stats->count)))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_s_table_stats fetches statistics about the SourceTable list we have
+ * in our catalog.
+ */
+bool
+catalog_s_table_stats(DatabaseCatalog *catalog, CatalogTableStats *stats)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_s_table_stats: db is NULL");
+		return false;
+	}
+
+	char *sql =
+		"select count(t.oid) as count, "
+		"       count(p.oid) as countSplits, "
+		"       sum(p.partcount) as countParts, "
+		"       sum(bytes) as totalBytes, "
+		"       sum(reltuples) as totalTuples "
+		"  from s_table t "
+		"       left join "
+		"         ("
+		"             select oid, count(*) as partcount "
+		"               from s_table_part "
+		"           group by oid"
+		"         ) p "
+		"        on p.oid = t.oid";
+
+	SQLiteQuery query = {
+		.context = stats,
+		.fetchFunction = &catalog_s_table_stats_fetch
+	};
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which return exactly one row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_s_table_stats_fetch is a SQLiteQuery callback.
+ */
+bool
+catalog_s_table_stats_fetch(SQLiteQuery *query)
+{
+	CatalogTableStats *stats = (CatalogTableStats *) query->context;
+
+	stats->count = sqlite3_column_int64(query->ppStmt, 0);
+	stats->countSplits = sqlite3_column_int64(query->ppStmt, 1);
+	stats->countParts = sqlite3_column_int64(query->ppStmt, 2);
+	stats->totalBytes = sqlite3_column_int64(query->ppStmt, 3);
+	stats->totalTuples = sqlite3_column_int64(query->ppStmt, 4);
+
+	(void) pretty_print_bytes(stats->bytesPretty, BUFSIZE, stats->totalBytes);
+	(void) pretty_print_count(stats->relTuplesPretty, BUFSIZE, stats->totalTuples);
+
+	return true;
+}
+
+
+/*
+ * catalog_count_objects returns how many objects were added to the catalogs.
+ */
+bool
+catalog_count_objects(DatabaseCatalog *catalog, CatalogCounts *count)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_count_objects: db is NULL");
+		return false;
+	}
+
+	char *sql = NULL;
+
+	switch (catalog->type)
+	{
+		case DATABASE_CATALOG_TYPE_SOURCE:
+		{
+			sql =
+				"select (select count(1) as rel from s_table), "
+				"       (select count(1) as idx from s_index), "
+				"       (select count(1) as con from s_constraint),"
+				"       (select count(1) as seq from s_seq),"
+				"       0 as rol,"
+				"       (select count(1) as dat from s_database),"
+				"       0 as nsp,"
+				"       0 as ext,"
+				"       0 as colls,"
+				"       0 as pg_depend";
+			break;
+		}
+
+		case DATABASE_CATALOG_TYPE_FILTER:
+		{
+			sql =
+				"select (select count(1) as rel from s_table), "
+				"       (select count(1) as idx from s_index), "
+				"       (select count(1) as con from s_constraint),"
+				"       (select count(1) as seq from s_seq),"
+				"       0 as rol,"
+				"       0 as dat,"
+				"       (select count(1) as nsp from s_namespace),"
+				"       (select count(1) as ext from s_extension),"
+				"       (select count(1) as col from s_coll),"
+				"       (select count(1) as dep from s_depend)";
+			break;
+		}
+
+		case DATABASE_CATALOG_TYPE_TARGET:
+		{
+			sql =
+				"select (select count(1) as rel from s_table), "
+				"       (select count(1) as idx from s_index), "
+				"       (select count(1) as con from s_constraint),"
+				"       0 as seq,"
+				"       (select count(1) as rol from s_role),"
+				"       0 as dat,"
+				"       (select count(1) as nsp from s_namespace),"
+				"       0 as ext,"
+				"       0 as colls,"
+				"       0 as pg_depend";
+			break;
+		}
+
+		default:
+		{
+			log_error("BUG: called catalog_count_objects for unknown type %d",
+					  catalog->type);
+			return false;
+		}
+	}
+
+	SQLiteQuery query = {
+		.context = count,
+		.fetchFunction = &catalog_count_fetch
+	};
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which return exactly one row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_count_fetch fetches a CatalogIndexCount from a query ppStmt
+ * result.
+ */
+bool
+catalog_count_fetch(SQLiteQuery *query)
+{
+	CatalogCounts *count = (CatalogCounts *) query->context;
+
+	count->tables = sqlite3_column_int64(query->ppStmt, 0);
+	count->indexes = sqlite3_column_int64(query->ppStmt, 1);
+	count->constraints = sqlite3_column_int64(query->ppStmt, 2);
+	count->sequences = sqlite3_column_int64(query->ppStmt, 3);
+
+	count->roles = sqlite3_column_int64(query->ppStmt, 4);
+	count->databases = sqlite3_column_int64(query->ppStmt, 5);
+	count->namespaces = sqlite3_column_int64(query->ppStmt, 6);
+	count->extensions = sqlite3_column_int64(query->ppStmt, 7);
+	count->colls = sqlite3_column_int64(query->ppStmt, 8);
+	count->depends = sqlite3_column_int64(query->ppStmt, 9);
+
+	return true;
+}
+
+
+/*
+ * catalog_lookup_s_table fetches a SourceTable entry from our catalogs.
+ */
+bool
+catalog_lookup_s_table(DatabaseCatalog *catalog,
+					   uint32_t oid,
+					   int partNumber,
+					   SourceTable *table)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_lookup_s_table: db is NULL");
+		return false;
+	}
+
+	SQLiteQuery query = {
+		.context = table,
+		.fetchFunction = &catalog_s_table_fetch
+	};
+
+	if (partNumber > 0)
+	{
+		char *sql =
+			"  select t.oid, qname, nspname, relname, amname, restore_list_name, "
+			"         relpages, reltuples, bytes, bytes_pretty, "
+			"         exclude_data, part_key, "
+			"         p.partcount as partcount, p.partnum, p.min, p.max "
+			"    from s_table t "
+			"         join s_table_part p "
+			"           on t.oid = p.oid "
+			"          and p.partnum = $1"
+			"   where t.oid = $2 ";
+
+		if (!catalog_sql_prepare(db, sql, &query))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+
+		/* bind our parameters now */
+		BindParam params[] = {
+			{ BIND_PARAMETER_TYPE_INT64, "partnum", partNumber, NULL },
+			{ BIND_PARAMETER_TYPE_INT64, "oid", oid, NULL }
+		};
+
+		int count = sizeof(params) / sizeof(params[0]);
+
+		if (!catalog_sql_bind(&query, params, count))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+	}
+	else
+	{
+		char *sql =
+			"  select t.oid, qname, nspname, relname, amname, restore_list_name, "
+			"         relpages, reltuples, bytes, bytes_pretty, "
+			"         exclude_data, part_key, "
+			"         count(p.oid) as partcount "
+			"    from s_table t left join s_table_part p on t.oid = p.oid"
+			"   where t.oid = $1 ";
+
+		if (!catalog_sql_prepare(db, sql, &query))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+
+		/* bind our parameters now */
+		BindParam params[] = {
+			{ BIND_PARAMETER_TYPE_INT64, "oid", oid, NULL }
+		};
+
+		int count = sizeof(params) / sizeof(params[0]);
+
+		if (!catalog_sql_bind(&query, params, count))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+	}
+
+	/* now execute the query, which return exactly one row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_lookup_s_table_by_name fetches a SourceTable from our catalogs.
+ */
+bool
+catalog_lookup_s_table_by_name(DatabaseCatalog *catalog,
+							   const char *nspname,
+							   const char *relname,
+							   SourceTable *table)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_s_table_stats: db is NULL");
+		return false;
+	}
+
+	char *sql =
+		"  select t.oid, qname, nspname, relname, amname, restore_list_name, "
+		"         relpages, reltuples, bytes, bytes_pretty, "
+		"         exclude_data, part_key, "
+		"         p.partcount, 0 as partnum, 0 as min, 0 as max "
+		"    from s_table t "
+		"         left join "
+		"         ("
+		"             select oid, count(*) as partcount "
+		"               from s_table_part "
+		"           group by oid"
+		"         ) p "
+		"        on p.oid = t.oid"
+		"   where nspname = $1 and relname = $2 ";
+
+	SQLiteQuery query = {
+		.context = table,
+		.fetchFunction = &catalog_s_table_fetch
+	};
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_TEXT, "nspname", 0, (char *) nspname },
+		{ BIND_PARAMETER_TYPE_TEXT, "relname", 0, (char *) relname },
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(&query, params, count))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which return exactly one row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_lookup_s_attr_by_name fetches a SourceTable from our catalogs.
+ */
+bool
+catalog_lookup_s_attr_by_name(DatabaseCatalog *catalog,
+							  uint32_t reloid,
+							  const char *attname,
+							  SourceTableAttribute *attribute)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_lookup_s_attr_by_name: db is NULL");
+		return false;
+	}
+
+	char *sql =
+		"  select attnum, attypid, attname, attisprimary, attisgenerated "
+		"    from s_attr "
+		"   where oid = $1 and attname = $2";
+
+	SQLiteQuery query = {
+		.context = attribute,
+		.fetchFunction = &catalog_s_attr_fetch
+	};
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_INT64, "oid", reloid, NULL },
+		{ BIND_PARAMETER_TYPE_TEXT, "attname", 0, (char *) attname },
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(&query, params, count))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which return exactly one row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_delete_s_table deletes an s_table entry for the given oid.
+ */
+bool
+catalog_delete_s_table(DatabaseCatalog *catalog,
+					   const char *nspname,
+					   const char *relname)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: Failed to initialize s_table iterator: db is NULL");
+		return false;
+	}
+
+	char *sql = "delete from s_table where nspname = $1 and relname = $2";
+
+	SQLiteQuery query = { 0 };
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_TEXT, "nspname", 0, (char *) nspname },
+		{ BIND_PARAMETER_TYPE_TEXT, "relname", 0, (char *) relname }
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(&query, params, count))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which does not return any row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_table iterates over the list of tables in our catalogs.
+ */
+bool
+catalog_iter_s_table(DatabaseCatalog *catalog,
+					 void *context,
+					 SourceTableIterFun *callback)
+{
+	SourceTableIterator *iter =
+		(SourceTableIterator *) calloc(1, sizeof(SourceTableIterator));
+
+	iter->catalog = catalog;
+
+	if (!catalog_iter_s_table_init(iter))
+	{
+		/* errors have already been logged */
+		free(iter);
+		return false;
+	}
+
+	for (;;)
+	{
+		if (!catalog_iter_s_table_next(iter))
+		{
+			/* errors have already been logged */
+			free(iter);
+			return false;
+		}
+
+		SourceTable *table = iter->table;
+
+		if (table == NULL)
+		{
+			if (!catalog_iter_s_table_finish(iter))
+			{
+				/* errors have already been logged */
+				free(iter);
+				return false;
+			}
+
+			break;
+		}
+
+		/* now call the provided callback */
+		if (!(*callback)(context, table))
+		{
+			log_error("Failed to iterate over list of tables, "
+					  "see above for details");
+			return false;
+		}
+	}
+
+	free(iter);
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_table_nopk iterates over the list of tables that don't have a
+ * Primary Key in our catalogs.
+ */
+bool
+catalog_iter_s_table_nopk(DatabaseCatalog *catalog,
+						  void *context,
+						  SourceTableIterFun *callback)
+{
+	SourceTableIterator *iter =
+		(SourceTableIterator *) calloc(1, sizeof(SourceTableIterator));
+
+	iter->catalog = catalog;
+
+	if (!catalog_iter_s_table_nopk_init(iter))
+	{
+		/* errors have already been logged */
+		free(iter);
+		return false;
+	}
+
+	for (;;)
+	{
+		if (!catalog_iter_s_table_next(iter))
+		{
+			/* errors have already been logged */
+			free(iter);
+			return false;
+		}
+
+		SourceTable *table = iter->table;
+
+		if (table == NULL)
+		{
+			if (!catalog_iter_s_table_finish(iter))
+			{
+				/* errors have already been logged */
+				free(iter);
+				return false;
+			}
+
+			break;
+		}
+
+		/* now call the provided callback */
+		if (!(*callback)(context, table))
+		{
+			log_error("Failed to iterate over list of tables, "
+					  "see above for details");
+			return false;
+		}
+	}
+
+	free(iter);
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_table_init initializes an Interator over our catalog of
+ * SourceTable entries.
+ */
+bool
+catalog_iter_s_table_init(SourceTableIterator *iter)
+{
+	sqlite3 *db = iter->catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: Failed to initialize s_table iterator: db is NULL");
+		return false;
+	}
+
+	iter->table = (SourceTable *) calloc(1, sizeof(SourceTable));
+
+	if (iter->table == NULL)
+	{
+		log_error(ALLOCATION_FAILED_ERROR);
+		return false;
+	}
+
+	char *sql = NULL;
+
+	if (iter->splitTableLargerThanBytes > 0)
+	{
+		sql =
+			"  select t.oid, qname, nspname, relname, amname, restore_list_name, "
+			"         relpages, reltuples, bytes, bytes_pretty, "
+			"         exclude_data, part_key, "
+			"         count(p.oid), 0 as partnum, 0 as min, 0 as max, "
+			"         c.srcrowcount, c.srcsum, c.dstrowcount, c.dstsum "
+			"    from s_table t "
+			"         left join s_table_part p on t.oid = p.oid "
+			"         left join s_table_chksum c on t.oid = c.oid "
+			"   where bytes >= $1 "
+			"group by t.oid "
+			"order by bytes desc";
+	}
+	else
+	{
+		sql =
+			"  select t.oid, qname, nspname, relname, amname, restore_list_name, "
+			"         relpages, reltuples, bytes, bytes_pretty, "
+			"         exclude_data, part_key, "
+			"         count(p.oid), 0 as partnum, 0 as min, 0 as max, "
+			"         c.srcrowcount, c.srcsum, c.dstrowcount, c.dstsum "
+			"    from s_table t "
+			"         left join s_table_part p on t.oid = p.oid "
+			"         left join s_table_chksum c on t.oid = c.oid "
+			"group by t.oid "
+			"order by bytes desc";
+	}
+
+	SQLiteQuery *query = &(iter->query);
+
+	query->context = iter->table;
+	query->fetchFunction = &catalog_s_table_fetch;
+
+	if (!catalog_sql_prepare(db, sql, query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	if (iter->splitTableLargerThanBytes > 0)
+	{
+		BindParam params[1] = {
+			{
+				BIND_PARAMETER_TYPE_INT64,
+				"bytes",
+				iter->splitTableLargerThanBytes,
+				NULL
+			}
+		};
+
+		if (!catalog_sql_bind(query, params, 1))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_table_init initializes an Interator over our catalog of
+ * SourceTable entries.
+ */
+bool
+catalog_iter_s_table_nopk_init(SourceTableIterator *iter)
+{
+	sqlite3 *db = iter->catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: Failed to initialize s_table iterator: db is NULL");
+		return false;
+	}
+
+	iter->table = (SourceTable *) calloc(1, sizeof(SourceTable));
+
+	if (iter->table == NULL)
+	{
+		log_error(ALLOCATION_FAILED_ERROR);
+		return false;
+	}
+
+	char *sql =
+		"  select t.oid, qname, nspname, relname, amname, restore_list_name, "
+		"         relpages, reltuples, bytes, bytes_pretty, "
+		"         exclude_data, part_key, "
+		"         (select count(1) from s_table_part p where p.oid = t.oid) "
+		"    from s_table t join join s_attr a on a.oid = t.oid "
+		"group by t.oid "
+		"  having sum(a.attisprimary) = 0 "
+		"order by bytes desc";
+
+	SQLiteQuery *query = &(iter->query);
+
+	query->context = iter->table;
+	query->fetchFunction = &catalog_s_table_fetch;
+
+	if (!catalog_sql_prepare(db, sql, query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_table_next fetches the next SourceTable entry in our catalogs.
+ */
+bool
+catalog_iter_s_table_next(SourceTableIterator *iter)
+{
+	SQLiteQuery *query = &(iter->query);
+
+	int rc = catalog_sql_step(query);
+
+	if (rc == SQLITE_DONE)
+	{
+		free(iter->table);
+		iter->table = NULL;
+
+		return true;
+	}
+
+	if (rc != SQLITE_ROW)
+	{
+		log_error("Failed to step through statement: %s", query->sql);
+		log_error("[SQLite] %s", sqlite3_errmsg(query->db));
+		return false;
+	}
+
+	return catalog_s_table_fetch(query);
+}
+
+
+/*
+ * catalog_s_table_fetch fetches a SourceTable entry from a SQLite ppStmt
+ * result set.
+ */
+bool
+catalog_s_table_fetch(SQLiteQuery *query)
+{
+	SourceTable *table = (SourceTable *) query->context;
+
+	/* cleanup the memory area before re-use */
+	bzero(table, sizeof(SourceTable));
+
+	table->oid = sqlite3_column_int64(query->ppStmt, 0);
+
+	strlcpy(table->qname,
+			(char *) sqlite3_column_text(query->ppStmt, 1),
+			sizeof(table->qname));
+
+	strlcpy(table->nspname,
+			(char *) sqlite3_column_text(query->ppStmt, 2),
+			sizeof(table->nspname));
+
+	strlcpy(table->relname,
+			(char *) sqlite3_column_text(query->ppStmt, 3),
+			sizeof(table->relname));
+
+	strlcpy(table->amname,
+			(char *) sqlite3_column_text(query->ppStmt, 4),
+			sizeof(table->amname));
+
+	strlcpy(table->restoreListName,
+			(char *) sqlite3_column_text(query->ppStmt, 5),
+			sizeof(table->restoreListName));
+
+	table->relpages = sqlite3_column_int64(query->ppStmt, 6);
+	table->reltuples = sqlite3_column_int64(query->ppStmt, 7);
+	table->bytes = sqlite3_column_int64(query->ppStmt, 8);
+
+	strlcpy(table->bytesPretty,
+			(char *) sqlite3_column_text(query->ppStmt, 9),
+			sizeof(table->bytesPretty));
+
+	table->excludeData = sqlite3_column_int64(query->ppStmt, 10) == 1;
+
+	strlcpy(table->partKey,
+			(char *) sqlite3_column_text(query->ppStmt, 11),
+			sizeof(table->partKey));
+
+	table->partition.partCount = sqlite3_column_int64(query->ppStmt, 12);
+
+	/*
+	 * The main iterator query returns partition count, whereas the catalog
+	 * fetch query, which is given a table oid, then returns partNumber, min,
+	 * max, and count values.
+	 */
+	int cols = sqlite3_column_count(query->ppStmt);
+
+	if (cols >= 16)
+	{
+		table->partition.partNumber = sqlite3_column_int64(query->ppStmt, 13);
+		table->partition.min = sqlite3_column_int64(query->ppStmt, 14);
+		table->partition.max = sqlite3_column_int64(query->ppStmt, 15);
+	}
+
+	if (cols == 20)
+	{
+		table->sourceChecksum.rowcount =
+			sqlite3_column_int64(query->ppStmt, 16);
+
+		if (sqlite3_column_type(query->ppStmt, 17) != SQLITE_NULL)
+		{
+			strlcpy(table->sourceChecksum.checksum,
+					(char *) sqlite3_column_text(query->ppStmt, 17),
+					sizeof(table->sourceChecksum.checksum));
+		}
+
+		table->targetChecksum.rowcount =
+			sqlite3_column_int64(query->ppStmt, 18);
+
+		if (sqlite3_column_type(query->ppStmt, 19) != SQLITE_NULL)
+		{
+			strlcpy(table->targetChecksum.checksum,
+					(char *) sqlite3_column_text(query->ppStmt, 19),
+					sizeof(table->targetChecksum.checksum));
+		}
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_table_finish cleans-up the internal memory used for the
+ * iteration.
+ */
+bool
+catalog_iter_s_table_finish(SourceTableIterator *iter)
+{
+	SQLiteQuery *query = &(iter->query);
+
+	/* in case we finish before reaching the DONE step */
+	if (iter->table != NULL)
+	{
+		free(iter->table);
+	}
+
+	if (!catalog_sql_finalize(query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_table_part iterates over the list of a table partitions in
+ * our catalogs.
+ */
+bool
+catalog_iter_s_table_parts(DatabaseCatalog *catalog,
+						   uint32_t oid,
+						   void *context,
+						   SourceTablePartsIterFun *callback)
+{
+	SourceTablePartsIterator *iter =
+		(SourceTablePartsIterator *) calloc(1, sizeof(SourceTablePartsIterator));
+
+	iter->catalog = catalog;
+	iter->oid = oid;
+
+	if (!catalog_iter_s_table_part_init(iter))
+	{
+		/* errors have already been logged */
+		free(iter);
+		return false;
+	}
+
+	for (;;)
+	{
+		if (!catalog_iter_s_table_part_next(iter))
+		{
+			/* errors have already been logged */
+			free(iter);
+			return false;
+		}
+
+		SourceTableParts *part = iter->part;
+
+		if (part == NULL)
+		{
+			if (!catalog_iter_s_table_part_finish(iter))
+			{
+				/* errors have already been logged */
+				free(iter);
+				return false;
+			}
+
+			break;
+		}
+
+		/* now call the provided callback */
+		if (!(*callback)(context, part))
+		{
+			log_error("Failed to iterate over list of tables, "
+					  "see above for details");
+			return false;
+		}
+	}
+
+	free(iter);
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_table_part_init initializes an Interator over our catalog of
+ * SourceTable entries.
+ */
+bool
+catalog_iter_s_table_part_init(SourceTablePartsIterator *iter)
+{
+	sqlite3 *db = iter->catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: Failed to initialize s_table iterator: db is NULL");
+		return false;
+	}
+
+	iter->part = (SourceTableParts *) calloc(1, sizeof(SourceTableParts));
+
+	if (iter->part == NULL)
+	{
+		log_error(ALLOCATION_FAILED_ERROR);
+		return false;
+	}
+
+	char *sql =
+		"  select partnum, partcount, min, max, count "
+		"    from s_table_part "
+		"   where oid = $1 "
+		"order by partnum";
+
+	SQLiteQuery *query = &(iter->query);
+
+	query->context = iter->part;
+	query->fetchFunction = &catalog_s_table_part_fetch;
+
+	if (!catalog_sql_prepare(db, sql, query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	BindParam params[1] = {
+		{ BIND_PARAMETER_TYPE_INT64, "oid", iter->oid, NULL }
+	};
+
+	if (!catalog_sql_bind(query, params, 1))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_table_part_next fetches the next SourceTable entry in our catalogs.
+ */
+bool
+catalog_iter_s_table_part_next(SourceTablePartsIterator *iter)
+{
+	SQLiteQuery *query = &(iter->query);
+
+	int rc = catalog_sql_step(query);
+
+	if (rc == SQLITE_DONE)
+	{
+		free(iter->part);
+		iter->part = NULL;
+
+		return true;
+	}
+
+	if (rc != SQLITE_ROW)
+	{
+		log_error("Failed to step through statement: %s", query->sql);
+		log_error("[SQLite] %s", sqlite3_errmsg(query->db));
+		return false;
+	}
+
+	return catalog_s_table_part_fetch(query);
+}
+
+
+/*
+ * catalog_s_table_part_fetch fetches a SourceTableParts entry from a SQLite
+ * ppStmt result set.
+ */
+bool
+catalog_s_table_part_fetch(SQLiteQuery *query)
+{
+	SourceTableParts *part = (SourceTableParts *) query->context;
+
+	/* cleanup the memory area before re-use */
+	bzero(part, sizeof(SourceTableParts));
+
+	part->partNumber = sqlite3_column_int64(query->ppStmt, 0);
+	part->partCount = sqlite3_column_int64(query->ppStmt, 1);
+	part->min = sqlite3_column_int64(query->ppStmt, 2);
+	part->max = sqlite3_column_int64(query->ppStmt, 3);
+	part->count = sqlite3_column_int64(query->ppStmt, 4);
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_table_part_finish cleans-up the internal memory used for the
+ * iteration.
+ */
+bool
+catalog_iter_s_table_part_finish(SourceTablePartsIterator *iter)
+{
+	SQLiteQuery *query = &(iter->query);
+
+	/* in case we finish before reaching the DONE step */
+	if (iter->part != NULL)
+	{
+		free(iter->part);
+	}
+
+	if (!catalog_sql_finalize(query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_s_table_fetch_attrs fetches the table SourceTableAttribute array
+ * from our s_attr catalog.
+ */
+bool
+catalog_s_table_fetch_attrs(DatabaseCatalog *catalog, SourceTable *table)
+{
+	SourceTableAttrsIterator *iter =
+		(SourceTableAttrsIterator *) calloc(1,
+											sizeof(SourceTableAttrsIterator));
+
+	if (iter == NULL)
+	{
+		log_error(ALLOCATION_FAILED_ERROR);
+		return false;
+	}
+
+	iter->catalog = catalog;
+	iter->table = table;
+
+	if (!catalog_iter_s_table_attrs_init(iter))
+	{
+		/* errors have already been logged */
+		free(iter);
+		return false;
+	}
+
+	while (!iter->done)
+	{
+		if (!catalog_iter_s_table_attrs_next(iter))
+		{
+			/* errors have already been logged */
+			free(iter);
+			return false;
+		}
+	}
+
+	if (!catalog_iter_s_table_attrs_finish(iter))
+	{
+		/* errors have already been logged */
+		free(iter);
+		return false;
+	}
+
+	free(iter);
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_table_attrs_init initializes an Interator over our catalog of
+ * SourceTableAttributes entries.
+ */
+bool
+catalog_iter_s_table_attrs_init(SourceTableAttrsIterator *iter)
+{
+	sqlite3 *db = iter->catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: Failed to initialize s_table iterator: db is NULL");
+		return false;
+	}
+
+	SourceTable *table = iter->table;
+
+	if (iter->table == NULL)
+	{
+		log_error("BUG: Failed to initialize s_table iterator: table is NULL");
+		return false;
+	}
+
+	char *sql =
+		"  select attnum, "
+		"         count(*) over() as count, "
+		"         attypid, attname, attisprimary, attisgenerated "
+		"    from s_attr "
+		"   where oid = $1 "
+		"order by attnum";
+
+	SQLiteQuery *query = &(iter->query);
+
+	query->context = iter->table;
+	query->fetchFunction = &catalog_s_table_attrs_fetch;
+
+	if (!catalog_sql_prepare(db, sql, query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[1] = {
+		{ BIND_PARAMETER_TYPE_INT64, "oid", table->oid, NULL }
+	};
+
+	if (!catalog_sql_bind(query, params, 1))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_table_attrs_next fetches the next SourceTable entry in our
+ * catalogs.
+ */
+bool
+catalog_iter_s_table_attrs_next(SourceTableAttrsIterator *iter)
+{
+	SQLiteQuery *query = &(iter->query);
+
+	int rc = catalog_sql_step(query);
+
+	if (rc == SQLITE_DONE)
+	{
+		iter->done = true;
+		return true;
+	}
+
+	if (rc != SQLITE_ROW)
+	{
+		log_error("Failed to step through statement: %s", query->sql);
+		log_error("[SQLite] %s", sqlite3_errmsg(query->db));
+		return false;
+	}
+
+	return catalog_s_table_attrs_fetch(query);
+}
+
+
+/*
+ * catalog_iter_s_table_attrs_finish cleans-up the internal memory used for the
+ * iteration.
+ */
+bool
+catalog_iter_s_table_attrs_finish(SourceTableAttrsIterator *iter)
+{
+	SQLiteQuery *query = &(iter->query);
+
+	if (!catalog_sql_finalize(query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_s_table_attrs_fetch  is a SQLiteQuery callback.
+ */
+bool
+catalog_s_table_attrs_fetch(SQLiteQuery *query)
+{
+	SourceTable *table = (SourceTable *) query->context;
+
+	int attnum = sqlite3_column_int(query->ppStmt, 0);
+	int count = sqlite3_column_int(query->ppStmt, 1);
+
+	if (attnum == 1)
+	{
+		table->attributes.count = count;
+		table->attributes.array =
+			(SourceTableAttribute *) calloc(count,
+											sizeof(SourceTableAttribute));
+
+		if (table->attributes.array == NULL)
+		{
+			log_error(ALLOCATION_FAILED_ERROR);
+			return false;
+		}
+	}
+
+	SourceTableAttribute *attr = &(table->attributes.array[attnum - 1]);
+
+	attr->attnum = attnum;
+	attr->atttypid = sqlite3_column_int64(query->ppStmt, 2);
+
+	strlcpy(attr->attname,
+			(char *) sqlite3_column_text(query->ppStmt, 3),
+			sizeof(attr->attname));
+
+	attr->attisprimary = sqlite3_column_int(query->ppStmt, 4) == 1;
+	attr->attisgenerated = sqlite3_column_int(query->ppStmt, 5) == 1;
+
+	return true;
+}
+
+
+/*
+ * catalog_s_attr_fetch  is a SQLiteQuery callback.
+ */
+bool
+catalog_s_attr_fetch(SQLiteQuery *query)
+{
+	SourceTableAttribute *attr = (SourceTableAttribute *) query->context;
+
+	attr->attnum = sqlite3_column_int64(query->ppStmt, 0);
+	attr->atttypid = sqlite3_column_int64(query->ppStmt, 1);
+
+	strlcpy(attr->attname,
+			(char *) sqlite3_column_text(query->ppStmt, 2),
+			sizeof(attr->attname));
+
+	attr->attisprimary = sqlite3_column_int(query->ppStmt, 3) == 1;
+	attr->attisgenerated = sqlite3_column_int(query->ppStmt, 4) == 1;
+
+	return true;
+}
+
+
+/*
+ * catalog_s_table_fetch_attrs fetches the table SourceTableAttribute array
+ * from our s_attr catalog.
+ */
+bool
+catalog_s_table_count_attrs(DatabaseCatalog *catalog, SourceTable *table)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_s_table_count_attrs: db is NULL");
+		return false;
+	}
+
+	char *sql = "select count(1) from s_attr where oid = $1";
+
+	SQLiteQuery query = {
+		.context = table,
+		.fetchFunction = &catalog_s_table_count_attrs_fetch
+	};
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[1] = {
+		{ BIND_PARAMETER_TYPE_INT64, "oid", table->oid, NULL }
+	};
+
+	if (!catalog_sql_bind(&query, params, 1))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which return exactly one row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_s_table_count_attrs_fetch  is a SQLiteQuery callback.
+ */
+bool
+catalog_s_table_count_attrs_fetch(SQLiteQuery *query)
+{
+	SourceTable *table = (SourceTable *) query->context;
+
+	int count = sqlite3_column_int(query->ppStmt, 0);
+
+	table->attributes.count = count;
+	table->attributes.array = NULL;
+
+	return true;
+}
+
+
+/*
+ * catalog_add_s_index INSERTs a SourceIndex to our internal catalogs database.
+ */
+bool
+catalog_add_s_index(DatabaseCatalog *catalog, SourceIndex *index)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_add_s_index: db is NULL");
+		return false;
+	}
+
+	char *sql =
+		"insert into s_index("
+		"  oid, qname, nspname, relname, restore_list_name, tableoid, "
+		"  isprimary, isunique, columns, sql) "
+		"values($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)";
+
+	SQLiteQuery query = { 0 };
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_INT64, "oid", index->indexOid, NULL },
+		{ BIND_PARAMETER_TYPE_TEXT, "qname", 0, index->indexQname },
+		{ BIND_PARAMETER_TYPE_TEXT, "nspname", 0, index->indexNamespace },
+		{ BIND_PARAMETER_TYPE_TEXT, "relname", 0, index->indexRelname },
+
+		{ BIND_PARAMETER_TYPE_TEXT, "restore_list_name", 0,
+		  index->indexRestoreListName },
+
+		{ BIND_PARAMETER_TYPE_INT64, "tableoid", index->tableOid, NULL },
+
+		{ BIND_PARAMETER_TYPE_INT, "isprimary", index->isPrimary ? 1 : 0, NULL },
+		{ BIND_PARAMETER_TYPE_INT, "isunique", index->isUnique ? 1 : 0, NULL },
+
+		{ BIND_PARAMETER_TYPE_TEXT, "columns", 0, index->indexColumns },
+		{ BIND_PARAMETER_TYPE_TEXT, "sql", 0, index->indexDef }
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(&query, params, count))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which does not return any row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_add_s_constraint INSERTs a SourceIndex constraint to our internal
+ * catalogs database.
+ */
+bool
+catalog_add_s_constraint(DatabaseCatalog *catalog, SourceIndex *index)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_add_s_index: db is NULL");
+		return false;
+	}
+
+	char *sql =
+		"insert into s_constraint("
+		"  oid, conname, indexoid, condeferrable, condeferred, sql)"
+		"values($1, $2, $3, $4, $5, $6)";
+
+	SQLiteQuery query = { 0 };
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_INT64, "oid", index->constraintOid, NULL },
+		{ BIND_PARAMETER_TYPE_TEXT, "conname", 0, index->constraintName },
+		{ BIND_PARAMETER_TYPE_INT64, "indexoid", index->indexOid, NULL },
+
+		{ BIND_PARAMETER_TYPE_INT, "condeferable",
+		  index->condeferrable ? 1 : 0, NULL },
+		{ BIND_PARAMETER_TYPE_INT, "condeffered",
+		  index->condeferred ? 1 : 0, NULL },
+
+		{ BIND_PARAMETER_TYPE_TEXT, "sql", 0, index->constraintDef }
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(&query, params, count))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which does not return any row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_lookup_s_index fetches a SourceIndex entry from our catalogs.
+ */
+bool
+catalog_lookup_s_index(DatabaseCatalog *catalog, uint32_t oid, SourceIndex *index)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_lookup_s_index: db is NULL");
+		return false;
+	}
+
+	char *sql =
+		"  select i.oid, i.qname, i.nspname, i.relname, i.restore_list_name, "
+		"         i.tableoid, t.qname, t.nspname, t.relname, "
+		"         isprimary, isunique, columns, i.sql, "
+		"         c.oid as constraintoid, conname, "
+		"         condeferrable, condeferred, c.sql as condef"
+		"    from s_index i "
+		"         join s_table t on t.oid = i.tableoid "
+		"         left join s_constraint c on c.indexoid = i.oid"
+		"   where i.oid = $1 ";
+
+	SQLiteQuery query = {
+		.context = index,
+		.fetchFunction = &catalog_s_index_fetch
+	};
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[1] = {
+		{ BIND_PARAMETER_TYPE_INT64, "oid", oid, NULL },
+	};
+
+	if (!catalog_sql_bind(&query, params, 1))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which return exactly one row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_lookup_s_index_by_name fetches a SourceIndex entry from our catalogs.
+ */
+bool
+catalog_lookup_s_index_by_name(DatabaseCatalog *catalog,
+							   const char *nspname,
+							   const char *relname,
+							   SourceIndex *index)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_lookup_s_index_by_name: db is NULL");
+		return false;
+	}
+
+	char *sql =
+		"  select i.oid, i.qname, i.nspname, i.relname, i.restore_list_name, "
+		"         i.tableoid, t.qname, t.nspname, t.relname, "
+		"         isprimary, isunique, columns, i.sql, "
+		"         c.oid as constraintoid, conname, "
+		"         condeferrable, condeferred, c.sql as condef"
+		"    from s_index i "
+		"         join s_table t on t.oid = i.tableoid "
+		"         left join s_constraint c on c.indexoid = i.oid"
+		"   where i.nspname = $1 and i.relname = $2 ";
+
+	SQLiteQuery query = {
+		.context = index,
+		.fetchFunction = &catalog_s_index_fetch
+	};
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_TEXT, "nspname", 0, (char *) nspname },
+		{ BIND_PARAMETER_TYPE_TEXT, "relname", 0, (char *) relname }
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(&query, params, count))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which return exactly one row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_s_index_fetch fetches a SourceIndex entry from a SQLite ppStmt
+ * result set.
+ */
+bool
+catalog_s_index_fetch(SQLiteQuery *query)
+{
+	SourceIndex *index = (SourceIndex *) query->context;
+
+	/* cleanup the memory area before re-use */
+	bzero(index, sizeof(SourceIndex));
+
+	index->indexOid = sqlite3_column_int64(query->ppStmt, 0);
+
+	strlcpy(index->indexQname,
+			(char *) sqlite3_column_text(query->ppStmt, 1),
+			sizeof(index->indexQname));
+
+	strlcpy(index->indexNamespace,
+			(char *) sqlite3_column_text(query->ppStmt, 2),
+			sizeof(index->indexNamespace));
+
+	strlcpy(index->indexRelname,
+			(char *) sqlite3_column_text(query->ppStmt, 3),
+			sizeof(index->indexRelname));
+
+	strlcpy(index->indexRestoreListName,
+			(char *) sqlite3_column_text(query->ppStmt, 4),
+			sizeof(index->indexRestoreListName));
+
+	index->tableOid = sqlite3_column_int64(query->ppStmt, 5);
+
+	strlcpy(index->tableQname,
+			(char *) sqlite3_column_text(query->ppStmt, 6),
+			sizeof(index->tableQname));
+
+	strlcpy(index->tableNamespace,
+			(char *) sqlite3_column_text(query->ppStmt, 7),
+			sizeof(index->tableNamespace));
+
+	strlcpy(index->tableRelname,
+			(char *) sqlite3_column_text(query->ppStmt, 8),
+			sizeof(index->tableRelname));
+
+	index->isPrimary = sqlite3_column_int(query->ppStmt, 9) == 1;
+	index->isUnique = sqlite3_column_int(query->ppStmt, 10) == 1;
+
+	int len = sqlite3_column_bytes(query->ppStmt, 11);
+	int bytes = len + 1;
+
+	index->indexColumns = (char *) calloc(bytes, sizeof(char));
+
+	if (index->indexColumns == NULL)
+	{
+		log_fatal(ALLOCATION_FAILED_ERROR);
+		return false;
+	}
+
+	strlcpy(index->indexColumns,
+			(char *) sqlite3_column_text(query->ppStmt, 11),
+			bytes);
+
+	len = sqlite3_column_bytes(query->ppStmt, 12);
+	bytes = len + 1;
+
+	index->indexDef = (char *) calloc(bytes, sizeof(char));
+
+	if (index->indexDef == NULL)
+	{
+		log_fatal(ALLOCATION_FAILED_ERROR);
+		return false;
+	}
+
+	strlcpy(index->indexDef,
+			(char *) sqlite3_column_text(query->ppStmt, 12),
+			bytes);
+
+	/* constraint */
+	if (sqlite3_column_type(query->ppStmt, 13) != SQLITE_NULL)
+	{
+		index->constraintOid = sqlite3_column_int64(query->ppStmt, 13);
+
+		strlcpy(index->constraintName,
+				(char *) sqlite3_column_text(query->ppStmt, 14),
+				sizeof(index->constraintName));
+
+		index->condeferrable = sqlite3_column_int(query->ppStmt, 15) == 1;
+		index->condeferred = sqlite3_column_int(query->ppStmt, 16) == 1;
+
+		len = sqlite3_column_bytes(query->ppStmt, 17);
+		bytes = len + 1;
+
+		index->constraintDef = (char *) calloc(bytes, sizeof(char));
+
+		if (index->constraintDef == NULL)
+		{
+			log_fatal(ALLOCATION_FAILED_ERROR);
+			return false;
+		}
+
+		strlcpy(index->constraintDef,
+				(char *) sqlite3_column_text(query->ppStmt, 17),
+				bytes);
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_index iterates over the list of indexes in our catalogs.
+ */
+bool
+catalog_iter_s_index(DatabaseCatalog *catalog,
+					 void *context,
+					 SourceIndexIterFun *callback)
+{
+	SourceIndexIterator *iter =
+		(SourceIndexIterator *) calloc(1, sizeof(SourceIndexIterator));
+
+	if (iter == NULL)
+	{
+		log_error(ALLOCATION_FAILED_ERROR);
+		return false;
+	}
+
+	iter->catalog = catalog;
+
+	if (!catalog_iter_s_index_init(iter))
+	{
+		/* errors have already been logged */
+		free(iter);
+		return false;
+	}
+
+	for (;;)
+	{
+		if (!catalog_iter_s_index_next(iter))
+		{
+			/* errors have already been logged */
+			free(iter);
+			return false;
+		}
+
+		SourceIndex *index = iter->index;
+
+		if (index == NULL)
+		{
+			if (!catalog_iter_s_index_finish(iter))
+			{
+				/* errors have already been logged */
+				free(iter);
+				return false;
+			}
+
+			break;
+		}
+
+		/* now call the provided callback */
+		if (!(*callback)(context, index))
+		{
+			log_error("Failed to iterate over list of indexes, "
+					  "see above for details");
+			return false;
+		}
+	}
+
+	free(iter);
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_index iterates over the list of indexes in our catalogs.
+ */
+bool
+catalog_iter_s_index_table(DatabaseCatalog *catalog,
+						   const char *nspname,
+						   const char *relname,
+						   void *context,
+						   SourceIndexIterFun *callback)
+{
+	SourceIndexIterator *iter =
+		(SourceIndexIterator *) calloc(1, sizeof(SourceIndexIterator));
+
+	iter->catalog = catalog;
+	iter->nspname = nspname;
+	iter->relname = relname;
+
+	if (!catalog_iter_s_index_table_init(iter))
+	{
+		/* errors have already been logged */
+		free(iter);
+		return false;
+	}
+
+	for (;;)
+	{
+		if (!catalog_iter_s_index_next(iter))
+		{
+			/* errors have already been logged */
+			free(iter);
+			return false;
+		}
+
+		SourceIndex *index = iter->index;
+
+		if (index == NULL)
+		{
+			if (!catalog_iter_s_index_finish(iter))
+			{
+				/* errors have already been logged */
+				free(iter);
+				return false;
+			}
+
+			break;
+		}
+
+		/* now call the provided callback */
+		if (!(*callback)(context, index))
+		{
+			log_error("Failed to iterate over list of indexes, "
+					  "see above for details");
+			return false;
+		}
+	}
+
+	free(iter);
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_index_init initializes an Interator over our catalog of
+ * SourceIndex entries.
+ */
+bool
+catalog_iter_s_index_init(SourceIndexIterator *iter)
+{
+	sqlite3 *db = iter->catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: Failed to initialize s_index iterator: db is NULL");
+		return false;
+	}
+
+	iter->index = (SourceIndex *) calloc(1, sizeof(SourceIndex));
+
+	if (iter->index == NULL)
+	{
+		log_error(ALLOCATION_FAILED_ERROR);
+		return false;
+	}
+
+	char *sql =
+		"  select i.oid, i.qname, i.nspname, i.relname, i.restore_list_name, "
+		"         i.tableoid, t.qname, t.nspname, t.relname, "
+		"         isprimary, isunique, columns, i.sql, "
+		"         c.oid as constraintoid, conname, "
+		"         condeferrable, condeferred, c.sql as condef"
+		"    from s_index i "
+		"         join s_table t on t.oid = i.tableoid "
+		"         left join s_constraint c on c.indexoid = i.oid "
+		"order by t.bytes desc, t.oid";
+
+	SQLiteQuery *query = &(iter->query);
+
+	query->context = iter->index;
+	query->fetchFunction = &catalog_s_index_fetch;
+
+	if (!catalog_sql_prepare(db, sql, query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_index_init initializes an Interator over our catalog of
+ * SourceIndex entries.
+ */
+bool
+catalog_iter_s_index_table_init(SourceIndexIterator *iter)
+{
+	sqlite3 *db = iter->catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: Failed to initialize s_index iterator: db is NULL");
+		return false;
+	}
+
+	iter->index = (SourceIndex *) calloc(1, sizeof(SourceIndex));
+
+	if (iter->index == NULL)
+	{
+		log_error(ALLOCATION_FAILED_ERROR);
+		return false;
+	}
+
+	char *sql =
+		"  select i.oid, i.qname, i.nspname, i.relname, i.restore_list_name, "
+		"         i.tableoid, t.qname, t.nspname, t.relname, "
+		"         isprimary, isunique, columns, i.sql, "
+		"         c.oid as constraintoid, conname, "
+		"         condeferrable, condeferred, c.sql as condef"
+		"    from s_index i "
+		"         join s_table t on t.oid = i.tableoid "
+		"         left join s_constraint c on c.indexoid = i.oid "
+		"   where t.nspname = $1 and t.relname = $2";
+
+	SQLiteQuery *query = &(iter->query);
+
+	query->context = iter->index;
+	query->fetchFunction = &catalog_s_index_fetch;
+
+	if (!catalog_sql_prepare(db, sql, query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_TEXT, "nspname", 0, (char *) iter->nspname },
+		{ BIND_PARAMETER_TYPE_TEXT, "relname", 0, (char *) iter->relname }
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(query, params, count))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_index_next fetches the next SourceIndex entry in our catalogs.
+ */
+bool
+catalog_iter_s_index_next(SourceIndexIterator *iter)
+{
+	SQLiteQuery *query = &(iter->query);
+
+	int rc = catalog_sql_step(query);
+
+	if (rc == SQLITE_DONE)
+	{
+		free(iter->index->indexDef);
+		free(iter->index->indexColumns);
+		free(iter->index->constraintDef);
+		free(iter->index);
+
+		iter->index = NULL;
+
+		return true;
+	}
+
+	if (rc != SQLITE_ROW)
+	{
+		log_error("Failed to step through statement: %s", query->sql);
+		log_error("[SQLite] %s", sqlite3_errmsg(query->db));
+		return false;
+	}
+
+	return catalog_s_index_fetch(query);
+}
+
+
+/*
+ * catalog_iter_s_index_finish cleans-up the internal memory used for the
+ * iteration.
+ */
+bool
+catalog_iter_s_index_finish(SourceIndexIterator *iter)
+{
+	SQLiteQuery *query = &(iter->query);
+
+	/* in case we finish before reaching the DONE step */
+	if (iter->index != NULL)
+	{
+		free(iter->index->indexDef);
+		free(iter->index->indexColumns);
+		free(iter->index->constraintDef);
+		free(iter->index);
+
+		iter->index = NULL;
+	}
+
+	if (!catalog_sql_finalize(query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_s_table_fetch_attrs fetches the table SourceTableAttribute array
+ * from our s_attr catalog.
+ */
+bool
+catalog_s_table_count_indexes(DatabaseCatalog *catalog, SourceTable *table)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_s_table_count_indexes: db is NULL");
+		return false;
+	}
+
+	char *sql =
+		"select count(1) as indexes, "
+		"       count(1) filter(where c.oid is not null) as constraints "
+		"  from s_index i "
+		"       left join s_constraint c on c.indexoid = i.oid "
+		" where tableoid = $1";
+
+	SQLiteQuery query = {
+		.context = table,
+		.fetchFunction = &catalog_s_table_count_indexes_fetch
+	};
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[1] = {
+		{ BIND_PARAMETER_TYPE_INT64, "oid", table->oid, NULL }
+	};
+
+	if (!catalog_sql_bind(&query, params, 1))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which return exactly one row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_s_table_count_indexes_fetch  is a SQLiteQuery callback.
+ */
+bool
+catalog_s_table_count_indexes_fetch(SQLiteQuery *query)
+{
+	SourceTable *table = (SourceTable *) query->context;
+
+	table->indexCount = sqlite3_column_int64(query->ppStmt, 0);
+	table->constraintCount = sqlite3_column_int64(query->ppStmt, 1);
+
+	return true;
+}
+
+
+/*
+ * catalog_delete_s_index_all DELETE all the indexes registered in the given
+ * database catalog.
+ */
+bool
+catalog_delete_s_index_all(DatabaseCatalog *catalog)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_delete_s_index_all: db is NULL");
+		return false;
+	}
+
+	char *sql = "delete from s_index";
+
+	SQLiteQuery query = { 0 };
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which does not return any row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_delete_s_index_table DELETE all the indexes registered in the given
+ * database catalog for the given table.
+ */
+bool
+catalog_delete_s_index_table(DatabaseCatalog *catalog,
+							 const char *nspname,
+							 const char *relname)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: Failed to initialize s_index iterator: db is NULL");
+		return false;
+	}
+
+	char *sql =
+		"delete from s_index "
+		" where tableoid = "
+		"       ("
+		"        select oid "
+		"          from s_table "
+		"         where nspname = $1 and relname = $2"
+		"        )";
+
+	SQLiteQuery query = { 0 };
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_TEXT, "nspname", 0, (char *) nspname },
+		{ BIND_PARAMETER_TYPE_TEXT, "relname", 0, (char *) relname }
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(&query, params, count))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which does not return any row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_add_s_seq INSERTs a SourceSequence to our internal catalogs database.
+ */
+bool
+catalog_add_s_seq(DatabaseCatalog *catalog, SourceSequence *seq)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_add_s_seq: db is NULL");
+		return false;
+	}
+
+	char *sql =
+		"insert into s_seq("
+		"  oid, ownedby, attrelid, attroid, "
+		"  qname, nspname, relname, restore_list_name)"
+		"values($1, $2, $3, $4, $5, $6, $7, $8)";
+
+	SQLiteQuery query = { 0 };
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_INT64, "oid", seq->oid, NULL },
+		{ BIND_PARAMETER_TYPE_INT64, "ownedby", seq->ownedby, NULL },
+		{ BIND_PARAMETER_TYPE_INT64, "attrelid", seq->attrelid, NULL },
+		{ BIND_PARAMETER_TYPE_INT64, "attroid", seq->attroid, NULL },
+
+		{ BIND_PARAMETER_TYPE_TEXT, "qname", 0, seq->qname },
+		{ BIND_PARAMETER_TYPE_TEXT, "nspname", 0, seq->nspname },
+		{ BIND_PARAMETER_TYPE_TEXT, "relname", 0, seq->relname },
+
+		{ BIND_PARAMETER_TYPE_TEXT, "restore_list_name", 0,
+		  seq->restoreListName }
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(&query, params, count))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which does not return any row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_update_sequence_values UPDATEs a SourceSequence lastValue and
+ * isCalled parameters in our catalogs.
+ */
+bool
+catalog_update_sequence_values(DatabaseCatalog *catalog, SourceSequence *seq)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_update_sequence_values: db is NULL");
+		return false;
+	}
+
+	char *sql =
+		"update s_seq "
+		"   set last_value = $1, isCalled = $2 "
+		" where nspname = $3 and relname = $4";
+
+	SQLiteQuery query = { 0 };
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_INT64, "last_alue", seq->lastValue, NULL },
+		{ BIND_PARAMETER_TYPE_INT64, "isCalled", seq->isCalled ? 1 : 0, NULL },
+		{ BIND_PARAMETER_TYPE_TEXT, "nspname", 0, seq->nspname },
+		{ BIND_PARAMETER_TYPE_TEXT, "relname", 0, seq->relname }
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(&query, params, count))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which does not return any row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_lookup_s_seq_by_name fetches a SourceSeq from our catalogs.
+ */
+bool
+catalog_lookup_s_seq_by_name(DatabaseCatalog *catalog,
+							 const char *nspname,
+							 const char *relname,
+							 SourceSequence *seq)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_s_seq_stats: db is NULL");
+		return false;
+	}
+
+	char *sql =
+		"  select oid, ownedby, attrelid, attroid, "
+		"         qname, nspname, relname, restore_list_name, "
+		"         last_value, isCalled "
+		"    from s_seq "
+		"   where nspname = $1 and relname = $2 ";
+
+	SQLiteQuery query = {
+		.context = seq,
+		.fetchFunction = &catalog_s_seq_fetch
+	};
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_TEXT, "nspname", 0, (char *) nspname },
+		{ BIND_PARAMETER_TYPE_TEXT, "relname", 0, (char *) relname },
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(&query, params, count))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which return exactly one row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_seq iterates over the list of sequences in our catalogs.
+ */
+bool
+catalog_iter_s_seq(DatabaseCatalog *catalog,
+				   void *context,
+				   SourceSequenceIterFun *callback)
+{
+	SourceSeqIterator *iter =
+		(SourceSeqIterator *) calloc(1, sizeof(SourceSeqIterator));
+
+	iter->catalog = catalog;
+
+	if (!catalog_iter_s_seq_init(iter))
+	{
+		/* errors have already been logged */
+		free(iter);
+		return false;
+	}
+
+	for (;;)
+	{
+		if (!catalog_iter_s_seq_next(iter))
+		{
+			/* errors have already been logged */
+			free(iter);
+			return false;
+		}
+
+		SourceSequence *seq = iter->seq;
+
+		if (seq == NULL)
+		{
+			if (!catalog_iter_s_seq_finish(iter))
+			{
+				/* errors have already been logged */
+				free(iter);
+				return false;
+			}
+
+			break;
+		}
+
+		/* now call the provided callback */
+		if (!(*callback)(context, seq))
+		{
+			log_error("Failed to iterate over list of seqs, "
+					  "see above for details");
+			return false;
+		}
+	}
+
+	free(iter);
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_seq_init initializes an Interator over our catalog of
+ * SourceSequence entries.
+ */
+bool
+catalog_iter_s_seq_init(SourceSeqIterator *iter)
+{
+	sqlite3 *db = iter->catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: Failed to initialize s_seq iterator: db is NULL");
+		return false;
+	}
+
+	iter->seq = (SourceSequence *) calloc(1, sizeof(SourceSequence));
+
+	if (iter->seq == NULL)
+	{
+		log_error(ALLOCATION_FAILED_ERROR);
+		return false;
+	}
+
+	char *sql =
+		"  select oid, ownedby, attrelid, attroid, "
+		"         qname, nspname, relname, restore_list_name, "
+		"         last_value, isCalled "
+		"    from s_seq "
+		"order by nspname, relname";
+
+	SQLiteQuery *query = &(iter->query);
+
+	query->context = iter->seq;
+	query->fetchFunction = &catalog_s_seq_fetch;
+
+	if (!catalog_sql_prepare(db, sql, query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_seq_next fetches the next SourceSequence entry in our catalogs.
+ */
+bool
+catalog_iter_s_seq_next(SourceSeqIterator *iter)
+{
+	SQLiteQuery *query = &(iter->query);
+
+	int rc = catalog_sql_step(query);
+
+	if (rc == SQLITE_DONE)
+	{
+		free(iter->seq);
+		iter->seq = NULL;
+
+		return true;
+	}
+
+	if (rc != SQLITE_ROW)
+	{
+		log_error("Failed to step through statement: %s", query->sql);
+		log_error("[SQLite] %s", sqlite3_errmsg(query->db));
+		return false;
+	}
+
+	return catalog_s_seq_fetch(query);
+}
+
+
+/*
+ * catalog_s_seq_fetch fetches a SourceSequence entry from a SQLite ppStmt
+ * result set.
+ */
+bool
+catalog_s_seq_fetch(SQLiteQuery *query)
+{
+	SourceSequence *seq = (SourceSequence *) query->context;
+
+	/* cleanup the memory area before re-use */
+	bzero(seq, sizeof(SourceSequence));
+
+	seq->oid = sqlite3_column_int64(query->ppStmt, 0);
+	seq->ownedby = sqlite3_column_int64(query->ppStmt, 1);
+	seq->attrelid = sqlite3_column_int64(query->ppStmt, 2);
+	seq->attroid = sqlite3_column_int64(query->ppStmt, 3);
+
+	strlcpy(seq->qname,
+			(char *) sqlite3_column_text(query->ppStmt, 4),
+			sizeof(seq->qname));
+
+	strlcpy(seq->nspname,
+			(char *) sqlite3_column_text(query->ppStmt, 5),
+			sizeof(seq->nspname));
+
+	strlcpy(seq->relname,
+			(char *) sqlite3_column_text(query->ppStmt, 6),
+			sizeof(seq->relname));
+
+	strlcpy(seq->restoreListName,
+			(char *) sqlite3_column_text(query->ppStmt, 7),
+			sizeof(seq->restoreListName));
+
+	seq->lastValue = sqlite3_column_int(query->ppStmt, 8);
+	seq->isCalled = sqlite3_column_int(query->ppStmt, 9);
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_seq_finish cleans-up the internal memory used for the
+ * iteration.
+ */
+bool
+catalog_iter_s_seq_finish(SourceSeqIterator *iter)
+{
+	SQLiteQuery *query = &(iter->query);
+
+	/* in case we finish before reaching the DONE step */
+	if (iter->seq != NULL)
+	{
+		free(iter->seq);
+		iter->seq = NULL;
+	}
+
+	if (!catalog_sql_finalize(query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_prepare_filter prepares our filter Hash-Table, that used to be an
+ * in-memory only thing, and now is a SQLite table with indexes, so that it can
+ * spill to disk when we have giant database catalogs to take care of.
+ */
+bool
+catalog_prepare_filter(DatabaseCatalog *catalog)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_prepare_filter: db is NULL");
+		return false;
+	}
+
+	char *sql =
+		"insert into filter(oid, restore_list_name, kind) "
+
+		"     select oid, restore_list_name, 's_namespace' "
+		"       from s_namespace "
+
+		"  union all "
+
+		"    select oid, restore_list_name, 'coll' "
+		"      from s_coll "
+
+		"  union all "
+
+		"     select oid, restore_list_name, 'table' "
+		"       from s_table "
+
+		"  union all "
+
+		"     select oid, restore_list_name, 'index' "
+		"       from s_index "
+
+		"  union all "
+
+		/* at the moment we lack restore names for constraints */
+		"     select oid, NULL as restore_list_name, 'constraint' "
+		"       from s_constraint "
+
+		/*
+		 * Filtering-out sequences works with the following 3 Archive Catalog
+		 * entry kinds:
+		 *
+		 *  - SEQUENCE, matched by sequence oid
+		 *  - SEQUENCE OWNED BY, matched by sequence restore name
+		 *  - DEFAULT, matched by attribute oid
+		 *
+		 * In some cases we want to create the sequence, but we might want to
+		 * skip the SEQUENCE OWNED BY statement, because we didn't actually
+		 * create the owner table.
+		 *
+		 * In those cases we will find the sequence both in the catalogs of
+		 * objects we want to migrate, and also in the list of objects we want
+		 * to skip. The catalog entry typically has seq->ownedby !=
+		 * seq->attrelid, where the ownedby table is skipped from the migration
+		 * because of the filtering.
+		 */
+		"  union all "
+
+		/*
+		 * When we find the sequence in our source catalog selection, then we
+		 * still create it and refrain to add the sequence Oid to our hash
+		 * table here.
+		 */
+		"     select distinct s.oid, NULL as restore_list_name, 'sequence' "
+		"       from s_seq s "
+		"      where not exists"
+		"            (select 1 from source.s_seq ss where ss.oid = s.oid)"
+
+		/*
+		 * Only filter-out the SEQUENCE OWNED BY when our catalog selection
+		 * does not contain the target table.
+		 */
+		"  union all "
+
+		"     select NULL as oid, s.restore_list_name, 'sequence owned by' "
+		"       from s_seq s "
+		"      where not exists"
+		"            (select 1 from source.s_seq ss where ss.oid = s.oid)"
+		"        and not exists"
+		"            (select 1 from source.s_table st where st.oid = s.ownedby) "
+
+		/*
+		 * Also add pg_attribute.oid when it's not null (non-zero here). This
+		 * takes care of the DEFAULT entries in the pg_dump Archive Catalog,
+		 * and these entries target the attroid directly.
+		 */
+		"  union all "
+
+		"     select s.attroid, s.restore_list_name, 'default' "
+		"       from s_seq s ";
+
+	SQLiteQuery query = { 0 };
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which does not return any row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/*
+	 * In some cases with sequences we might want to skip adding a dependency
+	 * in our hash table here. See the previous discussion for details.
+	 */
+	char *s_depend_sql =
+		"insert or ignore into filter(oid, restore_list_name, kind) "
+		"     select distinct objid, identity as restore_list_name, 'pg_depend' "
+		"       from s_depend d "
+		"      where not exists"
+		"            (select 1 from source.s_seq ss where ss.oid = d.objid) ";
+
+	if (!catalog_sql_prepare(db, s_depend_sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which does not return any row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_lookup_filter_by_oid fetches a  entry from our catalogs.
+ */
+bool
+catalog_lookup_filter_by_oid(DatabaseCatalog *catalog,
+							 CatalogFilter *result,
+							 uint32_t oid)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_lookup_filter_by_oid: db is NULL");
+		return false;
+	}
+
+	char *sql =
+		"  select oid, restore_list_name, kind "
+		"    from filter "
+		"   where oid = $1 ";
+
+	SQLiteQuery query = {
+		.context = result,
+		.fetchFunction = &catalog_filter_fetch
+	};
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[1] = {
+		{ BIND_PARAMETER_TYPE_INT64, "oid", oid, NULL },
+	};
+
+	if (!catalog_sql_bind(&query, params, 1))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which return exactly one row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_lookup_filter_by_rlname fetches a  entry from our catalogs.
+ */
+bool
+catalog_lookup_filter_by_rlname(DatabaseCatalog *catalog,
+								CatalogFilter *result,
+								const char *restoreListName)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_lookup_filter_by_oid: db is NULL");
+		return false;
+	}
+
+	char *sql =
+		"  select oid, restore_list_name, kind "
+		"    from filter "
+		"   where restore_list_name = $1 ";
+
+	SQLiteQuery query = {
+		.context = result,
+		.fetchFunction = &catalog_filter_fetch
+	};
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[1] = {
+		{ BIND_PARAMETER_TYPE_TEXT, "restore_list_name", 0,
+		  (char *) restoreListName },
+	};
+
+	if (!catalog_sql_bind(&query, params, 1))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which return exactly one row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_s_index_fetch fetches a SourceIndex entry from a SQLite ppStmt
+ * result set.
+ */
+bool
+catalog_filter_fetch(SQLiteQuery *query)
+{
+	CatalogFilter *entry = (CatalogFilter *) query->context;
+
+	/* cleanup the memory area before re-use */
+	bzero(entry, sizeof(CatalogFilter));
+
+	entry->oid = sqlite3_column_int64(query->ppStmt, 0);
+
+	if (sqlite3_column_type(query->ppStmt, 1) != SQLITE_NULL)
+	{
+		strlcpy(entry->restoreListName,
+				(char *) sqlite3_column_text(query->ppStmt, 1),
+				sizeof(entry->restoreListName));
+	}
+
+	strlcpy(entry->kind,
+			(char *) sqlite3_column_text(query->ppStmt, 2),
+			sizeof(entry->kind));
+
+	return true;
+}
+
+
+/*
+ * catalog_add_s_database INSERTs a SourceDatabase to our internal catalogs
+ * database.
+ */
+bool
+catalog_add_s_database(DatabaseCatalog *catalog, SourceDatabase *dat)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_add_s_database: db is NULL");
+		return false;
+	}
+
+	char *sql =
+		"insert or replace into s_database(oid, datname, bytes, bytes_pretty)"
+		"values($1, $2, $3, $4)";
+
+	SQLiteQuery query = { 0 };
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_INT64, "oid", dat->oid, NULL },
+		{ BIND_PARAMETER_TYPE_TEXT, "datname", 0, dat->datname },
+		{ BIND_PARAMETER_TYPE_INT64, "bytes", dat->bytes, NULL },
+		{ BIND_PARAMETER_TYPE_TEXT, "bytes_pretty", 0, dat->bytesPretty }
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(&query, params, count))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which does not return any row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_add_s_database_properties INSERTs a SourceProperty to our internal
+ * catalogs database.
+ */
+bool
+catalog_add_s_database_properties(DatabaseCatalog *catalog, SourceProperty *guc)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_add_s_database_properties: db is NULL");
+		return false;
+	}
+
+	char *sql =
+		"insert or replace into s_database_property("
+		"  role_in_database, rolname, datname, setconfig)"
+		"values($1, $2, $3, $4)";
+
+	SQLiteQuery query = { 0 };
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_INT, "role_in_database",
+		  guc->roleInDatabase ? 1 : 0, NULL },
+
+		{ BIND_PARAMETER_TYPE_TEXT, "rolname", 0, guc->rolname },
+		{ BIND_PARAMETER_TYPE_TEXT, "datname", 0, guc->datname },
+		{ BIND_PARAMETER_TYPE_TEXT, "setconfig", 0, guc->setconfig }
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(&query, params, count))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which does not return any row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_database iterates over the list of databases in our catalogs.
+ */
+bool
+catalog_iter_s_database(DatabaseCatalog *catalog,
+						void *context,
+						SourceDatabaseIterFun *callback)
+{
+	SourceDatabaseIterator *iter =
+		(SourceDatabaseIterator *) calloc(1, sizeof(SourceDatabaseIterator));
+
+	iter->catalog = catalog;
+
+	if (!catalog_iter_s_database_init(iter))
+	{
+		/* errors have already been logged */
+		free(iter);
+		return false;
+	}
+
+	for (;;)
+	{
+		if (!catalog_iter_s_database_next(iter))
+		{
+			/* errors have already been logged */
+			free(iter);
+			return false;
+		}
+
+		SourceDatabase *dat = iter->dat;
+
+		if (dat == NULL)
+		{
+			if (!catalog_iter_s_database_finish(iter))
+			{
+				/* errors have already been logged */
+				free(iter);
+				return false;
+			}
+
+			break;
+		}
+
+		/* now call the provided callback */
+		if (!(*callback)(context, dat))
+		{
+			log_error("Failed to iterate over list of dats, "
+					  "see above for details");
+			return false;
+		}
+	}
+
+	free(iter);
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_database_init initializes an Interator over our catalog of
+ * SourceDatabase entries.
+ */
+bool
+catalog_iter_s_database_init(SourceDatabaseIterator *iter)
+{
+	sqlite3 *db = iter->catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: Failed to initialize s_dat iterator: db is NULL");
+		return false;
+	}
+
+	iter->dat = (SourceDatabase *) calloc(1, sizeof(SourceDatabase));
+
+	if (iter->dat == NULL)
+	{
+		log_error(ALLOCATION_FAILED_ERROR);
+		return false;
+	}
+
+	char *sql =
+		"  select oid, datname, bytes, bytes_pretty"
+		"    from s_database "
+		"order by datname";
+
+	SQLiteQuery *query = &(iter->query);
+
+	query->context = iter->dat;
+	query->fetchFunction = &catalog_s_database_fetch;
+
+	if (!catalog_sql_prepare(db, sql, query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_database_next fetches the next SourceDatabase entry in our
+ * catalogs.
+ */
+bool
+catalog_iter_s_database_next(SourceDatabaseIterator *iter)
+{
+	SQLiteQuery *query = &(iter->query);
+
+	int rc = catalog_sql_step(query);
+
+	if (rc == SQLITE_DONE)
+	{
+		free(iter->dat);
+		iter->dat = NULL;
+
+		return true;
+	}
+
+	if (rc != SQLITE_ROW)
+	{
+		log_error("Failed to step through statement: %s", query->sql);
+		log_error("[SQLite] %s", sqlite3_errmsg(query->db));
+		return false;
+	}
+
+	return catalog_s_database_fetch(query);
+}
+
+
+/*
+ * catalog_s_dat_fetch fetches a SourceDatabase entry from a SQLite ppStmt
+ * result set.
+ */
+bool
+catalog_s_database_fetch(SQLiteQuery *query)
+{
+	SourceDatabase *dat = (SourceDatabase *) query->context;
+
+	/* cleanup the memory area before re-use */
+	bzero(dat, sizeof(SourceDatabase));
+
+	dat->oid = sqlite3_column_int64(query->ppStmt, 0);
+
+	strlcpy(dat->datname,
+			(char *) sqlite3_column_text(query->ppStmt, 1),
+			sizeof(dat->datname));
+
+	dat->bytes = sqlite3_column_int64(query->ppStmt, 2);
+
+	strlcpy(dat->bytesPretty,
+			(char *) sqlite3_column_text(query->ppStmt, 3),
+			sizeof(dat->bytesPretty));
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_database_finish cleans-up the internal memory used for the
+ * iteration.
+ */
+bool
+catalog_iter_s_database_finish(SourceDatabaseIterator *iter)
+{
+	SQLiteQuery *query = &(iter->query);
+
+	/* in case we finish before reaching the DONE step */
+	if (iter->dat != NULL)
+	{
+		free(iter->dat);
+		iter->dat = NULL;
+	}
+
+	if (!catalog_sql_finalize(query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_database_guc iterates over the list of database properties in
+ * our catalogs.
+ */
+bool
+catalog_iter_s_database_guc(DatabaseCatalog *catalog,
+							const char *dbname,
+							void *context,
+							SourcePropertyIterFun *callback)
+{
+	SourcePropertyIterator *iter =
+		(SourcePropertyIterator *) calloc(1, sizeof(SourcePropertyIterator));
+
+	iter->catalog = catalog;
+	iter->dbname = dbname;
+
+	if (!catalog_iter_s_database_guc_init(iter))
+	{
+		/* errors have already been logged */
+		free(iter);
+		return false;
+	}
+
+	for (;;)
+	{
+		if (!catalog_iter_s_database_guc_next(iter))
+		{
+			/* errors have already been logged */
+			free(iter);
+			return false;
+		}
+
+		SourceProperty *property = iter->property;
+
+		if (property == NULL)
+		{
+			if (!catalog_iter_s_database_guc_finish(iter))
+			{
+				/* errors have already been logged */
+				free(iter);
+				return false;
+			}
+
+			break;
+		}
+
+		/* now call the provided callback */
+		if (!(*callback)(context, property))
+		{
+			log_error("Failed to iterate over list of dats, "
+					  "see above for details");
+			free(iter);
+			return false;
+		}
+	}
+
+	free(iter);
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_database_guc_init initializes an Interator over our catalog of
+ * SourceProperty entries.
+ */
+bool
+catalog_iter_s_database_guc_init(SourcePropertyIterator *iter)
+{
+	sqlite3 *db = iter->catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: Failed to initialize s_database_guc iterator: db is NULL");
+		return false;
+	}
+
+	iter->property = (SourceProperty *) calloc(1, sizeof(SourceProperty));
+
+	if (iter->property == NULL)
+	{
+		log_error(ALLOCATION_FAILED_ERROR);
+		return false;
+	}
+
+	char *sql =
+		"  select role_in_database, rolname, datname, setconfig"
+		"    from s_database_property "
+		"   where datname = $1 ";
+
+	SQLiteQuery *query = &(iter->query);
+
+	query->context = iter->property;
+	query->fetchFunction = &catalog_s_database_guc_fetch;
+
+	if (!catalog_sql_prepare(db, sql, query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_TEXT, "datname", 0, (char *) iter->dbname }
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(query, params, count))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_database_guc_next fetches the next SourceProperty entry in our
+ * catalogs.
+ */
+bool
+catalog_iter_s_database_guc_next(SourcePropertyIterator *iter)
+{
+	SQLiteQuery *query = &(iter->query);
+
+	int rc = catalog_sql_step(query);
+
+	if (rc == SQLITE_DONE)
+	{
+		free(iter->property->setconfig);
+		free(iter->property);
+		iter->property = NULL;
+
+		return true;
+	}
+
+	if (rc != SQLITE_ROW)
+	{
+		log_error("Failed to step through statement: %s", query->sql);
+		log_error("[SQLite] %s", sqlite3_errmsg(query->db));
+		return false;
+	}
+
+	return catalog_s_database_guc_fetch(query);
+}
+
+
+/*
+ * catalog_s_dat_fetch fetches a SourceProperty entry from a SQLite ppStmt
+ * result set.
+ */
+bool
+catalog_s_database_guc_fetch(SQLiteQuery *query)
+{
+	SourceProperty *property = (SourceProperty *) query->context;
+
+	/* cleanup the memory area before re-use */
+	bzero(property, sizeof(SourceProperty));
+
+	property->roleInDatabase = sqlite3_column_int(query->ppStmt, 0) == 1;
+
+	strlcpy(property->rolname,
+			(char *) sqlite3_column_text(query->ppStmt, 1),
+			sizeof(property->rolname));
+
+	strlcpy(property->datname,
+			(char *) sqlite3_column_text(query->ppStmt, 2),
+			sizeof(property->datname));
+
+	int len = sqlite3_column_bytes(query->ppStmt, 3);
+	int bytes = len + 1;
+
+	property->setconfig = (char *) calloc(bytes, sizeof(char));
+
+	if (property->setconfig == NULL)
+	{
+		log_fatal(ALLOCATION_FAILED_ERROR);
+		return false;
+	}
+
+	strlcpy(property->setconfig,
+			(char *) sqlite3_column_text(query->ppStmt, 3),
+			bytes);
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_database_guc_finish cleans-up the internal memory used for the
+ * iteration.
+ */
+bool
+catalog_iter_s_database_guc_finish(SourcePropertyIterator *iter)
+{
+	SQLiteQuery *query = &(iter->query);
+
+	/* in case we finish before reaching the DONE step */
+	if (iter->property != NULL)
+	{
+		free(iter->property->setconfig);
+		free(iter->property);
+		iter->property = NULL;
+	}
+
+	if (!catalog_sql_finalize(query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_add_s_coll INSERTs a SourceSchema to our internal catalogs
+ * database.
+ */
+bool
+catalog_add_s_coll(DatabaseCatalog *catalog, SourceCollation *coll)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_add_s_coll: db is NULL");
+		return false;
+	}
+
+	char *sql =
+		"insert into s_coll(oid, collname, description, restore_list_name) "
+		"values($1, $2, $3, $4)";
+
+	SQLiteQuery query = { 0 };
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_INT64, "oid", coll->oid, NULL },
+		{ BIND_PARAMETER_TYPE_TEXT, "nspname", 0, coll->collname },
+		{ BIND_PARAMETER_TYPE_TEXT, "description", 0, coll->desc },
+
+		{ BIND_PARAMETER_TYPE_TEXT, "restore_list_name", 0,
+		  coll->restoreListName }
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(&query, params, count))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which does not return any row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_coll iterates over the list of datuences in our catalogs.
+ */
+bool
+catalog_iter_s_coll(DatabaseCatalog *catalog,
+					void *context,
+					SourceCollationIterFun *callback)
+{
+	SourceCollationIterator *iter =
+		(SourceCollationIterator *) calloc(1, sizeof(SourceCollationIterator));
+
+	iter->catalog = catalog;
+
+	if (!catalog_iter_s_coll_init(iter))
+	{
+		/* errors have already been logged */
+		free(iter);
+		return false;
+	}
+
+	for (;;)
+	{
+		if (!catalog_iter_s_coll_next(iter))
+		{
+			/* errors have already been logged */
+			free(iter);
+			return false;
+		}
+
+		SourceCollation *coll = iter->coll;
+
+		if (coll == NULL)
+		{
+			if (!catalog_iter_s_coll_finish(iter))
+			{
+				/* errors have already been logged */
+				free(iter);
+				return false;
+			}
+
+			break;
+		}
+
+		/* now call the provided callback */
+		if (!(*callback)(context, coll))
+		{
+			log_error("Failed to iterate over list of colls, "
+					  "see above for details");
+			return false;
+		}
+	}
+
+	free(iter);
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_coll_init initializes an Interator over our catalog of
+ * SourceCollation entries.
+ */
+bool
+catalog_iter_s_coll_init(SourceCollationIterator *iter)
+{
+	sqlite3 *db = iter->catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: Failed to initialize s_coll iterator: db is NULL");
+		return false;
+	}
+
+	iter->coll = (SourceCollation *) calloc(1, sizeof(SourceCollation));
+
+	if (iter->coll == NULL)
+	{
+		log_error(ALLOCATION_FAILED_ERROR);
+		return false;
+	}
+
+	char *sql =
+		"  select oid, collname, description, restore_list_name"
+		"    from s_coll "
+		"order by oid";
+
+	SQLiteQuery *query = &(iter->query);
+
+	query->context = iter->coll;
+	query->fetchFunction = &catalog_s_coll_fetch;
+
+	if (!catalog_sql_prepare(db, sql, query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_coll_next fetches the next SourceCollation entry in our
+ * catalogs.
+ */
+bool
+catalog_iter_s_coll_next(SourceCollationIterator *iter)
+{
+	SQLiteQuery *query = &(iter->query);
+
+	int rc = catalog_sql_step(query);
+
+	if (rc == SQLITE_DONE)
+	{
+		free(iter->coll->desc);
+		free(iter->coll);
+		iter->coll = NULL;
+
+		return true;
+	}
+
+	if (rc != SQLITE_ROW)
+	{
+		log_error("Failed to step through statement: %s", query->sql);
+		log_error("[SQLite] %s", sqlite3_errmsg(query->db));
+		return false;
+	}
+
+	return catalog_s_coll_fetch(query);
+}
+
+
+/*
+ * catalog_s_coll_fetch fetches a SourceCollation entry from a SQLite ppStmt
+ * result set.
+ */
+bool
+catalog_s_coll_fetch(SQLiteQuery *query)
+{
+	SourceCollation *coll = (SourceCollation *) query->context;
+
+	/* cleanup the memory area before re-use */
+	bzero(coll, sizeof(SourceCollation));
+
+	coll->oid = sqlite3_column_int64(query->ppStmt, 0);
+
+	strlcpy(coll->collname,
+			(char *) sqlite3_column_text(query->ppStmt, 1),
+			sizeof(coll->collname));
+
+	/* coll->desc is a malloc'ed area */
+	int len = sqlite3_column_bytes(query->ppStmt, 2);
+	int bytes = len + 1;
+
+	coll->desc = (char *) calloc(bytes, sizeof(char));
+
+	if (coll->desc == NULL)
+	{
+		log_fatal(ALLOCATION_FAILED_ERROR);
+		return false;
+	}
+
+	strlcpy(coll->desc,
+			(char *) sqlite3_column_text(query->ppStmt, 2),
+			bytes);
+
+	strlcpy(coll->restoreListName,
+			(char *) sqlite3_column_text(query->ppStmt, 3),
+			sizeof(coll->restoreListName));
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_coll_finish cleans-up the internal memory used for the
+ * iteration.
+ */
+bool
+catalog_iter_s_coll_finish(SourceCollationIterator *iter)
+{
+	SQLiteQuery *query = &(iter->query);
+
+	/* in case we finish before reaching the DONE step */
+	if (iter->coll != NULL)
+	{
+		free(iter->coll->desc);
+		free(iter->coll);
+		iter->coll = NULL;
+	}
+
+	if (!catalog_sql_finalize(query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_add_s_namespace INSERTs a SourceSchema to our internal catalogs
+ * database.
+ */
+bool
+catalog_add_s_namespace(DatabaseCatalog *catalog, SourceSchema *namespace)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_add_s_namespace: db is NULL");
+		return false;
+	}
+
+	char *sql =
+		"insert into s_namespace(oid, nspname, restore_list_name) "
+		"values($1, $2, $3)";
+
+	SQLiteQuery query = { 0 };
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_INT64, "oid", namespace->oid, NULL },
+		{ BIND_PARAMETER_TYPE_TEXT, "nspname", 0, namespace->nspname },
+
+		{ BIND_PARAMETER_TYPE_TEXT, "restore_list_name", 0,
+		  namespace->restoreListName }
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(&query, params, count))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which does not return any row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_lookup_s_namespace_by_rlname fetches a  entry from our catalogs.
+ */
+bool
+catalog_lookup_s_namespace_by_rlname(DatabaseCatalog *catalog,
+									 const char *restoreListName,
+									 SourceSchema *result)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_lookup_s_namespace_by_rlname: db is NULL");
+		return false;
+	}
+
+	char *sql =
+		"  select oid, nspname, restore_list_name "
+		"    from s_namespace "
+		"   where restore_list_name = $1 ";
+
+	SQLiteQuery query = {
+		.context = result,
+		.fetchFunction = &catalog_s_namespace_fetch
+	};
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[1] = {
+		{ BIND_PARAMETER_TYPE_TEXT, "restore_list_name", 0,
+		  (char *) restoreListName },
+	};
+
+	if (!catalog_sql_bind(&query, params, 1))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which return exactly one row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_s_extension_fetch fetches a SourceExtension entry from a SQLite
+ * ppStmt result set.
+ */
+bool
+catalog_s_namespace_fetch(SQLiteQuery *query)
+{
+	SourceSchema *schema = (SourceSchema *) query->context;
+
+	/* cleanup the memory area before re-use */
+	bzero(schema, sizeof(SourceSchema));
+
+	schema->oid = sqlite3_column_int64(query->ppStmt, 0);
+
+	strlcpy(schema->nspname,
+			(char *) sqlite3_column_text(query->ppStmt, 1),
+			sizeof(schema->nspname));
+
+	strlcpy(schema->restoreListName,
+			(char *) sqlite3_column_text(query->ppStmt, 2),
+			sizeof(schema->restoreListName));
+
+	return true;
+}
+
+
+/*
+ * catalog_add_s_extension INSERTs a SourceExtension to our internal catalogs
+ * database.
+ */
+bool
+catalog_add_s_extension(DatabaseCatalog *catalog, SourceExtension *extension)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_add_s_extension: db is NULL");
+		return false;
+	}
+
+	char *sql =
+		"insert into s_extension(oid, extname, extnamespace, extrelocatable) "
+		"values($1, $2, $3, $4)";
+
+	SQLiteQuery query = { 0 };
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_INT64, "oid", extension->oid, NULL },
+		{ BIND_PARAMETER_TYPE_TEXT, "extname", 0, extension->extname },
+		{ BIND_PARAMETER_TYPE_TEXT, "extnamespace", 0, extension->extnamespace },
+
+		{ BIND_PARAMETER_TYPE_INT, "extrelocatable",
+		  extension->extrelocatable ? 1 : 0, NULL }
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(&query, params, count))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which does not return any row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_add_s_extension_config INSERTs a SourceExtensionConfig to our internal
+ * catalogs database.
+ */
+bool
+catalog_add_s_extension_config(DatabaseCatalog *catalog,
+							   SourceExtensionConfig *config)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_add_s_extension_config: db is NULL");
+		return false;
+	}
+
+	char *sql =
+		"insert into s_extension_config"
+		"  (extoid, reloid, nspname, relname, condition) "
+		"values($1, $2, $3, $4, $5)";
+
+	SQLiteQuery query = { 0 };
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_INT64, "extoid", config->extoid, NULL },
+		{ BIND_PARAMETER_TYPE_INT64, "reloid", config->reloid, NULL },
+		{ BIND_PARAMETER_TYPE_TEXT, "nspname", 0, config->nspname },
+		{ BIND_PARAMETER_TYPE_TEXT, "relname", 0, config->relname },
+		{ BIND_PARAMETER_TYPE_TEXT, "condition", 0, config->condition }
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(&query, params, count))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which does not return any row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_extension iterates over the list of extensions in our
+ * catalogs.
+ */
+bool
+catalog_iter_s_extension(DatabaseCatalog *catalog,
+						 void *context,
+						 SourceExtensionIterFun *callback)
+{
+	SourceExtensionIterator *iter =
+		(SourceExtensionIterator *) calloc(1, sizeof(SourceExtensionIterator));
+
+	iter->catalog = catalog;
+
+	if (!catalog_iter_s_extension_init(iter))
+	{
+		/* errors have already been logged */
+		free(iter);
+		return false;
+	}
+
+	for (;;)
+	{
+		if (!catalog_iter_s_extension_next(iter))
+		{
+			/* errors have already been logged */
+			free(iter);
+			return false;
+		}
+
+		SourceExtension *ext = iter->ext;
+
+		if (ext == NULL)
+		{
+			if (!catalog_iter_s_extension_finish(iter))
+			{
+				/* errors have already been logged */
+				free(iter);
+				return false;
+			}
+
+			break;
+		}
+
+		/* now call the provided callback */
+		if (!(*callback)(context, ext))
+		{
+			log_error("Failed to iterate over list of extensions, "
+					  "see above for details");
+			return false;
+		}
+	}
+
+	free(iter);
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_extension_init initializes an Interator over our catalog of
+ * SourceExtension entries.
+ */
+bool
+catalog_iter_s_extension_init(SourceExtensionIterator *iter)
+{
+	sqlite3 *db = iter->catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: Failed to initialize s_extension iterator: db is NULL");
+		return false;
+	}
+
+	iter->ext = (SourceExtension *) calloc(1, sizeof(SourceExtension));
+
+	if (iter->ext == NULL)
+	{
+		log_error(ALLOCATION_FAILED_ERROR);
+		return false;
+	}
+
+	char *sql =
+		"  select oid, extname, extnamespace, extrelocatable "
+		"    from s_extension "
+		"order by extname";
+
+	SQLiteQuery *query = &(iter->query);
+
+	query->context = iter->ext;
+	query->fetchFunction = &catalog_s_extension_fetch;
+
+	if (!catalog_sql_prepare(db, sql, query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_extension_next fetches the next SourceExtension entry in our
+ * catalogs.
+ */
+bool
+catalog_iter_s_extension_next(SourceExtensionIterator *iter)
+{
+	SQLiteQuery *query = &(iter->query);
+
+	int rc = catalog_sql_step(query);
+
+	if (rc == SQLITE_DONE)
+	{
+		free(iter->ext);
+		iter->ext = NULL;
+
+		return true;
+	}
+
+	if (rc != SQLITE_ROW)
+	{
+		log_error("Failed to step through statement: %s", query->sql);
+		log_error("[SQLite] %s", sqlite3_errmsg(query->db));
+		return false;
+	}
+
+	return catalog_s_extension_fetch(query);
+}
+
+
+/*
+ * catalog_s_extension_fetch fetches a SourceExtension entry from a SQLite
+ * ppStmt result set.
+ */
+bool
+catalog_s_extension_fetch(SQLiteQuery *query)
+{
+	SourceExtension *ext = (SourceExtension *) query->context;
+
+	/* cleanup the memory area before re-use */
+	bzero(ext, sizeof(SourceExtension));
+
+	ext->oid = sqlite3_column_int64(query->ppStmt, 0);
+
+	strlcpy(ext->extname,
+			(char *) sqlite3_column_text(query->ppStmt, 1),
+			sizeof(ext->extname));
+
+	strlcpy(ext->extnamespace,
+			(char *) sqlite3_column_text(query->ppStmt, 2),
+			sizeof(ext->extnamespace));
+
+	ext->extrelocatable = sqlite3_column_int(query->ppStmt, 3) == 1;
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_extension_finish cleans-up the internal memory used for the
+ * iteration.
+ */
+bool
+catalog_iter_s_extension_finish(SourceExtensionIterator *iter)
+{
+	SQLiteQuery *query = &(iter->query);
+
+	/* in case we finish before reaching the DONE step */
+	if (iter->ext != NULL)
+	{
+		free(iter->ext);
+		iter->ext = NULL;
+	}
+
+	if (!catalog_sql_finalize(query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_s_ext_fetch_extconfig fetches the ext SourceExtensionConfig array
+ * from our s_extension_config catalog.
+ */
+bool
+catalog_s_ext_fetch_extconfig(DatabaseCatalog *catalog, SourceExtension *ext)
+{
+	SourceExtConfigIterator *iter =
+		(SourceExtConfigIterator *) calloc(1, sizeof(SourceExtConfigIterator));
+
+	if (iter == NULL)
+	{
+		log_error(ALLOCATION_FAILED_ERROR);
+		return false;
+	}
+
+	iter->catalog = catalog;
+	iter->ext = ext;
+
+	if (!catalog_iter_s_ext_extconfig_init(iter))
+	{
+		/* errors have already been logged */
+		free(iter);
+		return false;
+	}
+
+	while (!iter->done)
+	{
+		if (!catalog_iter_s_ext_extconfig_next(iter))
+		{
+			/* errors have already been logged */
+			free(iter);
+			return false;
+		}
+	}
+
+	if (!catalog_iter_s_ext_extconfig_finish(iter))
+	{
+		/* errors have already been logged */
+		free(iter);
+		return false;
+	}
+
+	free(iter);
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_ext_extconfig_init initializes an Interator over our catalog
+ * of SourceExtensionConfig entries.
+ */
+bool
+catalog_iter_s_ext_extconfig_init(SourceExtConfigIterator *iter)
+{
+	sqlite3 *db = iter->catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: Failed to initialize s_ext iterator: db is NULL");
+		return false;
+	}
+
+	SourceExtension *ext = iter->ext;
+
+	if (iter->ext == NULL)
+	{
+		log_error("BUG: Failed to initialize s_ext iterator: ext is NULL");
+		return false;
+	}
+
+	char *sql =
+		"  select count(*) over(order by reloid) as num,  "
+		"         count(*) over() as count, "
+		"         oid, reloid, nspname, relname, condition "
+		"    from s_extension_config "
+		"   where extoid = $1 "
+		"order by reloid";
+
+	SQLiteQuery *query = &(iter->query);
+
+	query->context = iter->ext;
+	query->fetchFunction = &catalog_s_ext_extconfig_fetch;
+
+	if (!catalog_sql_prepare(db, sql, query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[1] = {
+		{ BIND_PARAMETER_TYPE_INT64, "oid", ext->oid, NULL }
+	};
+
+	if (!catalog_sql_bind(query, params, 1))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_ext_extconfig_next fetches the next SourceExtensionConfig
+ * entry in our catalogs.
+ */
+bool
+catalog_iter_s_ext_extconfig_next(SourceExtConfigIterator *iter)
+{
+	SQLiteQuery *query = &(iter->query);
+
+	int rc = catalog_sql_step(query);
+
+	if (rc == SQLITE_DONE)
+	{
+		iter->done = true;
+		return true;
+	}
+
+	if (rc != SQLITE_ROW)
+	{
+		log_error("Failed to step through statement: %s", query->sql);
+		log_error("[SQLite] %s", sqlite3_errmsg(query->db));
+		return false;
+	}
+
+	return catalog_s_ext_extconfig_fetch(query);
+}
+
+
+/*
+ * catalog_iter_s_ext_extconfig_finish cleans-up the internal memory used for the
+ * iteration.
+ */
+bool
+catalog_iter_s_ext_extconfig_finish(SourceExtConfigIterator *iter)
+{
+	SQLiteQuery *query = &(iter->query);
+
+	if (!catalog_sql_finalize(query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_s_ext_extconfig_fetch is a SQLiteQuery callback.
+ */
+bool
+catalog_s_ext_extconfig_fetch(SQLiteQuery *query)
+{
+	SourceExtension *ext = (SourceExtension *) query->context;
+
+	int num = sqlite3_column_int(query->ppStmt, 0);
+	int count = sqlite3_column_int(query->ppStmt, 1);
+
+	if (num == 1)
+	{
+		ext->config.count = count;
+		ext->config.array =
+			(SourceExtensionConfig *) calloc(count,
+											 sizeof(SourceExtensionConfig));
+
+		if (ext->config.array == NULL)
+		{
+			log_error(ALLOCATION_FAILED_ERROR);
+			return false;
+		}
+	}
+
+	SourceExtensionConfig *conf = &(ext->config.array[num - 1]);
+
+	conf->extoid = sqlite3_column_int64(query->ppStmt, 2);
+	conf->reloid = sqlite3_column_int64(query->ppStmt, 3);
+
+	strlcpy(conf->nspname,
+			(char *) sqlite3_column_text(query->ppStmt, 4),
+			sizeof(conf->nspname));
+
+	strlcpy(conf->relname,
+			(char *) sqlite3_column_text(query->ppStmt, 5),
+			sizeof(conf->relname));
+
+	/* config->condition is a malloc'ed area */
+	int len = sqlite3_column_bytes(query->ppStmt, 6);
+	int bytes = len + 1;
+
+	conf->condition = (char *) calloc(bytes, sizeof(char));
+
+	if (conf->condition == NULL)
+	{
+		log_fatal(ALLOCATION_FAILED_ERROR);
+		return false;
+	}
+
+	strlcpy(conf->condition,
+			(char *) sqlite3_column_text(query->ppStmt, 6),
+			bytes);
+
+	return true;
+}
+
+
+/*
+ * catalog_add_s_role INSERTs a SourceRole to our internal catalogs
+ * database.
+ */
+bool
+catalog_add_s_role(DatabaseCatalog *catalog, SourceRole *role)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_add_s_role: db is NULL");
+		return false;
+	}
+
+	char *sql =
+		"insert into s_role(oid, rolname) values($1, $2)";
+
+	SQLiteQuery query = { 0 };
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_INT64, "oid", role->oid, NULL },
+		{ BIND_PARAMETER_TYPE_TEXT, "rolname", 0, role->rolname }
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(&query, params, count))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which does not return any row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_lookup_s_role fetches a SourceRole entry from our catalogs.
+ */
+bool
+catalog_lookup_s_role_by_name(DatabaseCatalog *catalog,
+							  const char *rolname,
+							  SourceRole *role)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_lookup_s_role_by_name: db is NULL");
+		return false;
+	}
+
+	SQLiteQuery query = {
+		.context = role,
+		.fetchFunction = &catalog_s_role_fetch
+	};
+
+	char *sql =
+		"  select oid, rolname "
+		"    from s_role"
+		"   where rolname = $1 ";
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_TEXT, "rolname", 0, (char *) rolname }
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(&query, params, count))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which return exactly one row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_s_role_stats_fetch is a SQLiteQuery callback.
+ */
+bool
+catalog_s_role_fetch(SQLiteQuery *query)
+{
+	SourceRole *role = (SourceRole *) query->context;
+
+	role->oid = sqlite3_column_int64(query->ppStmt, 0);
+
+	strlcpy(role->rolname,
+			(char *) sqlite3_column_text(query->ppStmt, 1),
+			sizeof(role->rolname));
+
+	return true;
+}
+
+
+/*
+ * catalog_add_s_depend INSERTs a SourceDepend to our internal catalogs
+ * database.
+ */
+bool
+catalog_add_s_depend(DatabaseCatalog *catalog, SourceDepend *depend)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_add_s_depend: db is NULL");
+		return false;
+	}
+
+	char *sql =
+		"insert into s_depend("
+		"  nspname, relname, refclassid, refobjid, classid, objid, "
+		"  deptype, type, identity)"
+		"values($1, $2, $3, $4, $5, $6, $7, $8, $9)";
+
+	SQLiteQuery query = { 0 };
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* depend->deptype is a single char, we want a C-string */
+	char deptype[2] = " ";
+	deptype[0] = depend->deptype;
+
+	/* bind our parameters now */
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_TEXT, "nspname", 0, depend->nspname },
+		{ BIND_PARAMETER_TYPE_TEXT, "relname", 0, depend->relname },
+		{ BIND_PARAMETER_TYPE_INT64, "refclassid", depend->refclassid, NULL },
+		{ BIND_PARAMETER_TYPE_INT64, "refobjid", depend->refobjid, NULL },
+		{ BIND_PARAMETER_TYPE_INT64, "classid", depend->classid, NULL },
+		{ BIND_PARAMETER_TYPE_INT64, "objid", depend->objid, NULL },
+		{ BIND_PARAMETER_TYPE_TEXT, "deptype", 0, deptype },
+		{ BIND_PARAMETER_TYPE_TEXT, "type", 0, depend->type },
+		{ BIND_PARAMETER_TYPE_TEXT, "identity", 0, depend->identity }
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(&query, params, count))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which does not return any row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_depend iterates over the list of datuences in our catalogs.
+ */
+bool
+catalog_iter_s_depend(DatabaseCatalog *catalog,
+					  void *context,
+					  SourceDependIterFun *callback)
+{
+	SourceDependIterator *iter =
+		(SourceDependIterator *) calloc(1, sizeof(SourceDependIterator));
+
+	iter->catalog = catalog;
+
+	if (!catalog_iter_s_depend_init(iter))
+	{
+		/* errors have already been logged */
+		free(iter);
+		return false;
+	}
+
+	for (;;)
+	{
+		if (!catalog_iter_s_depend_next(iter))
+		{
+			/* errors have already been logged */
+			free(iter);
+			return false;
+		}
+
+		SourceDepend *dep = iter->dep;
+
+		if (dep == NULL)
+		{
+			if (!catalog_iter_s_depend_finish(iter))
+			{
+				/* errors have already been logged */
+				free(iter);
+				return false;
+			}
+
+			break;
+		}
+
+		/* now call the provided callback */
+		if (!(*callback)(context, dep))
+		{
+			log_error("Failed to iterate over list of deps, "
+					  "see above for details");
+			return false;
+		}
+	}
+
+	free(iter);
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_depend_init initializes an Interator over our catalog of
+ * SourceDepend entries.
+ */
+bool
+catalog_iter_s_depend_init(SourceDependIterator *iter)
+{
+	sqlite3 *db = iter->catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: Failed to initialize s_depend iterator: db is NULL");
+		return false;
+	}
+
+	iter->dep = (SourceDepend *) calloc(1, sizeof(SourceDepend));
+
+	if (iter->dep == NULL)
+	{
+		log_error(ALLOCATION_FAILED_ERROR);
+		return false;
+	}
+
+	char *sql =
+		"  select nspname, relname, refclassid, refobjid, classid, objid, "
+		"         deptype, type, identity "
+		"    from s_depend "
+		"order by nspname, relname, refclassid";
+
+	SQLiteQuery *query = &(iter->query);
+
+	query->context = iter->dep;
+	query->fetchFunction = &catalog_s_depend_fetch;
+
+	if (!catalog_sql_prepare(db, sql, query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_depend_next fetches the next SourceDepend entry in our
+ * catalogs.
+ */
+bool
+catalog_iter_s_depend_next(SourceDependIterator *iter)
+{
+	SQLiteQuery *query = &(iter->query);
+
+	int rc = catalog_sql_step(query);
+
+	if (rc == SQLITE_DONE)
+	{
+		free(iter->dep);
+		iter->dep = NULL;
+
+		return true;
+	}
+
+	if (rc != SQLITE_ROW)
+	{
+		log_error("Failed to step through statement: %s", query->sql);
+		log_error("[SQLite] %s", sqlite3_errmsg(query->db));
+		return false;
+	}
+
+	return catalog_s_depend_fetch(query);
+}
+
+
+/*
+ * catalog_s_depend_fetch fetches a SourceDepend entry from a SQLite ppStmt
+ * result set.
+ */
+bool
+catalog_s_depend_fetch(SQLiteQuery *query)
+{
+	SourceDepend *dep = (SourceDepend *) query->context;
+
+	/* cleanup the memory area before re-use */
+	bzero(dep, sizeof(SourceDepend));
+
+	strlcpy(dep->nspname,
+			(char *) sqlite3_column_text(query->ppStmt, 0),
+			sizeof(dep->nspname));
+
+	strlcpy(dep->relname,
+			(char *) sqlite3_column_text(query->ppStmt, 1),
+			sizeof(dep->relname));
+
+	dep->refclassid = sqlite3_column_int64(query->ppStmt, 2);
+	dep->refobjid = sqlite3_column_int64(query->ppStmt, 3);
+	dep->classid = sqlite3_column_int64(query->ppStmt, 4);
+	dep->objid = sqlite3_column_int64(query->ppStmt, 5);
+
+	char *deptype = (char *) sqlite3_column_text(query->ppStmt, 6);
+
+	/* we have a single char deptype */
+	dep->deptype = deptype[0];
+
+	strlcpy(dep->type,
+			(char *) sqlite3_column_text(query->ppStmt, 7),
+			sizeof(dep->type));
+
+	strlcpy(dep->identity,
+			(char *) sqlite3_column_text(query->ppStmt, 8),
+			sizeof(dep->identity));
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_depend_finish cleans-up the internal memory used for the
+ * iteration.
+ */
+bool
+catalog_iter_s_depend_finish(SourceDependIterator *iter)
+{
+	SQLiteQuery *query = &(iter->query);
+
+	/* in case we finish before reaching the DONE step */
+	if (iter->dep != NULL)
+	{
+		free(iter->dep);
+		iter->dep = NULL;
+	}
+
+	if (!catalog_sql_finalize(query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_upsert_process_info INSERTs or UPDATEs a process information entry
+ * in our catalogs, allowing to keep track of what's happening.
+ */
+bool
+catalog_upsert_process_info(DatabaseCatalog *catalog, ProcessInfo *ps)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_upsert_process_info: db is NULL");
+		return false;
+	}
+
+	char *sql =
+		"insert or replace into process("
+		"  pid, ps_type, ps_title, tableoid, partnum, indexoid)"
+		"values($1, $2, $3, $4, $5, $6)";
+
+	SQLiteQuery query = { 0 };
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_INT64, "pid", (long long) ps->pid, NULL },
+		{ BIND_PARAMETER_TYPE_TEXT, "ps_type", 0, ps->psType },
+		{ BIND_PARAMETER_TYPE_TEXT, "ps_title", 0, ps->psTitle },
+		{ BIND_PARAMETER_TYPE_INT64, "tableoid", ps->tableOid, NULL },
+		{ BIND_PARAMETER_TYPE_INT64, "partnum", ps->partNumber, NULL },
+		{ BIND_PARAMETER_TYPE_INT64, "indexoid", ps->indexOid, NULL }
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(&query, params, count))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which does not return any row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_delete_s_table deletes an s_table entry for the given oid.
+ */
+bool
+catalog_delete_process(DatabaseCatalog *catalog, pid_t pid)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_delete_process: db is NULL");
+		return false;
+	}
+
+	char *sql = "delete from process where pid = $1";
+
+	SQLiteQuery query = { 0 };
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_INT64, "pid", (long long) pid, NULL }
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(&query, params, count))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which does not return any row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_table_in_copy iterates over the list of tables with a COPY
+ * process in our catalogs.
+ */
+bool
+catalog_iter_s_table_in_copy(DatabaseCatalog *catalog,
+							 void *context,
+							 SourceTableIterFun *callback)
+{
+	SourceTableIterator *iter =
+		(SourceTableIterator *) calloc(1, sizeof(SourceTableIterator));
+
+	iter->catalog = catalog;
+
+	if (!catalog_iter_s_table_in_copy_init(iter))
+	{
+		/* errors have already been logged */
+		free(iter);
+		return false;
+	}
+
+	for (;;)
+	{
+		if (!catalog_iter_s_table_next(iter))
+		{
+			/* errors have already been logged */
+			free(iter);
+			return false;
+		}
+
+		SourceTable *table = iter->table;
+
+		if (table == NULL)
+		{
+			if (!catalog_iter_s_table_finish(iter))
+			{
+				/* errors have already been logged */
+				free(iter);
+				return false;
+			}
+
+			break;
+		}
+
+		/* now call the provided callback */
+		if (!(*callback)(context, table))
+		{
+			log_error("Failed to iterate over list of tables, "
+					  "see above for details");
+			return false;
+		}
+	}
+
+	free(iter);
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_table_in_copy_init initializes an Interator over our catalog
+ * of SourceTable entries.
+ */
+bool
+catalog_iter_s_table_in_copy_init(SourceTableIterator *iter)
+{
+	sqlite3 *db = iter->catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: Failed to initialize s_table iterator: db is NULL");
+		return false;
+	}
+
+	iter->table = (SourceTable *) calloc(1, sizeof(SourceTable));
+
+	if (iter->table == NULL)
+	{
+		log_error(ALLOCATION_FAILED_ERROR);
+		return false;
+	}
+
+	char *sql =
+		"  select t.oid, qname, nspname, relname, amname, restore_list_name, "
+		"         relpages, reltuples, bytes, bytes_pretty, "
+		"         exclude_data, part_key, "
+		"         count(p.oid), 0 as partnum, 0 as min, 0 as max "
+		"    from process p join s_table t on p.tableoid = t.oid "
+		"   where p.ps_type = 'COPY' "
+		"order by p.pid";
+
+	SQLiteQuery *query = &(iter->query);
+
+	query->context = iter->table;
+	query->fetchFunction = &catalog_s_table_fetch;
+
+	if (!catalog_sql_prepare(db, sql, query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_index_in_progress iterates over the list of indexs with a
+ * CREATE INDEX process in our catalogs.
+ */
+bool
+catalog_iter_s_index_in_progress(DatabaseCatalog *catalog,
+								 void *context,
+								 SourceIndexIterFun *callback)
+{
+	SourceIndexIterator *iter =
+		(SourceIndexIterator *) calloc(1, sizeof(SourceIndexIterator));
+
+	iter->catalog = catalog;
+
+	if (!catalog_iter_s_index_in_progress_init(iter))
+	{
+		/* errors have already been logged */
+		free(iter);
+		return false;
+	}
+
+	for (;;)
+	{
+		if (!catalog_iter_s_index_next(iter))
+		{
+			/* errors have already been logged */
+			free(iter);
+			return false;
+		}
+
+		SourceIndex *index = iter->index;
+
+		if (index == NULL)
+		{
+			if (!catalog_iter_s_index_finish(iter))
+			{
+				/* errors have already been logged */
+				free(iter);
+				return false;
+			}
+
+			break;
+		}
+
+		/* now call the provided callback */
+		if (!(*callback)(context, index))
+		{
+			log_error("Failed to iterate over list of indexs, "
+					  "see above for details");
+			return false;
+		}
+	}
+
+	free(iter);
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_index_in_progress_init initializes an Interator over our
+ * catalog of SourceIndex entries.
+ */
+bool
+catalog_iter_s_index_in_progress_init(SourceIndexIterator *iter)
+{
+	sqlite3 *db = iter->catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: Failed to initialize s_index iterator: db is NULL");
+		return false;
+	}
+
+	iter->index = (SourceIndex *) calloc(1, sizeof(SourceIndex));
+
+	if (iter->index == NULL)
+	{
+		log_error(ALLOCATION_FAILED_ERROR);
+		return false;
+	}
+
+	char *sql =
+		"  select i.oid, i.qname, i.nspname, i.relname, i.restore_list_name, "
+		"         i.tableoid, t.qname, t.nspname, t.relname, "
+		"         isprimary, isunique, columns, i.sql, "
+		"         c.oid as constraintoid, conname, "
+		"         condeferrable, condeferred, c.sql as condef"
+		"    from process p "
+		"         join s_index i on p.indexoid = i.oid "
+		"         join s_table t on t.oid = i.tableoid "
+		"         left join s_constraint c on c.indexoid = i.oid"
+		"   where p.ps_type = 'CREATE INDEX'";
+
+	SQLiteQuery *query = &(iter->query);
+
+	query->context = iter->index;
+	query->fetchFunction = &catalog_s_index_fetch;
+
+	if (!catalog_sql_prepare(db, sql, query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_sql_prepare prepares a SQLite query for our internal catalogs.
+ */
+bool
+catalog_sql_prepare(sqlite3 *db, const char *sql, SQLiteQuery *query)
+{
+	query->db = db;
+	query->sql = sql;
+
+	log_sqlite("[SQLite] %s", sql);
+
+	int rc = sqlite3_prepare_v2(db, sql, -1, &(query->ppStmt), NULL);
+
+	if (rc == SQLITE_LOCKED || rc == SQLITE_BUSY)
+	{
+		ConnectionRetryPolicy retryPolicy = { 0 };
+
+		int maxT = 1;            /* 1s */
+		int maxSleepTime = 50;   /* 50ms */
+		int baseSleepTime = 10;  /* 10ms */
+
+		(void) pgsql_set_retry_policy(&retryPolicy,
+									  maxT,
+									  -1, /* unbounded number of attempts */
+									  maxSleepTime,
+									  baseSleepTime);
+
+		while (rc == SQLITE_LOCKED || rc == SQLITE_BUSY)
+		{
+			int sleepTimeMs =
+				pgsql_compute_connection_retry_sleep_time(&retryPolicy);
+
+			log_trace("[SQLite %d]: %s, try again in %dms",
+					  rc,
+					  sqlite3_errstr(rc),
+					  sleepTimeMs);
+
+			/* we have milliseconds, pg_usleep() wants microseconds */
+			(void) pg_usleep(sleepTimeMs * 1000);
+
+			rc = sqlite3_prepare_v2(db, sql, -1, &(query->ppStmt), NULL);
+		}
+	}
+
+	if (rc != SQLITE_OK || query->ppStmt == NULL)
+	{
+		log_error("Failed to prepare SQLite statement: %s", query->sql);
+		log_error("[SQLite] %s", sqlite3_errmsg(query->db));
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_sql_bind binds parameters to our SQL query before execution.
+ */
+bool
+catalog_sql_bind(SQLiteQuery *query, BindParam *params, int count)
+{
+	if (!catalog_bind_parameters(query->db, query->ppStmt, params, count))
+	{
+		/* errors have already been logged */
+		(void) sqlite3_clear_bindings(query->ppStmt);
+		(void) sqlite3_finalize(query->ppStmt);
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_sql_execute_once executes a query once and fetches its results.
+ */
+bool
+catalog_sql_execute_once(SQLiteQuery *query)
+{
+	if (!catalog_sql_execute(query))
+	{
+		log_error("Failed to execute SQLite query, see above for details");
+		return false;
+	}
+
+	if (!catalog_sql_finalize(query))
+	{
+		log_error("Failed to finalize SQLite query, see above for details");
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_sql_execute executes a query and fetches its results.
+ */
+bool
+catalog_sql_execute(SQLiteQuery *query)
+{
+	/* we expect SQLITE_DONE when we don't have a fetchFunction callback */
+	if (query->fetchFunction == NULL)
+	{
+		int rc = catalog_sql_step(query);
+
+		if (rc != SQLITE_DONE)
+		{
+			log_error("Failed to execute statement: %s", query->sql);
+			log_error("[SQLite] %s", sqlite3_errmsg(query->db));
+
+			(void) sqlite3_clear_bindings(query->ppStmt);
+			(void) sqlite3_finalize(query->ppStmt);
+
+			return false;
+		}
+	}
+	/* when we have a fetchFunction we expect only one row, and exactly one */
+	else
+	{
+		int rc = catalog_sql_step(query);
+
+		if (rc == SQLITE_DONE)
+		{
+			log_sqlite("catalog_sql_execute: 0 row: %s", query->sql);
+		}
+		else
+		{
+			if (rc != SQLITE_ROW)
+			{
+				log_error("Failed to step through statement: %s", query->sql);
+				log_error("[SQLite] %s", sqlite3_errmsg(query->db));
+
+				(void) sqlite3_clear_bindings(query->ppStmt);
+				(void) sqlite3_finalize(query->ppStmt);
+
+				return false;
+			}
+
+			/* callback */
+			if (!query->fetchFunction(query))
+			{
+				log_error("Failed to fetch current row, "
+						  "see above for details");
+				(void) sqlite3_clear_bindings(query->ppStmt);
+				(void) sqlite3_finalize(query->ppStmt);
+				return false;
+			}
+
+			if (catalog_sql_step(query) != SQLITE_DONE)
+			{
+				log_error("Failed to execute statement: %s", query->sql);
+				log_error("[SQLite] %s", sqlite3_errmsg(query->db));
+
+				(void) sqlite3_clear_bindings(query->ppStmt);
+				(void) sqlite3_finalize(query->ppStmt);
+
+				return false;
+			}
+		}
+	}
+
+	/* clean-up after execute */
+	if (sqlite3_clear_bindings(query->ppStmt) != SQLITE_OK)
+	{
+		log_error("Failed to clear SQLite bindings: %s",
+				  sqlite3_errmsg(query->db));
+		return false;
+	}
+
+	/* reset the prepared Statement too */
+	if (sqlite3_reset(query->ppStmt) != SQLITE_OK)
+	{
+		log_error("Failed to reset SQLite statement: %s",
+				  sqlite3_errmsg(query->db));
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_sql_step is a wrapper around sqlite3_step() that implements a retry
+ * policy when the return code is SQLITE_LOCKED or SQLITE_BUSY, allowing for
+ * hanlding concurrent accesses between our sub-processes.
+ */
+int
+catalog_sql_step(SQLiteQuery *query)
+{
+	int rc = sqlite3_step(query->ppStmt);
+
+	if (rc == SQLITE_LOCKED || rc == SQLITE_BUSY)
+	{
+		ConnectionRetryPolicy retryPolicy = { 0 };
+
+		int maxT = 1;            /* 1s */
+		int maxSleepTime = 50;   /* 50ms */
+		int baseSleepTime = 10;  /* 10ms */
+
+		(void) pgsql_set_retry_policy(&retryPolicy,
+									  maxT,
+									  -1, /* unbounded number of attempts */
+									  maxSleepTime,
+									  baseSleepTime);
+
+		while (rc == SQLITE_LOCKED || rc == SQLITE_BUSY)
+		{
+			int sleepTimeMs =
+				pgsql_compute_connection_retry_sleep_time(&retryPolicy);
+
+			log_trace("[SQLite %d]: %s, try again in %dms",
+					  rc,
+					  sqlite3_errstr(rc),
+					  sleepTimeMs);
+
+			/* we have milliseconds, pg_usleep() wants microseconds */
+			(void) pg_usleep(sleepTimeMs * 1000);
+
+			rc = sqlite3_step(query->ppStmt);
+		}
+	}
+
+	return rc;
+}
+
+
+/*
+ * catalog_sql_finalize finalizes a SQL query.
+ */
+bool
+catalog_sql_finalize(SQLiteQuery *query)
+{
+	if (sqlite3_finalize(query->ppStmt) != SQLITE_OK)
+	{
+		log_error("Failed to finalize SQLite statement: %s",
+				  sqlite3_errmsg(query->db));
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_bind_parameters binds parameters to a SQLite prepared statement.
+ */
+bool
+catalog_bind_parameters(sqlite3 *db,
+						sqlite3_stmt *ppStmt,
+						BindParam *params,
+						int count)
+{
+	PQExpBuffer debugParameters = createPQExpBuffer();
+
+	for (int i = 0; i < count; i++)
+	{
+		int n = i + 1;
+		BindParam *p = &(params[i]);
+
+		if (i > 0)
+		{
+			appendPQExpBufferStr(debugParameters, ", ");
+		}
+
+		switch (p->type)
+		{
+			case BIND_PARAMETER_TYPE_INT:
+			{
+				int rc = sqlite3_bind_int(ppStmt, n, p->intVal);
+
+				if (rc != SQLITE_OK)
+				{
+					log_error("[SQLite %d] Failed to bind \"%s\" value %lld: %s",
+							  rc,
+							  p->name,
+							  (long long) p->intVal,
+							  sqlite3_errstr(rc));
+					return false;
+				}
+
+				appendPQExpBuffer(debugParameters, "%lld", (long long) p->intVal);
+
+				break;
+			}
+
+			case BIND_PARAMETER_TYPE_INT64:
+			{
+				int rc = sqlite3_bind_int64(ppStmt, n, p->intVal);
+
+				if (rc != SQLITE_OK)
+				{
+					log_error("[SQLite %d] Failed to bind \"%s\" value %lld: %s",
+							  rc,
+							  p->name,
+							  (long long) p->intVal,
+							  sqlite3_errstr(rc));
+					return false;
+				}
+
+				appendPQExpBuffer(debugParameters, "%lld", (long long) p->intVal);
+
+				break;
+			}
+
+			case BIND_PARAMETER_TYPE_TEXT:
+			{
+				int rc;
+
+				if (p->strVal == NULL)
+				{
+					rc = sqlite3_bind_null(ppStmt, n);
+
+					appendPQExpBuffer(debugParameters, "%s", "null");
+				}
+				else
+				{
+					rc = sqlite3_bind_text(ppStmt,
+										   n,
+										   p->strVal,
+										   strlen(p->strVal),
+										   SQLITE_STATIC);
+
+					appendPQExpBuffer(debugParameters, "%s", p->strVal);
+				}
+
+				if (rc != SQLITE_OK)
+				{
+					log_error("[SQLite %d] Failed to bind \"%s\" value \"%s\": %s",
+							  rc,
+							  p->name,
+							  p->strVal,
+							  sqlite3_errstr(rc));
+					return false;
+				}
+
+				break;
+			}
+
+			default:
+			{
+				log_error("BUG: catalog_bind_parameters called with unknown "
+						  "parameter type %d",
+						  p->type);
+				return false;
+			}
+		}
+	}
+
+	if (PQExpBufferBroken(debugParameters))
+	{
+		log_error("Failed to create log message for SQL query parameters: "
+				  "out of memory");
+		destroyPQExpBuffer(debugParameters);
+		return false;
+	}
+
+	log_sqlite("[SQLite] %s", debugParameters->data);
+	destroyPQExpBuffer(debugParameters);
+
+	return true;
+}

--- a/src/bin/pgcopydb/catalog.h
+++ b/src/bin/pgcopydb/catalog.h
@@ -1,0 +1,554 @@
+/*
+ * src/bin/pgcopydb/catalog.h
+ *	 Catalog management as a SQLite internal file
+ */
+
+#ifndef CATALOG_H
+#define CATALOG_H
+
+#include "copydb.h"
+#include "schema.h"
+
+/*
+ * Internal infrastructure to bind values to SQLite prepared statements.
+ */
+typedef struct SQLiteQuery SQLiteQuery;
+typedef bool (CatalogFetchResult)(SQLiteQuery *query);
+
+struct SQLiteQuery
+{
+	sqlite3 *db;
+	sqlite3_stmt *ppStmt;
+	const char *sql;
+	CatalogFetchResult *fetchFunction;
+	void *context;
+};
+
+
+/*
+ * Catalog API.
+ */
+bool catalog_init_from_specs(CopyDataSpec *copySpecs);
+bool catalog_close_from_specs(CopyDataSpec *copySpecs);
+
+bool catalog_open(DatabaseCatalog *catalog);
+bool catalog_init(DatabaseCatalog *catalog);
+bool catalog_attach(DatabaseCatalog *a, DatabaseCatalog *b, const char *name);
+bool catalog_close(DatabaseCatalog *catalog);
+
+bool catalog_create_schema(DatabaseCatalog *catalog);
+bool catalog_drop_schema(DatabaseCatalog *catalog);
+
+
+bool catalog_begin(DatabaseCatalog *catalog);
+bool catalog_commit(DatabaseCatalog *catalog);
+
+bool catalog_register_setup(DatabaseCatalog *catalog,
+							const char *source_pg_uri,
+							const char *target_pg_uri,
+							const char *snapshot,
+							uint64_t splitTablesLargerThanBytes,
+							const char *filters);
+
+bool catalog_setup(DatabaseCatalog *catalog);
+bool catalog_setup_fetch(SQLiteQuery *query);
+
+bool catalog_register_section(DatabaseCatalog *catalog, CopyDataSection section);
+bool catalog_section_state(DatabaseCatalog *catalog, CatalogSection *section);
+bool catalog_section_fetch(SQLiteQuery *query);
+
+char * CopyDataSectionToString(CopyDataSection section);
+
+/*
+ * Statistics over our catalogs.
+ */
+typedef struct CatalogTableStats
+{
+	uint64_t count;
+	uint64_t countSplits;
+	uint64_t countParts;
+	uint64_t totalBytes;
+	uint64_t totalTuples;
+	char bytesPretty[BUFSIZE];
+	char relTuplesPretty[BUFSIZE];
+} CatalogTableStats;
+
+typedef struct CatalogCounts
+{
+	uint64_t tables;
+	uint64_t indexes;
+	uint64_t constraints;
+	uint64_t sequences;
+
+	uint64_t roles;
+	uint64_t databases;
+	uint64_t namespaces;
+	uint64_t extensions;
+	uint64_t colls;
+	uint64_t depends;
+} CatalogCounts;
+
+
+typedef struct CatalogStats
+{
+	CatalogTableStats table;
+	CatalogCounts count;
+} CatalogStats;
+
+bool catalog_stats(DatabaseCatalog *catalog, CatalogStats *stats);
+bool catalog_s_table_stats(DatabaseCatalog *catalog, CatalogTableStats *stats);
+bool catalog_s_table_stats_fetch(SQLiteQuery *query);
+bool catalog_count_objects(DatabaseCatalog *catalog, CatalogCounts *count);
+bool catalog_count_fetch(SQLiteQuery *query);
+
+/*
+ * Tables and their attributes and parts (COPY partitioning).
+ */
+bool catalog_add_s_table(DatabaseCatalog *catalog, SourceTable *table);
+bool catalog_add_attributes(DatabaseCatalog *catalog, SourceTable *table);
+bool catalog_add_s_table_parts(DatabaseCatalog *catalog, SourceTable *table);
+
+bool catalog_add_s_table_chksum(DatabaseCatalog *catalog,
+								SourceTable *table,
+								TableChecksum *srcChk,
+								TableChecksum *dstChk);
+
+bool catalog_delete_s_table(DatabaseCatalog *catalog,
+							const char *nspname,
+							const char *relname);
+
+bool catalog_delete_s_table_chksum_all(DatabaseCatalog *catalog);
+
+/*
+ * To loop over our catalog "arrays" we provide an iterator based API, which
+ * allows for allocating a single item in memory for the whole scan.
+ */
+typedef bool (SourceTableIterFun)(void *context, SourceTable *table);
+
+bool catalog_iter_s_table(DatabaseCatalog *catalog,
+						  void *context,
+						  SourceTableIterFun *callback);
+
+bool catalog_iter_s_table_nopk(DatabaseCatalog *catalog,
+							   void *context,
+							   SourceTableIterFun *callback);
+
+typedef struct SourceTableIterator
+{
+	DatabaseCatalog *catalog;
+	SourceTable *table;
+	SQLiteQuery query;
+
+	/* optional parameters */
+	uint64_t splitTableLargerThanBytes;
+} SourceTableIterator;
+
+bool catalog_iter_s_table_init(SourceTableIterator *iter);
+bool catalog_iter_s_table_nopk_init(SourceTableIterator *iter);
+bool catalog_iter_s_table_next(SourceTableIterator *iter);
+bool catalog_iter_s_table_finish(SourceTableIterator *iter);
+
+bool catalog_lookup_s_table(DatabaseCatalog *catalog,
+							uint32_t oid,
+							int partNumber,
+							SourceTable *table);
+
+bool catalog_lookup_s_table_by_name(DatabaseCatalog *catalog,
+									const char *nspname,
+									const char *relname,
+									SourceTable *table);
+
+bool catalog_s_table_fetch(SQLiteQuery *query);
+
+
+typedef bool (SourceTablePartsIterFun)(void *context, SourceTableParts *part);
+
+bool catalog_iter_s_table_parts(DatabaseCatalog *catalog,
+								uint32_t oid,
+								void *context,
+								SourceTablePartsIterFun *callback);
+
+typedef struct SourceTablePartsIterator
+{
+	DatabaseCatalog *catalog;
+	SourceTableParts *part;
+	SQLiteQuery query;
+
+	/* optional parameters */
+	uint32_t oid;
+} SourceTablePartsIterator;
+
+bool catalog_iter_s_table_part_init(SourceTablePartsIterator *iter);
+bool catalog_iter_s_table_part_next(SourceTablePartsIterator *iter);
+bool catalog_iter_s_table_part_finish(SourceTablePartsIterator *iter);
+
+bool catalog_s_table_part_fetch(SQLiteQuery *query);
+
+typedef struct SourceTableAttrsIterator
+{
+	DatabaseCatalog *catalog;
+	SourceTable *table;
+	SQLiteQuery query;
+	bool done;
+} SourceTableAttrsIterator;
+
+bool catalog_s_table_fetch_attrs(DatabaseCatalog *catalog,
+								 SourceTable *table);
+
+bool catalog_iter_s_table_attrs_init(SourceTableAttrsIterator *iter);
+bool catalog_iter_s_table_attrs_next(SourceTableAttrsIterator *iter);
+bool catalog_iter_s_table_attrs_finish(SourceTableAttrsIterator *iter);
+
+bool catalog_s_table_attrs_fetch(SQLiteQuery *query);
+
+bool catalog_s_table_count_attrs(DatabaseCatalog *catalog,
+								 SourceTable *table);
+
+bool catalog_s_table_count_attrs_fetch(SQLiteQuery *query);
+
+
+bool catalog_lookup_s_attr_by_name(DatabaseCatalog *catalog,
+								   uint32_t reloid,
+								   const char *attname,
+								   SourceTableAttribute *attribute);
+
+bool catalog_s_attr_fetch(SQLiteQuery *query);
+
+/*
+ * Indexes
+ */
+bool catalog_add_s_index(DatabaseCatalog *catalog, SourceIndex *index);
+bool catalog_add_s_constraint(DatabaseCatalog *catalog, SourceIndex *index);
+
+bool catalog_lookup_s_index(DatabaseCatalog *catalog,
+							uint32_t oid,
+							SourceIndex *index);
+
+bool catalog_lookup_s_index_by_name(DatabaseCatalog *catalog,
+									const char *nspname,
+									const char *relname,
+									SourceIndex *index);
+
+bool catalog_delete_s_index_table(DatabaseCatalog *catalog,
+								  const char *nspname,
+								  const char *relname);
+
+bool catalog_delete_s_index_all(DatabaseCatalog *catalog);
+
+
+typedef bool (SourceIndexIterFun)(void *context, SourceIndex *index);
+
+bool catalog_iter_s_index(DatabaseCatalog *catalog,
+						  void *context,
+						  SourceIndexIterFun *callback);
+
+bool catalog_iter_s_index_table(DatabaseCatalog *catalog,
+								const char *nspname,
+								const char *relname,
+								void *context,
+								SourceIndexIterFun *callback);
+
+bool catalog_s_table_count_indexes(DatabaseCatalog *catalog,
+								   SourceTable *table);
+
+bool catalog_s_table_count_indexes_fetch(SQLiteQuery *query);
+
+typedef struct SourceIndexIterator
+{
+	DatabaseCatalog *catalog;
+	SourceIndex *index;
+	SQLiteQuery query;
+
+	/* optional parameters */
+	const char *nspname;
+	const char *relname;
+} SourceIndexIterator;
+
+bool catalog_iter_s_index_init(SourceIndexIterator *iter);
+bool catalog_iter_s_index_table_init(SourceIndexIterator *iter);
+bool catalog_iter_s_index_next(SourceIndexIterator *iter);
+bool catalog_iter_s_index_finish(SourceIndexIterator *iter);
+
+bool catalog_s_index_fetch(SQLiteQuery *query);
+
+/*
+ * Sequences
+ */
+bool catalog_add_s_seq(DatabaseCatalog *catalog, SourceSequence *index);
+bool catalog_update_sequence_values(DatabaseCatalog *catalog, SourceSequence *seq);
+
+typedef bool (SourceSequenceIterFun)(void *context, SourceSequence *seq);
+
+bool catalog_iter_s_seq(DatabaseCatalog *catalog,
+						void *context,
+						SourceSequenceIterFun *callback);
+
+bool catalog_lookup_s_seq_by_name(DatabaseCatalog *catalog,
+								  const char *nspname,
+								  const char *relname,
+								  SourceSequence *seq);
+
+typedef struct SourceSeqIterator
+{
+	DatabaseCatalog *catalog;
+	SourceSequence *seq;
+	SQLiteQuery query;
+} SourceSeqIterator;
+
+bool catalog_iter_s_seq_init(SourceSeqIterator *iter);
+bool catalog_iter_s_seq_next(SourceSeqIterator *iter);
+bool catalog_iter_s_seq_finish(SourceSeqIterator *iter);
+
+bool catalog_s_seq_fetch(SQLiteQuery *query);
+
+/*
+ * Filtering is done through a single table that concatenates the Oid and
+ * pg_restore archives TOC list names (restore_list_name) in such a way that we
+ * can get away with a single hash-table like lookup.
+ */
+bool catalog_prepare_filter(DatabaseCatalog *catalog);
+
+typedef struct CatalogFilter
+{
+	uint32_t oid;
+	char restoreListName[RESTORE_LIST_NAMEDATALEN];
+	char kind[PG_NAMEDATALEN];
+} CatalogFilter;
+
+bool catalog_lookup_filter_by_oid(DatabaseCatalog *catalog,
+								  CatalogFilter *result,
+								  uint32_t oid);
+
+bool catalog_lookup_filter_by_rlname(DatabaseCatalog *catalog,
+									 CatalogFilter *result,
+									 const char *restoreListName);
+
+bool catalog_filter_fetch(SQLiteQuery *query);
+
+/*
+ * Databases
+ */
+bool catalog_add_s_database(DatabaseCatalog *catalog, SourceDatabase *dat);
+
+bool catalog_add_s_database_properties(DatabaseCatalog *catalog,
+									   SourceProperty *guc);
+
+typedef bool (SourceDatabaseIterFun)(void *context, SourceDatabase *dat);
+
+bool catalog_iter_s_database(DatabaseCatalog *catalog,
+							 void *context,
+							 SourceDatabaseIterFun *callback);
+
+typedef struct SourceDatabaseIterator
+{
+	DatabaseCatalog *catalog;
+	SourceDatabase *dat;
+	SQLiteQuery query;
+} SourceDatabaseIterator;
+
+bool catalog_iter_s_database_init(SourceDatabaseIterator *iter);
+bool catalog_iter_s_database_next(SourceDatabaseIterator *iter);
+bool catalog_iter_s_database_finish(SourceDatabaseIterator *iter);
+
+bool catalog_s_database_fetch(SQLiteQuery *query);
+
+typedef bool (SourcePropertyIterFun)(void *context, SourceProperty *property);
+
+bool catalog_iter_s_database_guc(DatabaseCatalog *catalog,
+								 const char *dbname,
+								 void *context,
+								 SourcePropertyIterFun *callback);
+
+typedef struct SourcePropertyIterator
+{
+	DatabaseCatalog *catalog;
+	SourceProperty *property;
+	SQLiteQuery query;
+	const char *dbname;
+} SourcePropertyIterator;
+
+bool catalog_iter_s_database_guc_init(SourcePropertyIterator *iter);
+bool catalog_iter_s_database_guc_next(SourcePropertyIterator *iter);
+bool catalog_iter_s_database_guc_finish(SourcePropertyIterator *iter);
+
+bool catalog_s_database_guc_fetch(SQLiteQuery *query);
+
+
+/*
+ * Namespaces
+ */
+bool catalog_add_s_namespace(DatabaseCatalog * catalog, SourceSchema *namespace);
+
+bool catalog_lookup_s_namespace_by_rlname(DatabaseCatalog *catalog,
+										  const char *restoreListName,
+										  SourceSchema *result);
+
+bool catalog_s_namespace_fetch(SQLiteQuery *query);
+
+/*
+ * Roles
+ */
+bool catalog_add_s_role(DatabaseCatalog *catalog, SourceRole *role);
+
+bool catalog_lookup_s_role_by_name(DatabaseCatalog *catalog,
+								   const char *rolname,
+								   SourceRole *role);
+
+bool catalog_s_role_fetch(SQLiteQuery *query);
+
+
+/*
+ * Extensions
+ */
+bool catalog_add_s_extension(DatabaseCatalog *catalog,
+							 SourceExtension *extension);
+
+bool catalog_add_s_extension_config(DatabaseCatalog *catalog,
+									SourceExtensionConfig *config);
+
+typedef bool (SourceExtensionIterFun)(void *context, SourceExtension *ext);
+
+bool catalog_iter_s_extension(DatabaseCatalog *catalog,
+							  void *context,
+							  SourceExtensionIterFun *callback);
+
+typedef struct SourceExtensionIterator
+{
+	DatabaseCatalog *catalog;
+	SourceExtension *ext;
+	SQLiteQuery query;
+} SourceExtensionIterator;
+
+bool catalog_iter_s_extension_init(SourceExtensionIterator *iter);
+bool catalog_iter_s_extension_next(SourceExtensionIterator *iter);
+bool catalog_s_extension_fetch(SQLiteQuery *query);
+bool catalog_iter_s_extension_finish(SourceExtensionIterator *iter);
+
+typedef struct SourceExtConfigIterator
+{
+	DatabaseCatalog *catalog;
+	SourceExtension *ext;
+	SQLiteQuery query;
+	bool done;
+} SourceExtConfigIterator;
+
+
+bool catalog_s_ext_fetch_extconfig(DatabaseCatalog *catalog, SourceExtension *ext);
+bool catalog_iter_s_ext_extconfig_init(SourceExtConfigIterator *iter);
+bool catalog_iter_s_ext_extconfig_next(SourceExtConfigIterator *iter);
+bool catalog_iter_s_ext_extconfig_finish(SourceExtConfigIterator *iter);
+bool catalog_s_ext_extconfig_fetch(SQLiteQuery *query);
+
+
+/*
+ * Collations
+ */
+bool catalog_add_s_coll(DatabaseCatalog *catalog, SourceCollation *coll);
+
+typedef bool (SourceCollationIterFun)(void *context, SourceCollation *coll);
+
+bool catalog_iter_s_coll(DatabaseCatalog *catalog,
+						 void *context,
+						 SourceCollationIterFun *callback);
+
+typedef struct SourceCollationIterator
+{
+	DatabaseCatalog *catalog;
+	SourceCollation *coll;
+	SQLiteQuery query;
+} SourceCollationIterator;
+
+bool catalog_iter_s_coll_init(SourceCollationIterator *iter);
+bool catalog_iter_s_coll_next(SourceCollationIterator *iter);
+bool catalog_iter_s_coll_finish(SourceCollationIterator *iter);
+
+bool catalog_s_coll_fetch(SQLiteQuery *query);
+
+/*
+ * Dependencies
+ */
+bool catalog_add_s_depend(DatabaseCatalog *catalog, SourceDepend *depend);
+
+typedef bool (SourceDependIterFun)(void *context, SourceDepend *coll);
+
+bool catalog_iter_s_depend(DatabaseCatalog *catalog,
+						   void *context,
+						   SourceDependIterFun *callback);
+
+typedef struct SourceDependIterator
+{
+	DatabaseCatalog *catalog;
+	SourceDepend *dep;
+	SQLiteQuery query;
+} SourceDependIterator;
+
+bool catalog_iter_s_depend_init(SourceDependIterator *iter);
+bool catalog_iter_s_depend_next(SourceDependIterator *iter);
+bool catalog_iter_s_depend_finish(SourceDependIterator *iter);
+
+bool catalog_s_depend_fetch(SQLiteQuery *query);
+
+/*
+ * Processes
+ */
+typedef struct ProcessInfo
+{
+	pid_t pid;
+	char psType[PG_NAMEDATALEN];
+	char *psTitle;
+	uint32_t tableOid;
+	uint32_t partNumber;
+	uint32_t indexOid;
+} ProcessInfo;
+
+bool catalog_upsert_process_info(DatabaseCatalog *catalog, ProcessInfo *ps);
+bool catalog_delete_process(DatabaseCatalog *catalog, pid_t pid);
+
+bool catalog_iter_s_table_in_copy(DatabaseCatalog *catalog,
+								  void *context,
+								  SourceTableIterFun *callback);
+
+bool catalog_iter_s_table_in_copy_init(SourceTableIterator *iter);
+
+bool catalog_iter_s_index_in_progress(DatabaseCatalog *catalog,
+									  void *context,
+									  SourceIndexIterFun *callback);
+
+bool catalog_iter_s_index_in_progress_init(SourceIndexIterator *iter);
+
+
+/*
+ * Internal tooling for catalogs management
+ */
+typedef enum
+{
+	BIND_PARAMETER_TYPE_UNKNOWN = 0,
+	BIND_PARAMETER_TYPE_INT,
+	BIND_PARAMETER_TYPE_INT64,
+	BIND_PARAMETER_TYPE_TEXT
+} BindParameterType;
+
+
+typedef struct BindParam
+{
+	BindParameterType type;
+	char *name;
+	uint64_t intVal;
+	char *strVal;
+} BindParam;
+
+
+bool catalog_sql_prepare(sqlite3 *db, const char *sql, SQLiteQuery *query);
+bool catalog_sql_bind(SQLiteQuery *query, BindParam *params, int count);
+bool catalog_sql_execute(SQLiteQuery *query);
+bool catalog_sql_execute_once(SQLiteQuery *query);
+bool catalog_sql_finalize(SQLiteQuery *query);
+
+int catalog_sql_step(SQLiteQuery *query);
+
+bool catalog_bind_parameters(sqlite3 *db,
+							 sqlite3_stmt *ppStmt,
+							 BindParam *params,
+							 int count);
+
+#endif  /* CATALOG_H */

--- a/src/bin/pgcopydb/cli_copy.c
+++ b/src/bin/pgcopydb/cli_copy.c
@@ -395,7 +395,7 @@ cli_copy_table_data(int argc, char **argv)
 		exit(EXIT_CODE_TARGET);
 	}
 
-	if (!copydb_copy_all_table_data(&copySpecs))
+	if (!copydb_copy_supervisor(&copySpecs))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);
@@ -683,7 +683,7 @@ cli_copy_extensions(int argc, char **argv)
 {
 	CopyDataSpec copySpecs = { 0 };
 
-	(void) cli_copy_prepare_specs(&copySpecs, DATA_SECTION_EXTENSION);
+	(void) cli_copy_prepare_specs(&copySpecs, DATA_SECTION_EXTENSIONS);
 
 	if (!copydb_prepare_snapshot(&copySpecs))
 	{

--- a/src/bin/pgcopydb/cli_dump.c
+++ b/src/bin/pgcopydb/cli_dump.c
@@ -401,15 +401,18 @@ cli_dump_schema_section(CopyDBOptions *dumpDBoptions,
 	}
 
 	/*
-	 * First, we need to open a snapshot that we're going to re-use in all our
-	 * connections to the source database. When the --snapshot option has been
-	 * used, instead of exporting a new snapshot, we can just re-use it.
+	 * Prepare our internal catalogs for storing the source database catalog
+	 * query results.
 	 */
-	if (!copydb_prepare_snapshot(&copySpecs))
+	copySpecs.section = DATA_SECTION_ALL;
+
+	if (!copydb_fetch_schema_and_prepare_specs(&copySpecs))
 	{
 		/* errors have already been logged */
-		exit(EXIT_CODE_INTERNAL_ERROR);
+		exit(EXIT_CODE_SOURCE);
 	}
+
+	copySpecs.section = DATA_SECTION_NONE;
 
 	if (section == PG_DUMP_SECTION_ROLES)
 	{
@@ -431,13 +434,5 @@ cli_dump_schema_section(CopyDBOptions *dumpDBoptions,
 			/* errors have already been logged */
 			exit(EXIT_CODE_INTERNAL_ERROR);
 		}
-	}
-
-	if (!copydb_close_snapshot(&copySpecs))
-	{
-		log_fatal("Failed to close snapshot \"%s\" on \"%s\"",
-				  copySpecs.sourceSnapshot.snapshot,
-				  copySpecs.sourceSnapshot.pguri);
-		exit(EXIT_CODE_SOURCE);
 	}
 }

--- a/src/bin/pgcopydb/cli_list.h
+++ b/src/bin/pgcopydb/cli_list.h
@@ -28,11 +28,16 @@ typedef struct ListDBOptions
 
 	bool listSkipped;
 	bool noPKey;
+	bool force;
 	bool cache;
 	bool dropCache;
 	bool summary;
 	bool availableVersions;
 	bool requirements;
+	bool resume;
+	bool notConsistent;
+
+	char snapshot[BUFSIZE];
 
 	SplitTableLargerThan splitTablesLargerThan;
 } ListDBOptions;

--- a/src/bin/pgcopydb/cli_snapshot.c
+++ b/src/bin/pgcopydb/cli_snapshot.c
@@ -314,7 +314,7 @@ cli_create_snapshot(int argc, char **argv)
 							   createSNoptions.origin,
 							   createSNoptions.endpos,
 							   STREAM_MODE_CATCHUP,
-							   &(copySpecs.catalog),
+							   &(copySpecs.catalogs.source),
 							   createSNoptions.stdIn,
 							   createSNoptions.stdOut,
 							   logSQL))

--- a/src/bin/pgcopydb/copydb_paths.h
+++ b/src/bin/pgcopydb/copydb_paths.h
@@ -17,7 +17,6 @@ typedef struct DirectoryState
 	bool directoryExists;
 	bool directoryIsReady;
 
-	/* when we have a directory, what part of the job has been done? */
 	bool schemaDumpIsDone;
 	bool schemaPreDataHasBeenRestored;
 	bool schemaPostDataHasBeenRestored;
@@ -73,6 +72,9 @@ typedef struct CopyFilePaths
 	char topdir[MAXPGPATH];           /* /tmp/pgcopydb */
 	char pidfile[MAXPGPATH];          /* /tmp/pgcopydb/pgcopydb.pid */
 	char spidfile[MAXPGPATH];         /* /tmp/pgcopydb/pgcopydb.service.pid */
+	char sdbfile[MAXPGPATH];          /* /tmp/pgcopydb/schema/source.db */
+	char fdbfile[MAXPGPATH];          /* /tmp/pgcopydb/schema/filter.db */
+	char tdbfile[MAXPGPATH];          /* /tmp/pgcopydb/schema/target.db */
 	char snfile[MAXPGPATH];           /* /tmp/pgcopydb/snapshot */
 	char schemadir[MAXPGPATH];        /* /tmp/pgcopydb/schema */
 	char schemafile[MAXPGPATH];       /* /tmp/pgcopydb/schema.json */

--- a/src/bin/pgcopydb/filtering.h
+++ b/src/bin/pgcopydb/filtering.h
@@ -99,4 +99,6 @@ char * filterTypeToString(SourceFilterType type);
 SourceFilterType filterTypeComplement(SourceFilterType type);
 bool parse_filters(const char *filebname, SourceFilters *filters);
 
+bool filters_as_json(SourceFilters *filters, JSON_Value *jsFilter);
+
 #endif  /* FILTERING_H */

--- a/src/bin/pgcopydb/follow.c
+++ b/src/bin/pgcopydb/follow.c
@@ -270,16 +270,6 @@ follow_main_loop(CopyDataSpec *copySpecs, StreamSpecs *streamSpecs)
 	}
 
 	/*
-	 * Read the catalogs from the source table from on-file disk if
-	 * the schema dump has been done already.
-	 */
-	if (copySpecs->dirState.schemaDumpIsDone && !copydb_parse_schema_json_file(copySpecs))
-	{
-		/* errors have already been logged */
-		return false;
-	}
-
-	/*
 	 * In case of successful exit from the follow sub-processes, we
 	 * switch back and forth between CATCHUP and REPLAY modes and
 	 * continue replaying changes. In case of error, we stop.

--- a/src/bin/pgcopydb/ld_stream.c
+++ b/src/bin/pgcopydb/ld_stream.c
@@ -48,7 +48,7 @@ stream_init_specs(StreamSpecs *specs,
 				  char *origin,
 				  uint64_t endpos,
 				  LogicalStreamMode mode,
-				  SourceCatalog *catalog,
+				  DatabaseCatalog *sourceDB,
 				  bool stdin,
 				  bool stdout,
 				  bool logSQL)
@@ -62,7 +62,7 @@ stream_init_specs(StreamSpecs *specs,
 	specs->paths = *paths;
 	specs->endpos = endpos;
 
-	specs->catalog = catalog;
+	specs->sourceDB = sourceDB;
 
 	/*
 	 * Copy the given ReplicationSlot: it comes from command line parsing, or
@@ -399,7 +399,7 @@ stream_init_context(StreamSpecs *specs)
 	privateContext->maxWrittenLSN = specs->startpos;
 
 	/* transform needs some catalog lookups (pkey, type oid) */
-	privateContext->catalog = specs->catalog;
+	privateContext->sourceDB = specs->sourceDB;
 
 	return true;
 }

--- a/src/bin/pgcopydb/ld_stream.h
+++ b/src/bin/pgcopydb/ld_stream.h
@@ -304,7 +304,7 @@ typedef struct StreamContext
 	uint64_t lastWriteTime;
 
 	/* transform needs some catalog lookups (pkey, type oid) */
-	SourceCatalog *catalog;
+	DatabaseCatalog *sourceDB;
 
 	Queue *transformQueue;
 	uint32_t WalSegSz;
@@ -456,7 +456,7 @@ struct StreamSpecs
 	FollowSubProcess catchup;
 
 	/* transform needs some catalog lookups (pkey, type oid) */
-	SourceCatalog *catalog;
+	DatabaseCatalog *sourceDB;
 
 	/* receive push json filenames to a queue for transform */
 	Queue transformQueue;
@@ -484,7 +484,7 @@ bool stream_init_specs(StreamSpecs *specs,
 					   char *origin,
 					   uint64_t endpos,
 					   LogicalStreamMode mode,
-					   SourceCatalog *catalog,
+					   DatabaseCatalog *sourceDB,
 					   bool stdIn,
 					   bool stdOut,
 					   bool logSQL);

--- a/src/bin/pgcopydb/parsing_utils.h
+++ b/src/bin/pgcopydb/parsing_utils.h
@@ -103,11 +103,14 @@ bool parse_pguri_info_key_vals(const char *pguri,
 							   URIParams *uriParameters,
 							   bool checkForCompleteURI);
 
+bool buildPostgresBareURIfromPieces(URIParams *uriParams, char **pguri);
 bool buildPostgresURIfromPieces(URIParams *uriParams, char **pguri);
 
 bool escapeWithPercentEncoding(const char *str, char **dst);
 
 bool parse_and_scrub_connection_string(const char *pguri, SafeURI *safeURI);
+
+bool bareConnectionString(const char *pguri, SafeURI *safeURI);
 
 void freeSafeURI(SafeURI *safeURI);
 void freeURIParams(URIParams *params);

--- a/src/bin/pgcopydb/pgcmd.h
+++ b/src/bin/pgcopydb/pgcmd.h
@@ -203,7 +203,7 @@ bool pg_dump_db(PostgresPaths *pgPaths,
 				const char *snapshot,
 				const char *section,
 				SourceFilters *filters,
-				SourceExtensionArray *extensionArray,
+				DatabaseCatalog *filtersDB,
 				const char *filename);
 
 bool pg_dumpall_roles(PostgresPaths *pgPaths,

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -1535,6 +1535,16 @@ pgsql_execute_with_params(PGSQL *pgsql, const char *sql, int paramCount,
 									  NULL, NULL, 0);
 	}
 
+	/*
+	 * TODO
+	 *
+	 * Use PQsetSingleRowMode(connection) to switch to select single-row mode
+	 * and fetch only one result at a time in memory. Most queries are already
+	 * fine with the idea, thanks to inserting the value into our SQLite
+	 * internal catalogs. Some query still expect PQntuples() to reflect the
+	 * actual number of tuples returned by the query etc.
+	 */
+
 	bool done = false;
 	int errors = 0;
 

--- a/src/bin/pgcopydb/progress.c
+++ b/src/bin/pgcopydb/progress.c
@@ -11,8 +11,10 @@
 
 #include "parson.h"
 
+#include "catalog.h"
 #include "copydb.h"
 #include "env_utils.h"
+#include "filtering.h"
 #include "log.h"
 #include "parsing_utils.h"
 #include "pidfile.h"
@@ -30,17 +32,28 @@ static bool copydb_filtering_as_json(CopyDataSpec *copySpecs,
 									 JSON_Object *jsobj,
 									 const char *key);
 
-static bool copydb_table_array_as_json(SourceTableArray *tableArray,
+static bool copydb_table_array_as_json(DatabaseCatalog *sourceDB,
 									   JSON_Object *jsobj,
 									   const char *key);
 
-static bool copydb_index_array_as_json(SourceIndexArray *indexArray,
+static bool copydb_index_array_as_json(DatabaseCatalog *sourceDB,
 									   JSON_Object *jsobj,
 									   const char *key);
 
-static bool copydb_seq_array_as_json(SourceSequenceArray *sequenceArray,
+static bool copydb_seq_array_as_json(DatabaseCatalog *sourceDB,
 									 JSON_Object *jsobj,
 									 const char *key);
+
+static bool copydb_table_array_as_json_hook(void *ctx, SourceTable *table);
+static bool copydb_index_array_as_json_hook(void *ctx, SourceIndex *index);
+static bool copydb_seq_array_as_json_hook(void *ctx, SourceSequence *seq);
+
+static bool copydb_table_parts_array_as_json_hook(void *ctx,
+												  SourceTableParts *part);
+
+static bool copydb_update_progress_table_hook(void *ctx, SourceTable *table);
+static bool copydb_update_progress_index_hook(void *ctx, SourceIndex *index);
+
 
 /*
  * copydb_prepare_schema_json_file prepares a JSON formatted file that contains
@@ -50,6 +63,8 @@ static bool copydb_seq_array_as_json(SourceSequenceArray *sequenceArray,
 bool
 copydb_prepare_schema_json_file(CopyDataSpec *copySpecs)
 {
+	DatabaseCatalog *sourceDB = &(copySpecs->catalogs.source);
+
 	JSON_Value *js = json_value_init_object();
 	JSON_Object *jsobj = json_value_get_object(js);
 
@@ -70,34 +85,21 @@ copydb_prepare_schema_json_file(CopyDataSpec *copySpecs)
 	}
 
 	/* array of tables */
-	SourceTableArray *tableArray = &(copySpecs->catalog.sourceTableArray);
-
-	log_trace("copydb_prepare_schema_json_file: %d tables", tableArray->count);
-
-	if (!copydb_table_array_as_json(tableArray, jsobj, "tables"))
+	if (!copydb_table_array_as_json(sourceDB, jsobj, "tables"))
 	{
 		/* errors have already been logged */
 		return false;
 	}
 
 	/* array of indexes */
-	SourceIndexArray *indexArray = &(copySpecs->catalog.sourceIndexArray);
-
-	log_trace("copydb_prepare_schema_json_file: %d indexes", indexArray->count);
-
-	if (!copydb_index_array_as_json(indexArray, jsobj, "indexes"))
+	if (!copydb_index_array_as_json(sourceDB, jsobj, "indexes"))
 	{
 		/* errors have already been logged */
 		return false;
 	}
 
 	/* array of sequences */
-	SourceSequenceArray *sequenceArray = &(copySpecs->catalog.sequenceArray);
-
-	log_trace("copydb_prepare_schema_json_file: %d sequences",
-			  sequenceArray->count);
-
-	if (!copydb_seq_array_as_json(sequenceArray, jsobj, "sequences"))
+	if (!copydb_seq_array_as_json(sourceDB, jsobj, "sequences"))
 	{
 		/* errors have already been logged */
 		return false;
@@ -187,218 +189,51 @@ copydb_filtering_as_json(CopyDataSpec *copySpecs,
 	log_trace("copydb_filtering_as_json: filtering");
 
 	SourceFilters *filters = &(copySpecs->filters);
+	JSON_Value *jsFilters = json_value_init_object();
 
-	JSON_Value *jsFilter = json_value_init_object();
-	JSON_Object *jsFilterObj = json_value_get_object(jsFilter);
-
-	json_object_set_string(jsFilterObj,
-						   "type",
-						   filterTypeToString(filters->type));
-
-	/* include-only-schema */
-	if (filters->includeOnlySchemaList.count > 0)
+	if (!filters_as_json(filters, jsFilters))
 	{
-		JSON_Value *jsSchema = json_value_init_array();
-		JSON_Array *jsSchemaArray = json_value_get_array(jsSchema);
-
-		for (int i = 0; i < filters->includeOnlySchemaList.count; i++)
-		{
-			char *nspname = filters->includeOnlySchemaList.array[i].nspname;
-
-			json_array_append_string(jsSchemaArray, nspname);
-		}
-
-		json_object_set_value(jsFilterObj, "include-only-schema", jsSchema);
-	}
-
-	/* exclude-schema */
-	if (filters->excludeSchemaList.count > 0)
-	{
-		JSON_Value *jsSchema = json_value_init_array();
-		JSON_Array *jsSchemaArray = json_value_get_array(jsSchema);
-
-		for (int i = 0; i < filters->excludeSchemaList.count; i++)
-		{
-			char *nspname = filters->excludeSchemaList.array[i].nspname;
-
-			json_array_append_string(jsSchemaArray, nspname);
-		}
-
-		json_object_set_value(jsFilterObj, "exclude-schema", jsSchema);
-	}
-
-	/* exclude table lists */
-	struct section
-	{
-		char name[PG_NAMEDATALEN];
-		SourceFilterTableList *list;
-	};
-
-	struct section sections[] = {
-		{ "exclude-table", &(filters->excludeTableList) },
-		{ "exclude-table-data", &(filters->excludeTableDataList) },
-		{ "exclude-index", &(filters->excludeIndexList) },
-		{ "include-only-table", &(filters->includeOnlyTableList) },
-		{ "", NULL },
-	};
-
-	for (int i = 0; sections[i].list != NULL; i++)
-	{
-		char *sectionName = sections[i].name;
-		SourceFilterTableList *list = sections[i].list;
-
-		if (list->count > 0)
-		{
-			JSON_Value *jsList = json_value_init_array();
-			JSON_Array *jsListArray = json_value_get_array(jsList);
-
-			for (int i = 0; i < list->count; i++)
-			{
-				SourceFilterTable *table = &(list->array[i]);
-
-				JSON_Value *jsTable = json_value_init_object();
-				JSON_Object *jsTableObj = json_value_get_object(jsTable);
-
-				json_object_set_string(jsTableObj, "schema", table->nspname);
-				json_object_set_string(jsTableObj, "name", table->relname);
-
-				json_array_append_value(jsListArray, jsTable);
-			}
-
-			json_object_set_value(jsFilterObj, sectionName, jsList);
-		}
+		/* errors have already been logged */
+		return false;
 	}
 
 	/* attach the JSON array to the main JSON object under the provided key */
-	json_object_set_value(jsobj, key, jsFilter);
+	json_object_set_value(jsobj, key, jsFilters);
 
 	return true;
 }
 
+
+typedef struct TableContext
+{
+	DatabaseCatalog *sourceDB;
+	JSON_Array *jsTableArray;
+} TableContext;
 
 /*
  * copydb_table_array_as_json prepares the given tableArray as a JSON array of
  * objects within the given JSON_Value.
  */
 static bool
-copydb_table_array_as_json(SourceTableArray *tableArray,
+copydb_table_array_as_json(DatabaseCatalog *sourceDB,
 						   JSON_Object *jsobj,
 						   const char *key)
 {
 	JSON_Value *jsTables = json_value_init_array();
 	JSON_Array *jsTableArray = json_value_get_array(jsTables);
 
-	for (int tableIndex = 0; tableIndex < tableArray->count; tableIndex++)
+	TableContext context = {
+		.sourceDB = sourceDB,
+		.jsTableArray = jsTableArray
+	};
+
+	if (!catalog_iter_s_table(sourceDB,
+							  &context,
+							  &copydb_table_array_as_json_hook))
 	{
-		SourceTable *table = &(tableArray->array[tableIndex]);
-
-		log_trace("copydb_prepare_schema_json_file: tables[%d]: %s.%s",
-				  tableIndex,
-				  table->nspname,
-				  table->relname);
-
-		JSON_Value *jsTable = json_value_init_object();
-		JSON_Object *jsTableObj = json_value_get_object(jsTable);
-
-		json_object_set_number(jsTableObj, "oid", (double) table->oid);
-		json_object_set_string(jsTableObj, "schema", table->nspname);
-		json_object_set_string(jsTableObj, "name", table->relname);
-		json_object_set_string(jsTableObj, "qname", table->qname);
-
-		json_object_set_number(jsTableObj, "reltuples", (double) table->reltuples);
-		json_object_set_number(jsTableObj, "bytes", (double) table->bytes);
-		json_object_set_string(jsTableObj, "bytes-pretty", table->bytesPretty);
-
-		json_object_set_boolean(jsTableObj, "exclude-data", table->excludeData);
-
-		json_object_set_string(jsTableObj,
-							   "restore-list-name",
-							   table->restoreListName);
-
-		json_object_set_string(jsTableObj, "part-key", table->partKey);
-
-		/* now add table attributes (columns) */
-		SourceTableAttributeArray *attributes = &(table->attributes);
-
-		JSON_Value *jsAttrs = json_value_init_array();
-		JSON_Array *jsAttrArray = json_value_get_array(jsAttrs);
-
-		for (int attrIndex = 0; attrIndex < attributes->count; attrIndex++)
-		{
-			SourceTableAttribute *attr = &(attributes->array[attrIndex]);
-
-			JSON_Value *jsAttr = json_value_init_object();
-			JSON_Object *jsAttrObj = json_value_get_object(jsAttr);
-
-			json_object_set_number(jsAttrObj, "attnum", attr->attnum);
-			json_object_set_number(jsAttrObj, "atttypid", attr->atttypid);
-			json_object_set_string(jsAttrObj, "attname", attr->attname);
-			json_object_set_boolean(jsAttrObj, "attisprimary", attr->attisprimary);
-			json_object_set_boolean(jsAttrObj, "attisgenerated", attr->attisgenerated);
-
-			json_array_append_value(jsAttrArray, jsAttr);
-		}
-
-		json_object_set_value(jsTableObj, "cols", jsAttrs);
-
-		/* if we have COPY partitioning, create an array of parts */
-		JSON_Value *jsParts = json_value_init_array();
-		JSON_Array *jsPartArray = json_value_get_array(jsParts);
-
-		if (table->partsArray.count > 1)
-		{
-			for (int i = 0; i < table->partsArray.count; i++)
-			{
-				SourceTableParts *part = &(table->partsArray.array[i]);
-
-				JSON_Value *jsPart = json_value_init_object();
-				JSON_Object *jsPartObj = json_value_get_object(jsPart);
-
-				json_object_set_number(jsPartObj, "number",
-									   (double) part->partNumber);
-
-				json_object_set_number(jsPartObj, "total",
-									   (double) part->partCount);
-
-				json_object_set_number(jsPartObj, "min",
-									   (double) part->min);
-
-				json_object_set_number(jsPartObj, "max",
-									   (double) part->max);
-
-				json_object_set_number(jsPartObj, "count",
-									   (double) part->count);
-
-				json_array_append_value(jsPartArray, jsPart);
-			}
-
-			json_object_set_value(jsTableObj, "parts", jsParts);
-		}
-
-		/* append source and target checksums if we have them */
-		if (table->sourceChecksum.rowcount > 0)
-		{
-			json_object_dotset_number(jsTableObj,
-									  "check.source.rowcount",
-									  table->sourceChecksum.rowcount);
-
-			json_object_dotset_string(jsTableObj,
-									  "check.source.checksum",
-									  table->sourceChecksum.checksum);
-		}
-
-		if (table->targetChecksum.rowcount > 0)
-		{
-			json_object_dotset_number(jsTableObj,
-									  "check.target.rowcount",
-									  table->targetChecksum.rowcount);
-
-			json_object_dotset_string(jsTableObj,
-									  "check.target.checksum",
-									  table->targetChecksum.checksum);
-		}
-
-		json_array_append_value(jsTableArray, jsTable);
+		log_error("Failed to prepare a JSON array for our catalog of tables, "
+				  "see above for details");
+		return false;
 	}
 
 	/* attach the JSON array to the main JSON object under the provided key */
@@ -409,77 +244,154 @@ copydb_table_array_as_json(SourceTableArray *tableArray,
 
 
 /*
+ * copydb_table_array_as_json_hook is an iterator callback function.
+ */
+static bool
+copydb_table_array_as_json_hook(void *ctx, SourceTable *table)
+{
+	TableContext *context = (TableContext *) ctx;
+	DatabaseCatalog *sourceDB = context->sourceDB;
+	JSON_Array *jsTableArray = context->jsTableArray;
+
+	JSON_Value *jsTable = json_value_init_object();
+	JSON_Object *jsTableObj = json_value_get_object(jsTable);
+
+	json_object_set_number(jsTableObj, "oid", (double) table->oid);
+	json_object_set_string(jsTableObj, "schema", table->nspname);
+	json_object_set_string(jsTableObj, "name", table->relname);
+	json_object_set_string(jsTableObj, "qname", table->qname);
+
+	json_object_set_number(jsTableObj, "reltuples", (double) table->reltuples);
+	json_object_set_number(jsTableObj, "bytes", (double) table->bytes);
+	json_object_set_string(jsTableObj, "bytes-pretty", table->bytesPretty);
+
+	json_object_set_boolean(jsTableObj, "exclude-data", table->excludeData);
+
+	json_object_set_string(jsTableObj,
+						   "restore-list-name",
+						   table->restoreListName);
+
+	json_object_set_string(jsTableObj, "part-key", table->partKey);
+
+	/* now add table attributes (columns) */
+	if (!catalog_s_table_fetch_attrs(sourceDB, table))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	SourceTableAttributeArray *attributes = &(table->attributes);
+
+	JSON_Value *jsAttrs = json_value_init_array();
+	JSON_Array *jsAttrArray = json_value_get_array(jsAttrs);
+
+	for (int attrIndex = 0; attrIndex < attributes->count; attrIndex++)
+	{
+		SourceTableAttribute *attr = &(attributes->array[attrIndex]);
+
+		JSON_Value *jsAttr = json_value_init_object();
+		JSON_Object *jsAttrObj = json_value_get_object(jsAttr);
+
+		json_object_set_number(jsAttrObj, "attnum", attr->attnum);
+		json_object_set_number(jsAttrObj, "atttypid", attr->atttypid);
+		json_object_set_string(jsAttrObj, "attname", attr->attname);
+		json_object_set_boolean(jsAttrObj, "attisprimary", attr->attisprimary);
+		json_object_set_boolean(jsAttrObj, "attisgenerated", attr->attisgenerated);
+
+		json_array_append_value(jsAttrArray, jsAttr);
+	}
+
+	json_object_set_value(jsTableObj, "cols", jsAttrs);
+
+	/* if we have COPY partitioning, create an array of parts */
+	JSON_Value *jsParts = json_value_init_array();
+	JSON_Array *jsPartArray = json_value_get_array(jsParts);
+
+	if (table->partition.partCount > 1)
+	{
+		if (!catalog_iter_s_table_parts(sourceDB,
+										table->oid,
+										jsPartArray,
+										&copydb_table_parts_array_as_json_hook))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+
+		json_object_set_value(jsTableObj, "parts", jsParts);
+	}
+
+	/* append source and target checksums if we have them */
+	if (table->sourceChecksum.rowcount > 0)
+	{
+		json_object_dotset_number(jsTableObj,
+								  "check.source.rowcount",
+								  table->sourceChecksum.rowcount);
+
+		json_object_dotset_string(jsTableObj,
+								  "check.source.checksum",
+								  table->sourceChecksum.checksum);
+	}
+
+	if (table->targetChecksum.rowcount > 0)
+	{
+		json_object_dotset_number(jsTableObj,
+								  "check.target.rowcount",
+								  table->targetChecksum.rowcount);
+
+		json_object_dotset_string(jsTableObj,
+								  "check.target.checksum",
+								  table->targetChecksum.checksum);
+	}
+
+	json_array_append_value(jsTableArray, jsTable);
+
+	return true;
+}
+
+
+/*
+ * copydb_table_parts_array_as_json_hook is an iterator callback function.
+ */
+static bool
+copydb_table_parts_array_as_json_hook(void *ctx, SourceTableParts *part)
+{
+	JSON_Array *jsPartArray = (JSON_Array *) ctx;
+
+	JSON_Value *jsPart = json_value_init_object();
+	JSON_Object *jsPartObj = json_value_get_object(jsPart);
+
+	json_object_set_number(jsPartObj, "number", (double) part->partNumber);
+	json_object_set_number(jsPartObj, "total", (double) part->partCount);
+	json_object_set_number(jsPartObj, "min", (double) part->min);
+	json_object_set_number(jsPartObj, "max", (double) part->max);
+	json_object_set_number(jsPartObj, "count", (double) part->count);
+
+	json_array_append_value(jsPartArray, jsPart);
+
+	return true;
+}
+
+
+/*
  * copydb_index_array_as_json prepares the given indexArray as a JSON array of
  * objects within the given JSON_Value.
  */
 static bool
-copydb_index_array_as_json(SourceIndexArray *indexArray,
+copydb_index_array_as_json(DatabaseCatalog *sourceDB,
 						   JSON_Object *jsobj,
 						   const char *key)
 {
 	JSON_Value *jsIndexes = json_value_init_array();
 	JSON_Array *jsIndexArray = json_value_get_array(jsIndexes);
 
-	for (int i = 0; i < indexArray->count; i++)
+	if (!catalog_iter_s_index(sourceDB,
+							  jsIndexArray,
+							  &copydb_index_array_as_json_hook))
 	{
-		SourceIndex *index = &(indexArray->array[i]);
-
-		JSON_Value *jsIndex = json_value_init_object();
-		JSON_Object *jsIndexObj = json_value_get_object(jsIndex);
-
-		json_object_set_number(jsIndexObj, "oid", (double) index->indexOid);
-		json_object_set_string(jsIndexObj, "schema", index->indexNamespace);
-		json_object_set_string(jsIndexObj, "name", index->indexRelname);
-		json_object_set_string(jsIndexObj, "qname", index->indexQname);
-
-		json_object_set_boolean(jsIndexObj, "isPrimary", index->isPrimary);
-		json_object_set_boolean(jsIndexObj, "isUnique", index->isUnique);
-
-		json_object_set_string(jsIndexObj, "columns", index->indexColumns);
-		json_object_set_string(jsIndexObj, "sql", index->indexDef);
-
-		json_object_set_string(jsIndexObj,
-							   "restore-list-name",
-							   index->indexRestoreListName);
-
-		/* add a table object */
-		JSON_Value *jsTable = json_value_init_object();
-		JSON_Object *jsTableObj = json_value_get_object(jsTable);
-
-		json_object_set_number(jsTableObj, "oid", (double) index->tableOid);
-		json_object_set_string(jsTableObj, "schema", index->tableNamespace);
-		json_object_set_string(jsTableObj, "name", index->tableRelname);
-		json_object_set_string(jsTableObj, "qname", index->tableQname);
-
-		json_object_set_value(jsIndexObj, "table", jsTable);
-
-		/* add a constraint object */
-		if (index->constraintOid != 0)
-		{
-			JSON_Value *jsConstraint = json_value_init_object();
-			JSON_Object *jsConstraintObj = json_value_get_object(jsConstraint);
-
-			json_object_set_number(jsConstraintObj,
-								   "oid",
-								   (double) index->constraintOid);
-
-			json_object_set_string(jsConstraintObj,
-								   "name",
-								   index->constraintName);
-
-			json_object_set_string(jsConstraintObj,
-								   "sql",
-								   index->constraintDef);
-
-			json_object_set_string(jsConstraintObj,
-								   "restore-list-name",
-								   index->constraintRestoreListName);
-
-			json_object_set_value(jsIndexObj, "constraint", jsConstraint);
-		}
-
-		/* append the JSON index to the index table */
-		json_array_append_value(jsIndexArray, jsIndex);
+		log_error("Failed to prepare a JSON array for our catalog of indexes, "
+				  "see above for details");
+		return false;
 	}
 
 	/* attach the JSON array to the main JSON object under the provided key */
@@ -490,37 +402,93 @@ copydb_index_array_as_json(SourceIndexArray *indexArray,
 
 
 /*
+ * copydb_index_array_as_json_hook is an iterator callback function.
+ */
+static bool
+copydb_index_array_as_json_hook(void *ctx, SourceIndex *index)
+{
+	JSON_Array *jsIndexArray = (JSON_Array *) ctx;
+
+	JSON_Value *jsIndex = json_value_init_object();
+	JSON_Object *jsIndexObj = json_value_get_object(jsIndex);
+
+	json_object_set_number(jsIndexObj, "oid", (double) index->indexOid);
+	json_object_set_string(jsIndexObj, "schema", index->indexNamespace);
+	json_object_set_string(jsIndexObj, "name", index->indexRelname);
+	json_object_set_string(jsIndexObj, "qname", index->indexQname);
+
+	json_object_set_boolean(jsIndexObj, "isPrimary", index->isPrimary);
+	json_object_set_boolean(jsIndexObj, "isUnique", index->isUnique);
+
+	json_object_set_string(jsIndexObj, "columns", index->indexColumns);
+	json_object_set_string(jsIndexObj, "sql", index->indexDef);
+
+	json_object_set_string(jsIndexObj,
+						   "restore-list-name",
+						   index->indexRestoreListName);
+
+	/* add a table object */
+	JSON_Value *jsTable = json_value_init_object();
+	JSON_Object *jsTableObj = json_value_get_object(jsTable);
+
+	json_object_set_number(jsTableObj, "oid", (double) index->tableOid);
+	json_object_set_string(jsTableObj, "schema", index->tableNamespace);
+	json_object_set_string(jsTableObj, "name", index->tableRelname);
+	json_object_set_string(jsTableObj, "qname", index->tableQname);
+
+	json_object_set_value(jsIndexObj, "table", jsTable);
+
+	/* add a constraint object */
+	if (index->constraintOid != 0)
+	{
+		JSON_Value *jsConstraint = json_value_init_object();
+		JSON_Object *jsConstraintObj = json_value_get_object(jsConstraint);
+
+		json_object_set_number(jsConstraintObj,
+							   "oid",
+							   (double) index->constraintOid);
+
+		json_object_set_string(jsConstraintObj,
+							   "name",
+							   index->constraintName);
+
+		json_object_set_string(jsConstraintObj,
+							   "sql",
+							   index->constraintDef);
+
+		json_object_set_string(jsConstraintObj,
+							   "restore-list-name",
+							   index->constraintRestoreListName);
+
+		json_object_set_value(jsIndexObj, "constraint", jsConstraint);
+	}
+
+	/* append the JSON index to the index table */
+	json_array_append_value(jsIndexArray, jsIndex);
+
+	return true;
+}
+
+
+/*
  * copydb_seq_array_as_json prepares the given sequencesArray as a JSON array
  * of objects within the given JSON_Value.
  */
 static bool
-copydb_seq_array_as_json(SourceSequenceArray *sequenceArray,
+copydb_seq_array_as_json(DatabaseCatalog *sourceDB,
 						 JSON_Object *jsobj,
 						 const char *key)
 {
 	JSON_Value *jsSeqs = json_value_init_array();
 	JSON_Array *jsSeqArray = json_value_get_array(jsSeqs);
 
-	for (int seqIndex = 0; seqIndex < sequenceArray->count; seqIndex++)
+	if (!catalog_iter_s_seq(sourceDB,
+							jsSeqArray,
+							&copydb_seq_array_as_json_hook))
 	{
-		SourceSequence *seq = &(sequenceArray->array[seqIndex]);
-
-		JSON_Value *jsSeq = json_value_init_object();
-		JSON_Object *jsSeqObj = json_value_get_object(jsSeq);
-
-		json_object_set_number(jsSeqObj, "oid", (double) seq->oid);
-		json_object_set_string(jsSeqObj, "schema", seq->nspname);
-		json_object_set_string(jsSeqObj, "name", seq->relname);
-		json_object_set_string(jsSeqObj, "qname", seq->qname);
-
-		json_object_set_number(jsSeqObj, "last-value", (double) seq->lastValue);
-		json_object_set_boolean(jsSeqObj, "is-called", (double) seq->isCalled);
-
-		json_object_set_string(jsSeqObj,
-							   "restore-list-name",
-							   seq->restoreListName);
-
-		json_array_append_value(jsSeqArray, jsSeq);
+		log_error("Failed to prepare a JSON array for our catalog of sequences, "
+				  "see above for details");
+		return false;
 	}
 
 	/* attach the JSON array to the main JSON object under the provided key */
@@ -531,299 +499,39 @@ copydb_seq_array_as_json(SourceSequenceArray *sequenceArray,
 
 
 /*
- * copydb_parse_schema_json_file parses the JSON file prepared with
- * copydb_prepare_schema_json_file and fills-in the given CopyDataSpec
- * structure with the information found in the JSON file.
+ * copydb_seq_array_as_json_hook is an iterator callback function.
  */
-bool
-copydb_parse_schema_json_file(CopyDataSpec *copySpecs)
+static bool
+copydb_seq_array_as_json_hook(void *ctx, SourceSequence *seq)
 {
-	log_notice("Reading catalogs from file \"%s\"",
-			   copySpecs->cfPaths.schemafile);
+	JSON_Array *jsSeqArray = (JSON_Array *) ctx;
 
-	if (!file_exists(copySpecs->cfPaths.schemafile))
-	{
-		log_error("Failed to parse JSON file \"%s\": file does not exists",
-				  copySpecs->cfPaths.schemafile);
-		return false;
-	}
+	JSON_Value *jsSeq = json_value_init_object();
+	JSON_Object *jsSeqObj = json_value_get_object(jsSeq);
 
-	JSON_Value *json = json_parse_file(copySpecs->cfPaths.schemafile);
+	json_object_set_number(jsSeqObj, "oid", (double) seq->oid);
+	json_object_set_string(jsSeqObj, "schema", seq->nspname);
+	json_object_set_string(jsSeqObj, "name", seq->relname);
+	json_object_set_string(jsSeqObj, "qname", seq->qname);
 
-	if (json == NULL)
-	{
-		log_error("Failed to parse JSON file \"%s\"",
-				  copySpecs->cfPaths.schemafile);
-		return false;
-	}
+	json_object_set_number(jsSeqObj, "last-value", (double) seq->lastValue);
+	json_object_set_boolean(jsSeqObj, "is-called", (double) seq->isCalled);
 
-	JSON_Object *jsObj = json_value_get_object(json);
+	json_object_set_string(jsSeqObj,
+						   "restore-list-name",
+						   seq->restoreListName);
 
-	/* setup section */
-	copySpecs->tableJobs = json_object_dotget_number(jsObj, "setup.table-jobs");
-	copySpecs->indexJobs = json_object_dotget_number(jsObj, "setup.index-jobs");
-
-	/* table section */
-	JSON_Array *jsTableArray = json_object_get_array(jsObj, "tables");
-	int tableCount = json_array_get_count(jsTableArray);
-
-	log_debug("copydb_parse_schema_json_file: parsing %d tables", tableCount);
-
-	copySpecs->catalog.sourceTableArray.count = tableCount;
-	copySpecs->catalog.sourceTableArray.array =
-		(SourceTable *) calloc(tableCount, sizeof(SourceTable));
-
-	if (copySpecs->catalog.sourceTableArray.array == NULL)
-	{
-		log_fatal(ALLOCATION_FAILED_ERROR);
-		return false;
-	}
-
-	/* prepare the SourceTable hash tables */
-	SourceTable *sourceTableHashByOid = NULL;
-	SourceTable *sourceTableHashByQName = NULL;
-
-	for (int tableIndex = 0; tableIndex < tableCount; tableIndex++)
-	{
-		SourceTable *table = &(copySpecs->catalog.sourceTableArray.array[tableIndex]);
-		JSON_Object *jsTable = json_array_get_object(jsTableArray, tableIndex);
-
-		table->oid = json_object_get_number(jsTable, "oid");
-
-		char *schema = (char *) json_object_get_string(jsTable, "schema");
-		char *name = (char *) json_object_get_string(jsTable, "name");
-		char *qname = (char *) json_object_get_string(jsTable, "qname");
-
-		char *bytesPretty =
-			(char *) json_object_get_string(jsTable, "bytes-pretty");
-
-		char *restoreListName =
-			(char *) json_object_get_string(jsTable, "restore-list-name");
-
-		char *partKey = (char *) json_object_get_string(jsTable, "part-key");
-
-		strlcpy(table->nspname, schema, sizeof(table->nspname));
-		strlcpy(table->relname, name, sizeof(table->relname));
-		strlcpy(table->qname, qname, sizeof(table->qname));
-
-		/* add the current table to the Hash-by-OID */
-		HASH_ADD(hh, sourceTableHashByOid, oid, sizeof(uint32_t), table);
-
-		/* also add the current table to the Hash-by-QName */
-		size_t len = strlen(table->qname);
-		HASH_ADD(hhQName, sourceTableHashByQName, qname, len, table);
-
-		table->reltuples = json_object_get_number(jsTable, "reltuples");
-		table->bytes = json_object_get_number(jsTable, "bytes");
-		table->excludeData = json_object_get_boolean(jsTable, "exclude-data");
-
-		strlcpy(table->bytesPretty, bytesPretty, sizeof(table->bytesPretty));
-
-		strlcpy(table->restoreListName,
-				restoreListName,
-				sizeof(table->restoreListName));
-
-		strlcpy(table->partKey, partKey, sizeof(table->partKey));
-
-		if (json_object_has_value(jsTable, "cols"))
-		{
-			JSON_Array *jsAttrsArray = json_object_get_array(jsTable, "cols");
-			int attrsCount = json_array_get_count(jsAttrsArray);
-
-			table->attributes.count = attrsCount;
-			table->attributes.array =
-				(SourceTableAttribute *)
-				calloc(attrsCount, sizeof(SourceTableAttribute));
-
-			if (table->attributes.array == NULL)
-			{
-				log_fatal(ALLOCATION_FAILED_ERROR);
-				return false;
-			}
-
-			for (int i = 0; i < attrsCount; i++)
-			{
-				SourceTableAttribute *attr = &(table->attributes.array[i]);
-				JSON_Object *jsAttr = json_array_get_object(jsAttrsArray, i);
-
-				attr->attnum = json_object_get_number(jsAttr, "attnum");
-				attr->atttypid = json_object_get_number(jsAttr, "atttypid");
-
-				strlcpy(attr->attname,
-						json_object_get_string(jsAttr, "attname"),
-						sizeof(attr->attname));
-
-				attr->attisprimary =
-					json_object_get_boolean(jsAttr, "attisprimary");
-
-				attr->attisgenerated =
-					json_object_get_boolean(jsAttr, "attisgenerated");
-			}
-		}
-
-		if (json_object_has_value(jsTable, "parts"))
-		{
-			JSON_Array *jsPartsArray = json_object_get_array(jsTable, "parts");
-			int partsCount = json_array_get_count(jsPartsArray);
-
-			table->partsArray.count = partsCount;
-			table->partsArray.array =
-				(SourceTableParts *) calloc(partsCount, sizeof(SourceTableParts));
-
-			if (table->partsArray.array == NULL)
-			{
-				log_fatal(ALLOCATION_FAILED_ERROR);
-				return false;
-			}
-
-			for (int i = 0; i < partsCount; i++)
-			{
-				SourceTableParts *part = &(table->partsArray.array[i]);
-				JSON_Object *jsPart = json_array_get_object(jsPartsArray, i);
-
-				part->partNumber = json_object_get_number(jsPart, "number");
-				part->partCount = json_object_get_number(jsPart, "total");
-				part->min = json_object_get_number(jsPart, "min");
-				part->max = json_object_get_number(jsPart, "max");
-				part->count = json_object_get_number(jsPart, "count");
-			}
-		}
-		else
-		{
-			table->partsArray.count = 0;
-			table->partsArray.array = NULL;
-		}
-	}
-
-	/* now attach the final hash table head to the specs */
-	copySpecs->catalog.sourceTableHashByOid = sourceTableHashByOid;
-	copySpecs->catalog.sourceTableHashByQName = sourceTableHashByQName;
-
-	/* index section */
-	JSON_Array *jsIndexArray = json_object_get_array(jsObj, "indexes");
-	int indexCount = json_array_get_count(jsIndexArray);
-
-	log_debug("copydb_parse_schema_json_file: parsing %d indexes", indexCount);
-
-	copySpecs->catalog.sourceIndexArray.count = indexCount;
-	copySpecs->catalog.sourceIndexArray.array =
-		(SourceIndex *) calloc(indexCount, sizeof(SourceIndex));
-
-	if (copySpecs->catalog.sourceIndexArray.array == NULL)
-	{
-		log_fatal(ALLOCATION_FAILED_ERROR);
-		return false;
-	}
-
-	/* also build the index hash-table */
-	SourceIndex *sourceIndexHashByOid = copySpecs->catalog.sourceIndexHashByOid;
-
-	for (int i = 0; i < indexCount; i++)
-	{
-		SourceIndex *index = &(copySpecs->catalog.sourceIndexArray.array[i]);
-		JSON_Object *jsIndex = json_array_get_object(jsIndexArray, i);
-
-		index->indexOid = json_object_get_number(jsIndex, "oid");
-
-		/* add the current index to the index Hash-by-OID */
-		HASH_ADD(hh, sourceIndexHashByOid, indexOid, sizeof(uint32_t), index);
-
-		char *schema = (char *) json_object_get_string(jsIndex, "schema");
-		char *name = (char *) json_object_get_string(jsIndex, "name");
-		char *qname = (char *) json_object_get_string(jsIndex, "qname");
-		char *cols = (char *) json_object_get_string(jsIndex, "columns");
-		char *def = (char *) json_object_get_string(jsIndex, "sql");
-		char *listName =
-			(char *) json_object_get_string(jsIndex, "restore-list-name");
-
-		strlcpy(index->indexNamespace, schema, sizeof(index->indexNamespace));
-		strlcpy(index->indexRelname, name, sizeof(index->indexRelname));
-		strlcpy(index->indexQname, qname, sizeof(index->indexQname));
-
-		int lenCols = strlen(cols) + 1;
-
-		index->indexColumns = (char *) calloc(lenCols, sizeof(char));
-
-		if (index->indexColumns == NULL)
-		{
-			log_fatal(ALLOCATION_FAILED_ERROR);
-			return false;
-		}
-
-		strlcpy(index->indexColumns, cols, lenCols);
-
-		int lenDef = strlen(def) + 1;
-
-		index->indexDef = (char *) calloc(lenDef, sizeof(char));
-
-		if (index->indexDef == NULL)
-		{
-			log_fatal(ALLOCATION_FAILED_ERROR);
-			return false;
-		}
-
-		strlcpy(index->indexDef, def, lenDef);
-
-		strlcpy(index->indexRestoreListName,
-				listName,
-				sizeof(index->indexRestoreListName));
-
-		index->isPrimary = json_object_get_boolean(jsIndex, "isPrimary");
-		index->isUnique = json_object_get_boolean(jsIndex, "isUnique");
-
-		index->tableOid = json_object_dotget_number(jsIndex, "table.oid");
-
-		schema = (char *) json_object_dotget_string(jsIndex, "table.schema");
-		name = (char *) json_object_dotget_string(jsIndex, "table.name");
-		qname = (char *) json_object_dotget_string(jsIndex, "table.qname");
-
-		strlcpy(index->tableNamespace, schema, sizeof(index->tableNamespace));
-		strlcpy(index->tableRelname, name, sizeof(index->tableRelname));
-		strlcpy(index->tableQname, name, sizeof(index->tableQname));
-
-		if (json_object_has_value(jsIndex, "constraint"))
-		{
-			index->constraintOid =
-				json_object_dotget_number(jsIndex, "constraint.oid");
-
-			name = (char *) json_object_dotget_string(jsIndex, "constraint.name");
-			def = (char *) json_object_dotget_string(jsIndex, "constraint.sql");
-
-			listName =
-				(char *) json_object_get_string(jsIndex,
-												"constraint.restore-list-name");
-
-			strlcpy(index->constraintName, name, sizeof(index->constraintName));
-
-			int len = strlen(def) + 1;
-			index->constraintDef = (char *) calloc(len, sizeof(char));
-
-			if (index->constraintDef == NULL)
-			{
-				log_fatal(ALLOCATION_FAILED_ERROR);
-				return false;
-			}
-
-			strlcpy(index->constraintDef, def, len);
-
-			if (listName != NULL)
-			{
-				strlcpy(index->constraintRestoreListName,
-						listName,
-						sizeof(index->constraintRestoreListName));
-			}
-		}
-		else
-		{
-			index->constraintOid = 0;
-		}
-	}
-
-	/* now attach the final hash table head to the specs */
-	copySpecs->catalog.sourceIndexHashByOid = sourceIndexHashByOid;
+	json_array_append_value(jsSeqArray, jsSeq);
 
 	return true;
 }
+
+
+typedef struct TableProgressContext
+{
+	CopyDataSpec *copySpecs;
+	CopyProgress *progress;
+} TableProgressContext;
 
 
 /*
@@ -833,11 +541,18 @@ copydb_parse_schema_json_file(CopyDataSpec *copySpecs)
 bool
 copydb_update_progress(CopyDataSpec *copySpecs, CopyProgress *progress)
 {
-	SourceTableArray *tableArray = &(copySpecs->catalog.sourceTableArray);
-	SourceIndexArray *indexArray = &(copySpecs->catalog.sourceIndexArray);
+	DatabaseCatalog *sourceDB = &(copySpecs->catalogs.source);
 
-	progress->tableCount = tableArray->count;
-	progress->indexCount = indexArray->count;
+	CatalogCounts count = { 0 };
+
+	if (!catalog_count_objects(sourceDB, &count))
+	{
+		log_error("Failed to count indexes and constraints in our catalogs");
+		return false;
+	}
+
+	progress->tableCount = count.tables;
+	progress->indexCount = count.indexes;
 
 	log_debug("copydb_update_progress for %d tables, %d indexes",
 			  progress->tableCount,
@@ -868,105 +583,17 @@ copydb_update_progress(CopyDataSpec *copySpecs, CopyProgress *progress)
 		return false;
 	}
 
-	SourceTableArray *tableInProgress = &(progress->tableInProgress);
-	CopyTableSummaryArray *summaryArray = &(progress->tableSummaryArray);
+	TableProgressContext context = {
+		.copySpecs = copySpecs,
+		.progress = progress
+	};
 
-	for (int i = 0; i < progress->tableCount; i++)
+	if (!catalog_iter_s_table_in_copy(sourceDB,
+									  &context,
+									  &copydb_update_progress_table_hook))
 	{
-		SourceTable *source = &(tableArray->array[i]);
-
-		int partCount = source->partsArray.count;
-
-		bool done = false;
-
-		if (partCount <= 1)
-		{
-			CopyTableDataSpec tableSpecs = { 0 };
-
-			if (!copydb_init_table_specs(&tableSpecs, copySpecs, source, 0))
-			{
-				/* errors have already been logged */
-				return false;
-			}
-
-			if (file_exists(tableSpecs.tablePaths.doneFile))
-			{
-				done = true;
-			}
-			else if (file_exists(tableSpecs.tablePaths.lockFile))
-			{
-				CopyTableSummary summary = { .table = source };
-
-				if (!read_table_summary(&summary,
-										tableSpecs.tablePaths.lockFile))
-				{
-					/* errors have already been logged */
-					return false;
-				}
-
-				/*
-				 * Copy the SourceTable struct in-place to the tableInProgress
-				 * array.
-				 */
-				tableInProgress->array[progress->tableInProgress.count++] =
-					*source;
-
-				summaryArray->array[progress->tableSummaryArray.count++] =
-					summary;
-			}
-		}
-		else
-		{
-			bool allPartsAreDone = true;
-
-			for (int partIndex = 0; partIndex < partCount; partIndex++)
-			{
-				CopyTableDataSpec tableSpecs = { 0 };
-
-				if (!copydb_init_table_specs(&tableSpecs,
-											 copySpecs,
-											 source,
-											 partIndex))
-				{
-					/* errors have already been logged */
-					return false;
-				}
-
-				if (!file_exists(tableSpecs.tablePaths.doneFile))
-				{
-					allPartsAreDone = false;
-				}
-
-				if (file_exists(tableSpecs.tablePaths.lockFile))
-				{
-					CopyTableSummary summary = { .table = source };
-
-					if (!read_table_summary(&summary,
-											tableSpecs.tablePaths.lockFile))
-					{
-						/* errors have already been logged */
-						return false;
-					}
-
-					/*
-					 * Copy the SourceTable struct in-place to the
-					 * tableInProgress array.
-					 */
-					tableInProgress->array[progress->tableInProgress.count++] =
-						*source;
-
-					summaryArray->array[progress->tableSummaryArray.count++] =
-						summary;
-				}
-			}
-
-			done = allPartsAreDone;
-		}
-
-		if (done)
-		{
-			++progress->tableDoneCount;
-		}
+		/* errors have already been logged */
+		return false;
 	}
 
 	/* count index in progress, index done */
@@ -994,49 +621,174 @@ copydb_update_progress(CopyDataSpec *copySpecs, CopyProgress *progress)
 		return false;
 	}
 
-	SourceIndexArray *indexInProgress = &(progress->indexInProgress);
-	CopyIndexSummaryArray *summaryArrayIdx = &(progress->indexSummaryArray);
-
-	IndexFilePathsArray indexPathsArray = { 0, NULL };
-
-	/* build the index file paths we need for the upcoming operations */
-	if (!copydb_init_indexes_paths(&(copySpecs->cfPaths),
-								   indexArray,
-								   &indexPathsArray))
+	if (!catalog_iter_s_index_in_progress(sourceDB,
+										  &context,
+										  &copydb_update_progress_index_hook))
 	{
 		/* errors have already been logged */
 		return false;
 	}
 
-	for (int i = 0; i < progress->indexCount; i++)
+	return true;
+}
+
+
+/*
+ * copydb_update_progress_table_hook is an iterator callback function.
+ */
+static bool
+copydb_update_progress_table_hook(void *ctx, SourceTable *table)
+{
+	TableProgressContext *context = (TableProgressContext *) ctx;
+
+	CopyDataSpec *copySpecs = context->copySpecs;
+	CopyProgress *progress = context->progress;
+
+	SourceTableArray *tableInProgress = &(progress->tableInProgress);
+	CopyTableSummaryArray *summaryArray = &(progress->tableSummaryArray);
+
+	int partCount = table->partition.partCount;
+
+	bool done = false;
+
+	if (partCount <= 1)
 	{
-		SourceIndex *index = &(indexArray->array[i]);
-		IndexFilePaths *indexPaths = &(indexPathsArray.array[i]);
+		CopyTableDataSpec tableSpecs = { 0 };
 
-		if (file_exists(indexPaths->doneFile))
+		if (!copydb_init_table_specs(&tableSpecs, copySpecs, table, 0))
 		{
-			++progress->indexDoneCount;
+			/* errors have already been logged */
+			return false;
 		}
-		else if (file_exists(indexPaths->lockFile))
-		{
-			CopyIndexSummary summary = { .index = index };
 
-			if (!read_index_summary(&summary, indexPaths->lockFile))
+		if (file_exists(tableSpecs.tablePaths.doneFile))
+		{
+			done = true;
+		}
+		else if (file_exists(tableSpecs.tablePaths.lockFile))
+		{
+			CopyTableSummary summary = { .table = table };
+
+			if (!read_table_summary(&summary,
+									tableSpecs.tablePaths.lockFile))
 			{
 				/* errors have already been logged */
 				return false;
 			}
 
 			/*
-			 * Copy the SourceIndex struct in-place to the indexInProgress
+			 * Copy the SourceTable struct in-place to the tableInProgress
 			 * array.
 			 */
-			indexInProgress->array[progress->indexInProgress.count++] =
-				*index;
+			tableInProgress->array[progress->tableInProgress.count++] =
+				*table;
 
-			summaryArrayIdx->array[progress->indexSummaryArray.count++] =
+			summaryArray->array[progress->tableSummaryArray.count++] =
 				summary;
 		}
+	}
+	else
+	{
+		bool allPartsAreDone = true;
+
+		for (int partIndex = 0; partIndex < partCount; partIndex++)
+		{
+			CopyTableDataSpec tableSpecs = { 0 };
+
+			if (!copydb_init_table_specs(&tableSpecs,
+										 copySpecs,
+										 table,
+										 partIndex))
+			{
+				/* errors have already been logged */
+				return false;
+			}
+
+			if (!file_exists(tableSpecs.tablePaths.doneFile))
+			{
+				allPartsAreDone = false;
+			}
+
+			if (file_exists(tableSpecs.tablePaths.lockFile))
+			{
+				CopyTableSummary summary = { .table = table };
+
+				if (!read_table_summary(&summary,
+										tableSpecs.tablePaths.lockFile))
+				{
+					/* errors have already been logged */
+					return false;
+				}
+
+				/*
+				 * Copy the SourceTable struct in-place to the
+				 * tableInProgress array.
+				 */
+				tableInProgress->array[progress->tableInProgress.count++] =
+					*table;
+
+				summaryArray->array[progress->tableSummaryArray.count++] =
+					summary;
+			}
+		}
+
+		done = allPartsAreDone;
+	}
+
+	if (done)
+	{
+		++progress->tableDoneCount;
+	}
+
+	return true;
+}
+
+
+/*
+ * copydb_update_progress_index_hook is an iterator callback function.
+ */
+static bool
+copydb_update_progress_index_hook(void *ctx, SourceIndex *index)
+{
+	TableProgressContext *context = (TableProgressContext *) ctx;
+
+	CopyDataSpec *copySpecs = context->copySpecs;
+	CopyProgress *progress = context->progress;
+
+	SourceIndexArray *indexInProgress = &(progress->indexInProgress);
+	CopyIndexSummaryArray *summaryArrayIdx = &(progress->indexSummaryArray);
+
+	IndexFilePaths indexPaths = { 0 };
+
+	if (!copydb_init_index_paths(&(copySpecs->cfPaths), index, &indexPaths))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	if (file_exists(indexPaths.doneFile))
+	{
+		++progress->indexDoneCount;
+	}
+	else if (file_exists(indexPaths.lockFile))
+	{
+		CopyIndexSummary summary = { .index = index };
+
+		if (!read_index_summary(&summary, indexPaths.lockFile))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+
+		/*
+		 * Copy the SourceIndex struct in-place to the indexInProgress
+		 * array.
+		 */
+		indexInProgress->array[progress->indexInProgress.count++] =
+			*index;
+
+		summaryArrayIdx->array[progress->indexSummaryArray.count++] =
+			summary;
 	}
 
 	return true;
@@ -1052,6 +804,8 @@ copydb_progress_as_json(CopyDataSpec *copySpecs,
 						CopyProgress *progress,
 						JSON_Value *js)
 {
+	DatabaseCatalog *sourceDB = &(copySpecs->catalogs.source);
+
 	JSON_Object *jsobj = json_value_get_object(js);
 
 	json_object_set_number(jsobj, "table-jobs", copySpecs->tableJobs);
@@ -1067,7 +821,7 @@ copydb_progress_as_json(CopyDataSpec *copySpecs,
 	/* in-progress */
 	SourceTableArray *tableArray = &(progress->tableInProgress);
 
-	if (!copydb_table_array_as_json(tableArray, jsTableObj, "in-progress"))
+	if (!copydb_table_array_as_json(sourceDB, jsTableObj, "in-progress"))
 	{
 		/* errors have already been logged */
 		return false;
@@ -1103,7 +857,7 @@ copydb_progress_as_json(CopyDataSpec *copySpecs,
 	/* in-progress */
 	SourceIndexArray *indexArray = &(progress->indexInProgress);
 
-	if (!copydb_index_array_as_json(indexArray, jsIndexObj, "in-progress"))
+	if (!copydb_index_array_as_json(sourceDB, jsIndexObj, "in-progress"))
 	{
 		/* errors have already been logged */
 		return false;

--- a/src/bin/pgcopydb/progress.h
+++ b/src/bin/pgcopydb/progress.h
@@ -49,4 +49,5 @@ bool copydb_progress_as_json(CopyDataSpec *copySpecs,
 							 CopyProgress *progress,
 							 JSON_Value *js);
 
+
 #endif  /* PROGRESS_H */

--- a/src/bin/pgcopydb/string_utils.c
+++ b/src/bin/pgcopydb/string_utils.c
@@ -738,7 +738,7 @@ pretty_print_count(char *buffer, size_t size, uint64_t number)
 {
 	const char *suffixes[7] = {
 		"",                     /* units */
-		"",                     /* thousands */
+		"thousands",            /* 10^3 */
 		"million",              /* 10^6 */
 		"billion",              /* 10^9 */
 		"trillion",             /* 10^12 */

--- a/src/bin/pgcopydb/summary.h
+++ b/src/bin/pgcopydb/summary.h
@@ -74,6 +74,7 @@ typedef struct SummaryTableHeaders
 	int maxOidSize;
 	int maxNspnameSize;
 	int maxRelnameSize;
+	int maxPartCountSize;
 	int maxTableMsSize;
 	int maxBytesSize;
 	int maxIndexCountSize;
@@ -82,6 +83,7 @@ typedef struct SummaryTableHeaders
 	char oidSeparator[NAMEDATALEN];
 	char nspnameSeparator[NAMEDATALEN];
 	char relnameSeparator[NAMEDATALEN];
+	char partCountSeparator[NAMEDATALEN];
 	char tableMsSeparator[NAMEDATALEN];
 	char bytesSeparator[NAMEDATALEN];
 	char indexCountSeparator[NAMEDATALEN];
@@ -114,6 +116,7 @@ typedef struct SummaryTableEntry
 	char oidStr[INTSTRING_MAX_DIGITS];
 	char nspname[PG_NAMEDATALEN];
 	char relname[PG_NAMEDATALEN];
+	char partCount[INTSTRING_MAX_DIGITS];
 	char tableMs[INTERVAL_MAXLEN];
 	uint64_t bytes;
 	char bytesStr[INTSTRING_MAX_DIGITS];
@@ -204,8 +207,9 @@ bool prepare_table_summary_as_json(CopyTableSummary *summary,
 								   JSON_Object *jsobj,
 								   const char *key);
 
-bool create_table_index_file(SourceTable *table, char *filename);
-bool read_table_index_file(SourceIndexArray *indexArray, char *filename);
+bool create_table_index_file(DatabaseCatalog *sourceDB,
+							 SourceTable *table,
+							 char *filename);
 
 bool write_blobs_summary(CopyBlobsSummary *summary, char *filename);
 bool read_blobs_summary(CopyBlobsSummary *summary, char *filename);

--- a/tests/.sqliterc
+++ b/tests/.sqliterc
@@ -1,0 +1,3 @@
+.headers on
+.mode column
+.echo on

--- a/tests/Dockerfile.pagila
+++ b/tests/Dockerfile.pagila
@@ -17,6 +17,7 @@ RUN apt-get update \
     htop \
 	strace \
 	gdb \
+	sqlite3 \
     libpq5 \
     postgresql-client-common \
     curl \
@@ -44,3 +45,4 @@ RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 COPY --from=pgcopydb /usr/local/bin/pgcopydb /usr/local/bin
 COPY .psqlrc /var/lib/postgres
+COPY .sqliterc /var/lib/postgres

--- a/tests/extensions/copydb.sh
+++ b/tests/extensions/copydb.sh
@@ -58,13 +58,17 @@ coproc ( pgcopydb snapshot --debug )
 sleep 1
 
 # copy the extensions separately, needs superuser (both on source and target)
-pgcopydb list extensions
+pgcopydb list extensions --source ${PGCOPYDB_SOURCE_PGURI_SU}
 
 # now get the extension versions requirements from the target server
 e=/tmp/extensions.json
 r=/tmp/requirements.json
 
-pgcopydb list extensions --source ${PGCOPYDB_TARGET_PGURI} --requirements --json > ${e}
+# make sure to fetch the target list of extensions in a separate directory
+TARGET_OPTS="--dir /tmp/target/pgcopydb"
+TARGET_OPTS="${TARGET_OPTS} --source ${PGCOPYDB_TARGET_PGURI}"
+
+pgcopydb list extensions --requirements --json ${TARGET_OPTS} > ${e}
 
 jq 'map(select(.name == "postgis" or .name == "address_standardizer" or .name == "address_standardizer_data_us" or .name == "postgis_tiger_geocoder" or .name == "postgis_topology"))' < ${e} > ${r}
 
@@ -74,13 +78,16 @@ pgcopydb copy extensions \
          --source ${PGCOPYDB_SOURCE_PGURI_SU} \
          --target ${PGCOPYDB_TARGET_PGURI_SU} \
          --requirements ${r} \
-         --notice
+         --resume --debug
 
 # now clone without superuser privileges (using role pagila on source and target)
-pgcopydb clone --skip-extensions
+pgcopydb clone --skip-extensions --restart
 
 kill -TERM ${COPROC_PID}
 wait ${COPROC_PID}
 
-pgcopydb list extensions --source ${PGCOPYDB_SOURCE_PGURI}
-pgcopydb list extensions --source ${PGCOPYDB_TARGET_PGURI}
+pgcopydb compare schema
+pgcopydb compare data
+
+pgcopydb list extensions --source ${PGCOPYDB_SOURCE_PGURI} --dir /tmp/check/source --debug
+pgcopydb list extensions --source ${PGCOPYDB_TARGET_PGURI} --dir /tmp/check/target

--- a/tests/filtering/copydb.sh
+++ b/tests/filtering/copydb.sh
@@ -17,6 +17,8 @@ psql -o /tmp/s.out -d ${PGCOPYDB_SOURCE_PGURI} -1 -f /usr/src/pagila/pagila-sche
 psql -o /tmp/d.out -d ${PGCOPYDB_SOURCE_PGURI} -1 -f /usr/src/pagila/pagila-data.sql
 psql -o /tmp/e.out -d ${PGCOPYDB_SOURCE_PGURI} -1 -f /usr/src/pgcopydb/extra.sql
 
+export TMPDIR=/tmp/exclude
+
 # list the exclude filters now, and the computed dependencies
 cat /usr/src/pgcopydb/exclude.ini
 
@@ -24,22 +26,39 @@ cat /usr/src/pgcopydb/exclude.ini
 pgcopydb list tables --filters /usr/src/pgcopydb/exclude.ini
 pgcopydb list tables --filters /usr/src/pgcopydb/exclude.ini --list-skipped
 
-# list the dependencies of objects that are (not) selected by the filters
-pgcopydb list depends --filters /usr/src/pgcopydb/exclude.ini
+# list the dependencies of objects that are not selected by the filters
 pgcopydb list depends --filters /usr/src/pgcopydb/exclude.ini --list-skipped
 
 # list the sequences that are (not) selected by the filters
 pgcopydb list sequences --filters /usr/src/pgcopydb/exclude.ini
 pgcopydb list sequences --filters /usr/src/pgcopydb/exclude.ini --list-skipped
 
-pgcopydb clone --filters /usr/src/pgcopydb/exclude.ini
+sqlite3 /tmp/exclude/pgcopydb/schema/filter.db <<EOF
+select * from section;
+
+select oid, qname, restore_list_name, ownedby, attrelid, attroid from s_seq;
+
+select f.kind, count(*) from filter f group by kind;
+select f.oid, f.kind from filter f where kind like 'sequence';
+
+attach '/tmp/exclude/pgcopydb/schema/source.db' as source;
+
+select NULL as oid, s.restore_list_name, 'sequence owned by'
+  from s_seq s
+ where not exists
+       (select 1 from source.s_table st where st.oid = s.ownedby);
+EOF
+
+pgcopydb clone --filters /usr/src/pgcopydb/exclude.ini --resume --not-consistent
+
+export TMPDIR=/tmp/include
 
 # list the tables that are (not) selected by the filters
 pgcopydb list tables --filters /usr/src/pgcopydb/include.ini
 pgcopydb list tables --filters /usr/src/pgcopydb/include.ini --list-skipped
 
 # now another migration with the "include-only" parts of the data
-pgcopydb clone --filters /usr/src/pgcopydb/include.ini --restart
+pgcopydb clone --filters /usr/src/pgcopydb/include.ini --resume --not-consistent
 
 # print out the definition of the copy.foo table
 psql -d ${PGCOPYDB_SOURCE_PGURI} -c '\d app|copy.foo'

--- a/tests/filtering/exclude.ini
+++ b/tests/filtering/exclude.ini
@@ -4,12 +4,12 @@ bar
 schema_name_20_chars
 
 [exclude-table]
-# public.actor
-# public.category
-# public.film
-# public.film_actor
-# public.film_category
-# public.language
-# public.rental
+; public.actor
+; public.category
+; public.film
+; public.film_actor
+; public.film_category
+; public.language
+; public.rental
 foo.test_tbl_2
 app.foo

--- a/tests/pagila-multi-steps/copydb.sh
+++ b/tests/pagila-multi-steps/copydb.sh
@@ -33,13 +33,16 @@ sleep 1
 pgcopydb dump schema --resume --debug
 pgcopydb restore pre-data --resume
 
-pgcopydb copy table-data --resume
-pgcopydb copy sequences --resume
+pgcopydb copy table-data --resume --notice
+pgcopydb copy sequences --resume --notice
 pgcopydb copy blobs --resume
-pgcopydb copy indexes --resume
-pgcopydb copy constraints --resume
+pgcopydb copy indexes --resume --notice
+pgcopydb copy constraints --resume --notice
 
 pgcopydb restore post-data --resume
 
 kill -TERM ${COPROC_PID}
 wait ${COPROC_PID}
+
+pgcopydb compare schema
+pgcopydb compare data

--- a/tests/pagila/copydb.sh
+++ b/tests/pagila/copydb.sh
@@ -40,7 +40,7 @@ grep -v "OWNER TO postgres" /usr/src/pagila/pagila-schema.sql > /tmp/pagila-sche
 psql -o /tmp/s.out -d ${PAGILA_SOURCE_PGURI} -1 -f /tmp/pagila-schema.sql
 psql -o /tmp/d.out -d ${PAGILA_SOURCE_PGURI} -1 -f /usr/src/pagila/pagila-data.sql
 
-pgcopydb clone --skip-ext-comments       \
+pgcopydb clone --skip-ext-comments \
          --source ${PAGILA_SOURCE_PGURI} \
          --target ${PAGILA_TARGET_PGURI}
 

--- a/tests/pagila/docker-compose.yml
+++ b/tests/pagila/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       PGCOPYDB_TARGET_PGURI: postgres://postgres:h4ckm3@target/postgres
       PGCOPYDB_TABLE_JOBS: 4
       PGCOPYDB_INDEX_JOBS: 4
+      PGCOPYDB_LARGE_OBJECTS_JOBS: 4
       PGCOPYDB_SPLIT_TABLES_LARGER_THAN: 200kB
       PGCOPYDB_FAIL_FAST: "true"
     depends_on:

--- a/tests/unit/copydb.sh
+++ b/tests/unit/copydb.sh
@@ -28,7 +28,7 @@ EOF
 
 # pgcopydb fork uses the environment variables
 export PGCOPYDB_SPLIT_TABLES_LARGER_THAN="2MB"
-pgcopydb fork --skip-collations --fail-fast --notice
+pgcopydb fork --skip-collations --fail-fast --debug
 
 # now compare the output of running the SQL command with what's expected
 # as we're not root when running tests, can't write in /usr/src

--- a/tests/unit/expected/3-collations.out
+++ b/tests/unit/expected/3-collations.out
@@ -1,6 +1,6 @@
        OID |                 Name |          Object name
 -----------+----------------------+---------------------
-     12329 |           en_US.utf8 |    database postgres
+     12329 |           en_US.utf8 | database postgres
      12440 |          de-DE-x-icu | column f2 of table colls 
      12559 |          en-US-x-icu | column f2 of table mycoltab 
      12658 |          fr-FR-x-icu | column f1 of table colls 

--- a/tests/unit/script/3-collations.sh
+++ b/tests/unit/script/3-collations.sh
@@ -7,4 +7,4 @@ set -e
 #
 #  - PGCOPYDB_SOURCE_PGURI
 
-pgcopydb list collations -q 2>&1
+pgcopydb list collations -q --dir /tmp/collations 2>&1

--- a/tests/unit/script/4-list-table-split.sh
+++ b/tests/unit/script/4-list-table-split.sh
@@ -14,18 +14,23 @@ set -e
 # pgcopydb commands will make decisions based on the available information in
 # the cache.
 
+DIR=/tmp/unit/split
+OPTS="--not-consistent --split-tables-larger-than 10kB"
+
+pgcopydb list schema --dir ${DIR} ${OPTS} >/dev/null
+
 # Cached size of table_1 is 100 KB, so this will be split into 10 parts
-pgcopydb list table-parts \
+pgcopydb list table-parts --dir ${DIR} \
     --schema-name "public" --table-name "table_1" \
     --split-tables-larger-than "10 kB" 2>&1
 
 # table_2 is identical to table_1 but with the size of 50 KB, so this will be
 # split into 5 parts
-pgcopydb list table-parts \
+pgcopydb list table-parts --dir ${DIR} \
     --schema-name "public" --table-name "table_2" \
     --split-tables-larger-than "10 kB" 2>&1
 
 # table_3 doesn't have size in cache, therefore it will not be split
-pgcopydb list table-parts \
+pgcopydb list table-parts --dir ${DIR} \
     --schema-name "public" --table-name "table_3" \
     --split-tables-larger-than "10 kB" 2>&1


### PR DESCRIPTION
This allows to implement an in-memory array with the capabilities to
spill-to-disk and also hash-table like lookup operations, and with good
multi-process concurrency handling.

Using SQLite internally will allow reducing the memory usage of pgcopydb and
make it possible to address databases with more than a million of tables
defined.

Fixes #545 
Fixes #532 