### PR TITLE
Remove summary files, use our SQLite database instead.

### DIFF
--- a/src/bin/pgcopydb/catalog.c
+++ b/src/bin/pgcopydb/catalog.c
@@ -263,6 +263,23 @@ static char *filterDBcreateDDLs[] = {
 	"create table filter(oid integer, restore_list_name text, kind text)",
 	"create unique index filter_oid on filter(oid)",
 	"create index filter_rlname on filter(restore_list_name)",
+
+	/*
+	 * While we don't use a summary table in the filter database, some queries
+	 * that are meant to work on both filters database and source database use
+	 * LEFT JOIN summary.
+	 */
+	"create table summary("
+	"  pid integer, "
+	"  tableoid integer references s_table(oid), "
+	"  partnum integer, "
+	"  indexoid integer references s_index(oid), "
+	"  conoid integer references s_constraint(oid), "
+	"  start_time_epoch integer, done_time_epoch integer, duration integer, "
+	"  bytes integer, "
+	"  command text, "
+	"  unique(tableoid, partnum)"
+	")",
 };
 
 
@@ -364,7 +381,8 @@ static char *filterDBdropDDLs[] = {
 	"drop table if exists s_constraint",
 	"drop table if exists s_seq",
 	"drop table if exists s_depend",
-	"drop table if exists filter"
+	"drop table if exists filter",
+	"drop table if exists summary"
 };
 
 

--- a/src/bin/pgcopydb/catalog.h
+++ b/src/bin/pgcopydb/catalog.h
@@ -107,7 +107,6 @@ bool catalog_count_fetch(SQLiteQuery *query);
 bool catalog_add_s_table(DatabaseCatalog *catalog, SourceTable *table);
 bool catalog_add_attributes(DatabaseCatalog *catalog, SourceTable *table);
 bool catalog_add_s_table_part(DatabaseCatalog *catalog, SourceTable *table);
-bool catalog_add_s_table_parts(DatabaseCatalog *catalog, SourceTable *table);
 
 bool catalog_add_s_table_chksum(DatabaseCatalog *catalog,
 								SourceTable *table,
@@ -517,6 +516,38 @@ bool catalog_iter_s_index_in_progress(DatabaseCatalog *catalog,
 
 bool catalog_iter_s_index_in_progress_init(SourceIndexIterator *iter);
 
+
+/*
+ * Manage catalog summary entries.
+ *
+ * see summary.c
+ */
+bool summary_add_table(DatabaseCatalog *catalog,
+					   CopyTableDataSpec *tableSpecs);
+
+bool summary_finish_table(DatabaseCatalog *catalog,
+						  CopyTableDataSpec *tableSpecs);
+
+bool summary_lookup_table(DatabaseCatalog *catalog,
+						  CopyTableDataSpec *tableSpecs);
+
+bool summary_table_fetch(SQLiteQuery *query);
+
+bool summary_delete_table(DatabaseCatalog *catalog,
+						  CopyTableDataSpec *tableSpecs);
+
+bool summary_table_count_parts_done(DatabaseCatalog *catalog,
+									CopyTableDataSpec *tableSpecs);
+
+bool summary_table_fetch_count_parts_done(SQLiteQuery *query);
+
+bool summary_add_table_parts_done(DatabaseCatalog *catalog,
+								  CopyTableDataSpec *tableSpecs);
+
+bool summary_lookup_table_parts_done(DatabaseCatalog *catalog,
+									 CopyTableDataSpec *tableSpecs);
+
+bool summary_table_parts_done_fetch(SQLiteQuery *query);
 
 /*
  * Internal tooling for catalogs management

--- a/src/bin/pgcopydb/catalog.h
+++ b/src/bin/pgcopydb/catalog.h
@@ -29,15 +29,18 @@ struct SQLiteQuery
  */
 bool catalog_open(DatabaseCatalog *catalog);
 bool catalog_init(DatabaseCatalog *catalog);
+bool catalog_create_semaphore(DatabaseCatalog *catalog);
 bool catalog_attach(DatabaseCatalog *a, DatabaseCatalog *b, const char *name);
 bool catalog_close(DatabaseCatalog *catalog);
 
 bool catalog_create_schema(DatabaseCatalog *catalog);
 bool catalog_drop_schema(DatabaseCatalog *catalog);
 
+bool catalog_set_wal_mode(DatabaseCatalog *catalog);
 
-bool catalog_begin(DatabaseCatalog *catalog);
+bool catalog_begin(DatabaseCatalog *catalog, bool immediate);
 bool catalog_commit(DatabaseCatalog *catalog);
+bool catalog_rollback(DatabaseCatalog *catalog);
 
 bool catalog_register_setup(DatabaseCatalog *catalog,
 							const char *source_pg_uri,

--- a/src/bin/pgcopydb/catalog.h
+++ b/src/bin/pgcopydb/catalog.h
@@ -6,7 +6,6 @@
 #ifndef CATALOG_H
 #define CATALOG_H
 
-#include "copydb.h"
 #include "schema.h"
 
 /*
@@ -28,9 +27,6 @@ struct SQLiteQuery
 /*
  * Catalog API.
  */
-bool catalog_init_from_specs(CopyDataSpec *copySpecs);
-bool catalog_close_from_specs(CopyDataSpec *copySpecs);
-
 bool catalog_open(DatabaseCatalog *catalog);
 bool catalog_init(DatabaseCatalog *catalog);
 bool catalog_attach(DatabaseCatalog *a, DatabaseCatalog *b, const char *name);
@@ -516,38 +512,6 @@ bool catalog_iter_s_index_in_progress(DatabaseCatalog *catalog,
 
 bool catalog_iter_s_index_in_progress_init(SourceIndexIterator *iter);
 
-
-/*
- * Manage catalog summary entries.
- *
- * see summary.c
- */
-bool summary_add_table(DatabaseCatalog *catalog,
-					   CopyTableDataSpec *tableSpecs);
-
-bool summary_finish_table(DatabaseCatalog *catalog,
-						  CopyTableDataSpec *tableSpecs);
-
-bool summary_lookup_table(DatabaseCatalog *catalog,
-						  CopyTableDataSpec *tableSpecs);
-
-bool summary_table_fetch(SQLiteQuery *query);
-
-bool summary_delete_table(DatabaseCatalog *catalog,
-						  CopyTableDataSpec *tableSpecs);
-
-bool summary_table_count_parts_done(DatabaseCatalog *catalog,
-									CopyTableDataSpec *tableSpecs);
-
-bool summary_table_fetch_count_parts_done(SQLiteQuery *query);
-
-bool summary_add_table_parts_done(DatabaseCatalog *catalog,
-								  CopyTableDataSpec *tableSpecs);
-
-bool summary_lookup_table_parts_done(DatabaseCatalog *catalog,
-									 CopyTableDataSpec *tableSpecs);
-
-bool summary_table_parts_done_fetch(SQLiteQuery *query);
 
 /*
  * Internal tooling for catalogs management

--- a/src/bin/pgcopydb/compare.c
+++ b/src/bin/pgcopydb/compare.c
@@ -200,7 +200,7 @@ compare_queue_table_hook(void *ctx, SourceTable *table)
 bool
 compare_start_workers(CopyDataSpec *copySpecs, Queue *queue)
 {
-	log_info("starting %d table compare processes", copySpecs->tableJobs);
+	log_info("Starting %d table compare processes", copySpecs->tableJobs);
 
 	for (int i = 0; i < copySpecs->tableJobs; i++)
 	{

--- a/src/bin/pgcopydb/compare.c
+++ b/src/bin/pgcopydb/compare.c
@@ -380,17 +380,7 @@ compare_data_by_table_oid(CopyDataSpec *copySpecs, uint32_t oid)
 		return false;
 	}
 
-	CopyFilePaths *cfPaths = &(copySpecs->cfPaths);
-	TableFilePaths tablePaths = { 0 };
-
-	if (!copydb_init_tablepaths(cfPaths, &tablePaths, oid))
-	{
-		log_error("Failed to prepare pathnames for table %u", oid);
-		return false;
-	}
-
-	log_trace("compare_data_by_table_oid: %u %s \"%s\"",
-			  oid, table->qname, tablePaths.chksumFile);
+	log_trace("compare_data_by_table_oid: %u %s", oid, table->qname);
 
 	if (!compare_table(copySpecs, table))
 	{

--- a/src/bin/pgcopydb/copydb.c
+++ b/src/bin/pgcopydb/copydb.c
@@ -851,7 +851,7 @@ copydb_init_table_specs(CopyTableDataSpec *tableSpecs,
 		.resume = specs->resume,
 
 		.sourceTable = source,
-		.summary = NULL,
+		.summary = { 0 },
 
 		.tableJobs = specs->tableJobs,
 		.indexJobs = specs->indexJobs,
@@ -914,7 +914,7 @@ copydb_init_table_specs(CopyTableDataSpec *tableSpecs,
 			log_error("BUG: copydb_init_table_specs partNumber is %d and "
 					  "source table partArray.count is %d",
 					  partNumber,
-					  source->partsArray.count);
+					  source->partition.partCount);
 			return false;
 		}
 

--- a/src/bin/pgcopydb/copydb.c
+++ b/src/bin/pgcopydb/copydb.c
@@ -729,9 +729,6 @@ copydb_init_specs(CopyDataSpec *specs,
 
 		.splitTablesLargerThan = options->splitTablesLargerThan,
 
-		.tableSemaphore = { 0 },
-		.indexSemaphore = { 0 },
-
 		.vacuumQueue = { 0 },
 		.indexQueue = { 0 },
 
@@ -769,28 +766,6 @@ copydb_init_specs(CopyDataSpec *specs,
 	strlcpy(source->dbfile, specs->cfPaths.sdbfile, sizeof(source->dbfile));
 	strlcpy(filter->dbfile, specs->cfPaths.fdbfile, sizeof(filter->dbfile));
 	strlcpy(target->dbfile, specs->cfPaths.tdbfile, sizeof(target->dbfile));
-
-	/* create the table semaphore (critical section, one at a time please) */
-	specs->tableSemaphore.initValue = 1;
-
-	if (!semaphore_create(&(specs->tableSemaphore)))
-	{
-		log_error("Failed to create the table concurrency semaphore "
-				  "to orchestrate %d TABLE DATA COPY jobs",
-				  options->tableJobs);
-		return false;
-	}
-
-	/* create the index semaphore (critical section, one at a time please) */
-	specs->indexSemaphore.initValue = 1;
-
-	if (!semaphore_create(&(specs->indexSemaphore)))
-	{
-		log_error("Failed to create the index concurrency semaphore "
-				  "to orchestrate %d CREATE INDEX jobs",
-				  options->indexJobs);
-		return false;
-	}
 
 	if (specs->section == DATA_SECTION_ALL ||
 		specs->section == DATA_SECTION_TABLE_DATA)
@@ -854,9 +829,7 @@ copydb_init_table_specs(CopyTableDataSpec *tableSpecs,
 		.summary = { 0 },
 
 		.tableJobs = specs->tableJobs,
-		.indexJobs = specs->indexJobs,
-
-		.indexSemaphore = &(specs->indexSemaphore)
+		.indexJobs = specs->indexJobs
 	};
 
 	/* copy the structure as a whole memory area to the target place */
@@ -879,32 +852,6 @@ copydb_init_table_specs(CopyTableDataSpec *tableSpecs,
 		{
 			strlcpy(tableSpecs->part.partKey, "ctid", NAMEDATALEN);
 		}
-
-		/* now compute the table-specific paths we are using in copydb */
-		if (!copydb_init_tablepaths_for_part(tableSpecs->cfPaths,
-											 &(tableSpecs->tablePaths),
-											 tableSpecs->sourceTable->oid,
-											 partNumber))
-		{
-			log_error("Failed to prepare pathnames for partition %d of table %s",
-					  partNumber,
-					  tableSpecs->sourceTable->qname);
-			return false;
-		}
-
-		/* used only by one process, the one finishing a partial COPY last */
-		sformat(tableSpecs->tablePaths.idxListFile, MAXPGPATH, "%s/%u.idx",
-				tableSpecs->cfPaths->tbldir,
-				source->oid);
-
-		/*
-		 * And now the truncateLockFile and truncateDoneFile, which are used to
-		 * provide a critical section to the same-table concurrent processes.
-		 */
-		sformat(tableSpecs->tablePaths.truncateDoneFile, MAXPGPATH,
-				"%s/%u.truncate",
-				tableSpecs->cfPaths->tbldir,
-				source->oid);
 	}
 	else
 	{
@@ -917,70 +864,7 @@ copydb_init_table_specs(CopyTableDataSpec *tableSpecs,
 					  source->partition.partCount);
 			return false;
 		}
-
-		/* now compute the table-specific paths we are using in copydb */
-		if (!copydb_init_tablepaths(tableSpecs->cfPaths,
-									&(tableSpecs->tablePaths),
-									tableSpecs->sourceTable->oid))
-		{
-			log_error("Failed to prepare pathnames for table %u",
-					  tableSpecs->sourceTable->oid);
-			return false;
-		}
 	}
-
-	return true;
-}
-
-
-/*
- * copydb_init_tablepaths computes the lockFile, doneFile, and idxListFile
- * pathnames for a given table oid and global cfPaths setup.
- */
-bool
-copydb_init_tablepaths(CopyFilePaths *cfPaths,
-					   TableFilePaths *tablePaths,
-					   uint32_t oid)
-{
-	sformat(tablePaths->lockFile, MAXPGPATH, "%s/%d",
-			cfPaths->rundir,
-			oid);
-
-	sformat(tablePaths->doneFile, MAXPGPATH, "%s/%d.done",
-			cfPaths->tbldir,
-			oid);
-
-	sformat(tablePaths->idxListFile, MAXPGPATH, "%s/%u.idx",
-			cfPaths->tbldir,
-			oid);
-
-	sformat(tablePaths->chksumFile, MAXPGPATH, "%s/%u.sum.json",
-			cfPaths->tbldir,
-			oid);
-
-	return true;
-}
-
-
-/*
- * copydb_init_tablepaths_for_part computes the lockFile and doneFile pathnames
- * for a given COPY partition of a table.
- */
-bool
-copydb_init_tablepaths_for_part(CopyFilePaths *cfPaths,
-								TableFilePaths *tablePaths,
-								uint32_t oid,
-								int partNumber)
-{
-	sformat(tablePaths->lockFile, MAXPGPATH, "%s/%d.%d",
-			cfPaths->rundir,
-			oid,
-			partNumber);
-
-	sformat(tablePaths->doneFile, MAXPGPATH, "%s/%d.%d.done",
-			cfPaths->tbldir,
-			oid,
-			partNumber);
 
 	return true;
 }

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -131,7 +131,7 @@ typedef struct CopyTableDataSpec
 	bool resume;
 
 	SourceTable *sourceTable;
-	CopyTableSummary *summary;
+	CopyTableSummary summary;
 
 	int tableJobs;
 	int indexJobs;
@@ -142,6 +142,9 @@ typedef struct CopyTableDataSpec
 
 	/* same-table concurrency with COPY WHERE clause partitioning */
 	CopyTableDataPartSpec part;
+	uint32_t countPartsDone;
+	pid_t partsDonePid;
+	bool allPartsAreDone;
 } CopyTableDataSpec;
 
 

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -135,24 +135,26 @@ typedef struct CopyTableDataSpec
 
 	int tableJobs;
 	int indexJobs;
-	Semaphore *indexSemaphore;  /* pointer to the main specs semaphore */
-	Semaphore *truncateSemaphore;
-
-	TableFilePaths tablePaths;
 
 	/* same-table concurrency with COPY WHERE clause partitioning */
 	CopyTableDataPartSpec part;
+
+	/* summary/activity tracking */
 	uint32_t countPartsDone;
 	pid_t partsDonePid;
 	bool allPartsAreDone;
+
+	uint32_t countIndexesLeft;
+	pid_t indexesDonePid;
+	bool allIndexesAreDone;
 } CopyTableDataSpec;
 
 
