### PR TITLE
Remove references to the removed subcommands

### DIFF
--- a/docs/ref/pgcopydb_stream.rst
+++ b/docs/ref/pgcopydb_stream.rst
@@ -45,14 +45,6 @@ This command prefixes the following sub-commands:
     transform  Transform changes from the source database into SQL commands
     apply      Apply changes from the source database into the target database
 
-  pgcopydb stream create
-    slot    Create a replication slot in the source database
-    origin  Create a replication origin in the target database
-
-  pgcopydb stream drop
-    slot    Drop a replication slot in the source database
-    origin  Drop a replication origin in the target database
-
   pgcopydb stream sentinel
     create  Create the sentinel table on the source database
     drop    Drop the sentinel table on the source database


### PR DESCRIPTION
The subcommands `pgcopydb stream create` and `pgcopydb stream drop` are removed but they are still referenced in the documentation. This commit removes those references.

This is also fixed in #565 and I prefer to merge that PR instead of this.