### PR TITLE
Improve `list table-parts` to list parts for all tables.

### DIFF
--- a/docs/include/list-table-parts.rst
+++ b/docs/include/list-table-parts.rst
@@ -4,8 +4,6 @@
    usage: pgcopydb list table-parts  --source ... 
    
      --source                    Postgres URI to the source database
-     --force                     Force fetching catalogs again
-     --schema-name               Name of the schema where to find the table
-     --table-name                Name of the target table
+     --force                     Force recalculation of copy partitions
      --split-tables-larger-than  Size threshold to consider partitioning
    

--- a/docs/include/list.rst
+++ b/docs/include/list.rst
@@ -8,7 +8,7 @@
        extensions   List all the source extensions to copy
        collations   List all the source collations to copy
        tables       List all the source tables to copy data from
-       table-parts  List a source table copy partitions
+       table-parts  List all the source tables copy partitions
        sequences    List all the source sequences to copy data from
        indexes      List all the indexes to create again after copying the data
        depends      List all the dependencies to filter-out

--- a/src/bin/pgcopydb/cli_common.h
+++ b/src/bin/pgcopydb/cli_common.h
@@ -20,12 +20,7 @@
 #include "parsing_utils.h"
 #include "pgcmd.h"
 #include "pgsql.h"
-
-typedef struct SplitTableLargerThan
-{
-	uint64_t bytes;
-	char bytesPretty[NAMEDATALEN];
-} SplitTableLargerThan;
+#include "schema.h"
 
 
 typedef struct CopyDBOptions

--- a/src/bin/pgcopydb/schema.h
+++ b/src/bin/pgcopydb/schema.h
@@ -373,6 +373,13 @@ typedef struct Catalogs
 } Catalogs;
 
 
+typedef struct SplitTableLargerThan
+{
+	uint64_t bytes;
+	char bytesPretty[NAMEDATALEN];
+} SplitTableLargerThan;
+
+
 bool schema_query_privileges(PGSQL *pgsql,
 							 bool *hasDBCreatePrivilage,
 							 bool *hasDBTempPrivilege);
