### PR TITLE
Fix pgcopydb list progress command.

### DIFF
--- a/src/bin/pgcopydb/catalog.h
+++ b/src/bin/pgcopydb/catalog.h
@@ -496,7 +496,7 @@ bool catalog_iter_s_depend_finish(SourceDependIterator *iter);
 bool catalog_s_depend_fetch(SQLiteQuery *query);
 
 /*
- * Processes
+ * Processes, progress, summary
  */
 typedef struct ProcessInfo
 {
@@ -507,6 +507,7 @@ typedef struct ProcessInfo
 	uint32_t partNumber;
 	uint32_t indexOid;
 } ProcessInfo;
+
 
 bool catalog_upsert_process_info(DatabaseCatalog *catalog, ProcessInfo *ps);
 bool catalog_delete_process(DatabaseCatalog *catalog, pid_t pid);
@@ -522,6 +523,17 @@ bool catalog_iter_s_index_in_progress(DatabaseCatalog *catalog,
 									  SourceIndexIterFun *callback);
 
 bool catalog_iter_s_index_in_progress_init(SourceIndexIterator *iter);
+
+
+typedef struct CatalogProgressCount
+{
+	uint64_t table;
+	uint64_t index;
+} CatalogProgressCount;
+
+bool catalog_count_summary_done(DatabaseCatalog *catalog,
+								CatalogProgressCount *count);
+bool catalog_count_summary_done_fetch(SQLiteQuery *query);
 
 
 /*

--- a/src/bin/pgcopydb/progress.c
+++ b/src/bin/pgcopydb/progress.c
@@ -558,8 +558,16 @@ copydb_update_progress(CopyDataSpec *copySpecs, CopyProgress *progress)
 			  progress->tableCount,
 			  progress->indexCount);
 
+	CatalogProgressCount done = { 0 };
+
+	if (!catalog_count_summary_done(sourceDB, &done))
+	{
+		log_error("Failed to count tables and indexes done in our catalogs");
+		return false;
+	}
+
 	/* count table in progress, table done */
-	progress->tableDoneCount = 0;
+	progress->tableDoneCount = done.table;
 	progress->tableInProgress.count = 0;
 
 	/* we can't have more table in progress than tableJobs */
@@ -597,7 +605,7 @@ copydb_update_progress(CopyDataSpec *copySpecs, CopyProgress *progress)
 	}
 
 	/* count index in progress, index done */
-	progress->indexDoneCount = 0;
+	progress->indexDoneCount = done.index;
 	progress->indexInProgress.count = 0;
 
 	/* we can't have more index in progress than indexJobs */


### PR DESCRIPTION
Introduce a new query to count the number of tables and indexes already processed from the summary table, fixing the list progress output for items "done".