### PR TITLE
Update actions/checkout version to v4

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # all history for all branches and tags
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -37,7 +37,7 @@ jobs:
           - endpos-in-multi-wal-txn
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # all history for all branches and tags
 
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     container: citus/stylechecker:latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Check C style
       run: citus_indent --check


### PR DESCRIPTION
This pull request updates the version of actions/checkout to v4. This update ensures that the latest version of actions/checkout is used, which may include bug fixes, improvements, or new features.