-typedef struct CopyTableDataSpecsArray
+typedef struct CopyIndexSpec
 {
-	int count;
-	CopyTableDataSpec *array;   /* malloc'ed area */
-} CopyTableDataSpecsArray;
+	SourceIndex *sourceIndex;
+	CopyIndexSummary summary;
+} CopyIndexSpec;
 
 
 /*
@@ -207,9 +209,6 @@ typedef struct CopyDataSpec
 	int lObjectJobs;
 
 	SplitTableLargerThan splitTablesLargerThan;
-
-	Semaphore tableSemaphore;
-	Semaphore indexSemaphore;
 
 	Queue copyQueue;
 	Queue indexQueue;
@@ -274,15 +273,6 @@ bool copydb_init_table_specs(CopyTableDataSpec *tableSpecs,
 							 SourceTable *source,
 							 int partNumber);
 
-bool copydb_init_tablepaths(CopyFilePaths *cfPaths,
-							TableFilePaths *tablePaths,
-							uint32_t oid);
-
-bool copydb_init_tablepaths_for_part(CopyFilePaths *cfPaths,
-									 TableFilePaths *tablePaths,
-									 uint32_t oid,
-									 int partNumber);
-
 bool copydb_export_snapshot(TransactionSnapshot *snapshot);
 
 bool copydb_fatal_exit(void);
@@ -295,6 +285,10 @@ bool copydb_unlink_sysv_semaphore(SysVResArray *array, Semaphore *semaphore);
 bool copydb_unlink_sysv_queue(SysVResArray *array, Queue *queue);
 
 bool copydb_cleanup_sysv_resources(SysVResArray *array);
+
+/* catalog.c */
+bool catalog_init_from_specs(CopyDataSpec *copySpecs);
+bool catalog_close_from_specs(CopyDataSpec *copySpecs);
 
 /* snapshot.c */
 bool copydb_copy_snapshot(CopyDataSpec *specs, TransactionSnapshot *snapshot);
@@ -318,10 +312,9 @@ bool copydb_parse_extensions_requirements(CopyDataSpec *copySpecs,
 										  char *filename);
 
 /* indexes.c */
-
 bool copydb_start_index_workers(CopyDataSpec *specs);
 bool copydb_index_worker(CopyDataSpec *specs);
-bool copydb_create_index_by_oid(CopyDataSpec *specs, uint32_t indexOid);
+bool copydb_create_index_by_oid(CopyDataSpec *specs, PGSQL *dst, uint32_t indexOid);
 
 bool copydb_add_table_indexes(CopyDataSpec *specs,
 							  CopyTableDataSpec *tableSpecs);
