### PR TITLE
Problem: Incorrect flush LSN from source being used to find durable LSN

### DIFF
--- a/src/bin/pgcopydb/ld_apply.c
+++ b/src/bin/pgcopydb/ld_apply.c
@@ -1606,7 +1606,7 @@ stream_apply_find_durable_lsn(StreamApplyContext *context, uint64_t *durableLSN)
 	uint64_t flushLSN = InvalidXLogRecPtr;
 
 	if (!stream_fetch_current_lsn(&flushLSN,
-								  context->connStrings->source_pguri,
+								  context->connStrings->target_pguri,
 								  PGSQL_CONN_SOURCE))
 	{
 		log_error("Failed to retrieve current WAL positions, "


### PR DESCRIPTION
Solution: Use flush LSN from target to find the durable LSN.

To find a durable LSN with async commit, we maintain a list of LSN mapping between source(sourceLSN) and target(insertLSN). New mapping will be inserted into the list on COMMIT or KEEPALIVE message.

While reporting the replay_lsn to sentinel we have to get the flush lsn from target and compare it against the insertLSN from the list to find the sourceLSN.

This has been discussed in https://github.com/dimitri/pgcopydb/pull/608#issuecomment-1875144153