### PR TITLE
Fix database name identifier in ALTER DATABASE properties using PQescapeIdentifier.

### DIFF
--- a/src/bin/pgcopydb/dump_restore.c
+++ b/src/bin/pgcopydb/dump_restore.c
@@ -18,7 +18,6 @@
 #include "env_utils.h"
 #include "lock_utils.h"
 #include "log.h"
-#include "pgsql.h"
 #include "pidfile.h"
 #include "schema.h"
 #include "signals.h"

--- a/src/bin/pgcopydb/dump_restore.c
+++ b/src/bin/pgcopydb/dump_restore.c
@@ -281,11 +281,12 @@ copydb_copy_database_properties_hook(void *ctx, SourceProperty *property)
 	PGSQL *dst = context->dst;
 	PGconn *conn = dst->connection;
 
-	const char *t_pguri = specs->connStrings.safeTargetPGURI.uriParams.dbname;
-	const char *t_dbname = pgsql_escape_identifier(dst, t_pguri);
+	const char *t_dbname = specs->connStrings.safeTargetPGURI.uriParams.dbname;
+	const char *t_escaped_dbname = pgsql_escape_identifier(dst, t_dbname);
 
-	if (t_dbname == NULL)
+	if (t_escaped_dbname == NULL)
 	{
+		/* errors are already logged */
 		return false;
 	}
 
@@ -318,7 +319,7 @@ copydb_copy_database_properties_hook(void *ctx, SourceProperty *property)
 			makeAlterConfigCommand(conn, property->setconfig,
 								   "ROLE", property->rolname,
 								   "DATABASE",
-								   t_dbname,
+								   t_escaped_dbname,
 								   command);
 
 			/* chomp the \n */
@@ -356,7 +357,7 @@ copydb_copy_database_properties_hook(void *ctx, SourceProperty *property)
 		PQExpBuffer command = createPQExpBuffer();
 
 		makeAlterConfigCommand(conn, property->setconfig,
-							   "DATABASE", t_dbname,
+							   "DATABASE", t_escaped_dbname,
 							   NULL, NULL,
 							   command);
 

--- a/src/bin/pgcopydb/dump_restore.c
+++ b/src/bin/pgcopydb/dump_restore.c
@@ -18,6 +18,7 @@
 #include "env_utils.h"
 #include "lock_utils.h"
 #include "log.h"
+#include "pgsql.h"
 #include "pidfile.h"
 #include "schema.h"
 #include "signals.h"
@@ -281,7 +282,12 @@ copydb_copy_database_properties_hook(void *ctx, SourceProperty *property)
 	PGSQL *dst = context->dst;
 	PGconn *conn = dst->connection;
 
-	const char *t_dbname = specs->connStrings.safeTargetPGURI.uriParams.dbname;
+	const char *t_dbname = pgsql_escape_identifier(dst, specs->connStrings.safeTargetPGURI.uriParams.dbname);
+	
+	if (t_dbname == NULL)
+	{
+		return false;
+	}
 
 	/*
 	 * ALTER ROLE rolname IN DATABASE datname SET ...

--- a/src/bin/pgcopydb/dump_restore.c
+++ b/src/bin/pgcopydb/dump_restore.c
@@ -281,8 +281,9 @@ copydb_copy_database_properties_hook(void *ctx, SourceProperty *property)
 	PGSQL *dst = context->dst;
 	PGconn *conn = dst->connection;
 
-	const char *t_dbname = pgsql_escape_identifier(dst, specs->connStrings.safeTargetPGURI.uriParams.dbname);
-	
+	const char *t_pguri = specs->connStrings.safeTargetPGURI.uriParams.dbname;
+	const char *t_dbname = pgsql_escape_identifier(dst, t_pguri);
+
 	if (t_dbname == NULL)
 	{
 		return false;


### PR DESCRIPTION
**Logs**

```
2024-01-18 14:10:58 53 ERROR  pgsql.c:1978              [TARGET 1664] ERROR:  syntax error at or near "-"
2024-01-18 14:10:58 53 ERROR  pgsql.c:1989              [TARGET 1664] SQL query: ALTER DATABASE vaibhave-test SET "search_path" TO '$user', 'public';
```