@@ -330,46 +323,28 @@ bool copydb_index_workers_send_stop(CopyDataSpec *specs);
 
 bool copydb_table_indexes_are_done(CopyDataSpec *specs,
 								   SourceTable *table,
-								   TableFilePaths *tablePaths,
 								   bool *indexesAreDone,
 								   bool *constraintsAreBeingBuilt);
 
-bool copydb_init_index_paths(CopyFilePaths *cfPaths,
-							 SourceIndex *index,
-							 IndexFilePaths *indexPaths);
-
 bool copydb_copy_all_indexes(CopyDataSpec *specs);
 
-bool copydb_create_index(const char *pguri,
+bool copydb_create_index(CopyDataSpec *specs,
+						 PGSQL *dst,
 						 SourceIndex *index,
-						 IndexFilePaths *indexPaths,
-						 Semaphore *lockFileSemaphore,
-						 bool constraint,
 						 bool ifNotExists);
 
+bool copydb_index_is_being_processed(CopyDataSpec *specs,
+									 CopyIndexSpec *indexSpecs,
+									 bool *isDone);
 
-bool copydb_index_is_being_processed(SourceIndex *index,
-									 IndexFilePaths *indexPaths,
-									 bool constraint,
-									 Semaphore *lockFileSemaphore,
-									 CopyIndexSummary *summary,
-									 bool *isDone,
-									 bool *isBeingProcessed);
+bool copydb_mark_index_as_done(CopyDataSpec *specs, CopyIndexSpec *indexSpecs);
 
-bool copydb_mark_index_as_done(SourceIndex *index,
-							   IndexFilePaths *indexPaths,
-							   bool constraint,
-							   Semaphore *lockFileSemaphore,
-							   CopyIndexSummary *summary);
+bool copydb_prepare_create_index_command(CopyIndexSpec *indexSpecs,
+										 bool ifNotExists);
 
-bool copydb_prepare_create_index_command(SourceIndex *index,
-										 bool ifNotExists,
-										 char **command);
+bool copydb_prepare_create_constraint_command(CopyIndexSpec *indexSpecs);
 
-bool copydb_prepare_create_constraint_command(SourceIndex *index,
-											  char **command);
-
-bool copydb_create_constraints(CopyDataSpec *spec, SourceTable *table);
+bool copydb_create_constraints(CopyDataSpec *spec, PGSQL *dst, SourceTable *table);
 
 /* dump_restore.c */
 bool copydb_dump_source_schema(CopyDataSpec *specs,
@@ -469,6 +444,83 @@ bool vacuum_send_stop(CopyDataSpec *specs);
 /* summary.c */
 bool prepare_summary_table(Summary *summary, CopyDataSpec *specs);
 bool print_summary(Summary *summary, CopyDataSpec *specs);
+
+bool summary_lookup_oid(DatabaseCatalog *catalog, uint32_t oid, bool *done);
+bool summary_oid_done_fetch(SQLiteQuery *query);
+
+/*
+ * Summary Table
+ */
+bool summary_lookup_table(DatabaseCatalog *catalog,
+						  CopyTableDataSpec *tableSpecs);
+
+bool summary_table_fetch(SQLiteQuery *query);
+
+bool summary_add_table(DatabaseCatalog *catalog,
+					   CopyTableDataSpec *tableSpecs);
+
+bool summary_finish_table(DatabaseCatalog *catalog,
+						  CopyTableDataSpec *tableSpecs);
+
+bool summary_delete_table(DatabaseCatalog *catalog,
+						  CopyTableDataSpec *tableSpecs);
+
+bool summary_table_count_parts_done(DatabaseCatalog *catalog,
+									CopyTableDataSpec *tableSpecs);
+
+bool summary_table_fetch_count_parts_done(SQLiteQuery *query);
+
+bool summary_add_table_parts_done(DatabaseCatalog *catalog,
+								  CopyTableDataSpec *tableSpecs);
+
+bool summary_lookup_table_parts_done(DatabaseCatalog *catalog,
+									 CopyTableDataSpec *tableSpecs);
+
+bool summary_table_parts_done_fetch(SQLiteQuery *query);
+
+/*
+ * Summary for Create Index and Constraints
+ */
+bool summary_lookup_index(DatabaseCatalog *catalog,
+						  CopyIndexSpec *indexSpecs);
+
+bool summary_index_fetch(SQLiteQuery *query);
+
+bool summary_add_index(DatabaseCatalog *catalog,
+					   CopyIndexSpec *indexSpecs);
+
+bool summary_finish_index(DatabaseCatalog *catalog,
+						  CopyIndexSpec *indexSpecs);
+
+bool summary_delete_index(DatabaseCatalog *catalog,
+						  CopyIndexSpec *indexSpecs);
+
+bool summary_lookup_constraint(DatabaseCatalog *catalog,
+							   CopyIndexSpec *indexSpecs);
+
+bool summary_add_constraint(DatabaseCatalog *catalog,
+							CopyIndexSpec *indexSpecs);
+
+bool summary_finish_constraint(DatabaseCatalog *catalog,
+							   CopyIndexSpec *indexSpecs);
+
+bool summary_table_count_indexes_left(DatabaseCatalog *catalog,
+									  CopyTableDataSpec *tableSpecs);
+
+bool summary_table_fetch_count_indexes_left(SQLiteQuery *query);
+
+bool summary_add_table_indexes_done(DatabaseCatalog *catalog,
+									CopyTableDataSpec *tableSpecs);
+
+bool summary_lookup_table_indexes_done(DatabaseCatalog *catalog,
+									   CopyTableDataSpec *tableSpecs);
+
+bool summary_table_indexes_done_fetch(SQLiteQuery *query);
+
+bool summary_prepare_index_entry(DatabaseCatalog *catalog,
+								 SourceIndex *index,
+								 bool constraint,
+								 SummaryIndexEntry *indexEntry);
 
 /* compare.c */
 bool compare_schemas(CopyDataSpec *copySpecs);

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -132,6 +132,7 @@ typedef struct CopyTableDataSpec
 
 	SourceTable *sourceTable;
 	CopyTableSummary summary;
+	CopyArgs copyArgs;
 
 	int tableJobs;
 	int indexJobs;
@@ -420,6 +421,9 @@ bool copydb_prepare_copy_query(CopyTableDataSpec *tableSpecs, CopyArgs *args);
 
 bool copydb_prepare_copy_query_attrlist(CopyTableDataSpec *tableSpecs,
 										PQExpBuffer attrList);
+
+bool copydb_prepare_summary_command(CopyTableDataSpec *tableSpecs);
+
 
 /* blobs.c */
 bool copydb_start_blob_process(CopyDataSpec *specs);

--- a/src/bin/pgcopydb/copydb_paths.h
+++ b/src/bin/pgcopydb/copydb_paths.h
@@ -105,32 +105,4 @@ typedef struct DumpPaths
 } DumpPaths;
 
 
-/* per-table file paths */
-typedef struct TableFilePaths
-{
-	char lockFile[MAXPGPATH];    /* table lock file */
-	char doneFile[MAXPGPATH];    /* table done file (summary) */
-	char idxListFile[MAXPGPATH]; /* index oids list file */
-
-	char chksumFile[MAXPGPATH]; /* table checksum file */
-
-	char truncateDoneFile[MAXPGPATH];    /* table truncate done file */
-} TableFilePaths;
-
-
-/* per-index file paths */
-typedef struct IndexFilePaths
-{
-	char lockFile[MAXPGPATH];           /* index lock file */
-	char doneFile[MAXPGPATH];           /* index done file (summary) */
-	char constraintLockFile[MAXPGPATH]; /* constraint lock file */
-	char constraintDoneFile[MAXPGPATH]; /* constraint done file */
-} IndexFilePaths;
-
-typedef struct IndexFilePathsArray
-{
-	int count;
-	IndexFilePaths *array;      /* malloc'ed area */
-} IndexFilePathsArray;
-
 #endif /* COPYDB_PATHS_H */

--- a/src/bin/pgcopydb/copydb_schema.c
+++ b/src/bin/pgcopydb/copydb_schema.c
@@ -617,13 +617,13 @@ copydb_prepare_table_specs_hook(void *ctx, SourceTable *source)
 		return false;
 	}
 
-	if (source->partsArray.count > 1)
+	if (source->partition.partCount > 1)
 	{
 		log_info("Table %s is %s large, "
 				 "%d COPY processes will be used, partitioning on %s.",
 				 source->qname,
 				 source->bytesPretty,
-				 source->partsArray.count,
+				 source->partition.partCount,
 				 source->partKey);
 	}
 

--- a/src/bin/pgcopydb/dump_restore.c
+++ b/src/bin/pgcopydb/dump_restore.c
@@ -26,7 +26,8 @@
 
 
 static bool copydb_append_table_hook(void *context, SourceTable *table);
