### PR TITLE
sqlite: fix misuse of aggregate: count() errors

### DIFF
--- a/src/bin/pgcopydb/catalog.c
+++ b/src/bin/pgcopydb/catalog.c
@@ -3654,7 +3654,7 @@ catalog_s_table_count_indexes(DatabaseCatalog *catalog, SourceTable *table)
 
 	char *sql =
 		"select count(1) as indexes, "
-		"       count(1) filter(where c.oid is not null) as constraints "
+		"       count(c.oid) as constraints "
 		"  from s_index i "
 		"       left join s_constraint c on c.indexoid = i.oid "
 		" where tableoid = $1";


### PR DESCRIPTION
The filter clause is not supported by my local SQLite for some reason, so I needed to use a different approach to count the number of constraints on a table.

This fixes the following error:

```
ERROR  Failed to prepare SQLite statement: select count(1) as indexes, count(1) filter(where c.oid is not null) OVER () as constraints from s_index i left join s_constraint c on c.indexoid = i.oid where tableoid = $1
ERROR  [SQLite] misuse of aggregate: count()
ERROR  Failed to count indexes attached to table dist_tables.t1
ERROR  Failed to copy data for table with oid 17226 and part number 0, see above for details
```

Relevant documentation at https://www.sqlite.org/lang_aggfunc.html says:

> The count(X) function returns a count of the number of times that X is not NULL in a group