### PR TITLE
Fix large sequence lastValue conversion to 32-bit integer

### DIFF
--- a/src/bin/pgcopydb/catalog.c
+++ b/src/bin/pgcopydb/catalog.c
@@ -4539,7 +4539,7 @@ catalog_s_seq_fetch(SQLiteQuery *query)
 			(char *) sqlite3_column_text(query->ppStmt, 7),
 			sizeof(seq->restoreListName));
 
-	seq->lastValue = sqlite3_column_int(query->ppStmt, 8);
+	seq->lastValue = sqlite3_column_int64(query->ppStmt, 8);
 	seq->isCalled = sqlite3_column_int(query->ppStmt, 9);
 
 	return true;


### PR DESCRIPTION
When testing clone on a database with BIGSERIAL sequences containing `last_value`s that don't fit into 32-bit integers, I encountered overflow/wrapping, e.g.:
```
[TARGET 27517] ERROR:  setval: value -1249415229 is out of bounds for sequence "image_cid_seq"
```
Adjusting the sqlite routine used resolved the issue, and the correct value was set on the target database.