### PR TITLE
Fix stack pointer access while cleaning up resources on exit

### DIFF
--- a/src/bin/pgcopydb/copydb.c
+++ b/src/bin/pgcopydb/copydb.c
@@ -1124,7 +1124,7 @@ copydb_register_sysv_semaphore(SysVResArray *array, Semaphore *semaphore)
 			  semaphore->semId);
 
 	array->array[array->count].kind = SYSV_SEMAPHORE;
-	array->array[array->count].res.semaphore = semaphore;
+	array->array[array->count].res.semaphore = *semaphore;
 
 	++(array->count);
 
@@ -1143,7 +1143,7 @@ copydb_unlink_sysv_semaphore(SysVResArray *array, Semaphore *semaphore)
 		SysVRes *res = &(array->array[i]);
 
 		if (res->kind == SYSV_SEMAPHORE &&
-			res->res.semaphore->semId == semaphore->semId)
+			res->res.semaphore.semId == semaphore->semId)
 		{
 			res->unlinked = true;
 			return true;
@@ -1178,7 +1178,7 @@ copydb_register_sysv_queue(SysVResArray *array, Queue *queue)
 			  queue->qId);
 
 	array->array[array->count].kind = SYSV_QUEUE;
-	array->array[array->count].res.queue = queue;
+	array->array[array->count].res.queue = *queue;
 
 	++(array->count);
 
