### PR TITLE
Fix sub-process "success" condition and error handling.

### DIFF
--- a/src/bin/pgcopydb/cli_clone_follow.c
+++ b/src/bin/pgcopydb/cli_clone_follow.c
@@ -776,5 +776,5 @@ cli_clone_follow_wait_subprocess(const char *name, pid_t pid)
 		pg_usleep(150 * 1000);
 	}
 
-	return returnCode == 0;
+	return returnCode == 0 && signal_is_handled(sig);
 }

--- a/src/bin/pgcopydb/copydb.c
+++ b/src/bin/pgcopydb/copydb.c
@@ -949,7 +949,7 @@ copydb_wait_for_subprocesses(bool failFast)
 					sig = WTERMSIG(status);
 				}
 
-				if (returnCode == 0 && sig == 0)
+				if (returnCode == 0 && signal_is_handled(sig))
 				{
 					log_debug("Sub-process %d exited with code %d",
 							  pid, returnCode);

--- a/src/bin/pgcopydb/signals.c
+++ b/src/bin/pgcopydb/signals.c
@@ -271,3 +271,21 @@ signal_to_string(int signal)
 		}
 	}
 }
+
+
+/*
+ * signal_is_handled returns true when the given signal is handled/expected by
+ * pgcopydb.
+ */
+bool
+signal_is_handled(int signal)
+{
+	return
+
+	    /* we add zero here for compliance with the waitpid() API */
+		signal == 0 ||
+		signal == SIGINT ||
+		signal == SIGTERM ||
+		signal == SIGQUIT ||
+		signal == SIGHUP;
+}

--- a/src/bin/pgcopydb/signals.h
+++ b/src/bin/pgcopydb/signals.h
@@ -31,5 +31,6 @@ void unset_signal_flags(void);
 int get_current_signal(int defaultSignal);
 int pick_stronger_signal(int sig1, int sig2);
 char * signal_to_string(int signal);
+bool signal_is_handled(int signal);
 
 #endif /* SIGNALS_H */


### PR DESCRIPTION
The waitpid() API provides the process return code, which can still be zero when the processed was terminated by a signal such as SIGSEGV. Improve our sub-process supervision with taking that into account as an unexpected error condition.