### PR TITLE
Fix eager extension/collation skipping.

### DIFF
--- a/src/bin/pgcopydb/catalog.h
+++ b/src/bin/pgcopydb/catalog.h
@@ -372,7 +372,9 @@ bool catalog_s_seq_fetch(SQLiteQuery *query);
  * pg_restore archives TOC list names (restore_list_name) in such a way that we
  * can get away with a single hash-table like lookup.
  */
-bool catalog_prepare_filter(DatabaseCatalog *catalog);
+bool catalog_prepare_filter(DatabaseCatalog *catalog,
+							bool skipExtensions,
+							bool skipCollations);
 
 typedef struct CatalogFilter
 {

--- a/src/bin/pgcopydb/extensions.c
+++ b/src/bin/pgcopydb/extensions.c
@@ -53,7 +53,7 @@ copydb_start_extension_data_process(CopyDataSpec *specs, bool createExtensions)
 		case 0:
 		{
 			/* child process runs the command */
-			(void) set_ps_title("pgcopydb: extension data");
+			(void) set_ps_title("pgcopydb: copy extensions");
 
 			if (!copydb_copy_extensions(specs, createExtensions))
 			{

--- a/src/bin/pgcopydb/schema.c
+++ b/src/bin/pgcopydb/schema.c
@@ -3868,8 +3868,6 @@ getSchemaList(void *ctx, PGresult *result)
 	SourceSchemaArrayContext *context = (SourceSchemaArrayContext *) ctx;
 	int nTuples = PQntuples(result);
 
-	log_debug("getSchemaList: %d", nTuples);
-
 	if (PQnfields(result) != 3)
 	{
 		log_error("Query returned %d columns, expected 3", PQnfields(result));
@@ -3956,8 +3954,6 @@ getRoleList(void *ctx, PGresult *result)
 	SourceRoleArrayContext *context = (SourceRoleArrayContext *) ctx;
 	int nTuples = PQntuples(result);
 
-	log_debug("getRoleList: %d", nTuples);
-
 	if (PQnfields(result) != 2)
 	{
 		log_error("Query returned %d columns, expected 2", PQnfields(result));
@@ -4028,8 +4024,6 @@ getDatabaseList(void *ctx, PGresult *result)
 {
 	SourceDatabaseArrayContext *context = (SourceDatabaseArrayContext *) ctx;
 	int nTuples = PQntuples(result);
-
-	log_debug("getDatabaseList: %d", nTuples);
 
 	if (PQnfields(result) != 4)
 	{
@@ -4147,8 +4141,6 @@ getDatabaseProperties(void *ctx, PGresult *result)
 {
 	SourcePropertiesArrayContext *context = (SourcePropertiesArrayContext *) ctx;
 	int nTuples = PQntuples(result);
-
-	log_debug("getDatabaseProperties: %d", nTuples);
 
 	if (PQnfields(result) != 3)
 	{
@@ -4278,8 +4270,6 @@ getExtensionList(void *ctx, PGresult *result)
 {
 	SourceExtensionArrayContext *context = (SourceExtensionArrayContext *) ctx;
 	int nTuples = PQntuples(result);
-
-	log_debug("getExtensionList: %d", nTuples);
 
 	if (PQnfields(result) != 11)
 	{
@@ -4559,8 +4549,6 @@ getExtensionsVersions(void *ctx, PGresult *result)
 
 	int nTuples = PQntuples(result);
 
-	log_debug("getExtensionsVersions: %d", nTuples);
-
 	if (PQnfields(result) != 4)
 	{
 		log_error("Query returned %d columns, expected 4", PQnfields(result));
@@ -4664,8 +4652,6 @@ getCollationList(void *ctx, PGresult *result)
 {
 	SourceCollationArrayContext *context = (SourceCollationArrayContext *) ctx;
 	int nTuples = PQntuples(result);
-
-	log_debug("getCollationList: %d", nTuples);
 
 	if (PQnfields(result) != 4)
 	{
@@ -5578,8 +5564,6 @@ getDependArray(void *ctx, PGresult *result)
 {
 	SourceDependArrayContext *context = (SourceDependArrayContext *) ctx;
 	int nTuples = PQntuples(result);
-
-	log_debug("getDependArray: %d", nTuples);
 
 	if (PQnfields(result) != 9)
 	{

--- a/tests/unit/setup/14-uuid.sql
+++ b/tests/unit/setup/14-uuid.sql
@@ -1,0 +1,6 @@
+create extension "uuid-ossp";
+
+create table uuid(id uuid default uuid_generate_v4(), f1 text);
+
+insert into uuid(f1)
+     select x::text from generate_series(100, 199, 1) as t(x);

--- a/tests/unit/setup/setup.sql
+++ b/tests/unit/setup/setup.sql
@@ -10,3 +10,4 @@
 \ir 10-search-path-index-enum.sql
 \ir 11-check-constraint.sql
 \ir 12-generated-column.sql
+\ir 14-uuid.sql


### PR DESCRIPTION
The SQLite patch series introduced a bug where we would skip extensions even
when the option --skip-extension is not used.
    
Also adjust the "pgcopydb copy extensions" to the recent changes where we
use a sub-process under a supervisor to simplify snapshot handling.

Fixes #639 