### PR TITLE
Review the COPY arguments API to fix TRUNCATE calls.

### DIFF
--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -436,9 +436,10 @@ bool copydb_table_parts_are_all_done(CopyDataSpec *specs,
 									 bool *allPartsDone,
 									 bool *isBeingProcessed);
 
-bool copydb_prepare_copy_query(CopyTableDataSpec *tableSpecs,
-							   PQExpBuffer query,
-							   bool source);
+bool copydb_prepare_copy_query(CopyTableDataSpec *tableSpecs, CopyArgs *args);
+
+bool copydb_prepare_copy_query_attrlist(CopyTableDataSpec *tableSpecs,
+										PQExpBuffer attrList);
 
 /* blobs.c */
 bool copydb_start_blob_process(CopyDataSpec *specs);

--- a/src/bin/pgcopydb/extensions.c
+++ b/src/bin/pgcopydb/extensions.c
@@ -212,24 +212,20 @@ copydb_copy_extensions_hook(void *ctx, SourceExtension *ext)
 					config->nspname,
 					config->relname);
 
-			/* apply extcondition to the source table */
-			PQExpBuffer sql = createPQExpBuffer();
+			CopyArgs args = {
+				.srcQname = qname,
+				.srcAttrList = "*",
+				.srcWhereClause = config->condition,
+				.dstQname = qname,
+				.dstAttrList = "",
+				.bytesTransmitted = 0
+			};
 
-			appendPQExpBuffer(sql, "(SELECT * FROM %s %s)",
-							  qname,
-							  config->condition);
-
-			bool truncate = false;
-			uint64_t bytesTransmitted = 0;
-
-			if (!pg_copy(src, dst, sql->data, qname, truncate, &bytesTransmitted))
+			if (!pg_copy(src, dst, &args))
 			{
 				/* errors have already been logged */
-				(void) destroyPQExpBuffer(sql);
 				return false;
 			}
-
-			(void) destroyPQExpBuffer(sql);
 		}
 	}
 

--- a/src/bin/pgcopydb/pgsql.h
+++ b/src/bin/pgcopydb/pgsql.h
@@ -310,9 +310,19 @@ bool validate_connection_string(const char *connectionString);
 
 bool pgsql_truncate(PGSQL *pgsql, const char *qname);
 
-bool pg_copy(PGSQL *src, PGSQL *dst,
-			 const char *srcQname, const char *dstQname,
-			 bool truncate, uint64_t *bytesTransmitted);
+typedef struct CopyArgs
+{
+	char *srcQname;
+	char *srcAttrList;
+	char *srcWhereClause;
+	char *dstQname;
+	char *dstAttrList;
+	bool truncate;
+	bool freeze;
+	uint64_t bytesTransmitted;
+} CopyArgs;
+
+bool pg_copy(PGSQL *src, PGSQL *dst, CopyArgs *args);
 
 bool pg_copy_from_stdin(PGSQL *pgsql, const char *qname);
 bool pg_copy_row_from_stdin(PGSQL *pgsql, char *fmt, ...);


### PR DESCRIPTION
The code to call TRUNCATE ONLY was only active for tables setup with COPY partitioning (--split-tables-larger-than), and was forced to "false" for the other tables.

The code also evolved in a way that it would build a sub-SELECT query with the table attribute list as the "srcQname" argument to the pgsql.c internal bits for the copy, making it impossible to then re-use that bit in the sql command for the TRUNCATE operation.

To fix, implement a new way to prepare the COPY query bits and pieces so that we can re-use the qualified table name in the TRUNCATE command and also build a full COPY (SELECT a, b, c FROM ONLY t WHERE ...) TO STDOUT; query.

In passing, because of the way we are changing the summary files to use our internal SQLite database instead, also push the TRUNCATE command of COPY partitionned table to the COPY supervisor process. This is a better way to solve the concurrency issues and make sure that TRUNCATE is done only once, and also finished before any of the copy-data worker processes get started.