### PR TITLE
Problem: Error logs are seen when listing extensions with large extension config tables

### DIFF
--- a/src/bin/pgcopydb/cli_list.c
+++ b/src/bin/pgcopydb/cli_list.c
@@ -814,7 +814,7 @@ cli_list_extension_print_hook(void *ctx, SourceExtension *ext)
 		return false;
 	}
 
-	char config[BUFSIZE] = { 0 };
+	char config[4 * BUFSIZE] = { 0 };
 
 	for (int c = 0; c < ext->config.count; c++)
 	{


### PR DESCRIPTION
The following error lines are seen with extension having many number config tables,
```
arajkumar@Arunprasads-MacBook-Pro pgcopydb % pgcopydb list extensions
16:36:19.797 57801 INFO   Running pgcopydb version 0.14.1.58.g1f03537 from "/Users/arajkumar/works/dimitri/pgcopydb/src/bin/pgcopydb/pgcopydb"
16:36:19.810 57801 INFO   Using work dir "/tmp/pgcopydb"
16:36:19.815 57801 INFO   Re-using catalog caches
       OID |                      Name |               Schema |      Count | Config
-----------+---------------------------+----------------------+------------+-----------
     17304 |              aiven_extras |         aiven_extras |          0 |
     14568 |                   plpgsql |           pg_catalog |          0 |
16:36:19.816 57801 ERROR  BUG: sformat needs 1067 bytes to expend format string "%s%s"%s"."%s"", and a target string of 1024 bytes only has been given.
16:36:19.816 57801 ERROR  BUG: sformat needs 1071 bytes to expend format string "%s%s"%s"."%s"", and a target string of 1024 bytes only has been given.
16:36:19.816 57801 ERROR  BUG: sformat needs 1071 bytes to expend format string "%s%s"%s"."%s"", and a target string of 1024 bytes only has been given.
16:36:19.816 57801 ERROR  BUG: sformat needs 1059 bytes to expend format string "%s%s"%s"."%s"", and a target string of 1024 bytes only has been given.
16:36:19.816 57801 ERROR  BUG: sformat needs 1076 bytes to expend format string "%s%s"%s"."%s"", and a target string of 1024 bytes only has been given.
16:36:19.816 57801 ERROR  BUG: sformat needs 1093 bytes to expend format string "%s%s"%s"."%s"", and a target string of 1024 bytes only has been given.
16:36:19.816 57801 ERROR  BUG: sformat needs 1081 bytes to expend format string "%s%s"%s"."%s"", and a target string of 1024 bytes only has been given.
16:36:19.816 57801 ERROR  BUG: sformat needs 1060 bytes to expend format string "%s%s"%s"."%s"", and a target string of 1024 bytes only has been given.
16:36:19.816 57801 ERROR  BUG: sformat needs 1069 bytes to expend format string "%s%s"%s"."%s"", and a target string of 1024 bytes only has been given.
16:36:19.816 57801 ERROR  BUG: sformat needs 1066 bytes to expend format string "%s%s"%s"."%s"", and a target string of 1024 bytes only has been given.
16:36:19.816 57801 ERROR  BUG: sformat needs 1068 bytes to expend format string "%s%s"%s"."%s"", and a target string of 1024 bytes only has been given.
     16420 |               timescaledb |               public |         34 | "_timescaledb_catalog"."hypertable_id_seq","_timescaledb_catalog"."hypertable","_timescaledb_catalog"."hypertable_data_node","_timescaledb_catalog"."tablespace","_timescaledb_catalog"."dimension_id_seq","_timescaledb_catalog"."dimension","_timescaledb_catalog"."dimension_partition","_timescaledb_catalog"."dimension_slice_id_seq","_timescaledb_catalog"."dimension_slice","_timescaledb_catalog"."chunk_id_seq","_timescaledb_catalog"."chunk","_timescaledb_catalog"."chunk_constraint","_timescaledb_catalog"."chunk_constraint_name","_timescaledb_catalog"."chunk_index","_timescaledb_catalog"."chunk_data_node","_timescaledb_config"."bgw_job_id_seq","_timescaledb_config"."bgw_job","_timescaledb_catalog"."metadata","_timescaledb_catalog"."continuous_agg","_timescaledb_catalog"."continuous_aggs_bucket_function","_timescaledb_catalog"."continuous_aggs_invalidation_threshold","_timescaledb_catalog"."continuous_aggs_watermark","_timescaledb_catalog"."continuous_aggs_hypertable_invalidation_log","_timescaledb_catalog"."conti
```

Solution: Bump the buffer size(4x) used for formatting extension configuration.