### PR TITLE
Improve sqlite catalog setup performance.

### DIFF
--- a/src/bin/pgcopydb/catalog.h
+++ b/src/bin/pgcopydb/catalog.h
@@ -618,6 +618,8 @@ typedef struct BindParam
 } BindParam;
 
 
+bool catalog_execute(DatabaseCatalog *catalog, char *sql);
+
 bool catalog_sql_prepare(sqlite3 *db, const char *sql, SQLiteQuery *query);
 bool catalog_sql_bind(SQLiteQuery *query, BindParam *params, int count);
 bool catalog_sql_execute(SQLiteQuery *query);

--- a/src/bin/pgcopydb/copydb_schema.c
+++ b/src/bin/pgcopydb/copydb_schema.c
@@ -504,6 +504,12 @@ copydb_fetch_source_schema(CopyDataSpec *specs, PGSQL *src)
 	 */
 	bool createdTableSizeTable = false;
 
+	if (!catalog_begin(sourceDB, false))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
 	/* now fetch the list of tables from the source database */
 	if ((specs->section == DATA_SECTION_ALL ||
 		 specs->section == DATA_SECTION_TABLE_DATA ||
@@ -570,6 +576,12 @@ copydb_fetch_source_schema(CopyDataSpec *specs, PGSQL *src)
 			/* errors have already been logged */
 			return false;
 		}
+	}
+
+	if (!catalog_commit(sourceDB))
+	{
+		/* errors have already been logged */
+		return false;
 	}
 
 	return true;
@@ -1234,6 +1246,12 @@ copydb_prepare_target_catalog(CopyDataSpec *specs)
 		return false;
 	}
 
+	if (!catalog_begin(targetDB, false))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
 	/*
 	 * First, get a list of the schema that already exist on the target system.
 	 * Some extensions scripts create schema in a way that does not register a
@@ -1279,6 +1297,12 @@ copydb_prepare_target_catalog(CopyDataSpec *specs)
 	}
 
 	if (!schema_list_all_indexes(&dst, &targetDBfilter, targetDB))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	if (!catalog_commit(targetDB))
 	{
 		/* errors have already been logged */
 		return false;

--- a/src/bin/pgcopydb/pgcmd.c
+++ b/src/bin/pgcopydb/pgcmd.c
@@ -448,12 +448,24 @@ pg_dump_db(PostgresPaths *pgPaths,
 		.extNamespaceCount = &extNamespaceCount,
 	};
 
+	if (!catalog_begin(filtersDB, false))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
 	if (!catalog_iter_s_extension(filtersDB,
 								  &context,
 								  &pg_dump_db_extension_namespace_hook))
 	{
 		log_error("Failed to prepare pg_dump command line arguments, "
 				  "see above for details");
+		return false;
+	}
+
+	if (!catalog_commit(filtersDB))
+	{
+		/* errors have already been logged */
 		return false;
 	}
 


### PR DESCRIPTION
Intentionally this PR contains two independent commits to achieve a single
goal mentioned in the title

1. Use appropriate sqlite PRAGMA commands which significantly improved the
   performance. Code comments are self explanatory.
2. Batched writes within one big transaction.

**Results**

For a setup of 13K+ tables below is the time taken by pgcopydb list tables
command excluding the time of running postgres query on source.

WAL => `PRAGMA journal_mode = WAL`
Normal => `PRAGMA synchronous = NORMAL`
Txn => `BEGIN`/`COMMIT`

No optimization | WAL | WAL + Normal | WAL + Normal + Txn | WAL + Txn
-|-|-|-|-
1h 18 mins | 8 mins | 53s | 18s | 18s

So finally decided to go with `journal_mode` as WAL along with one big insert transaction.
