### PR TITLE
Removes copy-db command

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ $ pgcopydb help
     clone     Clone an entire database from source to target
     fork      Clone an entire database from source to target
     follow    Replay changes from the source database to the target database
-    copy-db   Clone an entire database from source to target
     snapshot  Create and export a snapshot on the source database
   + compare   Compare source and target databases
   + copy      Implement the data section of the database copy

--- a/debian/tests/copydb
+++ b/debian/tests/copydb
@@ -10,7 +10,7 @@ pg_virtualenv << EOF
   createdb dst
   psql -c 'create table foo as select 123+456' src
   rm -rf $WORKDIR
-  HOME=$WORKDIR pgcopydb copy-db --source "dbname=src" --target "dbname=dst" --dir $WORKDIR
+  HOME=$WORKDIR pgcopydb clone --source "dbname=src" --target "dbname=dst" --dir $WORKDIR
   pg_dump -t foo dst
   pg_dump -t foo dst | grep 579
 EOF

--- a/docs/ref/pgcopydb.rst
+++ b/docs/ref/pgcopydb.rst
@@ -52,7 +52,6 @@ The ``pgcopydb help`` command lists all the supported sub-commands:
       clone     Clone an entire database from source to target
       fork      Clone an entire database from source to target
       follow    Replay changes from the source database to the target database
-      copy-db   Clone an entire database from source to target
       snapshot  Create and export a snapshot on the source database
     + copy      Implement the data section of the database copy
     + dump      Dump database objects from a Postgres instance

--- a/docs/ref/pgcopydb_clone.rst
+++ b/docs/ref/pgcopydb_clone.rst
@@ -10,7 +10,6 @@ same operation:
   pgcopydb
     clone     Clone an entire database from source to target
     fork      Clone an entire database from source to target
-    copy-db   Copy an entire database from source to target
 
 .. _pgcopydb_clone:
 
@@ -67,22 +66,6 @@ pgcopydb fork
 The command ``pgcopydb fork`` copies a database from the given source
 Postgres instance to the target Postgres instance. This command is an alias
 to the command ``pgcopydb clone`` seen above.
-
-.. _pgcopydb_copy__db:
-
-pgcopydb copy-db
-----------------
-
-The command ``pgcopydb copy-db`` copies a database from the given source
-Postgres instance to the target Postgres instance. This command is an alias
-to the command ``pgcopydb clone`` seen above, and available for backward
-compatibility only.
-
-.. warning::
-
-   The ``pgcopydb copy-db`` command is now deprecated and will get removed
-   from pgcopydb when hitting version 1.0, please upgrade your scripts and
-   integrations.
 
 Description
 -----------

--- a/src/bin/pgcopydb/cli_clone_follow.c
+++ b/src/bin/pgcopydb/cli_clone_follow.c
@@ -78,16 +78,6 @@ CommandLine fork_command =
 		cli_copy_db_getopts,
 		cli_clone);
 
