### PR TITLE
Use libpq Single Row Mode when fetching catalogs.

### DIFF
--- a/src/bin/pgcopydb/catalog.h
+++ b/src/bin/pgcopydb/catalog.h
@@ -106,6 +106,7 @@ bool catalog_count_fetch(SQLiteQuery *query);
  */
 bool catalog_add_s_table(DatabaseCatalog *catalog, SourceTable *table);
 bool catalog_add_attributes(DatabaseCatalog *catalog, SourceTable *table);
+bool catalog_add_s_table_part(DatabaseCatalog *catalog, SourceTable *table);
 bool catalog_add_s_table_parts(DatabaseCatalog *catalog, SourceTable *table);
 
 bool catalog_add_s_table_chksum(DatabaseCatalog *catalog,

--- a/src/bin/pgcopydb/copydb_schema.c
+++ b/src/bin/pgcopydb/copydb_schema.c
@@ -105,6 +105,9 @@ copydb_fetch_schema_and_prepare_specs(CopyDataSpec *specs)
 		}
 	}
 
+	/* make sure we receive only one row at a time in-memory */
+	src->singleRowMode = true;
+
 	if (!copydb_fetch_source_schema(specs, src))
 	{
 		/* errors have already been logged */

--- a/src/bin/pgcopydb/pgsql.h
+++ b/src/bin/pgcopydb/pgsql.h
@@ -186,6 +186,7 @@ typedef struct PGSQL
 	bool notificationReceived;
 
 	bool logSQL;
+	bool singleRowMode;
 } PGSQL;
 
 


### PR DESCRIPTION
Catalog queries may return a very large number of rows when the source database contain a very large number of objects (tables, indexes, etc). To best cope with that use Single Row Mode to fetch one row at a time in-memory before inserting it to our internal SQLite catalogs.

See #545 
Fixes #532 