-static bool copydb_copy_database_properties_hook(void *ctx, SourceProperty *property);
+static bool copydb_copy_database_properties_hook(void *ctx,
+												 SourceProperty *property);
 
 
 /*
@@ -36,14 +37,17 @@ static bool copydb_copy_database_properties_hook(void *ctx, SourceProperty *prop
 bool
 copydb_objectid_has_been_processed_already(CopyDataSpec *specs, uint32_t oid)
 {
-	char doneFile[MAXPGPATH] = { 0 };
+	DatabaseCatalog *sourceDB = &(specs->catalogs.source);
 
-	/* build the doneFile for the target index or constraint */
-	sformat(doneFile, sizeof(doneFile), "%s/%u.done",
-			specs->cfPaths.idxdir,
-			oid);
+	bool done = false;
 
-	return file_exists(doneFile);
+	if (!summary_lookup_oid(sourceDB, oid, &done))
+	{
+		/* errors have aleady been logged */
+		return false;
+	}
+
+	return done;
 }
 
 

--- a/src/bin/pgcopydb/lock_utils.h
+++ b/src/bin/pgcopydb/lock_utils.h
@@ -12,11 +12,24 @@
 #include <sys/ipc.h>
 #include <sys/sem.h>
 
+/*
+ * pgcopydb uses semaphores as a locking mechanism protecting a critical
+ * section, where a single worker/process is expected at any time.
+ *
+ * Some parts of the code might use the semaphore in a re-entrant way, for
+ * instance SQLite iterator query where the caller hook function then runs a
+ * query at each step of the iteration.
+ */
 typedef struct Semaphore
 {
 	int semId;
 	int initValue;
 	pid_t owner;
+
+	bool reentrant;
+	int depth;
+
+	bool debug;
 } Semaphore;
 
 

--- a/src/bin/pgcopydb/progress.c
+++ b/src/bin/pgcopydb/progress.c
@@ -649,90 +649,46 @@ copydb_update_progress_table_hook(void *ctx, SourceTable *table)
 
 	int partCount = table->partition.partCount;
 
+	CopyTableDataSpec tableSpecs = { 0 };
+
+	if (!copydb_init_table_specs(&tableSpecs, copySpecs, table, 0))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	DatabaseCatalog *sourceDB = &(copySpecs->catalogs.source);
+
+	if (!summary_lookup_table(sourceDB, &tableSpecs))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/*
+	 * Copy the SourceTable struct in-place to the tableInProgress array.
+	 */
+	tableInProgress->array[progress->tableInProgress.count++] = *table;
+	summaryArray->array[progress->tableSummaryArray.count++] = tableSpecs.summary;
+
 	bool done = false;
 
 	if (partCount <= 1)
 	{
-		CopyTableDataSpec tableSpecs = { 0 };
-
-		if (!copydb_init_table_specs(&tableSpecs, copySpecs, table, 0))
+		if (tableSpecs.summary.doneTime > 0)
+		{
+			done = true;
+		}
+	}
+	else
+	{
+		if (!summary_lookup_table_parts_done(sourceDB, &tableSpecs))
 		{
 			/* errors have already been logged */
 			return false;
 		}
 
-		if (file_exists(tableSpecs.tablePaths.doneFile))
-		{
-			done = true;
-		}
-		else if (file_exists(tableSpecs.tablePaths.lockFile))
-		{
-			CopyTableSummary summary = { .table = table };
-
-			if (!read_table_summary(&summary,
-									tableSpecs.tablePaths.lockFile))
-			{
-				/* errors have already been logged */
-				return false;
-			}
-
-			/*
-			 * Copy the SourceTable struct in-place to the tableInProgress
-			 * array.
-			 */
-			tableInProgress->array[progress->tableInProgress.count++] =
-				*table;
-
-			summaryArray->array[progress->tableSummaryArray.count++] =
-				summary;
-		}
-	}
-	else
-	{
-		bool allPartsAreDone = true;
-
-		for (int partIndex = 0; partIndex < partCount; partIndex++)
-		{
-			CopyTableDataSpec tableSpecs = { 0 };
-
-			if (!copydb_init_table_specs(&tableSpecs,
-										 copySpecs,
-										 table,
-										 partIndex))
-			{
-				/* errors have already been logged */
-				return false;
-			}
-
-			if (!file_exists(tableSpecs.tablePaths.doneFile))
-			{
-				allPartsAreDone = false;
-			}
-
-			if (file_exists(tableSpecs.tablePaths.lockFile))
-			{
-				CopyTableSummary summary = { .table = table };
-
-				if (!read_table_summary(&summary,
-										tableSpecs.tablePaths.lockFile))
-				{
-					/* errors have already been logged */
-					return false;
-				}
-
-				/*
-				 * Copy the SourceTable struct in-place to the
-				 * tableInProgress array.
-				 */
-				tableInProgress->array[progress->tableInProgress.count++] =
-					*table;
-
-				summaryArray->array[progress->tableSummaryArray.count++] =
-					summary;
-			}
-		}
-
-		done = allPartsAreDone;
+		done = tableSpecs.partsDonePid > 0;
 	}
 
 	if (done)

--- a/src/bin/pgcopydb/schema.c
+++ b/src/bin/pgcopydb/schema.c
@@ -3309,14 +3309,14 @@ schema_list_partitions(PGSQL *pgsql,
 	/* no partKey, no partitions, done. */
 	if (IS_EMPTY_STRING_BUFFER(table->partKey))
 	{
-		table->partsArray.count = 0;
+		table->partition.partCount = 0;
 		return true;
 	}
 
 	/* when partSize is zero, just don't partition the COPY */
 	if (partSize == 0)
 	{
-		table->partsArray.count = 0;
+		table->partition.partCount = 0;
 		return true;
 	}
 

--- a/src/bin/pgcopydb/schema.h
+++ b/src/bin/pgcopydb/schema.h
@@ -118,13 +118,6 @@ typedef struct SourceTableParts
 } SourceTableParts;
 
 
-typedef struct SourceTablePartsArray
-{
-	int count;
-	SourceTableParts *array;    /* malloc'ed area */
-} SourceTablePartsArray;
-
-
 typedef struct SourceTableAttribute
 {
 	int attnum;
@@ -173,12 +166,15 @@ typedef struct SourceTable
 
 	char partKey[PG_NAMEDATALEN];
 	SourceTableParts partition;
-	SourceTablePartsArray partsArray;
 
 	SourceTableAttributeArray attributes;
 
 	uint64_t indexCount;
 	uint64_t constraintCount;
+
+	/* summary information */
+	uint64_t durationMs;
+	uint64_t bytesTransmitted;
 } SourceTable;
 
 

--- a/src/bin/pgcopydb/schema.h
+++ b/src/bin/pgcopydb/schema.h
@@ -14,6 +14,7 @@
 #include "uthash.h"
 
 #include "filtering.h"
+#include "lock_utils.h"
 #include "pgsql.h"
 #include "pg_utils.h"
 
@@ -350,10 +351,14 @@ typedef struct CatalogSection
 typedef struct DatabaseCatalog
 {
 	DatabaseCatalogType type;
+
 	CatalogSetup setup;
 	CatalogSection sections[DATA_SECTION_COUNT];
+
 	char dbfile[MAXPGPATH];
 	sqlite3 *db;
+
+	Semaphore sema;
 } DatabaseCatalog;
 
 

--- a/src/bin/pgcopydb/summary.c
+++ b/src/bin/pgcopydb/summary.c
@@ -2773,9 +2773,9 @@ summary_prepare_index_entry(DatabaseCatalog *catalog,
 			return false;
 		}
 
-		indexEntry->oid = indexSummary->index->constraintOid;
+		indexEntry->oid = index->constraintOid;
 
-		IntString oidString = intToString(indexSummary->index->constraintOid);
+		IntString oidString = intToString(index->constraintOid);
 		strlcpy(indexEntry->oidStr,
 				oidString.strValue,
 				sizeof(indexEntry->oidStr));
@@ -2788,9 +2788,9 @@ summary_prepare_index_entry(DatabaseCatalog *catalog,
 			return false;
 		}
 
-		indexEntry->oid = indexSummary->index->indexOid;
+		indexEntry->oid = index->indexOid;
 
-		IntString oidString = intToString(indexSummary->index->indexOid);
+		IntString oidString = intToString(index->indexOid);
 		strlcpy(indexEntry->oidStr,
 				oidString.strValue,
 				sizeof(indexEntry->oidStr));
@@ -2801,10 +2801,13 @@ summary_prepare_index_entry(DatabaseCatalog *catalog,
 			sizeof(indexEntry->nspname));
 
 	strlcpy(indexEntry->relname,
-			indexSummary->index->indexRelname,
+			index->indexRelname,
 			sizeof(indexEntry->relname));
 
-	indexEntry->sql = strdup(indexSummary->command);
+	if (indexSummary->command != NULL)
+	{
+		indexEntry->sql = strdup(indexSummary->command);
+	}
 
 	indexEntry->durationMs = indexSummary->durationMs;
 

--- a/src/bin/pgcopydb/summary.c
+++ b/src/bin/pgcopydb/summary.c
@@ -23,9 +23,88 @@
 
 static void prepareLineSeparator(char dashes[], int size);
 
-static bool create_table_index_file_hook(void *ctx, SourceIndex *index);
 static bool prepare_summary_table_hook(void *context, SourceTable *table);
 static bool prepare_summary_table_index_hook(void *ctx, SourceIndex *index);
