### PR TITLE
Fix numerous issues with argument parsing

### DIFF
--- a/src/bin/pgcopydb/cli_common.c
+++ b/src/bin/pgcopydb/cli_common.c
@@ -51,19 +51,13 @@ cli_print_version_getopts(int argc, char **argv)
 
 	static struct option long_options[] = {
 		{ "json", no_argument, NULL, 'J' },
-		{ "version", no_argument, NULL, 'V' },
-		{ "verbose", no_argument, NULL, 'v' },
-		{ "notice", no_argument, NULL, 'v' },
-		{ "debug", no_argument, NULL, 'd' },
-		{ "trace", no_argument, NULL, 'z' },
-		{ "quiet", no_argument, NULL, 'q' },
 		{ "help", no_argument, NULL, 'h' },
 		{ NULL, 0, NULL, 0 }
 	};
 	optind = 0;
 
 	/*
-	 * The only command lines that are using keeper_cli_getopt_pgdata are
+	 * The only command lines that are using cli_print_version_getopts are
 	 * terminal ones: they don't accept subcommands. In that case our option
 	 * parsing can happen in any order and we don't need getopt_long to behave
 	 * in a POSIXLY_CORRECT way.
@@ -72,7 +66,7 @@ cli_print_version_getopts(int argc, char **argv)
 	 */
 	unsetenv("POSIXLY_CORRECT");
 
