### PR TITLE
Review zero-byte allocation hasards.

### DIFF
--- a/src/bin/pgcopydb/filtering.c
+++ b/src/bin/pgcopydb/filtering.c
@@ -190,7 +190,7 @@ parse_filters(const char *filename, SourceFilters *filters)
 
 		if (strcmp(ini_section_name(ini, sectionIndex), sectionName) != 0)
 		{
-			/* skip prefix match, only accept full lenght match */
+			/* skip prefix match, only accept full length match */
 			continue;
 		}
 
@@ -215,6 +215,12 @@ parse_filters(const char *filename, SourceFilters *filters)
 					(SourceFilterSchema *) calloc(optionCount,
 												  sizeof(SourceFilterSchema));
 
+				if (filters->includeOnlySchemaList.array == NULL)
+				{
+					log_error(ALLOCATION_FAILED_ERROR);
+					return false;
+				}
+
 				for (int o = 0; o < optionCount; o++)
 				{
 					SourceFilterSchema *schema =
@@ -236,6 +242,12 @@ parse_filters(const char *filename, SourceFilters *filters)
 				filters->excludeSchemaList.array =
 					(SourceFilterSchema *) calloc(optionCount,
 												  sizeof(SourceFilterSchema));
+
+				if (filters->excludeSchemaList.array == NULL)
+				{
+					log_error(ALLOCATION_FAILED_ERROR);
+					return false;
+				}
 
 				for (int o = 0; o < optionCount; o++)
 				{
@@ -260,8 +272,15 @@ parse_filters(const char *filename, SourceFilters *filters)
 				SourceFilterTableList *list = sections[i].list;
 
 				list->count = optionCount;
-				list->array = (SourceFilterTable *)
-							  malloc(optionCount * sizeof(SourceFilterTable));
+				list->array =
+					(SourceFilterTable *) calloc(optionCount,
+												 sizeof(SourceFilterTable));
+
+				if (list->array == NULL)
+				{
+					log_error(ALLOCATION_FAILED_ERROR);
+					return false;
+				}
 
 				for (int o = 0; o < optionCount; o++)
 				{

--- a/src/bin/pgcopydb/ld_transform.c
+++ b/src/bin/pgcopydb/ld_transform.c
@@ -1718,6 +1718,19 @@ bool
 AllocateLogicalMessageTuple(LogicalMessageTuple *tuple, int count)
 {
 	tuple->cols = count;
+
+	if (count == 0)
+	{
+		tuple->columns = NULL;
+
+		LogicalMessageValuesArray *valuesArray = &(tuple->values);
+		valuesArray->count = 0;
+		valuesArray->capacity = 0;
+		valuesArray->array = NULL;
+
+		return true;
+	}
+
 	tuple->columns = (char **) calloc(count, sizeof(char *));
 
 	if (tuple->columns == NULL)

--- a/src/bin/pgcopydb/parsing_utils.c
+++ b/src/bin/pgcopydb/parsing_utils.c
@@ -904,6 +904,7 @@ escapeWithPercentEncoding(const char *str, char **dst)
 		return false;
 	}
 
+	/* minimum computed size is 1 (for string terminator char \0) */
 	size_t size = computePercentEncodedSize(str);
 	char *escaped = (char *) calloc(size, sizeof(char));
 

--- a/src/bin/pgcopydb/pgcmd.c
+++ b/src/bin/pgcopydb/pgcmd.c
@@ -1331,6 +1331,14 @@ parse_archive_list_entry(ArchiveContentItem *item, const char *line)
 	}
 
 	item->desc = token.desc;
+	int itemDescLen = token.ptr - start + 1;
+
+	if (itemDescLen == 0)
+	{
+		log_error("Failed to parse Archive TOC: %s", line);
+		return false;
+	}
+
 	item->description = (char *) calloc(token.ptr - start + 1, sizeof(char));
 
 	if (item->description == NULL)
@@ -1380,6 +1388,13 @@ parse_archive_list_entry(ArchiveContentItem *item, const char *line)
 		/* 10. restore list name */
 		size_t len = strlen(token.ptr) + 1;
 		item->restoreListName = (char *) calloc(len, sizeof(char));
+
+		if (item->restoreListName == NULL)
+		{
+			log_error(ALLOCATION_FAILED_ERROR);
+			return false;
+		}
+
 		strlcpy(item->restoreListName, token.ptr, len);
 	}
 
@@ -1455,6 +1470,13 @@ tokenize_archive_list_entry(ArchiveToken *token)
 		int len = ptr - line + 1;
 		size_t size = len + 1;
 		char *buf = (char *) calloc(size, sizeof(char));
+
+		if (buf == NULL)
+		{
+			log_error(ALLOCATION_FAILED_ERROR);
+			return false;
+		}
+
 		strlcpy(buf, line, len);
 
 		if (!stringToUInt32(buf, &(token->oid)))

--- a/src/bin/pgcopydb/progress.c
+++ b/src/bin/pgcopydb/progress.c
@@ -543,6 +543,15 @@ copydb_update_progress(CopyDataSpec *copySpecs, CopyProgress *progress)
 {
 	DatabaseCatalog *sourceDB = &(copySpecs->catalogs.source);
 
+	/* avoid calloc of size zero */
+	if (copySpecs->tableJobs == 0 || copySpecs->indexJobs == 0)
+	{
+		log_error("BUG: --table-jobs %d --index-jobs %d",
+				  copySpecs->tableJobs,
+				  copySpecs->indexJobs);
+		return false;
+	}
+
 	CatalogCounts count = { 0 };
 
 	if (!catalog_count_objects(sourceDB, &count))

--- a/src/bin/pgcopydb/schema.c
+++ b/src/bin/pgcopydb/schema.c
@@ -4568,6 +4568,11 @@ getExtensionsVersions(void *ctx, PGresult *result)
 		return;
 	}
 
+	if (nTuples == 0)
+	{
+		return;
+	}
+
 	/* we're not supposed to re-cycle arrays here */
 	if (context->evArray->array != NULL)
 	{
@@ -5044,6 +5049,13 @@ parseAttributesArray(SourceTable *table, JSON_Value *json)
 	int count = json_array_get_count(jsAttsArray);
 
 	table->attributes.count = count;
+
+	if (count == 0)
+	{
+		table->attributes.array = NULL;
+		return true;
+	}
+
 	table->attributes.array =
 		(SourceTableAttribute *) calloc(count, sizeof(SourceTableAttribute));
 

--- a/src/bin/pgcopydb/summary.c
+++ b/src/bin/pgcopydb/summary.c
@@ -3163,6 +3163,13 @@ prepare_summary_table(Summary *summary, CopyDataSpec *specs)
 			 (long long) count.indexes);
 
 	summaryTable->count = count.tables;
+
+	if (count.tables == 0)
+	{
+		summaryTable->array = NULL;
+		return true;
+	}
+
 	summaryTable->array =
 		(SummaryTableEntry *) calloc(count.tables, sizeof(SummaryTableEntry));
 


### PR DESCRIPTION
Make sure we don't try and allocate a zero-size memory area, which can lead to "corrupted size vs. prev_size". Review all the calloc() call sites and protect them better when they need to be.

See https://github.com/dimitri/pgcopydb/issues/609