+
+
+/*
+ * summary_lookup_oid looks-up for a table summary in our catalogs.
+ *
+ * This is used in the context of pg_dump/pg_restore filtering, which concerns
+ * index and constraint oids. See copydb_objectid_has_been_processed_already.
+ */
+bool
+summary_lookup_oid(DatabaseCatalog *catalog, uint32_t oid, bool *done)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: summary_lookup_oid: db is NULL");
+		return false;
+	}
+
+	char *sql =
+		"  select pid, start_time_epoch, done_time_epoch, duration "
+		"    from summary "
+		"   where indexoid = $1 or conoid = $2 ";
+
+	CopyOidSummary s = { 0 };
+
+	SQLiteQuery query = {
+		.context = &s,
+		.fetchFunction = &summary_oid_done_fetch
+	};
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_INT64, "oid", oid, NULL },
+		{ BIND_PARAMETER_TYPE_INT64, "oid", oid, NULL }
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(&query, params, count))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which return exactly one row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	*done = s.pid > 0 && s.doneTime > 0;
+
+	return true;
+}
+
+
+/*
+ * summary_pid_done_fetch fetches a generic CopyOidSummary from a SQLiteQuery
+ * result.
+ */
+bool
+summary_oid_done_fetch(SQLiteQuery *query)
+{
+	CopyOidSummary *s = (CopyOidSummary *) query->context;
+
+	s->pid = sqlite3_column_int64(query->ppStmt, 0);
+	s->startTime = sqlite3_column_int64(query->ppStmt, 1);
+	s->doneTime = sqlite3_column_int64(query->ppStmt, 2);
+	s->durationMs = sqlite3_column_int64(query->ppStmt, 3);
+
+	return true;
+}
 
 
 /*
@@ -370,7 +449,8 @@ summary_table_count_parts_done(DatabaseCatalog *catalog,
 		"      left join summary s "
 		"             on s.tableoid = p.oid "
 		"            and s.partnum = p.partnum "
-		"where tableoid = $1";
+		"where tableoid = $1 "
+		"  and s.pid > 0 and s.done_time_epoch > 0";
 
 	SQLiteQuery query = {
 		.context = tableSpecs,
@@ -551,6 +631,750 @@ summary_table_parts_done_fetch(SQLiteQuery *query)
 
 
 /*
+ * summary_lookup_index looks-up for an index summary in our catalogs, in case
+ * the given index has already been done in a previous run.
+ */
+bool
+summary_lookup_index(DatabaseCatalog *catalog, CopyIndexSpec *indexSpecs)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: summary_lookup_index: db is NULL");
+		return false;
+	}
+
+	SourceIndex *index = indexSpecs->sourceIndex;
+	CopyIndexSummary *indexSummary = &(indexSpecs->summary);
+
+	indexSummary->index = indexSpecs->sourceIndex;
+
+	char *sql =
+		"  select pid, start_time_epoch, done_time_epoch, duration, command "
+		"    from summary "
+		"   where indexoid = $1";
+
+	SQLiteQuery query = {
+		.context = indexSummary,
+		.fetchFunction = &summary_index_fetch
+	};
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_INT64, "indexoid", index->indexOid, NULL }
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(&query, params, count))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which return exactly one row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * summary_lookup_constraint looks-up for an constraint summary in our
+ * catalogs.
+ */
+bool
+summary_lookup_constraint(DatabaseCatalog *catalog, CopyIndexSpec *indexSpecs)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: summary_lookup_constraint: db is NULL");
+		return false;
+	}
+
+	SourceIndex *index = indexSpecs->sourceIndex;
+	CopyIndexSummary *indexSummary = &(indexSpecs->summary);
+
+	indexSummary->index = indexSpecs->sourceIndex;
+
+	char *sql =
+		"  select pid, start_time_epoch, done_time_epoch, duration, command "
+		"    from summary "
+		"   where conoid = $1";
+
+	SQLiteQuery query = {
+		.context = indexSummary,
+		.fetchFunction = &summary_index_fetch
+	};
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_INT64, "conoid", index->constraintOid, NULL }
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(&query, params, count))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which return exactly one row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * index_summary_fetch fetches a CopyIndexSummary entry from a SQLite ppStmt
+ * result set.
+ */
+bool
+summary_index_fetch(SQLiteQuery *query)
+{
+	CopyIndexSummary *indexSummary = (CopyIndexSummary *) query->context;
+
+	indexSummary->pid = sqlite3_column_int64(query->ppStmt, 0);
+	indexSummary->startTime = sqlite3_column_int64(query->ppStmt, 1);
+	indexSummary->doneTime = sqlite3_column_int64(query->ppStmt, 2);
+	indexSummary->durationMs = sqlite3_column_int64(query->ppStmt, 3);
+
+	if (sqlite3_column_type(query->ppStmt, 4) == SQLITE_NULL)
+	{
+		indexSummary->command = NULL;
+	}
+	else
+	{
+		int len = sqlite3_column_bytes(query->ppStmt, 4);
+		int bytes = len + 1;
+
+		indexSummary->command = (char *) calloc(bytes, sizeof(char));
+
+		if (indexSummary->command == NULL)
+		{
+			log_fatal(ALLOCATION_FAILED_ERROR);
+			return false;
+		}
+
+		strlcpy(indexSummary->command,
+				(char *) sqlite3_column_text(query->ppStmt, 4),
+				bytes);
+	}
+
+	/* no serialization for that internal in-memory only data */
+	indexSummary->startTimeInstr = (instr_time) {
+		0
+	};
+	indexSummary->durationInstr = (instr_time) {
+		0
+	};
+
+	INSTR_TIME_SET_CURRENT(indexSummary->startTimeInstr);
+
+	return true;
+}
+
+
+/*
+ * summary_delete_index DELETEs the summary entry for the given index.
+ */
+bool
+summary_delete_index(DatabaseCatalog *catalog, CopyIndexSpec *indexSpecs)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: summary_delete_index: db is NULL");
+		return false;
+	}
+
+	char *sql = "delete from summary where indexoid = $1";
+
+	SQLiteQuery query = { 0 };
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	SourceIndex *index = indexSpecs->sourceIndex;
+
+	/* bind our parameters now */
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_INT64, "indexoid", index->indexOid, NULL }
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(&query, params, count))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which does not return any row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * summary_add_index INSERTs a SourceIndex summary entry to our internal
+ * catalogs database.
+ */
+bool
+summary_add_index(DatabaseCatalog *catalog, CopyIndexSpec *indexSpecs)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: summary_add_index: db is NULL");
+		return false;
+	}
+
+	SourceIndex *index = indexSpecs->sourceIndex;
+	CopyIndexSummary *indexSummary = &(indexSpecs->summary);
+
+	indexSummary->pid = getpid();
+	indexSummary->index = indexSpecs->sourceIndex;
+
+	if (!index_summary_init(indexSummary))
+	{
+		log_error("Failed to initialize index summary for pid %d and "
+				  "index %s",
+				  getpid(),
+				  index->indexQname);
+		return false;
+	}
+
+	char *sql =
+		"insert into summary(pid, indexoid, start_time_epoch, command)"
+		"values($1, $2, $3, $4)";
+
+	SQLiteQuery query = { 0 };
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_INT64, "pid", indexSummary->pid, NULL },
+		{ BIND_PARAMETER_TYPE_INT64, "indexoid", index->indexOid, NULL },
+
+		{ BIND_PARAMETER_TYPE_INT64, "start_time_epoch",
+		  indexSummary->startTime, NULL },
+
+		{ BIND_PARAMETER_TYPE_TEXT, "command",
+		  0, (char *) indexSummary->command }
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(&query, params, count))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which does not return any row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * summary_finish_index UPDATEs a SourceIndex summary entry to our internal
+ * catalogs database.
+ */
+bool
+summary_finish_index(DatabaseCatalog *catalog, CopyIndexSpec *indexSpecs)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: summary_add_index: db is NULL");
+		return false;
+	}
+
+	SourceIndex *index = indexSpecs->sourceIndex;
+	CopyIndexSummary *indexSummary = &(indexSpecs->summary);
+
+	if (!index_summary_finish(indexSummary))
+	{
+		log_error("Failed to finish summary for index %s", index->indexQname);
+		return false;
+	}
+
+	char *sql =
+		"update summary set done_time_epoch = $1, duration = $2 "
+		"where pid = $3 and indexoid = $4";
+
+	SQLiteQuery query = { 0 };
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_INT64, "done_time_epoch",
+		  indexSummary->doneTime, NULL },
+
+		{ BIND_PARAMETER_TYPE_INT64, "duration",
+		  indexSummary->durationMs, NULL },
+
+		{ BIND_PARAMETER_TYPE_INT64, "pid", getpid(), NULL },
+		{ BIND_PARAMETER_TYPE_INT64, "indexoid", index->indexOid, NULL }
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(&query, params, count))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which does not return any row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * summary_add_constraint INSERTs a SourceIndex summary entry to our internal
+ * catalogs database.
+ */
+bool
+summary_add_constraint(DatabaseCatalog *catalog, CopyIndexSpec *indexSpecs)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: summary_add_constraint: db is NULL");
+		return false;
+	}
+
+	SourceIndex *index = indexSpecs->sourceIndex;
+	CopyIndexSummary *indexSummary = &(indexSpecs->summary);
+
+	indexSummary->pid = getpid();
+	indexSummary->index = indexSpecs->sourceIndex;
+
+	if (!index_summary_init(indexSummary))
+	{
+		log_error("Failed to initialize constraint summary for pid %d and "
+				  "constraint %s",
+				  getpid(),
+				  index->constraintName);
+		return false;
+	}
+
+	char *sql =
+		"insert or replace into summary(pid, conoid, start_time_epoch, command)"
+		"values($1, $2, $3, $4)";
+
+	SQLiteQuery query = { 0 };
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_INT64, "pid", indexSummary->pid, NULL },
+		{ BIND_PARAMETER_TYPE_INT64, "conoid", index->constraintOid, NULL },
+
+		{ BIND_PARAMETER_TYPE_INT64, "start_time_epoch",
+		  indexSummary->startTime, NULL },
+
+		{ BIND_PARAMETER_TYPE_TEXT, "command",
+		  0, (char *) indexSummary->command }
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(&query, params, count))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which does not return any row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * summary_finish_constraint UPDATEs a SourceIndex summary entry to our internal
+ * catalogs database.
+ */
+bool
+summary_finish_constraint(DatabaseCatalog *catalog, CopyIndexSpec *indexSpecs)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: summary_finish_constraint: db is NULL");
+		return false;
+	}
+
+	SourceIndex *index = indexSpecs->sourceIndex;
+	CopyIndexSummary *indexSummary = &(indexSpecs->summary);
+
+	if (!index_summary_finish(indexSummary))
+	{
+		log_error("Failed to finish summary for constraint %s",
+				  index->constraintName);
+		return false;
+	}
+
+	char *sql =
+		"update summary set done_time_epoch = $1, duration = $2 "
+		"where pid = $3 and conoid = $4";
+
+	SQLiteQuery query = { 0 };
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_INT64, "done_time_epoch",
+		  indexSummary->doneTime, NULL },
+
+		{ BIND_PARAMETER_TYPE_INT64, "duration",
+		  indexSummary->durationMs, NULL },
+
+		{ BIND_PARAMETER_TYPE_INT64, "pid", getpid(), NULL },
+		{ BIND_PARAMETER_TYPE_INT64, "conoid", index->constraintOid, NULL }
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(&query, params, count))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which does not return any row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * summary_table_all_indexes_done sets tableSpecs->allIndexesAreDone to true
+ * when all the indexes have already been done in the summary table of our
+ * internal catalogs.
+ */
+bool
+summary_table_count_indexes_left(DatabaseCatalog *catalog,
+								 CopyTableDataSpec *tableSpecs)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: summary_table_count_indexes_left: db is NULL");
+		return false;
+	}
+
+	SourceTable *table = tableSpecs->sourceTable;
+
+	/*
+	 * When asked to create an index for a constraint and the index is neither
+	 * a UNIQUE nor a PRIMARY KEY index, then we can't use the ALTER TABLE ...
+	 * ADD CONSTRAINT ... USING INDEX ... command, because this only works with
+	 * UNIQUE and PRIMARY KEY indexes.
+	 *
+	 * This means that we have to skip creating the index first, and will only
+	 * then create it during the constraint phase, as part of the "plain" ALTER
+	 * TABLE ... ADD CONSTRAINT ... command.
+	 *
+	 * So when counting the indexes that are left to be created before we can
+	 * install the constraints, we should also skip counting these.
+	 */
+	char *sql =
+		"with idx(indexoid) as"
+		" ("
+		"  select i.oid as indexoid "
+		"    from s_table t join s_index i on i.tableoid = t.oid"
+		"   where tableoid = $1 "
+		" ), "
+		" skipidx(indexoid) as "
+		" ("
+		"  select i.oid as indexoid "
+		"    from s_table t "
+		"         join s_index i on i.tableoid = t.oid "
+		"         join s_constraint c on c.indexoid = i.oid "
+		"   where not i.isprimary and not i.isunique"
+		"     and tableoid = $2 "
+		" ),"
+		" indexlist(indexoid) as"
+		" ( "
+		"  select indexoid from idx "
+		"  except "
+		"  select indexoid from skipidx "
+		" ) "
+		" select count(l.indexoid) "
+		"   from indexlist l "
+		"  where not exists "
+		"        ( "
+		"          select 1 "
+		"            from summary s "
+		"           where s.indexoid = l.indexoid "
+		"             and s.pid > 0 and s.done_time_epoch > 0"
+		"        ) ";
+
+	SQLiteQuery query = {
+		.context = tableSpecs,
+		.fetchFunction = &summary_table_fetch_count_indexes_left
+	};
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_INT64, "tableoid", table->oid, NULL },
+		{ BIND_PARAMETER_TYPE_INT64, "tableoid", table->oid, NULL }
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(&query, params, count))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which does not return any row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * summary_table_fetch_count_indexes_left fetches the count of indexes already
+ * done in our summary from a SQLiteQuere ppStmt result.
+ */
+bool
+summary_table_fetch_count_indexes_left(SQLiteQuery *query)
+{
+	CopyTableDataSpec *tableSpecs = (CopyTableDataSpec *) query->context;
+
+	tableSpecs->countIndexesLeft = sqlite3_column_int(query->ppStmt, 0);
+
+	return true;
+}
+
+
+/*
+ * summary_add_table_indexes_done registers the first pid that sees all tables
+ * indexes are done, using SQLite insert-or-ignore returning facility to ensure
+ * concurrency control.
+ */
+bool
+summary_add_table_indexes_done(DatabaseCatalog *catalog,
+							   CopyTableDataSpec *tableSpecs)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: summary_add_table_indexes_done: db is NULL");
+		return false;
+	}
+
+	SourceTable *table = tableSpecs->sourceTable;
+
+	char *sql =
+		"insert or ignore into s_table_indexes_done(tableoid, pid) "
+		"values($1, $2)";
+
+	SQLiteQuery query = { 0 };
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_INT64, "tableoid", table->oid, NULL },
+		{ BIND_PARAMETER_TYPE_INT64, "pid", getpid(), NULL }
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(&query, params, count))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which return exactly one row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * summary_lookup_table_indexes_done selects the PID that went there first.
+ *
+ * We could use insert or ignore ... returning ... but that's supported by
+ * SQLite since version 3.35.0 (2021-03-12) and debian oldstable (bullseye) is
+ * still around with Package: libsqlite3-0 (3.34.1-3).
+ */
+bool
+summary_lookup_table_indexes_done(DatabaseCatalog *catalog,
+								  CopyTableDataSpec *tableSpecs)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: summary_add_table: db is NULL");
+		return false;
+	}
+
+	SourceTable *table = tableSpecs->sourceTable;
+
+	char *sql = "select pid from s_table_indexes_done where tableoid = $1 ";
+
+	SQLiteQuery query = {
+		.context = tableSpecs,
+		.fetchFunction = &summary_table_indexes_done_fetch
+	};
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_INT64, "tableoid", table->oid, NULL }
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(&query, params, count))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/* now execute the query, which does not return any row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * summary_table_indexes_done_fetch fetches a row from s_table_indexes_done.
+ */
+bool
+summary_table_indexes_done_fetch(SQLiteQuery *query)
+{
+	CopyTableDataSpec *tableSpecs = (CopyTableDataSpec *) query->context;
+
+	tableSpecs->indexesDonePid = sqlite3_column_int(query->ppStmt, 0);
+
+	return true;
+}
+
+
+/*
  * prepare_table_summary_as_json prepares the summary information as a JSON
  * object within the given JSON_Object under the given key.
  */
