### PR TITLE
Support skipping extensions & filtering in pgcopydb dump/restore cli

### DIFF
--- a/src/bin/pgcopydb/cli_dump.c
+++ b/src/bin/pgcopydb/cli_dump.c
@@ -38,6 +38,7 @@ static CommandLine dump_schema_command =
 		"  --source          Postgres URI to the source database\n"
 		"  --target          Directory where to save the dump files\n"
 		"  --dir             Work directory to use\n"
+		"  --skip-extensions Skip restoring extensions\n" \
 		"  --snapshot        Use snapshot obtained with pg_export_snapshot\n",
 		cli_dump_schema_getopts,
 		cli_dump_schema);
@@ -50,6 +51,7 @@ static CommandLine dump_schema_pre_data_command =
 		"  --source          Postgres URI to the source database\n"
 		"  --target          Directory where to save the dump files\n"
 		"  --dir             Work directory to use\n"
+		"  --skip-extensions Skip restoring extensions\n" \
 		"  --snapshot        Use snapshot obtained with pg_export_snapshot\n",
 		cli_dump_schema_getopts,
 		cli_dump_schema_pre_data);
@@ -109,6 +111,7 @@ cli_dump_schema_getopts(int argc, char **argv)
 		{ "no-role-passwords", no_argument, NULL, 'P' },
 		{ "restart", no_argument, NULL, 'r' },
 		{ "resume", no_argument, NULL, 'R' },
+		{ "skip-extensions", no_argument, NULL, 'e' },
 		{ "not-consistent", no_argument, NULL, 'C' },
 		{ "snapshot", required_argument, NULL, 'N' },
 		{ "version", no_argument, NULL, 'V' },
@@ -186,6 +189,13 @@ cli_dump_schema_getopts(int argc, char **argv)
 			{
 				options.resume = true;
 				log_trace("--resume");
+				break;
+			}
+
+			case 'e':
+			{
+				options.skipExtensions = true;
+				log_trace("--skip-extensions");
 				break;
 			}
 
@@ -391,13 +401,13 @@ cli_dump_schema_section(CopyDBOptions *dumpDBoptions,
 	{
 		log_info("Using pg_dumpall for Postgres \"%s\" at \"%s\"",
 				 pgPaths->pg_version,
-				 pgPaths->pg_dump);
+				 pgPaths->pg_dumpall);
 	}
 	else
 	{
 		log_info("Using pg_dump for Postgres \"%s\" at \"%s\"",
 				 pgPaths->pg_version,
-				 pgPaths->pg_dumpall);
+				 pgPaths->pg_dump);
 	}
 
 	/*

--- a/src/bin/pgcopydb/cli_restore.c
+++ b/src/bin/pgcopydb/cli_restore.c
@@ -64,6 +64,8 @@ static CommandLine restore_schema_pre_data_command =
 		"  --no-owner           Do not set ownership of objects to match the original database\n"
 		"  --no-acl             Prevent restoration of access privileges (grant/revoke commands).\n"
 		"  --no-comments        Do not output commands to restore comments\n"
+		"  --skip-extensions    Skip restoring extensions\n" \
+		"  --skip-ext-comments  Skip restoring COMMENT ON EXTENSION\n" \
 		"  --filters <filename> Use the filters defined in <filename>\n"
 		"  --restart            Allow restarting when temp files exist already\n"
 		"  --resume             Allow resuming operations after a failure\n"
@@ -83,6 +85,8 @@ static CommandLine restore_schema_post_data_command =
 		"  --no-owner           Do not set ownership of objects to match the original database\n"
 		"  --no-acl             Prevent restoration of access privileges (grant/revoke commands).\n"
 		"  --no-comments        Do not output commands to restore comments\n"
+		"  --skip-extensions    Skip restoring extensions\n" \
+		"  --skip-ext-comments  Skip restoring COMMENT ON EXTENSION\n" \
 		"  --filters <filename> Use the filters defined in <filename>\n"
 		"  --restart            Allow restarting when temp files exist already\n"
 		"  --resume             Allow resuming operations after a failure\n"
@@ -691,7 +695,7 @@ cli_restore_prepare_specs(CopyDataSpec *copySpecs)
 	if (!copydb_fetch_schema_and_prepare_specs(copySpecs))
 	{
 		/* errors have already been logged */
-		exit(EXIT_CODE_SOURCE);
+		exit(EXIT_CODE_TARGET);
 	}
 
 	copySpecs->section = DATA_SECTION_NONE;


### PR DESCRIPTION
Currently, pgcopydb dump & restore doesn't support skipping extensions or filtering because we don't populate the context with extension details & skip list information.