-	while ((c = getopt_long(argc, argv, "JVvdzqh",
+	while ((c = getopt_long(argc, argv, "Jh",
 							long_options, &option_index)) != -1)
 	{
 		switch (c)
@@ -91,6 +85,7 @@ cli_print_version_getopts(int argc, char **argv)
 				break;
 			}
 
+			case '?':
 			default:
 			{
 				/*
@@ -434,7 +429,7 @@ cli_copydb_getenv(CopyDBOptions *options)
 		}
 	}
 
-	/* when --fail-fast has not been used, check PGCOPYDB_FAIL_FAST */
+	/* when --skip-vacuum has not been used, check PGCOPYDB_SKIP_VACUUM */
 	if (!options->skipVacuum)
 	{
 		if (env_exists(PGCOPYDB_SKIP_VACUUM))
@@ -803,7 +798,7 @@ cli_copy_db_getopts(int argc, char **argv)
 	}
 
 	while ((c = getopt_long(argc, argv,
-							"S:T:D:J:I:b:L:cOBemlirRCN:xXj:Ctfo:p:s:E:F:Q:iVvdzqh",
+							"S:T:D:J:I:b:L:cAPOXj:xBeMlUF:F:Q:irRCN:fp:ws:o:tE:Vvdzqh",
 							long_options, &option_index)) != -1)
 	{
 		switch (c)
@@ -1187,6 +1182,7 @@ cli_copy_db_getopts(int argc, char **argv)
 			}
 
 			case '?':
+			default:
 			{
 				commandline_help(stderr);
 				exit(EXIT_CODE_BAD_ARGS);

--- a/src/bin/pgcopydb/cli_common.c
+++ b/src/bin/pgcopydb/cli_common.c
@@ -36,12 +36,6 @@ void
 cli_help(int argc, char **argv)
 {
 	CommandLine command = root;
-
-	if (env_exists(PGCOPYDB_DEBUG))
-	{
-		command = root_with_debug;
-	}
-
 	(void) commandline_print_command_tree(&command, stdout);
 }
 

--- a/src/bin/pgcopydb/cli_compare.c
+++ b/src/bin/pgcopydb/cli_compare.c
@@ -107,7 +107,7 @@ cli_compare_getopts(int argc, char **argv)
 	/* bypass computing partitionning specs */
 	options.splitTablesLargerThan.bytes = 0;
 
-	while ((c = getopt_long(argc, argv, "S:T:D:j:Vvdzqh",
+	while ((c = getopt_long(argc, argv, "S:T:D:j:JVvdzqh",
 							long_options, &option_index)) != -1)
 	{
 		switch (c)

--- a/src/bin/pgcopydb/cli_dump.c
+++ b/src/bin/pgcopydb/cli_dump.c
@@ -133,7 +133,7 @@ cli_dump_schema_getopts(int argc, char **argv)
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 
-	while ((c = getopt_long(argc, argv, "S:T:D:PrRCNVvdzqh",
+	while ((c = getopt_long(argc, argv, "S:T:D:PrReCNVvdzqh",
 							long_options, &option_index)) != -1)
 	{
 		switch (c)

--- a/src/bin/pgcopydb/cli_list.c
+++ b/src/bin/pgcopydb/cli_list.c
@@ -275,7 +275,7 @@ cli_list_db_getopts(int argc, char **argv)
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 
-	while ((c = getopt_long(argc, argv, "S:T:D:j:s:t:PL:cCJRIVvdzqh",
+	while ((c = getopt_long(argc, argv, "S:D:s:t:F:xPL:fcCyarJRIN:Vdzvqh",
 							long_options, &option_index)) != -1)
 	{
 		switch (c)
@@ -509,6 +509,7 @@ cli_list_db_getopts(int argc, char **argv)
 				break;
 			}
 
+			case '?':
 			default:
 			{
 				++errors;

--- a/src/bin/pgcopydb/cli_ping.c
+++ b/src/bin/pgcopydb/cli_ping.c
@@ -152,6 +152,12 @@ cli_ping_getopts(int argc, char **argv)
 				exit(EXIT_CODE_QUIT);
 				break;
 			}
+
+			case '?':
+			default:
+			{
+				++errors;
+			}
 		}
 	}
 
@@ -159,6 +165,12 @@ cli_ping_getopts(int argc, char **argv)
 		options.connStrings.target_pguri == NULL)
 	{
 		log_fatal("Options --source and --target are mandatory");
+		exit(EXIT_CODE_BAD_ARGS);
+	}
+
+	if (errors > 0)
+	{
+		commandline_help(stderr);
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 

--- a/src/bin/pgcopydb/cli_restore.c
+++ b/src/bin/pgcopydb/cli_restore.c
@@ -153,7 +153,6 @@ cli_restore_schema_getopts(int argc, char **argv)
 		{ "source", required_argument, NULL, 'S' },
 		{ "target", required_argument, NULL, 'T' },
 		{ "dir", required_argument, NULL, 'D' },
-		{ "schema", required_argument, NULL, 's' },
 		{ "drop-if-exists", no_argument, NULL, 'c' }, /* pg_restore -c */
 		{ "no-owner", no_argument, NULL, 'O' },       /* pg_restore -O */
 		{ "no-comments", no_argument, NULL, 'X' },
@@ -191,7 +190,7 @@ cli_restore_schema_getopts(int argc, char **argv)
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 
-	while ((c = getopt_long(argc, argv, "S:T:D:s:cOj:xXFeErRCNVvdzqh",
+	while ((c = getopt_long(argc, argv, "S:T:D:cOXj:xF:eErRCN:Vvdzqh",
 							long_options, &option_index)) != -1)
 	{
 		switch (c)
@@ -391,6 +390,12 @@ cli_restore_schema_getopts(int argc, char **argv)
 				exit(EXIT_CODE_QUIT);
 				break;
 			}
+
+			case '?':
+			default:
+			{
+				++errors;
+			}
 		}
 	}
 
@@ -408,6 +413,7 @@ cli_restore_schema_getopts(int argc, char **argv)
 
 	if (errors > 0)
 	{
+		commandline_help(stderr);
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 

--- a/src/bin/pgcopydb/cli_root.c
+++ b/src/bin/pgcopydb/cli_root.c
@@ -18,31 +18,6 @@ CommandLine version =
 				 cli_print_version_getopts,
 				 cli_print_version);
 
-/*
- * Command line options when using PGCOPYDB_DEBUG=1, as sub-processes do.
- */
-CommandLine *root_subcommands_with_debug[] = {
-	&clone_command,
-	&fork_command,
-	&follow_command,
-	&snapshot_command,
-	&compare_commands,
-	&copy_commands,
-	&dump_commands,
-	&restore_commands,
-	&list_commands,
-	&stream_commands,
-	&ping_command,
-	&help,
-	&version,
-	NULL
-};
-
-CommandLine root_with_debug =
-	make_command_set("pgcopydb",
-					 "pgcopydb tool",
-					 "[ --verbose --quiet ]", NULL,
-					 root_options, root_subcommands);
 
 /*
  * Command line options intended to normal users.

--- a/src/bin/pgcopydb/cli_root.h
+++ b/src/bin/pgcopydb/cli_root.h
@@ -26,9 +26,6 @@ extern CommandLine version;
 extern CommandLine root;
 extern CommandLine *root_subcommands[];
 
-extern CommandLine root_with_debug;
-extern CommandLine *root_subcommands_with_debug[];
-
 int root_options(int argc, char **argv);
 
 /* cli_clone_follow.c */

--- a/src/bin/pgcopydb/cli_sentinel.c
+++ b/src/bin/pgcopydb/cli_sentinel.c
@@ -150,7 +150,7 @@ cli_sentinel_getopts(int argc, char **argv)
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 
-	while ((c = getopt_long(argc, argv, "S:s:E:CVvdzqh",
+	while ((c = getopt_long(argc, argv, "S:D:E:s:CJVvdzqh",
 							long_options, &option_index)) != -1)
 	{
 		switch (c)
@@ -281,6 +281,12 @@ cli_sentinel_getopts(int argc, char **argv)
 				exit(EXIT_CODE_QUIT);
 				break;
 			}
+
+			case '?':
+			default:
+			{
+				++errors;
+			}
 		}
 	}
 
@@ -308,6 +314,7 @@ cli_sentinel_getopts(int argc, char **argv)
 
 	if (errors > 0)
 	{
+		commandline_help(stderr);
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 

--- a/src/bin/pgcopydb/cli_snapshot.c
+++ b/src/bin/pgcopydb/cli_snapshot.c
@@ -73,7 +73,7 @@ cli_create_snapshot_getopts(int argc, char **argv)
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 
-	while ((c = getopt_long(argc, argv, "S:T:D:Vvdzqh",
+	while ((c = getopt_long(argc, argv, "S:D:fp:ws:Vvdzqh",
 							long_options, &option_index)) != -1)
 	{
 		switch (c)
@@ -192,6 +192,13 @@ cli_create_snapshot_getopts(int argc, char **argv)
 				exit(EXIT_CODE_QUIT);
 				break;
 			}
+
+			case '?':
+			default:
+			{
+				++errors;
+				break;
+			}
 		}
 	}
 
@@ -235,6 +242,7 @@ cli_create_snapshot_getopts(int argc, char **argv)
 
 	if (errors > 0)
 	{
+		commandline_help(stderr);
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 

--- a/src/bin/pgcopydb/cli_stream.c
+++ b/src/bin/pgcopydb/cli_stream.c
@@ -235,7 +235,7 @@ cli_stream_getopts(int argc, char **argv)
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 
-	while ((c = getopt_long(argc, argv, "S:T:j:p:s:o:t:PVvdzqh",
+	while ((c = getopt_long(argc, argv, "S:T:D:p:ws:N:o:E:rRCOIVvdzqh",
 							long_options, &option_index)) != -1)
 	{
 		switch (c)
@@ -435,6 +435,7 @@ cli_stream_getopts(int argc, char **argv)
 			}
 
 			case '?':
+			default:
 			{
 				commandline_help(stderr);
 				exit(EXIT_CODE_BAD_ARGS);

--- a/src/bin/pgcopydb/main.c
+++ b/src/bin/pgcopydb/main.c
@@ -76,15 +76,6 @@ main(int argc, char **argv)
 	atexit(unlink_system_res_atexit);
 
 	/*
-	 * When PGCOPYDB_DEBUG is set in the environment, provide the user
-	 * commands available to debug a pgcopydb instance.
-	 */
-	if (env_exists(PGCOPYDB_DEBUG))
-	{
-		command = root_with_debug;
-	}
-
-	/*
 	 * We need to follow POSIX specifications for argument parsing, in
 	 * particular we want getopt() to stop as soon as it reaches a non option
 	 * in the command line.


### PR DESCRIPTION
The following issues were fixed:
- some options were not recognized
- some nonexistent options were recognized
- some options with required arguments were not expecting an argument
- some commands did not print help messages when given invalid options

I also removed `root_with_debug` global variable that is identical to root CommandLine.