@@ -656,186 +1480,6 @@ table_summary_finish(CopyTableSummary *summary)
 
 
 /*
- * create_table_index_file creates a file with one line per index attached to a
- * table. Each line contains only the index oid, from which we can find the
- * index doneFile.
- */
-bool
-create_table_index_file(DatabaseCatalog *catalog,
-						SourceTable *table,
-						char *filename)
-{
-	PQExpBuffer content = createPQExpBuffer();
-
-	if (content == NULL)
-	{
-		log_fatal("Failed to allocate memory to create the "
-				  " index list file \"%s\"", filename);
-		return false;
-	}
-
-	if (!catalog_iter_s_index_table(catalog,
-									table->nspname,
-									table->relname,
-									content,
-									&create_table_index_file_hook))
-	{
-		log_error("Failed to write table %s index list file, "
-				  "see above for details",
-				  table->qname);
-		return false;
-	}
-
-	/* memory allocation could have failed while building string */
-	if (PQExpBufferBroken(content))
-	{
-		log_error("Failed to create file \"%s\": out of memory", filename);
-		destroyPQExpBuffer(content);
-		return false;
-	}
-
-	if (!write_file(content->data, content->len, filename))
-	{
-		log_error("Failed to write file \"%s\"", filename);
-		destroyPQExpBuffer(content);
-		return false;
-	}
-
-	destroyPQExpBuffer(content);
-
-	return true;
-}
-
-
-/*
- * create_table_index_file_hook is an iterator callback function.
- */
-static bool
-create_table_index_file_hook(void *ctx, SourceIndex *index)
-{
-	PQExpBuffer content = (PQExpBuffer) ctx;
-
-	appendPQExpBuffer(content, "%u\n", index->indexOid);
-	appendPQExpBuffer(content, "%u\n", index->constraintOid);
-
-	return true;
-}
-
-
-/*
- * write_index_summary writes the current Index Summary to given filename. The
- * constraint bool allows to write the constraint definition instead of the
- * index definition.
- */
-bool
-write_index_summary(CopyIndexSummary *summary, char *filename, bool constraint)
-{
-	JSON_Value *js = json_value_init_object();
-	JSON_Object *jsObj = json_value_get_object(js);
-
-	uint32_t oid =
-		constraint
-		? summary->index->constraintOid
-		: summary->index->indexOid;
-
-	char *name =
-		constraint
-		? summary->index->constraintName
-		: summary->index->indexRelname;
-
-	json_object_set_number(jsObj, "pid", summary->pid);
-
-	json_object_dotset_number(jsObj, "index.oid", oid);
-	json_object_dotset_string(jsObj, "index.nspname",
-							  summary->index->indexNamespace);
-	json_object_dotset_string(jsObj, "index.relname", name);
-
-	json_object_set_number(jsObj, "start-time-epoch", summary->startTime);
-	json_object_set_number(jsObj, "done-time-epoch", summary->doneTime);
-	json_object_set_number(jsObj, "duration", summary->durationMs);
-	json_object_set_string(jsObj, "command", summary->command);
-
-	char *serialized_string = json_serialize_to_string_pretty(js);
-	size_t len = strlen(serialized_string);
-
-	/* write the summary to the doneFile */
-	bool success = write_file(serialized_string, len, filename);
-
-	json_free_serialized_string(serialized_string);
-	json_value_free(js);
-
-	if (!success)
-	{
-		log_error("Failed to write table summary file \"%s\"", filename);
-		return false;
-	}
-
-	return true;
-}
-
-
-/*
- * read_index_summary reads back in-memory a summary from disk.
- */
-bool
-read_index_summary(CopyIndexSummary *summary, const char *filename)
-{
-	JSON_Value *json = json_parse_file(filename);
-
-	if (json == NULL)
-	{
-		log_error("Failed to parse summary file \"%s\"", filename);
-		return false;
-	}
-
-	JSON_Object *jsObj = json_value_get_object(json);
-
-	summary->pid = json_object_get_number(jsObj, "pid");
-
-	summary->index->indexOid = json_object_dotget_number(jsObj, "index.oid");
-
-	char *schema = (char *) json_object_dotget_string(jsObj, "index.nspname");
-	char *name = (char *) json_object_dotget_string(jsObj, "index.relname");
-
-	strlcpy(summary->index->indexNamespace,
-			schema,
-			sizeof(summary->index->indexNamespace));
-
-	strlcpy(summary->index->indexRelname,
-			name,
-			sizeof(summary->index->indexRelname));
-
-	summary->startTime = json_object_get_number(jsObj, "start-time-epoch");
-	summary->doneTime = json_object_get_number(jsObj, "done-time-epoch");
-	summary->durationMs = json_object_get_number(jsObj, "duration");
-
-	if (json_object_has_value_of_type(jsObj, "command", JSONString))
-	{
-		const char *command = json_object_get_string(jsObj, "command");
-		summary->command = strdup(command);
-
-		if (summary->command == NULL)
-		{
-			log_error(ALLOCATION_FAILED_ERROR);
-			json_value_free(json);
-			return false;
-		}
-	}
-
-	/* we can't provide instr_time readers */
-	summary->startTimeInstr = (instr_time) {
-		0
-	};
-	summary->durationInstr = (instr_time) {
-		0
-	};
-
-	json_value_free(json);
-	return true;
-}
-
-
-/*
  * prepare_index_summary_as_json prepares the summary information as a JSON
  * object within the given JSON_Value.
  */