@@ -1196,7 +1196,7 @@ copydb_unlink_sysv_queue(SysVResArray *array, Queue *queue)
 	{
 		SysVRes *res = &(array->array[i]);
 
-		if (res->kind == SYSV_QUEUE && res->res.queue->qId == queue->qId)
+		if (res->kind == SYSV_QUEUE && res->res.queue.qId == queue->qId)
 		{
 			res->unlinked = true;
 			return true;
@@ -1240,7 +1240,7 @@ copydb_cleanup_sysv_resources(SysVResArray *array)
 		{
 			case SYSV_QUEUE:
 			{
-				Queue *queue = res->res.queue;
+				Queue *queue = &res->res.queue;
 
 				if (queue->owner == pid)
 				{
@@ -1256,7 +1256,7 @@ copydb_cleanup_sysv_resources(SysVResArray *array)
 
 			case SYSV_SEMAPHORE:
 			{
-				Semaphore *semaphore = res->res.semaphore;
+				Semaphore *semaphore = &res->res.semaphore;
 
 				if (!semaphore_finish(semaphore))
 				{

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -54,8 +54,8 @@ typedef struct SysVRes
 
 	union res
 	{
-		Queue *queue;
-		Semaphore *semaphore;
+		Queue queue;
+		Semaphore semaphore;
 	} res;
 } SysVRes;
 


### PR DESCRIPTION
We track resources likes semaphore and queue into a global array and deallocate the non freed objects using exit handler. The array tracking these resources uses pointers, which could inadvertently track resource handles allocated from the stack.

Here is a valgrind output,

```
valgrind --trace-children=yes --tool=memcheck --leak-check=no pgcopydb stream cleanup
==428404== Memcheck, a memory error detector
==428404== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==428404== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==428404== Command: pgcopydb stream cleanup
==428404==
08:42:09 428404 INFO   Running pgcopydb version 0.14.1.27.g7b14081 from "/home/ubuntu/dimitri/pgcopydb/src/bin/pgcopydb/pgcopydb"
08:42:13 428404 INFO   A previous run has run through completion
08:42:14 428404 INFO   Dropping replication slot "pgcopydb"
08:42:14 428404 INFO   Removing schema pgcopydb and its objects
08:42:14 428404 WARN   NOTICE:  schema "pgcopydb" does not exist, skipping
08:42:14 428404 INFO   Dropping replication origin "pgcopydb"
==428404== Invalid read of size 4
==428404==    at 0x140814: UnknownInlinedFun (lock_utils.c:109)
==428404==    by 0x140814: UnknownInlinedFun (copydb.c:1261)
==428404==    by 0x140814: unlink_system_res_atexit (main.c:275)
==428404==    by 0x4B33494: __run_exit_handlers (exit.c:113)
==428404==    by 0x4B3360F: exit (exit.c:143)
==428404==    by 0x4B17D96: (below main) (libc_start_call_main.h:74)
==428404==  Address 0x1ffeffac0c is on thread 1's stack
==428404==  20740 bytes below stack pointer
==428404==
==428404== Invalid read of size 4
==428404==    at 0x14066D: semaphore_unlink (lock_utils.c:220)
==428404==    by 0x14088F: UnknownInlinedFun (lock_utils.c:111)
==428404==    by 0x14088F: UnknownInlinedFun (copydb.c:1261)
==428404==    by 0x14088F: unlink_system_res_atexit (main.c:275)
==428404==    by 0x4B33494: __run_exit_handlers (exit.c:113)
==428404==    by 0x4B3360F: exit (exit.c:143)
==428404==    by 0x4B17D96: (below main) (libc_start_call_main.h:74)
==428404==  Address 0x1ffeffac04 is on thread 1's stack
==428404==  20716 bytes below stack pointer
==428404==
==428404== Invalid read of size 4
==428404==    at 0x14068A: UnknownInlinedFun (copydb.c:1153)
==428404==    by 0x14068A: semaphore_unlink (lock_utils.c:227)
==428404==    by 0x14088F: UnknownInlinedFun (lock_utils.c:111)
==428404==    by 0x14088F: UnknownInlinedFun (copydb.c:1261)
==428404==    by 0x14088F: unlink_system_res_atexit (main.c:275)
==428404==    by 0x4B33494: __run_exit_handlers (exit.c:113)
==428404==    by 0x4B3360F: exit (exit.c:143)
==428404==    by 0x4B17D96: (below main) (libc_start_call_main.h:74)
==428404==  Address 0x1ffeffac04 is on thread 1's stack
==428404==  20716 bytes below stack pointer
==428404==
==428404== Invalid read of size 4
==428404==    at 0x1406B4: UnknownInlinedFun (copydb.c:1145)
==428404==    by 0x1406B4: semaphore_unlink (lock_utils.c:227)
==428404==    by 0x14088F: UnknownInlinedFun (lock_utils.c:111)
==428404==    by 0x14088F: UnknownInlinedFun (copydb.c:1261)
==428404==    by 0x14088F: unlink_system_res_atexit (main.c:275)
==428404==    by 0x4B33494: __run_exit_handlers (exit.c:113)
==428404==    by 0x4B3360F: exit (exit.c:143)
==428404==    by 0x4B17D96: (below main) (libc_start_call_main.h:74)
==428404==  Address 0x1ffeffabf8 is on thread 1's stack
==428404==  20728 bytes below stack pointer
==428404==
==428404==
==428404== HEAP SUMMARY:
==428404==     in use at exit: 1,252 bytes in 43 blocks
==428404==   total heap usage: 49,671 allocs, 49,628 frees, 5,354,454 bytes allocated
==428404==
==428404== For a detailed leak analysis, rerun with: --leak-check=full
==428404==
==428404== For lists of detected and suppressed errors, rerun with: -s
==428404== ERROR SUMMARY: 9 errors from 4 contexts (suppressed: 0 from 0)
```

With this PR, the error disappears.

```
valgrind --trace-children=yes --tool=memcheck --leak-check=no pgcopydb stream cleanup
==431199== Memcheck, a memory error detector
==431199== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==431199== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==431199== Command: pgcopydb stream cleanup
==431199==
09:13:33 431199 INFO   Running pgcopydb version 0.14.1.27.g7b14081 from "/home/ubuntu/dimitri/pgcopydb/src/bin/pgcopydb/pgcopydb"
09:13:37 431199 INFO   A previous run has run through completion
09:13:38 431199 INFO   Dropping replication slot "pgcopydb"
09:13:38 431199 INFO   Removing schema pgcopydb and its objects
09:13:38 431199 WARN   NOTICE:  schema "pgcopydb" does not exist, skipping
09:13:39 431199 INFO   Dropping replication origin "pgcopydb"
==431199==
==431199== HEAP SUMMARY:
==431199==     in use at exit: 1,252 bytes in 43 blocks
==431199==   total heap usage: 49,671 allocs, 49,628 frees, 5,354,454 bytes allocated
==431199==
==431199== For a detailed leak analysis, rerun with: --leak-check=full
==431199==
==431199== For lists of detected and suppressed errors, rerun with: -s
==431199== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```