@@ -409,7 +416,8 @@ bool schema_list_table(PGSQL *pgsql,
 
 bool schema_list_ordinary_tables(PGSQL *pgsql,
 								 SourceFilters *filters,
-								 DatabaseCatalog *catalog);
+								 DatabaseCatalog *catalog,
+								 SplitTableLargerThan *splitTablesLargerThan);
 
 bool schema_list_ordinary_tables_without_pk(PGSQL *pgsql,
 											SourceFilters *filters,

--- a/tests/unit/expected/4-list-table-split.out
+++ b/tests/unit/expected/4-list-table-split.out
@@ -1,30 +1,54 @@
-2023-07-31 13:58:39 96 INFO   main.c:163                Running pgcopydb version 0.13.3.g1e88091 from "/usr/local/bin/pgcopydb"
-2023-07-31 13:58:39 96 INFO   cli_list.c:1081           Listing COPY partitions for table "public"."table_1" in "postgres://postgres@source/postgres"
-2023-07-31 13:58:39 96 INFO   cli_list.c:1195           Table "public"."table_1" COPY will be split 10-ways
-        Part |          Min |          Max |        Count
--------------+--------------+--------------+-------------
-        1/10 |            1 |           11 |           11
-        2/10 |           12 |           22 |           11
-        3/10 |           23 |           33 |           11
-        4/10 |           34 |           44 |           11
-        5/10 |           45 |           55 |           11
-        6/10 |           56 |           66 |           11
-        7/10 |           67 |           77 |           11
-        8/10 |           78 |           88 |           11
-        9/10 |           89 |           99 |           11
-       10/10 |          100 |          100 |            1
+     OID |               Schema Name |                Table Name |         Part |          Min |          Max |        Count
+---------+---------------------------+---------------------------+--------------+--------------+--------------+-------------
+   16432 |                    public |                   table_1 |         1/10 |            1 |           11 |           11
+   16432 |                    public |                   table_1 |         2/10 |           12 |           22 |           11
+   16432 |                    public |                   table_1 |         3/10 |           23 |           33 |           11
+   16432 |                    public |                   table_1 |         4/10 |           34 |           44 |           11
+   16432 |                    public |                   table_1 |         5/10 |           45 |           55 |           11
+   16432 |                    public |                   table_1 |         6/10 |           56 |           66 |           11
+   16432 |                    public |                   table_1 |         7/10 |           67 |           77 |           11
+   16432 |                    public |                   table_1 |         8/10 |           78 |           88 |           11
+   16432 |                    public |                   table_1 |         9/10 |           89 |           99 |           11
+   16432 |                    public |                   table_1 |        10/10 |          100 |          100 |            1
 
-2023-07-31 13:58:39 97 INFO   main.c:163                Running pgcopydb version 0.13.3.g1e88091 from "/usr/local/bin/pgcopydb"
-2023-07-31 13:58:39 97 INFO   cli_list.c:1081           Listing COPY partitions for table "public"."table_2" in "postgres://postgres@source/postgres"
-2023-07-31 13:58:39 97 INFO   cli_list.c:1195           Table "public"."table_2" COPY will be split 5-ways
-        Part |          Min |          Max |        Count
--------------+--------------+--------------+-------------
-         1/5 |            1 |           21 |           21
-         2/5 |           22 |           42 |           21
-         3/5 |           43 |           63 |           21
-         4/5 |           64 |           84 |           21
-         5/5 |           85 |          100 |           16
+     OID |               Schema Name |                Table Name |         Part |          Min |          Max |        Count
+---------+---------------------------+---------------------------+--------------+--------------+--------------+-------------
+   16456 |                    public |                   table_4 |         1/11 |        (0,0) |        (0,0) |            1
+   16456 |                    public |                   table_4 |         2/11 |        (1,0) |        (1,0) |            1
+   16456 |                    public |                   table_4 |        11/11 |        (1,0) |            - |            -
 
-2023-07-31 13:58:39 98 INFO   main.c:163                Running pgcopydb version 0.13.3.g1e88091 from "/usr/local/bin/pgcopydb"
-2023-07-31 13:58:39 98 INFO   cli_list.c:1081           Listing COPY partitions for table "public"."table_3" in "postgres://postgres@source/postgres"
-2023-07-31 13:58:39 98 INFO   cli_list.c:1188           Table "public"."table_3" () will not be split
+     OID |               Schema Name |                Table Name |         Part |          Min |          Max |        Count
+---------+---------------------------+---------------------------+--------------+--------------+--------------+-------------
+   16467 |          "Sp1eCial .Char" |            source1testing |         1/10 |            1 |         1001 |         1001
+   16467 |          "Sp1eCial .Char" |            source1testing |         2/10 |         1002 |         2002 |         1001
+   16467 |          "Sp1eCial .Char" |            source1testing |         3/10 |         2003 |         3003 |         1001
+   16467 |          "Sp1eCial .Char" |            source1testing |         4/10 |         3004 |         4004 |         1001
+   16467 |          "Sp1eCial .Char" |            source1testing |         5/10 |         4005 |         5005 |         1001
+   16467 |          "Sp1eCial .Char" |            source1testing |         6/10 |         5006 |         6006 |         1001
+   16467 |          "Sp1eCial .Char" |            source1testing |         7/10 |         6007 |         7007 |         1001
+   16467 |          "Sp1eCial .Char" |            source1testing |         8/10 |         7008 |         8008 |         1001
+   16467 |          "Sp1eCial .Char" |            source1testing |         9/10 |         8009 |         9009 |         1001
+   16467 |          "Sp1eCial .Char" |            source1testing |        10/10 |         9010 |        10000 |          991
+
+     OID |               Schema Name |                Table Name |         Part |          Min |          Max |        Count
+---------+---------------------------+---------------------------+--------------+--------------+--------------+-------------
+   16472 |          "Sp1eCial .Char" |         "Tabl e.1testing" |         1/10 |            1 |         1001 |         1001
+   16472 |          "Sp1eCial .Char" |         "Tabl e.1testing" |         2/10 |         1002 |         2002 |         1001
+   16472 |          "Sp1eCial .Char" |         "Tabl e.1testing" |         3/10 |         2003 |         3003 |         1001
+   16472 |          "Sp1eCial .Char" |         "Tabl e.1testing" |         4/10 |         3004 |         4004 |         1001
+   16472 |          "Sp1eCial .Char" |         "Tabl e.1testing" |         5/10 |         4005 |         5005 |         1001
+   16472 |          "Sp1eCial .Char" |         "Tabl e.1testing" |         6/10 |         5006 |         6006 |         1001
+   16472 |          "Sp1eCial .Char" |         "Tabl e.1testing" |         7/10 |         6007 |         7007 |         1001
+   16472 |          "Sp1eCial .Char" |         "Tabl e.1testing" |         8/10 |         7008 |         8008 |         1001
+   16472 |          "Sp1eCial .Char" |         "Tabl e.1testing" |         9/10 |         8009 |         9009 |         1001
+   16472 |          "Sp1eCial .Char" |         "Tabl e.1testing" |        10/10 |         9010 |        10000 |          991
+
+     OID |               Schema Name |                Table Name |         Part |          Min |          Max |        Count
+---------+---------------------------+---------------------------+--------------+--------------+--------------+-------------
+   16440 |                    public |                   table_2 |          1/5 |            1 |           21 |           21
+   16440 |                    public |                   table_2 |          2/5 |           22 |           42 |           21
+   16440 |                    public |                   table_2 |          3/5 |           43 |           63 |           21
+   16440 |                    public |                   table_2 |          4/5 |           64 |           84 |           21
+   16440 |                    public |                   table_2 |          5/5 |           85 |          100 |           16
+
+

--- a/tests/unit/script/4-list-table-split.sh
+++ b/tests/unit/script/4-list-table-split.sh
@@ -19,18 +19,5 @@ OPTS="--not-consistent --split-tables-larger-than 10kB"
 
 pgcopydb list schema --dir ${DIR} ${OPTS} >/dev/null
 
-# Cached size of table_1 is 100 KB, so this will be split into 10 parts
 pgcopydb list table-parts --dir ${DIR} \
-    --schema-name "public" --table-name "table_1" \
-    --split-tables-larger-than "10 kB" 2>&1
-
-# table_2 is identical to table_1 but with the size of 50 KB, so this will be
-# split into 5 parts
-pgcopydb list table-parts --dir ${DIR} \
-    --schema-name "public" --table-name "table_2" \
-    --split-tables-larger-than "10 kB" 2>&1
-
-# table_3 doesn't have size in cache, therefore it will not be split
-pgcopydb list table-parts --dir ${DIR} \
-    --schema-name "public" --table-name "table_3" \
-    --split-tables-larger-than "10 kB" 2>&1
+    --split-tables-larger-than "10 kB" 2>/dev/null

--- a/tests/unit/setup/4-list-table-split.sql
+++ b/tests/unit/setup/4-list-table-split.sql
@@ -20,7 +20,14 @@ create table table_3 (
     c_char char(10)
 );
 
--- Insert 100 rows into table_1 and duplicate data in table_2 and table_3.
+-- Create one more table with same schema except it doesn't have
+-- primary key (or any suitable part-key).
+create table table_4 (
+    c_bigserial bigserial,
+    c_char char(10)
+);
+
+-- Insert 100 rows into table_1 and duplicate it to table_2, table_3 and table_4.
 
 insert into table_1 (c_char)
 select
@@ -36,6 +43,12 @@ from
     table_1;
 
 insert into table_3
+select
+    *
+from
+    table_1;
+
+insert into table_4
 select
     *
 from
@@ -62,7 +75,11 @@ with cache_table_size as ((
     union (
         select
             'table_2'::regclass::oid,
-            51200))
+            51200)
+    union (
+        select
+            'table_4'::regclass::oid,
+            102400))
 insert into pgcopydb.pgcopydb_table_size (oid, bytes)
 select
     *
@@ -109,6 +126,6 @@ from
 
 insert into pgcopydb.pgcopydb_table_size (oid, bytes)
      select tname::regclass,
-            10 * 1024 * 1024
+            100 * 1024 -- 100 KiB
        from (values ('"Sp1eCial .Char"."source1testing"'),
                     ('"Sp1eCial .Char"."Tabl e.1testing"')) as t(tname);


### PR DESCRIPTION
[edit] See this commit for fresh description: https://github.com/dimitri/pgcopydb/pull/611/commits/4df109ed5119b06a35a0e2305aeecfb8c8a18861. Keeping below text for completeness of discussion.

----
- Replace `catalog_init_from_specs` with `copydb_fetch_schema_and_prepare_specs`. The former works only if the catalog already exists. The latter connects to the source and provides a fresh report.
- Correct confusing output where `Max` of last row was `(-1,0)`. Revert to old behavior for clarity.
- Limit `copydb_fetch_schema_and_prepare_specs` to fetch information only for the specified table and schema. Initialize the filter of specs with the passed single table and schema.