@@ -879,11 +1523,10 @@ prepare_index_summary_as_json(CopyIndexSummary *summary,
 
 
 /*
- * open_index_summary initializes the time elements of an index summary and
- * writes the summary in the given filename. Typically, the lockFile.
+ * index_summary_init initializes the time elements of an index summary.
  */
 bool
-open_index_summary(CopyIndexSummary *summary, char *filename, bool constraint)
+index_summary_init(CopyIndexSummary *summary)
 {
 	summary->startTime = time(NULL);
 	summary->doneTime = 0;
@@ -897,16 +1540,15 @@ open_index_summary(CopyIndexSummary *summary, char *filename, bool constraint)
 
 	INSTR_TIME_SET_CURRENT(summary->startTimeInstr);
 
-	return write_index_summary(summary, filename, constraint);
+	return true;
 }
 
 
 /*
- * finish_index_summary sets the duration of the summary fields and writes the
- * summary in the given filename. Typically, the doneFile.
+ * index_summary_finish updates the duration of the summary fields.
  */
 bool
-finish_index_summary(CopyIndexSummary *summary, char *filename, bool constraint)
+index_summary_finish(CopyIndexSummary *summary)
 {
 	summary->doneTime = time(NULL);
 
@@ -915,7 +1557,7 @@ finish_index_summary(CopyIndexSummary *summary, char *filename, bool constraint)
 
 	summary->durationMs = INSTR_TIME_GET_MILLISEC(summary->durationInstr);
 
-	return write_index_summary(summary, filename, constraint);
+	return true;
 }
 
 
@@ -1875,63 +2517,49 @@ prepare_summary_table_index_hook(void *ctx, SourceIndex *index)
 	SummaryTableContext *context = (SummaryTableContext *) ctx;
 
 	CopyDataSpec *specs = (CopyDataSpec *) context->specs;
-	CopyFilePaths *cfPaths = &(specs->cfPaths);
+	DatabaseCatalog *sourceDB = &(specs->catalogs.source);
 
 	TopLevelTimings *timings = &(context->summary->timings);
 	SummaryTable *summaryTable = &(context->summary->table);
 
 	SummaryTableEntry *entry = &(summaryTable->array[context->tableIndex]);
 
-	IndexFilePaths indexPaths = { 0 };
+	SummaryIndexEntry *indexEntry =
+		&(entry->indexArray.array[(entry->indexArray.count)++]);
 
-	if (!copydb_init_index_paths(cfPaths, index, &indexPaths))
+	if (!summary_prepare_index_entry(sourceDB,
+									 index,
+									 false, /* constraint */
+									 indexEntry))
 	{
-		/* errors have already been logged */
+		log_error("Failed to read index summary");
 		return false;
 	}
 
-	/* when a table has no indexes, the file doesn't exists */
-	if (file_exists(indexPaths.doneFile))
-	{
-		SummaryIndexEntry *indexEntry =
-			&(entry->indexArray.array[(entry->indexArray.count)++]);
+	/* accumulate total duration of creating all the indexes */
+	timings->indexDurationMs += indexEntry->durationMs;
+	context->indexingDurationMs += indexEntry->durationMs;
 
-		if (!summary_read_index_donefile(index,
-										 indexPaths.doneFile,
-										 false, /* constraint */
-										 indexEntry))
-		{
-			log_error("Failed to read index done file \"%s\"",
-					  indexPaths.doneFile);
-			return false;
-		}
-
-		/* accumulate total duration of creating all the indexes */
-		timings->indexDurationMs += indexEntry->durationMs;
-		context->indexingDurationMs += indexEntry->durationMs;
-	}
-
-	if (file_exists(indexPaths.constraintDoneFile))
+	if (index->constraintOid > 0)
 	{
 		SummaryIndexArray *constraintArray =
 			&(entry->constraintArray);
 
-		SummaryIndexEntry *indexEntry =
+		SummaryIndexEntry *constraintEntry =
 			&(constraintArray->array[(constraintArray->count)++]);
 
-		if (!summary_read_index_donefile(index,
-										 indexPaths.constraintDoneFile,
+		if (!summary_prepare_index_entry(sourceDB,
+										 index,
 										 true, /* constraint */
-										 indexEntry))
+										 constraintEntry))
 		{
-			log_error("Failed to read index done file \"%s\"",
-					  indexPaths.constraintDoneFile);
+			log_error("Failed to read constraint summary");
 			return false;
 		}
 
 		/* accumulate total duration of creating all the indexes */
-		timings->indexDurationMs += indexEntry->durationMs;
-		context->indexingDurationMs += indexEntry->durationMs;
+		timings->indexDurationMs += constraintEntry->durationMs;
+		context->indexingDurationMs += constraintEntry->durationMs;
 	}
 
 	return true;
@@ -1943,51 +2571,58 @@ prepare_summary_table_index_hook(void *ctx, SourceIndex *index)
  * information found in the SummaryIndexEntry structure.
  */
 bool
-summary_read_index_donefile(SourceIndex *index,
-							const char *filename,
+summary_prepare_index_entry(DatabaseCatalog *catalog,
+							SourceIndex *index,
 							bool constraint,
 							SummaryIndexEntry *indexEntry)
 {
-	CopyIndexSummary indexSummary = { .index = index };
-
-	if (!read_index_summary(&indexSummary, filename))
-	{
-		/* errors have already been logged */
-		return false;
-	}
+	CopyIndexSpec indexSpecs = { .sourceIndex = index };
+	CopyIndexSummary *indexSummary = &(indexSpecs.summary);
 
 	if (constraint)
 	{
-		indexEntry->oid = indexSummary.index->constraintOid;
+		if (!summary_lookup_constraint(catalog, &indexSpecs))
+		{
+			/* errors have already been logged */
+			return false;
+		}
 
-		IntString oidString = intToString(indexSummary.index->constraintOid);
+		indexEntry->oid = indexSummary->index->constraintOid;
+
+		IntString oidString = intToString(indexSummary->index->constraintOid);
 		strlcpy(indexEntry->oidStr,
 				oidString.strValue,
 				sizeof(indexEntry->oidStr));
 	}
 	else
 	{
-		indexEntry->oid = indexSummary.index->indexOid;
+		if (!summary_lookup_index(catalog, &indexSpecs))
+		{
+			/* errors have already been logged */
+			return false;
+		}
 
-		IntString oidString = intToString(indexSummary.index->indexOid);
+		indexEntry->oid = indexSummary->index->indexOid;
+
+		IntString oidString = intToString(indexSummary->index->indexOid);
 		strlcpy(indexEntry->oidStr,
 				oidString.strValue,
 				sizeof(indexEntry->oidStr));
 	}
 
 	strlcpy(indexEntry->nspname,
-			indexSummary.index->indexNamespace,
+			indexSummary->index->indexNamespace,
 			sizeof(indexEntry->nspname));
 
 	strlcpy(indexEntry->relname,
-			indexSummary.index->indexRelname,
+			indexSummary->index->indexRelname,
 			sizeof(indexEntry->relname));
 
-	indexEntry->sql = strdup(indexSummary.command);
+	indexEntry->sql = strdup(indexSummary->command);
 
-	indexEntry->durationMs = indexSummary.durationMs;
+	indexEntry->durationMs = indexSummary->durationMs;
 
-	(void) IntervalToString(indexSummary.durationMs,
+	(void) IntervalToString(indexSummary->durationMs,
 							indexEntry->indexMs,
 							sizeof(indexEntry->indexMs));
 

--- a/src/bin/pgcopydb/summary.h
+++ b/src/bin/pgcopydb/summary.h
@@ -198,11 +198,6 @@ typedef struct Summary
 	int lObjectJobs;
 } Summary;
 
-bool write_table_summary(CopyTableSummary *summary, char *filename);
-bool read_table_summary(CopyTableSummary *summary, const char *filename);
-bool open_table_summary(CopyTableSummary *summary, char *filename);
-bool finish_table_summary(CopyTableSummary *summary, char *filename);
-
 bool prepare_table_summary_as_json(CopyTableSummary *summary,
 								   JSON_Object *jsobj,
 								   const char *key);
@@ -241,5 +236,9 @@ bool summary_read_index_donefile(SourceIndex *index,
 								 const char *filename,
 								 bool constraint,
 								 SummaryIndexEntry *indexEntry);
+
+
+bool table_summary_init(CopyTableSummary *summary);
+bool table_summary_finish(CopyTableSummary *summary);
 
 #endif /* SUMMARY_H */

--- a/src/bin/pgcopydb/summary.h
+++ b/src/bin/pgcopydb/summary.h
@@ -18,10 +18,9 @@
 #include "pqexpbuffer.h"
 #include "portability/instr_time.h"
 
+#include "catalog.h"
 #include "string_utils.h"
 #include "schema.h"
-
-#define COPY_TABLE_SUMMARY_LINES 8
 
 typedef struct CopyTableSummary
 {
@@ -37,8 +36,6 @@ typedef struct CopyTableSummary
 } CopyTableSummary;
 
 
-#define COPY_INDEX_SUMMARY_LINES 8
-
 typedef struct CopyIndexSummary
 {
 	pid_t pid;                  /* pid */
@@ -51,6 +48,15 @@ typedef struct CopyIndexSummary
 	char *command;              /* malloc'ed area */
 } CopyIndexSummary;
 
+
+/* generic data type for OID lookup */
+typedef struct CopyOidSummary
+{
+	pid_t pid;                  /* pid */
+	uint64_t startTime;         /* time(NULL) at start time */
+	uint64_t doneTime;          /* time(NULL) at done time */
+	uint64_t durationMs;        /* instr_time duration in milliseconds */
+} CopyOidSummary;
 
 #define COPY_BLOBS_SUMMARY_LINES 3
 
@@ -198,47 +204,48 @@ typedef struct Summary
 	int lObjectJobs;
 } Summary;
 
+
+/*
+ * Internals
+ */
+bool table_summary_init(CopyTableSummary *summary);
+bool table_summary_finish(CopyTableSummary *summary);
+
+bool index_summary_init(CopyIndexSummary *summary);
+bool index_summary_finish(CopyIndexSummary *summary);
+
+/*
+ * Summary as JSON
+ */
 bool prepare_table_summary_as_json(CopyTableSummary *summary,
 								   JSON_Object *jsobj,
 								   const char *key);
-
-bool create_table_index_file(DatabaseCatalog *sourceDB,
-							 SourceTable *table,
-							 char *filename);
-
-bool write_blobs_summary(CopyBlobsSummary *summary, char *filename);
-bool read_blobs_summary(CopyBlobsSummary *summary, char *filename);
-
-
-void summary_set_current_time(TopLevelTimings *timings, TimingStep step);
-
-
-bool write_index_summary(CopyIndexSummary *summary, char *filename,
-						 bool constraint);
-bool read_index_summary(CopyIndexSummary *summary, const char *filename);
-bool open_index_summary(CopyIndexSummary *summary, char *filename,
-						bool constraint);
-bool finish_index_summary(CopyIndexSummary *summary, char *filename,
-						  bool constraint);
 
 bool prepare_index_summary_as_json(CopyIndexSummary *summary,
 								   JSON_Object *jsobj,
 								   const char *key);
 
+void print_summary_as_json(Summary *summary, const char *filename);
+
+/*
+ * Large Object top-level like summary
+ */
+bool write_blobs_summary(CopyBlobsSummary *summary, char *filename);
+bool read_blobs_summary(CopyBlobsSummary *summary, char *filename);
+
+
+/*
+ * Top-Level Summary.
+ */
+void summary_set_current_time(TopLevelTimings *timings, TimingStep step);
+
+
+/*
+ * Human Readable Summary Table
+ */
 void summary_prepare_toplevel_durations(Summary *summary);
 void print_toplevel_summary(Summary *summary);
 void print_summary_table(SummaryTable *summary);
 void prepare_summary_table_headers(SummaryTable *summary);
-
-void print_summary_as_json(Summary *summary, const char *filename);
-
-bool summary_read_index_donefile(SourceIndex *index,
-								 const char *filename,
-								 bool constraint,
-								 SummaryIndexEntry *indexEntry);
-
-
-bool table_summary_init(CopyTableSummary *summary);
-bool table_summary_finish(CopyTableSummary *summary);
 
 #endif /* SUMMARY_H */

--- a/src/bin/pgcopydb/table-data.c
+++ b/src/bin/pgcopydb/table-data.c
@@ -1055,10 +1055,8 @@ copydb_table_create_lockfile(CopyDataSpec *specs,
 		}
 		else
 		{
-			log_notice("Found stale pid %d in file \"%s\", removing it "
-					   "and processing table %s",
+			log_notice("Found stale pid %d, removing it to process table %s",
 					   tableSummary->pid,
-					   tableSpecs->tablePaths.lockFile,
 					   tableSpecs->sourceTable->qname);
 
 			/* stale pid, remove the summary entry and process the table */
@@ -1175,7 +1173,6 @@ copydb_table_parts_are_all_done(CopyDataSpec *specs,
 		*isBeingProcessed = (tableSpecs->partsDonePid != getpid());
 	}
 
-	/* keep compiler happy, we should never end-up here */
 	return true;
 }
 

--- a/tests/pagila/copydb.sh
+++ b/tests/pagila/copydb.sh
@@ -40,7 +40,7 @@ grep -v "OWNER TO postgres" /usr/src/pagila/pagila-schema.sql > /tmp/pagila-sche
 psql -o /tmp/s.out -d ${PAGILA_SOURCE_PGURI} -1 -f /tmp/pagila-schema.sql
 psql -o /tmp/d.out -d ${PAGILA_SOURCE_PGURI} -1 -f /usr/src/pagila/pagila-data.sql
 
-pgcopydb clone --skip-ext-comments \
+pgcopydb clone --skip-ext-comments --notice \
          --source ${PAGILA_SOURCE_PGURI} \
          --target ${PAGILA_TARGET_PGURI}
 

--- a/tests/pagila/docker-compose.yml
+++ b/tests/pagila/docker-compose.yml
@@ -28,6 +28,9 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    cap_add:
+      - SYS_ADMIN
+      - SYS_PTRACE
     environment:
       PGSSLMODE: "require"
       PGCOPYDB_SOURCE_PGURI: postgres://postgres:h4ckm3@source/postgres


### PR DESCRIPTION
This allows also to entirely remove the need for semaphores to handle
concurrency between worker processes, using SQLite insert-or-ignore for
concurrency control instead.
    
Also the idea of TablePaths and IndexPaths elements are gone, with the lock
files and the done files mechanisms.

That said, protect SQLite concurrent write access with a semaphore.

SQLite has not been designed for write-write concurrency, so implement a
critical section in our code so that SQLite only sees a single writer at all
time. It may still see multiple readers though.

Because we have re-entrant queries (an SQLite iterator function may then
choose to run another SQLite query), this commit also adds support for
re-entrant semaphore in a way that doesn't call into semop(2) again when we
already are in the critical section.