### PR TITLE
Attach source catalog even for follow only mode

### DIFF
--- a/src/bin/pgcopydb/cli_clone_follow.c
+++ b/src/bin/pgcopydb/cli_clone_follow.c
@@ -427,6 +427,30 @@ cli_follow(int argc, char **argv)
 		exit(EXIT_CODE_QUIT);
 	}
 
+	/* make sure that we have our own process local connection */
+	TransactionSnapshot snapshot = { 0 };
+
+	if (!copydb_copy_snapshot(&copySpecs, &snapshot))
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_SOURCE);
+	}
+
+	/* swap the new instance in place of the previous one */
+	copySpecs.sourceSnapshot = snapshot;
+
+	if (!copydb_set_snapshot(&copySpecs))
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_SOURCE);
+	}
+
+	if (!copydb_fetch_schema_and_prepare_specs(&copySpecs))
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_SOURCE);
+	}
+
 	if (!follow_main_loop(&copySpecs, &specs))
 	{
 		/* errors have already been logged */

--- a/tests/cdc-endpos-between-transaction/copydb.sh
+++ b/tests/cdc-endpos-between-transaction/copydb.sh
@@ -36,9 +36,6 @@ pgcopydb stream setup
 # pgcopydb copy db uses the environment variables
 pgcopydb clone
 
-kill -TERM ${COPROC_PID}
-wait ${COPROC_PID}
-
 # now that the copying is done, inject some SQL DML changes to the source
 psql -d ${PGCOPYDB_SOURCE_PGURI} -f /usr/src/pgcopydb/dml.sql
 
@@ -104,6 +101,9 @@ pgcopydb follow --resume --trace
 # now check that all the new rows made it
 sql="select count(*) from category"
 test 26 -eq `psql -AtqX -d ${PGCOPYDB_SOURCE_PGURI} -c "${sql}"`
+
+kill -TERM ${COPROC_PID}
+wait ${COPROC_PID}
 
 # cleanup
 pgcopydb stream cleanup

--- a/tests/endpos-in-multi-wal-txn/copydb.sh
+++ b/tests/endpos-in-multi-wal-txn/copydb.sh
@@ -36,9 +36,6 @@ pgcopydb stream setup
 # pgcopydb copy db uses the environment variables
 pgcopydb clone
 
-kill -TERM ${COPROC_PID}
-wait ${COPROC_PID}
-
 # now that the copying is done, inject some SQL DML changes to the source
 psql -d ${PGCOPYDB_SOURCE_PGURI} -f /usr/src/pgcopydb/multi-wal-txn.sql
 
@@ -121,6 +118,9 @@ pgcopydb stream apply --trace --resume /var/lib/postgres/.local/share/pgcopydb/0
 # now check that all the new rows made it
 sql="select count(*) from table_a"
 test 24 -eq `psql -AtqX -d ${PGCOPYDB_TARGET_PGURI} -c "${sql}"`
+
+kill -TERM ${COPROC_PID}
+wait ${COPROC_PID}
 
 # cleanup
 pgcopydb stream cleanup

--- a/tests/follow-data-only/copydb.sh
+++ b/tests/follow-data-only/copydb.sh
@@ -71,3 +71,9 @@ psql -d ${PGCOPYDB_SOURCE_PGURI} -c "${sql}" > /tmp/s.out
 psql -d ${PGCOPYDB_TARGET_PGURI} -c "${sql}" > /tmp/t.out
 
 diff /tmp/s.out /tmp/t.out
+
+sql="select * from update_test"
+psql -d ${PGCOPYDB_SOURCE_PGURI} -c "${sql}" > /tmp/s.out
+psql -d ${PGCOPYDB_TARGET_PGURI} -c "${sql}" > /tmp/t.out
+
+diff /tmp/s.out /tmp/t.out

--- a/tests/follow-data-only/ddl.sql
+++ b/tests/follow-data-only/ddl.sql
@@ -9,3 +9,13 @@ CREATE TABLE table_a (id serial PRIMARY KEY, f1 int4, f2 text);
 CREATE TABLE table_b (id serial PRIMARY KEY, f1 int4, f2 text[]);
 
 commit;
+
+begin;
+
+CREATE TABLE IF NOT EXISTS update_test
+(
+    id bigint primary key,
+    name text
+);
+
+commit;

--- a/tests/follow-data-only/inject.sh
+++ b/tests/follow-data-only/inject.sh
@@ -36,6 +36,24 @@ psql -v a=21 -v b=30 -d ${PGCOPYDB_SOURCE_PGURI} -f /usr/src/pgcopydb/dml.sql
 # also insert data that won't fit in a single Unix PIPE buffer
 psql -d ${PGCOPYDB_SOURCE_PGURI} -f /usr/src/pgcopydb/dml-bufsize.sql
 
+# add some data to update_test table
+psql -d ${PGCOPYDB_SOURCE_PGURI} << EOF
+begin;
+insert into update_test(id, name) values
+(1, 'a'),
+(2, 'b');
+commit;
+
+begin;
+update update_test set name = 'c' where id = 1;
+commit;
+
+begin;
+update update_test set name = 'd' where id = 2;
+commit;
+
+EOF
+
 # grab the current LSN, it's going to be our streaming end position
 lsn=`psql -At -d ${PGCOPYDB_SOURCE_PGURI} -c 'select pg_current_wal_flush_lsn()'`
 pgcopydb stream sentinel set endpos --current


### PR DESCRIPTION
test_decoding transform relies on source catalog to decode the update message.

Prior to this commit, update while using test_decoding would work only while doing `pgcopydb clone --follow`. This commit enables support for update message decoding while using test_decoding plugin in `pgcopydb follow` too.