### PR TITLE
Fix extra quotes of identifier in ALTER database properties

### DIFF
--- a/src/bin/lib/pg/dumputils.c
+++ b/src/bin/lib/pg/dumputils.c
@@ -183,9 +183,9 @@ makeAlterConfigCommand(PGconn *conn, const char *configitem,
 	*pos++ = '\0';
 
 	/* Build the command, with suitable quoting for everything. */
-	appendPQExpBuffer(buf, "ALTER %s \"%s\" ", type, name);
+	appendPQExpBuffer(buf, "ALTER %s %s ", type, PQescapeIdentifier(conn, name, strlen(name)));
 	if (type2 != NULL && name2 != NULL)
-		appendPQExpBuffer(buf, "IN %s \"%s\" ", type2, name2);
+		appendPQExpBuffer(buf, "IN %s %s ", type2, PQescapeIdentifier(conn, name2, strlen(name2)));
 	appendPQExpBuffer(buf, "SET \"%s\" TO ", mine);
 
 	/*

--- a/src/bin/lib/pg/dumputils.c
+++ b/src/bin/lib/pg/dumputils.c
@@ -183,9 +183,9 @@ makeAlterConfigCommand(PGconn *conn, const char *configitem,
 	*pos++ = '\0';
 
 	/* Build the command, with suitable quoting for everything. */
-	appendPQExpBuffer(buf, "ALTER %s %s ", type, PQescapeIdentifier(conn, name, strlen(name)));
+	appendPQExpBuffer(buf, "ALTER %s %s ", type, name);
 	if (type2 != NULL && name2 != NULL)
-		appendPQExpBuffer(buf, "IN %s %s ", type2, PQescapeIdentifier(conn, name2, strlen(name2)));
+		appendPQExpBuffer(buf, "IN %s %s ", type2, name2);
 	appendPQExpBuffer(buf, "SET \"%s\" TO ", mine);
 
 	/*

--- a/tests/unit/copydb.sh
+++ b/tests/unit/copydb.sh
@@ -13,7 +13,7 @@ set -e
 # make sure source and target databases are ready
 pgcopydb ping
 
-sql="ALTER DATABASE postgres SET search_path TO public, abc;"
+sql='ALTER DATABASE postgres SET search_path TO public, """abc""";'
 psql -a -d "${PGCOPYDB_SOURCE_PGURI}" -c "${sql}"
 psql -a -d "${PGCOPYDB_SOURCE_PGURI}" -1 -f ./setup/setup.sql
 

--- a/tests/unit/setup/10-search-path-index-enum.sql
+++ b/tests/unit/setup/10-search-path-index-enum.sql
@@ -5,20 +5,20 @@
 
 BEGIN;
 
-CREATE SCHEMA abc;
+CREATE SCHEMA """abc""";
 
-CREATE TYPE abc.state AS ENUM (
+CREATE TYPE """abc""".state AS ENUM (
     'PROPOSED',
     'SCHEDULED',
     'STARTED'
 );
 
-CREATE TABLE abc.job (
+CREATE TABLE """abc""".job (
     id bigint NOT NULL,
-    state abc.state DEFAULT 'SCHEDULED'::abc.state NOT NULL,
+    state """abc""".state DEFAULT 'SCHEDULED'::"""abc""".state NOT NULL,
     date date NOT NULL
 );
 
-CREATE INDEX indexname ON abc.job USING btree (state) WHERE (state = 'SCHEDULED'::state);
+CREATE INDEX indexname ON """abc""".job USING btree (state) WHERE (state = 'SCHEDULED'::state);
 
 COMMIT;


### PR DESCRIPTION
**Logs**

`zero-length delimited identifier at or near """" 2023-12-15 09:10:12 86 ERROR  pgsql.c:1949              [TARGET 10202] LINE 1: ALTER ROLE ""abc"" IN DATABASE "def" SET "searc... 2023-12-15 09:10:12 86 ERROR  pgsql.c:1949              [TARGET 10202]                    ^ 2023-12-15 09:10:12 86 ERROR  pgsql.c:19`

**Description**

- remove quotes from the identifier