-/* pgcopydb copy db is an alias for pgcopydb clone */
-CommandLine copy__db_command =
-	make_command(
-		"copy-db",
-		"Clone an entire database from source to target",
-		" --source ... --target ... [ --table-jobs ... --index-jobs ... ] ",
-		PGCOPYDB_CLONE_GETOPTS_HELP,
-		cli_copy_db_getopts,
-		cli_clone);
-
 
 CommandLine follow_command =
 	make_command(

--- a/src/bin/pgcopydb/cli_root.c
+++ b/src/bin/pgcopydb/cli_root.c
@@ -25,7 +25,6 @@ CommandLine *root_subcommands_with_debug[] = {
 	&clone_command,
 	&fork_command,
 	&follow_command,
-	&copy__db_command,          /* backward compat */
 	&snapshot_command,
 	&compare_commands,
 	&copy_commands,
@@ -52,7 +51,6 @@ CommandLine *root_subcommands[] = {
 	&clone_command,
 	&fork_command,
 	&follow_command,
-	&copy__db_command,          /* backward compat */
 	&snapshot_command,
 	&compare_commands,
 	&copy_commands,

--- a/src/bin/pgcopydb/cli_root.h
+++ b/src/bin/pgcopydb/cli_root.h
@@ -36,7 +36,6 @@ void cli_clone(int argc, char **argv);
 void cli_follow(int argc, char **argv);
 
 /* cli_copy.h */
-extern CommandLine copy__db_command;
 extern CommandLine clone_command;
 extern CommandLine fork_command;
 extern CommandLine follow_command;

--- a/src/bin/pgcopydb/copydb.c
+++ b/src/bin/pgcopydb/copydb.c
@@ -788,7 +788,7 @@ copydb_init_specs(CopyDataSpec *specs,
 		}
 	}
 
-	/* we only respect the --skip-blobs option in pgcopydb copy-db command */
+	/* we only respect the --skip-blobs option in pgcopydb clone command */
 	if (specs->section != DATA_SECTION_ALL)
 	{
 		specs->skipLargeObjects = true;

--- a/tests/cdc-endpos-between-transaction/copydb.sh
+++ b/tests/cdc-endpos-between-transaction/copydb.sh
@@ -33,7 +33,7 @@ sleep 1
 # now setup the replication origin (target) and the pgcopydb.sentinel (source)
 pgcopydb stream setup
 
-# pgcopydb copy db uses the environment variables
+# pgcopydb clone uses the environment variables
 pgcopydb clone
 
 # now that the copying is done, inject some SQL DML changes to the source

--- a/tests/cdc-low-level/copydb.sh
+++ b/tests/cdc-low-level/copydb.sh
@@ -30,8 +30,8 @@ sleep 1
 # now setup the replication origin (target) and the pgcopydb.sentinel (source)
 pgcopydb stream setup
 
-# pgcopydb copy db uses the environment variables
-pgcopydb copy-db
+# pgcopydb clone uses the environment variables
+pgcopydb clone
 
 kill -TERM ${COPROC_PID}
 wait ${COPROC_PID}

--- a/tests/cdc-test-decoding/copydb.sh
+++ b/tests/cdc-test-decoding/copydb.sh
@@ -28,8 +28,8 @@ sleep 1
 # now setup the replication origin (target) and the pgcopydb.sentinel (source)
 pgcopydb stream setup
 
-# pgcopydb copy db uses the environment variables
-pgcopydb copy-db
+# pgcopydb clone uses the environment variables
+pgcopydb clone
 
 kill -TERM ${COPROC_PID}
 wait ${COPROC_PID}

--- a/tests/cdc-wal2json/copydb.sh
+++ b/tests/cdc-wal2json/copydb.sh
@@ -29,8 +29,8 @@ sleep 1
 # now setup the replication origin (target) and the pgcopydb.sentinel (source)
 pgcopydb stream setup
 
-# pgcopydb copy db uses the environment variables
-pgcopydb copy-db
+# pgcopydb clone uses the environment variables
+pgcopydb clone
 
 kill -TERM ${COPROC_PID}
 wait ${COPROC_PID}

--- a/tests/endpos-in-multi-wal-txn/copydb.sh
+++ b/tests/endpos-in-multi-wal-txn/copydb.sh
@@ -33,7 +33,7 @@ sleep 1
 # now setup the replication origin (target) and the pgcopydb.sentinel (source)
 pgcopydb stream setup
 
-# pgcopydb copy db uses the environment variables
+# pgcopydb clone uses the environment variables
 pgcopydb clone
 
 # now that the copying is done, inject some SQL DML changes to the source

--- a/tests/follow-9.6/copydb.sh
+++ b/tests/follow-9.6/copydb.sh
@@ -49,8 +49,8 @@ psql -o /tmp/d.out -d ${PGCOPYDB_SOURCE_PGURI} -1 -f /tmp/data.sql
 # alter the pagila schema to allow capturing DDLs without pkey
 psql -d ${PGCOPYDB_SOURCE_PGURI} -f /usr/src/pgcopydb/ddl.sql
 
-# pgcopydb copy db uses the environment variables
-pgcopydb copy-db --follow
+# pgcopydb clone uses the environment variables
+pgcopydb clone --follow
 
 # cleanup
 pgcopydb stream sentinel get

--- a/tests/follow-wal2json/copydb.sh
+++ b/tests/follow-wal2json/copydb.sh
@@ -19,8 +19,8 @@ psql -o /tmp/d.out -d ${PGCOPYDB_SOURCE_PGURI} -1 -f /usr/src/pagila/pagila-data
 # alter the pagila schema to allow capturing DDLs without pkey
 psql -d ${PGCOPYDB_SOURCE_PGURI} -f /usr/src/pgcopydb/ddl.sql
 
-# pgcopydb copy db uses the environment variables
-pgcopydb copy-db --follow --plugin wal2json
+# pgcopydb clone uses the environment variables
+pgcopydb clone --follow --plugin wal2json
 
 # cleanup
 pgcopydb stream sentinel get


### PR DESCRIPTION
The copy-db command was deprecated for a while and will get removed from pgcopydb on next release, please upgrade your scripts and integrations.