### PR TITLE
Problem: `pgcopydb copy extension` fails when sequences exists part of ext configuration

### DIFF
--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -2855,7 +2855,7 @@ typedef struct SourceSequenceContext
  * The connection is expected to be opened and closed from the caller.
  */
 bool
-pgsql_get_sequence(PGSQL *pgsql, const char *nspname, const char *relname,
+pgsql_get_sequence(PGSQL *pgsql, const char *qname,
 				   int64_t *lastValue,
 				   bool *isCalled)
 {
@@ -2863,22 +2863,21 @@ pgsql_get_sequence(PGSQL *pgsql, const char *nspname, const char *relname,
 	SourceSequenceContext context = { 0 };
 
 	/* identifiers have already been escaped thanks to format('%I', ...) */
-	sformat(sql, sizeof(sql), "select last_value, is_called from %s.%s",
-			nspname,
-			relname);
+	sformat(sql, sizeof(sql), "select last_value, is_called from %s",
+			qname);
 
 	if (!pgsql_execute_with_params(pgsql, sql, 0, NULL, NULL,
 								   &context, &getSequenceValue))
 	{
-		log_error("Failed to retrieve metadata for sequence \"%s\".\"%s\"",
-				  nspname, relname);
+		log_error("Failed to retrieve metadata for sequence %s",
+				  qname);
 		return false;
 	}
 
 	if (!context.parsedOk)
 	{
-		log_error("Failed to retrieve metadata for sequence \"%s\".\"%s\"",
-				  nspname, relname);
+		log_error("Failed to retrieve metadata for sequence %s",
+				  qname);
 		return false;
 	}
 

--- a/src/bin/pgcopydb/pgsql.h
+++ b/src/bin/pgcopydb/pgsql.h
@@ -328,7 +328,7 @@ bool pg_copy_from_stdin(PGSQL *pgsql, const char *qname);
 bool pg_copy_row_from_stdin(PGSQL *pgsql, char *fmt, ...);
 bool pg_copy_end(PGSQL *pgsql);
 
-bool pgsql_get_sequence(PGSQL *pgsql, const char *nspname, const char *relname,
+bool pgsql_get_sequence(PGSQL *pgsql, const char *qname,
 						int64_t *lastValue,
 						bool *isCalled);
 

--- a/src/bin/pgcopydb/schema.h
+++ b/src/bin/pgcopydb/schema.h
@@ -59,6 +59,7 @@ typedef struct SourceExtensionConfig
 	char nspname[PG_NAMEDATALEN];
 	char relname[PG_NAMEDATALEN];
 	char *condition;            /* strdup from PQresult: malloc'ed area */
+	char relkind;                  /* 'r' for regular table, 'S' for sequence */
 } SourceExtensionConfig;
 
 


### PR DESCRIPTION
Solution: Populate extension configuration objects along with their type values. Based on the type value, perform either table copy or sequence copy.

At the moment we support only copying extension configuration tables & sequences.

I didn't add test for this PR, because I've to hunt the extension which has sequence as part of the config table. I've manually tested with timescaledb which happens to have few sequences part of the extension config table.

```
pgcopydb list extensions
16:26:50.957 49804 INFO   Running pgcopydb version 0.14.1.58.g1f03537 from "/Users/arajkumar/works/dimitri/pgcopydb/src/bin/pgcopydb/pgcopydb"
16:26:50.969 49804 INFO   Using work dir "/tmp/pgcopydb"
16:26:50.973 49804 INFO   Re-using catalog caches
       OID |                      Name |               Schema |      Count | Config
-----------+---------------------------+----------------------+------------+-----------
     14568 |                   plpgsql |           pg_catalog |          0 |
     16420 |               timescaledb |               public |         34 | "_timescaledb_catalog"."hypertable_id_seq","_timescaledb_catalog"."hypertable","_timescaledb_catalog"."hypertable_data_node","_timescaledb_catalog"."tablespace","_timescaledb_catalog"."dimension_id_seq","_timescaledb_catalog"."dimension","_timescaledb_catalog"."dimension_partition","_timescaledb_catalog"."dimension_slice_id_seq","_timescaledb_catalog"."dimension_slice","_timescaledb_catalog"."chunk_id_seq","_timescaledb_catalog"."chunk","_timescaledb_catalog"."chunk_constraint","_timescaledb_catalog"."chunk_constraint_name","_timescaledb_catalog"."chunk_index","_timescaledb_catalog"."chunk_data_node","_timescaledb_config"."bgw_job_id_seq","_timescaledb_config"."bgw_job","_timescaledb_catalog"."metadata","_timescaledb_catalog"."continuous_agg","_timescaledb_catalog"."continuous_aggs_bucket_function","_timescaledb_catalog"."continuous_aggs_invalidation_threshold","_timescaledb_catalog"."continuous_aggs_watermark","_timescaledb_catalog"."continuous_aggs_hypertable_invalidation_log","_timescaledb_catalog"."continuous_aggs_materialization_invalidation_log","_timescaledb_catalog"."hypertable_compression","_timescaledb_catalog"."compression_chunk_size","_timescaledb_catalog"."remote_txn","_timescaledb_catalog"."continuous_agg_migrate_plan","_timescaledb_catalog"."continuous_agg_migrate_plan_step_step_id_seq","_timescaledb_catalog"."continuous_agg_migrate_plan_step","_timescaledb_internal"."job_errors","_timescaledb_cache"."cache_inval_hypertable","_timescaledb_cache"."cache_inval_bgw_job","_timescaledb_cache"."cache_inval_extension"
```

With the fix, I could copy the timescale extension from source to target,

```
pgcopydb copy extensions --restart
11:00:32.933 2483944 INFO   Running pgcopydb version 0.14.1.27.g7b14081 from "/home/ubuntu/dimitri/pgcopydb/src/bin/pgcopydb/pgcopydb"
11:00:32.933 2483944 INFO   [SOURCE] Copying database from "postgres://xxxxo:xxx/defaultdb?sslmode=require&keepalives=1&keepalives_idle=10&keepalives_interval=10&keepalives_count=60"
11:00:32.933 2483944 INFO   [TARGET] Copying database into "postgres://xxx:xx/tsdb?sslmode=require&keepalives=1&keepalives_idle=10&keepalives_interval=10&keepalives_count=60"
11:00:32.966 2483944 INFO   Using work dir "/tmp/pgcopydb"
11:00:33.131 2483944 INFO   Exported snapshot "00000032-0000C683-1" from the source database
11:00:33.899 2483944 INFO   Fetched information for 2 extensions
11:00:34.174 2483944 INFO   Found 8 indexes (supporting 2 constraints) in the target database
11:00:34.193 2483944 INFO   Creating extension "plpgsql"
11:00:34.211 2483944 WARN   NOTICE:  extension "plpgsql" already exists, skipping
11:00:34.212 2483944 INFO   Creating extension "timescaledb"
11:00:34.246 2483944 WARN   NOTICE:  extension "timescaledb" already exists, skipping
11:00:34.260 2483944 INFO   COPY extension "timescaledb" configuration sequence _timescaledb_catalog.hypertable_id_seq
11:00:34.298 2483944 INFO   COPY extension "timescaledb" configuration table _timescaledb_catalog.hypertable
11:00:34.338 2483944 INFO   COPY extension "timescaledb" configuration table _timescaledb_catalog.hypertable_data_node
11:00:34.376 2483944 INFO   COPY extension "timescaledb" configuration table _timescaledb_catalog.tablespace
11:00:34.413 2483944 INFO   COPY extension "timescaledb" configuration sequence _timescaledb_catalog.dimension_id_seq
11:00:34.449 2483944 INFO   COPY extension "timescaledb" configuration table _timescaledb_catalog.dimension
11:00:34.488 2483944 INFO   COPY extension "timescaledb" configuration table _timescaledb_catalog.dimension_partition
11:00:34.528 2483944 INFO   COPY extension "timescaledb" configuration sequence _timescaledb_catalog.dimension_slice_id_seq
11:00:34.564 2483944 INFO   COPY extension "timescaledb" configuration table _timescaledb_catalog.dimension_slice
11:00:34.605 2483944 INFO   COPY extension "timescaledb" configuration sequence _timescaledb_catalog.chunk_id_seq
11:00:34.641 2483944 INFO   COPY extension "timescaledb" configuration table _timescaledb_catalog.chunk
11:00:34.679 2483944 INFO   COPY extension "timescaledb" configuration table _timescaledb_catalog.chunk_constraint
11:00:34.718 2483944 INFO   COPY extension "timescaledb" configuration sequence _timescaledb_catalog.chunk_constraint_name
11:00:34.756 2483944 INFO   COPY extension "timescaledb" configuration table _timescaledb_catalog.chunk_index
11:00:34.801 2483944 INFO   COPY extension "timescaledb" configuration table _timescaledb_catalog.chunk_data_node
11:00:34.840 2483944 INFO   COPY extension "timescaledb" configuration sequence _timescaledb_config.bgw_job_id_seq
11:00:34.876 2483944 INFO   COPY extension "timescaledb" configuration table _timescaledb_config.bgw_job
11:00:34.914 2483944 INFO   COPY extension "timescaledb" configuration table _timescaledb_catalog.metadata
11:00:34.952 2483944 INFO   COPY extension "timescaledb" configuration table _timescaledb_catalog.continuous_agg
11:00:34.990 2483944 INFO   COPY extension "timescaledb" configuration table _timescaledb_catalog.continuous_aggs_bucket_function
11:00:35.039 2483944 INFO   COPY extension "timescaledb" configuration table _timescaledb_catalog.continuous_aggs_invalidation_threshold
11:00:35.078 2483944 INFO   COPY extension "timescaledb" configuration table _timescaledb_catalog.continuous_aggs_watermark
11:00:35.115 2483944 INFO   COPY extension "timescaledb" configuration table _timescaledb_catalog.continuous_aggs_hypertable_invalidation_log
11:00:35.152 2483944 INFO   COPY extension "timescaledb" configuration table _timescaledb_catalog.continuous_aggs_materialization_invalidation_log
11:00:35.192 2483944 INFO   COPY extension "timescaledb" configuration table _timescaledb_catalog.hypertable_compression
11:00:35.232 2483944 INFO   COPY extension "timescaledb" configuration table _timescaledb_catalog.compression_chunk_size
11:00:35.271 2483944 INFO   COPY extension "timescaledb" configuration table _timescaledb_catalog.remote_txn
11:00:35.309 2483944 INFO   COPY extension "timescaledb" configuration table _timescaledb_catalog.continuous_agg_migrate_plan
11:00:35.348 2483944 INFO   COPY extension "timescaledb" configuration sequence _timescaledb_catalog.continuous_agg_migrate_plan_step_step_id_seq
11:00:35.384 2483944 INFO   COPY extension "timescaledb" configuration table _timescaledb_catalog.continuous_agg_migrate_plan_step
11:00:35.421 2483944 INFO   COPY extension "timescaledb" configuration table _timescaledb_internal.job_errors
11:00:35.459 2483944 INFO   COPY extension "timescaledb" configuration table _timescaledb_cache.cache_inval_hypertable
11:00:35.496 2483944 INFO   COPY extension "timescaledb" configuration table _timescaledb_cache.cache_inval_bgw_job
11:00:35.533 2483944 INFO   COPY extension "timescaledb" configuration table _timescaledb_cache.cache_inval_extension
```