### PR TITLE
Fix gcc warnings found when building on i386.

### DIFF
--- a/src/bin/pgcopydb/cli_common.c
+++ b/src/bin/pgcopydb/cli_common.c
@@ -110,13 +110,13 @@ cli_print_version(int argc, char **argv)
 	if (outputJSON)
 	{
 		JSON_Value *js = json_value_init_object();
-		JSON_Object *root = json_value_get_object(js);
+		JSON_Object *jsObj = json_value_get_object(js);
 
-		json_object_set_string(root, "pgcopydb", VERSION_STRING);
-		json_object_set_string(root, "pg_major", PG_MAJORVERSION);
-		json_object_set_string(root, "pg_version", PG_VERSION);
-		json_object_set_string(root, "pg_version_str", PG_VERSION_STR);
-		json_object_set_number(root, "pg_version_num", (double) PG_VERSION_NUM);
+		json_object_set_string(jsObj, "pgcopydb", VERSION_STRING);
+		json_object_set_string(jsObj, "pg_major", PG_MAJORVERSION);
+		json_object_set_string(jsObj, "pg_version", PG_VERSION);
+		json_object_set_string(jsObj, "pg_version_str", PG_VERSION_STR);
+		json_object_set_number(jsObj, "pg_version_num", (double) PG_VERSION_NUM);
 
 		(void) cli_pprint_json(js);
 	}

--- a/src/bin/pgcopydb/copydb_schema.c
+++ b/src/bin/pgcopydb/copydb_schema.c
@@ -623,11 +623,11 @@ copydb_prepare_table_specs(CopyDataSpec *specs, PGSQL *pgsql)
 		log_info("Splitting source candidate tables larger than %s",
 				 specs->splitTablesLargerThan.bytesPretty);
 
-		TopLevelTiming timing = {
+		TopLevelTiming partsTiming = {
 			.label = CopyDataSectionToString(DATA_SECTION_TABLE_DATA_PARTS)
 		};
 
-		(void) catalog_start_timing(&timing);
+		(void) catalog_start_timing(&partsTiming);
 
 		PrepareTableSpecsContext context = {
 			.specs = specs,
@@ -643,9 +643,9 @@ copydb_prepare_table_specs(CopyDataSpec *specs, PGSQL *pgsql)
 			return false;
 		}
 
-		(void) catalog_stop_timing(&timing);
+		(void) catalog_stop_timing(&partsTiming);
 
-		if (!catalog_register_section(sourceDB, &timing))
+		if (!catalog_register_section(sourceDB, &partsTiming))
 		{
 			/* errors have already been logged */
 			return false;

--- a/src/bin/pgcopydb/filtering.c
+++ b/src/bin/pgcopydb/filtering.c
@@ -555,9 +555,9 @@ filters_as_json(SourceFilters *filters, JSON_Value *jsFilter)
 			JSON_Value *jsList = json_value_init_array();
 			JSON_Array *jsListArray = json_value_get_array(jsList);
 
-			for (int i = 0; i < list->count; i++)
+			for (int j = 0; j < list->count; j++)
 			{
-				SourceFilterTable *table = &(list->array[i]);
+				SourceFilterTable *table = &(list->array[j]);
 
 				JSON_Value *jsTable = json_value_init_object();
 				JSON_Object *jsTableObj = json_value_get_object(jsTable);

--- a/src/bin/pgcopydb/ld_apply.c
+++ b/src/bin/pgcopydb/ld_apply.c
@@ -1038,9 +1038,7 @@ stream_apply_sql(StreamApplyContext *context,
 					return false;
 				}
 
-				PreparedStmt *stmt =
-					(PreparedStmt *) calloc(1, sizeof(PreparedStmt));
-
+				stmt = (PreparedStmt *) calloc(1, sizeof(PreparedStmt));
 				stmt->hash = hash;
 				stmt->prepared = true;
 

--- a/src/bin/pgcopydb/ld_test_decoding.c
+++ b/src/bin/pgcopydb/ld_test_decoding.c
@@ -907,10 +907,10 @@ listToTuple(LogicalMessageTuple *tuple, TestDecodingColumns *cols, int count)
 			}
 
 			/* copy the string contents without the surrounding quotes */
-			for (int i = 0, j = 0; i < cur->valueLen; i++)
+			for (int pidx = 0, vidx = 0; pidx < cur->valueLen; pidx++)
 			{
-				char *ptr = cur->valueStart + i;
-				char *nxt = cur->valueStart + i + 1;
+				char *ptr = cur->valueStart + pidx;
+				char *nxt = cur->valueStart + pidx + 1;
 
 				/* unescape the single-quotes */
 				if (*ptr == '\'' && *nxt == '\'')
@@ -918,7 +918,7 @@ listToTuple(LogicalMessageTuple *tuple, TestDecodingColumns *cols, int count)
 					continue;
 				}
 
-				valueColumn->val.str[j++] = *ptr;
+				valueColumn->val.str[vidx++] = *ptr;
 			}
 		}
 		else

