### PR TITLE
Fix our exclude-index filtering.

### DIFF
--- a/src/bin/pgcopydb/catalog.c
+++ b/src/bin/pgcopydb/catalog.c
@@ -288,7 +288,7 @@ static char *filterDBcreateDDLs[] = {
 
 	/* the filter table is our hash-table */
 	"create table filter(oid integer, restore_list_name text, kind text)",
-	"create unique index filter_oid on filter(oid)",
+	"create unique index filter_oid on filter(oid) where oid > 0",
 	"create index filter_rlname on filter(restore_list_name)",
 
 	/*
@@ -7340,7 +7340,7 @@ catalog_sql_step(SQLiteQuery *query)
 
 			log_sqlite("[SQLite %d]: %s, try again in %dms",
 					   rc,
-					   sqlite3_errstr(rc),
+					   sqlite3_errmsg(query->db),
 					   sleepTimeMs);
 
 			/* we have milliseconds, pg_usleep() wants microseconds */

--- a/src/bin/pgcopydb/schema.c
+++ b/src/bin/pgcopydb/schema.c
@@ -797,9 +797,12 @@ schema_prepare_pgcopydb_table_size(PGSQL *pgsql,
 {
 	log_trace("schema_prepare_pgcopydb_table_size");
 
+	SourceFilterType filterType = SOURCE_FILTER_TYPE_NONE;
+
 	switch (filters->type)
 	{
 		case SOURCE_FILTER_TYPE_NONE:
+		case SOURCE_FILTER_TYPE_EXCL_INDEX:
 		{
 			/* skip filters preparing (temp tables) */
 			break;
@@ -816,10 +819,18 @@ schema_prepare_pgcopydb_table_size(PGSQL *pgsql,
 						  "see above for details");
 				return false;
 			}
+
+			filterType = filters->type;
+
 			break;
 		}
 
-		/* SOURCE_FILTER_TYPE_EXCL_INDEX etc */
+		/* ignore "exclude-index" here */
+		case SOURCE_FILTER_TYPE_LIST_EXCL_INDEX:
+		{
+			return true;
+		}
+
 		default:
 		{
 			log_error("BUG: schema_prepare_pgcopydb_table_size called with "
@@ -889,14 +900,14 @@ schema_prepare_pgcopydb_table_size(PGSQL *pgsql,
 		appendPQExpBuffer(sql,
 						  "create table if not exists pgcopydb.%s as %s",
 						  tablename,
-						  listSourceTableSizeSQL[filters->type].sql);
+						  listSourceTableSizeSQL[filterType].sql);
 	}
 	else
 	{
 		appendPQExpBuffer(sql,
 						  "create temp table %s  on commit drop as %s",
 						  tablename,
-						  listSourceTableSizeSQL[filters->type].sql);
+						  listSourceTableSizeSQL[filterType].sql);
 	}
 
 	if (PQExpBufferBroken(sql))
@@ -1523,9 +1534,12 @@ schema_list_ordinary_tables(PGSQL *pgsql,
 
 	log_trace("schema_list_ordinary_tables");
 
+	SourceFilterType filterType = SOURCE_FILTER_TYPE_NONE;
+
 	switch (filters->type)
 	{
 		case SOURCE_FILTER_TYPE_NONE:
+		case SOURCE_FILTER_TYPE_EXCL_INDEX:
 		{
 			/* skip filters preparing (temp tables) */
 			break;
@@ -1542,10 +1556,18 @@ schema_list_ordinary_tables(PGSQL *pgsql,
 						  "see above for details");
 				return false;
 			}
+
+			filterType = filters->type;
+
 			break;
 		}
 
-		/* SOURCE_FILTER_TYPE_EXCL_INDEX etc */
+		/* ignore "exclude-index" listing of filtered-out tables */
+		case SOURCE_FILTER_TYPE_LIST_EXCL_INDEX:
+		{
+			return true;
+		}
+
 		default:
 		{
 			log_error("BUG: schema_list_ordinary_tables called with "
@@ -1555,9 +1577,9 @@ schema_list_ordinary_tables(PGSQL *pgsql,
 		}
 	}
 
-	log_debug("listSourceTablesSQL[%s]", filterTypeToString(filters->type));
+	log_debug("listSourceTablesSQL[%s]", filterTypeToString(filterType));
 
-	char *sql = listSourceTablesSQL[filters->type].sql;
+	char *sql = listSourceTablesSQL[filterType].sql;
 
 	if (!pgsql_execute_with_params(pgsql, sql, 0, NULL, NULL,
 								   &context, &getTableArray))
@@ -1875,9 +1897,12 @@ schema_list_ordinary_tables_without_pk(PGSQL *pgsql,
 
 	log_trace("schema_list_ordinary_tables_without_pk");
 
+	SourceFilterType filterType = SOURCE_FILTER_TYPE_NONE;
+
 	switch (filters->type)
 	{
 		case SOURCE_FILTER_TYPE_NONE:
+		case SOURCE_FILTER_TYPE_EXCL_INDEX:
 		{
 			/* skip filters preparing (temp tables) */
 			break;
@@ -1894,10 +1919,18 @@ schema_list_ordinary_tables_without_pk(PGSQL *pgsql,
 						  "see above for details");
 				return false;
 			}
+
+			filterType = filters->type;
+
 			break;
 		}
 
-		/* SOURCE_FILTER_TYPE_EXCL_INDEX etc */
+		/* ignore "exclude-index" listing of filtered-out tables */
+		case SOURCE_FILTER_TYPE_LIST_EXCL_INDEX:
+		{
+			return true;
+		}
+
 		default:
 		{
 			log_error("BUG: schema_list_ordinary_tables_without_pk called with "
@@ -1907,9 +1940,9 @@ schema_list_ordinary_tables_without_pk(PGSQL *pgsql,
 		}
 	}
 
-	log_debug("listSourceTablesNoPKSQL[%s]", filterTypeToString(filters->type));
+	log_debug("listSourceTablesNoPKSQL[%s]", filterTypeToString(filterType));
 
-	char *sql = listSourceTablesNoPKSQL[filters->type].sql;
+	char *sql = listSourceTablesNoPKSQL[filterType].sql;
 
 	if (!pgsql_execute_with_params(pgsql, sql, 0, NULL, NULL,
 								   &context, &getTableArray))
@@ -2325,9 +2358,12 @@ schema_list_sequences(PGSQL *pgsql,
 
 	log_trace("schema_list_sequences");
 
+	SourceFilterType filterType = SOURCE_FILTER_TYPE_NONE;
+
 	switch (filters->type)
 	{
 		case SOURCE_FILTER_TYPE_NONE:
+		case SOURCE_FILTER_TYPE_EXCL_INDEX:
 		{
 			/* skip filters preparing (temp tables) */
 			break;
@@ -2344,10 +2380,18 @@ schema_list_sequences(PGSQL *pgsql,
 						  "see above for details");
 				return false;
 			}
+
+			filterType = filters->type;
+
 			break;
 		}
 
-		/* SOURCE_FILTER_TYPE_EXCL_INDEX etc */
+		/* ignore "exclude-index" listing of filtered-out tables */
+		case SOURCE_FILTER_TYPE_LIST_EXCL_INDEX:
+		{
+			return true;
+		}
+
 		default:
 		{
 			log_error("BUG: schema_list_sequences called with "
@@ -2357,9 +2401,9 @@ schema_list_sequences(PGSQL *pgsql,
 		}
 	}
 
-	log_debug("listSourceSequencesSQL[%s]", filterTypeToString(filters->type));
+	log_debug("listSourceSequencesSQL[%s]", filterTypeToString(filterType));
 
-	char *sql = listSourceSequencesSQL[filters->type].sql;
+	char *sql = listSourceSequencesSQL[filterType].sql;
 
 	/*
 	 * A single sequence can be attached to more than one table, and it could
@@ -3252,6 +3296,13 @@ schema_list_pg_depend(PGSQL *pgsql,
 
 	switch (filters->type)
 	{
+		case SOURCE_FILTER_TYPE_NONE:
+		case SOURCE_FILTER_TYPE_EXCL_INDEX:
+		{
+			/* skip pg_depend computing entirely */
+			return true;
+		}
+
 		case SOURCE_FILTER_TYPE_INCL:
 		case SOURCE_FILTER_TYPE_EXCL:
 		case SOURCE_FILTER_TYPE_LIST_NOT_INCL:
@@ -3266,10 +3317,15 @@ schema_list_pg_depend(PGSQL *pgsql,
 			break;
 		}
 
-		/* SOURCE_FILTER_TYPE_EXCL_INDEX etc */
+		/* ignore "exclude-index" listing of filtered-out tables */
+		case SOURCE_FILTER_TYPE_LIST_EXCL_INDEX:
+		{
+			return true;
+		}
+
 		default:
 		{
-			log_error("BUG: schema_list_ordinary_tables called with "
+			log_error("BUG: schema_list_pg_depend called with "
 					  "filtering type %d",
 					  filters->type);
 			return false;


### PR DESCRIPTION
It turns out that when using just "exclude-index" in our filtering the code would be confused as to how to implement that filtering option for listing table and sequence objects from the Postgres catalogs.

Should-fix #575 