--- a/src/bin/pgcopydb/ld_transform.c
+++ b/src/bin/pgcopydb/ld_transform.c
@@ -483,16 +483,16 @@ stream_transform_write_message(StreamContext *privateContext,
 		new.isTransaction = true;
 		new.action = STREAM_ACTION_BEGIN;
 
-		LogicalTransaction *old = &(currentMsg->command.tx);
-		LogicalTransaction *txn = &(new.command.tx);
+		LogicalTransaction *oldTxn = &(currentMsg->command.tx);
+		LogicalTransaction *newTxn = &(new.command.tx);
 
-		txn->continued = true;
+		newTxn->continued = true;
 
-		txn->xid = old->xid;
-		txn->beginLSN = old->beginLSN;
-		strlcpy(txn->timestamp, old->timestamp, sizeof(txn->timestamp));
+		newTxn->xid = oldTxn->xid;
+		newTxn->beginLSN = oldTxn->beginLSN;
+		strlcpy(newTxn->timestamp, oldTxn->timestamp, sizeof(newTxn->timestamp));
 
-		txn->first = NULL;
+		newTxn->first = NULL;
 
 		*currentMsg = new;
 	}

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -1121,7 +1121,7 @@ parseVersionContext(void *ctx, PGresult *result)
 	if (length >= sizeof(context->pgversion))
 	{
 		log_error("Postgres version string \"%s\" is %d bytes long, "
-				  "the maximum expected is %ld",
+				  "the maximum expected is %zu",
 				  value, length, sizeof(context->pgversion) - 1);
 		++errors;
 	}
@@ -3730,7 +3730,7 @@ pgsql_create_logical_replication_slot(LogicalStreamClient *client,
 
 		if (length >= sizeof(slot->snapshot))
 		{
-			log_error("Snapshot \"%s\" is %d bytes long, the maximum is %ld",
+			log_error("Snapshot \"%s\" is %d bytes long, the maximum is %zu",
 					  value, length, sizeof(slot->snapshot) - 1);
 			pgsql_finish(pgsql);
 			return false;
@@ -4132,7 +4132,6 @@ pgsql_stream_logical(LogicalStreamClient *client, LogicalStreamContext *context)
 		{
 			int pos;
 			bool replyRequested;
-			XLogRecPtr cur_record_lsn;
 			bool endposReached = false;
 
 			/*

--- a/src/bin/pgcopydb/progress.c
+++ b/src/bin/pgcopydb/progress.c
@@ -788,10 +788,10 @@ copydb_progress_as_json(CopyDataSpec *copySpecs,
 
 	for (int i = 0; i < tableArray->count; i++)
 	{
-		JSON_Object *jsTableObj = json_array_get_object(jsTableArray, i);
+		JSON_Object *jsTableObjItem = json_array_get_object(jsTableArray, i);
 		CopyTableSummary *summary = &(progress->tableSummaryArray.array[i]);
 
-		if (!prepare_table_summary_as_json(summary, jsTableObj, "process"))
+		if (!prepare_table_summary_as_json(summary, jsTableObjItem, "process"))
 		{
 			/* errors have already been logged */
 			return false;
@@ -824,10 +824,10 @@ copydb_progress_as_json(CopyDataSpec *copySpecs,
 
 	for (int i = 0; i < indexArray->count; i++)
 	{
-		JSON_Object *jsIndexObj = json_array_get_object(jsIndexArray, i);
+		JSON_Object *jsIndexObjItem = json_array_get_object(jsIndexArray, i);
 		CopyIndexSummary *summary = &(progress->indexSummaryArray.array[i]);
 
-		if (!prepare_index_summary_as_json(summary, jsIndexObj, "process"))
+		if (!prepare_index_summary_as_json(summary, jsIndexObjItem, "process"))
 		{
 			/* errors have already been logged */
 			return false;


### PR DESCRIPTION
Unfortunately -Wshadow=compatible-local does not seem to be available when using llvm as the compiler. Still, debian builds for Postgres community are producing warnings that we can fix.