### PR TITLE
Use Boehm-Demers-Weiser Garbage Collector.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,12 +64,12 @@ LABEL org.opencontainers.image.source https://github.com/dimitri/pgcopydb
 RUN dpkg --add-architecture ${TARGETARCH:-arm64} && apt update \
   && apt install -qqy --no-install-suggests --no-install-recommends \
     sudo \
-	passwd \
+    passwd \
     ca-certificates \
     libgc1 \
-	libpq5 \
-	libsqlite3-0 \
-	lsof \
+    libpq5 \
+    libsqlite3-0 \
+    lsof \
     tmux \
     watch \
     psmisc \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN dpkg --add-architecture ${TARGETARCH:-arm64} && apt update \
     valgrind \
     build-essential \
     libedit-dev \
+    libgc-dev \
     libicu-dev \
     libkrb5-dev \
     liblz4-dev \
@@ -65,7 +66,8 @@ RUN dpkg --add-architecture ${TARGETARCH:-arm64} && apt update \
     sudo \
 	passwd \
     ca-certificates \
-    libpq5 \
+    libgc1 \
+	libpq5 \
 	libsqlite3-0 \
 	lsof \
     tmux \

--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,7 @@ Uploaders:
 Build-Depends:
  debhelper-compat (= 13),
  libedit-dev,
+ libgc-dev,
  libkrb5-dev,
  liblz4-dev,
  libncurses-dev,

--- a/src/bin/pgcopydb/Makefile
+++ b/src/bin/pgcopydb/Makefile
@@ -80,6 +80,7 @@ LIBS += $(shell $(PG_CONFIG) --libs)
 LIBS += -lpq
 LIBS += -lncurses
 LIBS += -lsqlite3
+LIBS += -lgc
 
 all: $(PGCOPYDB) ;
 

--- a/src/bin/pgcopydb/catalog.c
+++ b/src/bin/pgcopydb/catalog.c
@@ -571,7 +571,6 @@ catalog_register_setup_from_specs(CopyDataSpec *copySpecs)
 		{
 			/* errors have already been logged */
 			json_free_serialized_string(json);
-			json_value_free(jsFilters);
 			return false;
 		}
 	}
@@ -688,7 +687,6 @@ catalog_register_setup_from_specs(CopyDataSpec *copySpecs)
 	}
 
 	json_free_serialized_string(json);
-	json_value_free(jsFilters);
 
 	return true;
 }
@@ -2504,7 +2502,6 @@ catalog_iter_s_table(DatabaseCatalog *catalog,
 	if (!catalog_iter_s_table_init(iter))
 	{
 		/* errors have already been logged */
-		free(iter);
 		return false;
 	}
 
@@ -2513,7 +2510,6 @@ catalog_iter_s_table(DatabaseCatalog *catalog,
 		if (!catalog_iter_s_table_next(iter))
 		{
 			/* errors have already been logged */
-			free(iter);
 			return false;
 		}
 
@@ -2524,7 +2520,6 @@ catalog_iter_s_table(DatabaseCatalog *catalog,
 			if (!catalog_iter_s_table_finish(iter))
 			{
 				/* errors have already been logged */
-				free(iter);
 				return false;
 			}
 
@@ -2540,7 +2535,6 @@ catalog_iter_s_table(DatabaseCatalog *catalog,
 		}
 	}
 
-	free(iter);
 
 	return true;
 }
@@ -2563,7 +2557,6 @@ catalog_iter_s_table_nopk(DatabaseCatalog *catalog,
 	if (!catalog_iter_s_table_nopk_init(iter))
 	{
 		/* errors have already been logged */
-		free(iter);
 		return false;
 	}
 
@@ -2572,7 +2565,6 @@ catalog_iter_s_table_nopk(DatabaseCatalog *catalog,
 		if (!catalog_iter_s_table_next(iter))
 		{
 			/* errors have already been logged */
-			free(iter);
 			return false;
 		}
 
@@ -2583,7 +2575,6 @@ catalog_iter_s_table_nopk(DatabaseCatalog *catalog,
 			if (!catalog_iter_s_table_finish(iter))
 			{
 				/* errors have already been logged */
-				free(iter);
 				return false;
 			}
 
@@ -2599,7 +2590,6 @@ catalog_iter_s_table_nopk(DatabaseCatalog *catalog,
 		}
 	}
 
-	free(iter);
 
 	return true;
 }
@@ -2756,7 +2746,6 @@ catalog_iter_s_table_next(SourceTableIterator *iter)
 
 	if (rc == SQLITE_DONE)
 	{
-		free(iter->table);
 		iter->table = NULL;
 
 		return true;
@@ -2888,12 +2877,6 @@ catalog_iter_s_table_finish(SourceTableIterator *iter)
 {
 	SQLiteQuery *query = &(iter->query);
 
-	/* in case we finish before reaching the DONE step */
-	if (iter->table != NULL)
-	{
-		free(iter->table);
-	}
-
 	if (!catalog_sql_finalize(query))
 	{
 		/* errors have already been logged */
@@ -2923,7 +2906,6 @@ catalog_iter_s_table_parts(DatabaseCatalog *catalog,
 	if (!catalog_iter_s_table_part_init(iter))
 	{
 		/* errors have already been logged */
-		free(iter);
 		return false;
 	}
 
@@ -2932,7 +2914,6 @@ catalog_iter_s_table_parts(DatabaseCatalog *catalog,
 		if (!catalog_iter_s_table_part_next(iter))
 		{
 			/* errors have already been logged */
-			free(iter);
 			return false;
 		}
 
@@ -2943,7 +2924,6 @@ catalog_iter_s_table_parts(DatabaseCatalog *catalog,
 			if (!catalog_iter_s_table_part_finish(iter))
 			{
 				/* errors have already been logged */
-				free(iter);
 				return false;
 			}
 
@@ -2959,7 +2939,6 @@ catalog_iter_s_table_parts(DatabaseCatalog *catalog,
 		}
 	}
 
-	free(iter);
 
 	return true;
 }
@@ -3031,7 +3010,6 @@ catalog_iter_s_table_part_next(SourceTablePartsIterator *iter)
 
 	if (rc == SQLITE_DONE)
 	{
-		free(iter->part);
 		iter->part = NULL;
 
 		return true;
@@ -3079,12 +3057,6 @@ catalog_iter_s_table_part_finish(SourceTablePartsIterator *iter)
 {
 	SQLiteQuery *query = &(iter->query);
 
-	/* in case we finish before reaching the DONE step */
-	if (iter->part != NULL)
-	{
-		free(iter->part);
-	}
-
 	if (!catalog_sql_finalize(query))
 	{
 		/* errors have already been logged */
@@ -3118,7 +3090,6 @@ catalog_s_table_fetch_attrs(DatabaseCatalog *catalog, SourceTable *table)
 	if (!catalog_iter_s_table_attrs_init(iter))
 	{
 		/* errors have already been logged */
-		free(iter);
 		return false;
 	}
 
@@ -3127,7 +3098,6 @@ catalog_s_table_fetch_attrs(DatabaseCatalog *catalog, SourceTable *table)
 		if (!catalog_iter_s_table_attrs_next(iter))
 		{
 			/* errors have already been logged */
-			free(iter);
 			return false;
 		}
 	}
@@ -3135,11 +3105,9 @@ catalog_s_table_fetch_attrs(DatabaseCatalog *catalog, SourceTable *table)
 	if (!catalog_iter_s_table_attrs_finish(iter))
 	{
 		/* errors have already been logged */
-		free(iter);
 		return false;
 	}
 
-	free(iter);
 
 	return true;
 }
@@ -3791,7 +3759,6 @@ catalog_iter_s_index(DatabaseCatalog *catalog,
 	if (!catalog_iter_s_index_init(iter))
 	{
 		/* errors have already been logged */
-		free(iter);
 		return false;
 	}
 
@@ -3800,7 +3767,6 @@ catalog_iter_s_index(DatabaseCatalog *catalog,
 		if (!catalog_iter_s_index_next(iter))
 		{
 			/* errors have already been logged */
-			free(iter);
 			return false;
 		}
 
@@ -3811,7 +3777,6 @@ catalog_iter_s_index(DatabaseCatalog *catalog,
 			if (!catalog_iter_s_index_finish(iter))
 			{
 				/* errors have already been logged */
-				free(iter);
 				return false;
 			}
 
@@ -3827,7 +3792,6 @@ catalog_iter_s_index(DatabaseCatalog *catalog,
 		}
 	}
 
-	free(iter);
 
 	return true;
 }
@@ -3859,7 +3823,6 @@ catalog_iter_s_index_table(DatabaseCatalog *catalog,
 	if (!catalog_iter_s_index_table_init(iter))
 	{
 		/* errors have already been logged */
-		free(iter);
 		return false;
 	}
 
@@ -3868,7 +3831,6 @@ catalog_iter_s_index_table(DatabaseCatalog *catalog,
 		if (!catalog_iter_s_index_next(iter))
 		{
 			/* errors have already been logged */
-			free(iter);
 			(void) semaphore_unlock(&(catalog->sema));
 			return false;
 		}
@@ -3880,7 +3842,6 @@ catalog_iter_s_index_table(DatabaseCatalog *catalog,
 			if (!catalog_iter_s_index_finish(iter))
 			{
 				/* errors have already been logged */
-				free(iter);
 				(void) semaphore_unlock(&(catalog->sema));
 				return false;
 			}
@@ -3893,13 +3854,11 @@ catalog_iter_s_index_table(DatabaseCatalog *catalog,
 		{
 			log_error("Failed to iterate over list of indexes, "
 					  "see above for details");
-			free(iter);
 			(void) semaphore_unlock(&(catalog->sema));
 			return false;
 		}
 	}
 
-	free(iter);
 	(void) semaphore_unlock(&(catalog->sema));
 
 	return true;
@@ -4029,11 +3988,6 @@ catalog_iter_s_index_next(SourceIndexIterator *iter)
 
 	if (rc == SQLITE_DONE)
 	{
-		free(iter->index->indexDef);
-		free(iter->index->indexColumns);
-		free(iter->index->constraintDef);
-		free(iter->index);
-
 		iter->index = NULL;
 
 		return true;
@@ -4062,11 +4016,6 @@ catalog_iter_s_index_finish(SourceIndexIterator *iter)
 	/* in case we finish before reaching the DONE step */
 	if (iter->index != NULL)
 	{
-		free(iter->index->indexDef);
-		free(iter->index->indexColumns);
-		free(iter->index->constraintDef);
-		free(iter->index);
-
 		iter->index = NULL;
 	}
 
@@ -4449,7 +4398,6 @@ catalog_iter_s_seq(DatabaseCatalog *catalog,
 	if (!catalog_iter_s_seq_init(iter))
 	{
 		/* errors have already been logged */
-		free(iter);
 		return false;
 	}
 
@@ -4458,7 +4406,6 @@ catalog_iter_s_seq(DatabaseCatalog *catalog,
 		if (!catalog_iter_s_seq_next(iter))
 		{
 			/* errors have already been logged */
-			free(iter);
 			return false;
 		}
 
@@ -4469,7 +4416,6 @@ catalog_iter_s_seq(DatabaseCatalog *catalog,
 			if (!catalog_iter_s_seq_finish(iter))
 			{
 				/* errors have already been logged */
-				free(iter);
 				return false;
 			}
 
@@ -4485,7 +4431,6 @@ catalog_iter_s_seq(DatabaseCatalog *catalog,
 		}
 	}
 
-	free(iter);
 
 	return true;
 }
@@ -4548,7 +4493,6 @@ catalog_iter_s_seq_next(SourceSeqIterator *iter)
 
 	if (rc == SQLITE_DONE)
 	{
-		free(iter->seq);
 		iter->seq = NULL;
 
 		return true;
@@ -4617,7 +4561,6 @@ catalog_iter_s_seq_finish(SourceSeqIterator *iter)
 	/* in case we finish before reaching the DONE step */
 	if (iter->seq != NULL)
 	{
-		free(iter->seq);
 		iter->seq = NULL;
 	}
 
@@ -5080,7 +5023,6 @@ catalog_iter_s_database(DatabaseCatalog *catalog,
 	if (!catalog_iter_s_database_init(iter))
 	{
 		/* errors have already been logged */
-		free(iter);
 		return false;
 	}
 
@@ -5089,7 +5031,6 @@ catalog_iter_s_database(DatabaseCatalog *catalog,
 		if (!catalog_iter_s_database_next(iter))
 		{
 			/* errors have already been logged */
-			free(iter);
 			return false;
 		}
 
@@ -5100,7 +5041,6 @@ catalog_iter_s_database(DatabaseCatalog *catalog,
 			if (!catalog_iter_s_database_finish(iter))
 			{
 				/* errors have already been logged */
-				free(iter);
 				return false;
 			}
 
@@ -5116,7 +5056,6 @@ catalog_iter_s_database(DatabaseCatalog *catalog,
 		}
 	}
 
-	free(iter);
 
 	return true;
 }
@@ -5178,7 +5117,6 @@ catalog_iter_s_database_next(SourceDatabaseIterator *iter)
 
 	if (rc == SQLITE_DONE)
 	{
-		free(iter->dat);
 		iter->dat = NULL;
 
 		return true;
@@ -5235,7 +5173,6 @@ catalog_iter_s_database_finish(SourceDatabaseIterator *iter)
 	/* in case we finish before reaching the DONE step */
 	if (iter->dat != NULL)
 	{
-		free(iter->dat);
 		iter->dat = NULL;
 	}
 
@@ -5268,7 +5205,6 @@ catalog_iter_s_database_guc(DatabaseCatalog *catalog,
 	if (!catalog_iter_s_database_guc_init(iter))
 	{
 		/* errors have already been logged */
-		free(iter);
 		return false;
 	}
 
@@ -5277,7 +5213,6 @@ catalog_iter_s_database_guc(DatabaseCatalog *catalog,
 		if (!catalog_iter_s_database_guc_next(iter))
 		{
 			/* errors have already been logged */
-			free(iter);
 			return false;
 		}
 
@@ -5288,7 +5223,6 @@ catalog_iter_s_database_guc(DatabaseCatalog *catalog,
 			if (!catalog_iter_s_database_guc_finish(iter))
 			{
 				/* errors have already been logged */
-				free(iter);
 				return false;
 			}
 
@@ -5300,12 +5234,10 @@ catalog_iter_s_database_guc(DatabaseCatalog *catalog,
 		{
 			log_error("Failed to iterate over list of dats, "
 					  "see above for details");
-			free(iter);
 			return false;
 		}
 	}
 
-	free(iter);
 
 	return true;
 }
@@ -5380,8 +5312,6 @@ catalog_iter_s_database_guc_next(SourcePropertyIterator *iter)
 
 	if (rc == SQLITE_DONE)
 	{
-		free(iter->property->setconfig);
-		free(iter->property);
 		iter->property = NULL;
 
 		return true;
@@ -5460,8 +5390,6 @@ catalog_iter_s_database_guc_finish(SourcePropertyIterator *iter)
 	/* in case we finish before reaching the DONE step */
 	if (iter->property != NULL)
 	{
-		free(iter->property->setconfig);
-		free(iter->property);
 		iter->property = NULL;
 	}
 
@@ -5547,7 +5475,6 @@ catalog_iter_s_coll(DatabaseCatalog *catalog,
 	if (!catalog_iter_s_coll_init(iter))
 	{
 		/* errors have already been logged */
-		free(iter);
 		return false;
 	}
 
@@ -5556,7 +5483,6 @@ catalog_iter_s_coll(DatabaseCatalog *catalog,
 		if (!catalog_iter_s_coll_next(iter))
 		{
 			/* errors have already been logged */
-			free(iter);
 			return false;
 		}
 
@@ -5567,7 +5493,6 @@ catalog_iter_s_coll(DatabaseCatalog *catalog,
 			if (!catalog_iter_s_coll_finish(iter))
 			{
 				/* errors have already been logged */
-				free(iter);
 				return false;
 			}
 
@@ -5583,7 +5508,6 @@ catalog_iter_s_coll(DatabaseCatalog *catalog,
 		}
 	}
 
-	free(iter);
 
 	return true;
 }
@@ -5645,8 +5569,6 @@ catalog_iter_s_coll_next(SourceCollationIterator *iter)
 
 	if (rc == SQLITE_DONE)
 	{
-		free(iter->coll->desc);
-		free(iter->coll);
 		iter->coll = NULL;
 
 		return true;
@@ -5720,8 +5642,6 @@ catalog_iter_s_coll_finish(SourceCollationIterator *iter)
 	/* in case we finish before reaching the DONE step */
 	if (iter->coll != NULL)
 	{
-		free(iter->coll->desc);
-		free(iter->coll);
 		iter->coll = NULL;
 	}
 
@@ -6002,7 +5922,6 @@ catalog_iter_s_extension(DatabaseCatalog *catalog,
 	if (!catalog_iter_s_extension_init(iter))
 	{
 		/* errors have already been logged */
-		free(iter);
 		return false;
 	}
 
@@ -6011,7 +5930,6 @@ catalog_iter_s_extension(DatabaseCatalog *catalog,
 		if (!catalog_iter_s_extension_next(iter))
 		{
 			/* errors have already been logged */
-			free(iter);
 			return false;
 		}
 
@@ -6022,7 +5940,6 @@ catalog_iter_s_extension(DatabaseCatalog *catalog,
 			if (!catalog_iter_s_extension_finish(iter))
 			{
 				/* errors have already been logged */
-				free(iter);
 				return false;
 			}
 
@@ -6038,7 +5955,6 @@ catalog_iter_s_extension(DatabaseCatalog *catalog,
 		}
 	}
 
-	free(iter);
 
 	return true;
 }
@@ -6100,7 +6016,6 @@ catalog_iter_s_extension_next(SourceExtensionIterator *iter)
 
 	if (rc == SQLITE_DONE)
 	{
-		free(iter->ext);
 		iter->ext = NULL;
 
 		return true;
@@ -6157,7 +6072,6 @@ catalog_iter_s_extension_finish(SourceExtensionIterator *iter)
 	/* in case we finish before reaching the DONE step */
 	if (iter->ext != NULL)
 	{
-		free(iter->ext);
 		iter->ext = NULL;
 	}
 
@@ -6193,7 +6107,6 @@ catalog_s_ext_fetch_extconfig(DatabaseCatalog *catalog, SourceExtension *ext)
 	if (!catalog_iter_s_ext_extconfig_init(iter))
 	{
 		/* errors have already been logged */
-		free(iter);
 		return false;
 	}
 
@@ -6202,7 +6115,6 @@ catalog_s_ext_fetch_extconfig(DatabaseCatalog *catalog, SourceExtension *ext)
 		if (!catalog_iter_s_ext_extconfig_next(iter))
 		{
 			/* errors have already been logged */
-			free(iter);
 			return false;
 		}
 	}
@@ -6210,11 +6122,9 @@ catalog_s_ext_fetch_extconfig(DatabaseCatalog *catalog, SourceExtension *ext)
 	if (!catalog_iter_s_ext_extconfig_finish(iter))
 	{
 		/* errors have already been logged */
-		free(iter);
 		return false;
 	}
 
-	free(iter);
 
 	return true;
 }
@@ -6593,7 +6503,6 @@ catalog_iter_s_depend(DatabaseCatalog *catalog,
 	if (!catalog_iter_s_depend_init(iter))
 	{
 		/* errors have already been logged */
-		free(iter);
 		return false;
 	}
 
@@ -6602,7 +6511,6 @@ catalog_iter_s_depend(DatabaseCatalog *catalog,
 		if (!catalog_iter_s_depend_next(iter))
 		{
 			/* errors have already been logged */
-			free(iter);
 			return false;
 		}
 
@@ -6613,7 +6521,6 @@ catalog_iter_s_depend(DatabaseCatalog *catalog,
 			if (!catalog_iter_s_depend_finish(iter))
 			{
 				/* errors have already been logged */
-				free(iter);
 				return false;
 			}
 
@@ -6629,7 +6536,6 @@ catalog_iter_s_depend(DatabaseCatalog *catalog,
 		}
 	}
 
-	free(iter);
 
 	return true;
 }
@@ -6692,7 +6598,6 @@ catalog_iter_s_depend_next(SourceDependIterator *iter)
 
 	if (rc == SQLITE_DONE)
 	{
-		free(iter->dep);
 		iter->dep = NULL;
 
 		return true;
@@ -6769,7 +6674,6 @@ catalog_iter_s_depend_finish(SourceDependIterator *iter)
 	/* in case we finish before reaching the DONE step */
 	if (iter->dep != NULL)
 	{
-		free(iter->dep);
 		iter->dep = NULL;
 	}
 
@@ -6927,7 +6831,6 @@ catalog_iter_s_table_in_copy(DatabaseCatalog *catalog,
 	if (!catalog_iter_s_table_in_copy_init(iter))
 	{
 		/* errors have already been logged */
-		free(iter);
 		return false;
 	}
 
@@ -6936,7 +6839,6 @@ catalog_iter_s_table_in_copy(DatabaseCatalog *catalog,
 		if (!catalog_iter_s_table_next(iter))
 		{
 			/* errors have already been logged */
-			free(iter);
 			return false;
 		}
 
@@ -6947,7 +6849,6 @@ catalog_iter_s_table_in_copy(DatabaseCatalog *catalog,
 			if (!catalog_iter_s_table_finish(iter))
 			{
 				/* errors have already been logged */
-				free(iter);
 				return false;
 			}
 
@@ -6963,7 +6864,6 @@ catalog_iter_s_table_in_copy(DatabaseCatalog *catalog,
 		}
 	}
 
-	free(iter);
 
 	return true;
 }
@@ -7046,7 +6946,6 @@ catalog_iter_s_index_in_progress(DatabaseCatalog *catalog,
 	if (!catalog_iter_s_index_in_progress_init(iter))
 	{
 		/* errors have already been logged */
-		free(iter);
 		return false;
 	}
 
@@ -7055,7 +6954,6 @@ catalog_iter_s_index_in_progress(DatabaseCatalog *catalog,
 		if (!catalog_iter_s_index_next(iter))
 		{
 			/* errors have already been logged */
-			free(iter);
 			return false;
 		}
 
@@ -7066,7 +6964,6 @@ catalog_iter_s_index_in_progress(DatabaseCatalog *catalog,
 			if (!catalog_iter_s_index_finish(iter))
 			{
 				/* errors have already been logged */
-				free(iter);
 				return false;
 			}
 
@@ -7082,7 +6979,6 @@ catalog_iter_s_index_in_progress(DatabaseCatalog *catalog,
 		}
 	}
 
-	free(iter);
 
 	return true;
 }

--- a/src/bin/pgcopydb/cli_common.c
+++ b/src/bin/pgcopydb/cli_common.c
@@ -144,7 +144,6 @@ cli_pprint_json(JSON_Value *js)
 
 	/* free intermediate memory */
 	json_free_serialized_string(serialized_string);
-	json_value_free(js);
 }
 
 
@@ -703,7 +702,6 @@ cli_read_one_line(const char *filename,
 	if (lbuf.count != 1)
 	{
 		log_error("Failed to parse %s file \"%s\"", name, filename);
-		FreeLinesBuffer(&lbuf);
 		return false;
 	}
 
@@ -715,14 +713,11 @@ cli_read_one_line(const char *filename,
 				  lbuf.lines[0],
 				  (long long) strlen(lbuf.lines[0]) + 1,
 				  (long long) size);
-		FreeLinesBuffer(&lbuf);
 		return false;
 	}
 
 	/* publish the one line to the snapshot variable */
 	strlcpy(target, lbuf.lines[0], size);
-
-	FreeLinesBuffer(&lbuf);
 
 	return true;
 }

--- a/src/bin/pgcopydb/cli_common.c
+++ b/src/bin/pgcopydb/cli_common.c
@@ -693,7 +693,7 @@ cli_read_one_line(const char *filename,
 	/* make sure to use only the first line of the file, without \n */
 	LinesBuffer lbuf = { 0 };
 
-	if (!splitLines(&lbuf, contents, true))
+	if (!splitLines(&lbuf, contents))
 	{
 		/* errors have already been logged */
 		return false;

--- a/src/bin/pgcopydb/cli_compare.c
+++ b/src/bin/pgcopydb/cli_compare.c
@@ -392,7 +392,6 @@ cli_compare_data(int argc, char **argv)
 		fformat(stdout, "%s\n", serialized_string);
 
 		json_free_serialized_string(serialized_string);
-		json_value_free(js);
 	}
 	else
 	{

--- a/src/bin/pgcopydb/cli_list.c
+++ b/src/bin/pgcopydb/cli_list.c
@@ -718,7 +718,6 @@ cli_list_extensions(int argc, char **argv)
 		fformat(stdout, "%s\n", serialized_string);
 
 		json_free_serialized_string(serialized_string);
-		json_value_free(js);
 	}
 	else
 	{
@@ -887,7 +886,6 @@ cli_list_extension_versions(int argc, char **argv)
 		fformat(stdout, "%s\n", serialized_string);
 
 		json_free_serialized_string(serialized_string);
-		json_value_free(js);
 	}
 	else
 	{
@@ -971,7 +969,6 @@ cli_list_extension_requirements(int argc, char **argv)
 		fformat(stdout, "%s\n", serialized_string);
 
 		json_free_serialized_string(serialized_string);
-		json_value_free(js);
 	}
 	else
 	{
@@ -1829,7 +1826,6 @@ cli_list_schema(int argc, char **argv)
 		}
 
 		fformat(stdout, "%s\n", json);
-		free(json);
 	}
 }
 
@@ -1929,7 +1925,6 @@ cli_list_progress(int argc, char **argv)
 		fformat(stdout, "%s\n", serialized_string);
 
 		json_free_serialized_string(serialized_string);
-		json_value_free(js);
 	}
 	else
 	{

--- a/src/bin/pgcopydb/cli_restore.c
+++ b/src/bin/pgcopydb/cli_restore.c
@@ -585,8 +585,6 @@ cli_restore_schema_parse_list(int argc, char **argv)
 					item->restoreListName ? item->restoreListName : "");
 		}
 
-		FreeArchiveContentArray(&contents);
-
 		exit(EXIT_CODE_QUIT);
 	}
 

--- a/src/bin/pgcopydb/cli_sentinel.c
+++ b/src/bin/pgcopydb/cli_sentinel.c
@@ -642,7 +642,6 @@ cli_sentinel_get(int argc, char **argv)
 		fformat(stdout, "%s\n", serialized_string);
 
 		json_free_serialized_string(serialized_string);
-		json_value_free(js);
 	}
 	else
 	{

--- a/src/bin/pgcopydb/compare.c
+++ b/src/bin/pgcopydb/compare.c
@@ -359,7 +359,6 @@ compare_data_by_table_oid(CopyDataSpec *copySpecs, uint32_t oid)
 		log_error("Failed to lookup for table %u in our internal catalogs",
 				  oid);
 
-		free(table);
 		return false;
 	}
 
@@ -368,7 +367,6 @@ compare_data_by_table_oid(CopyDataSpec *copySpecs, uint32_t oid)
 		log_error("Failed to find table with oid %u in our internal catalogs",
 				  oid);
 
-		free(table);
 		return false;
 	}
 
@@ -558,7 +556,6 @@ compare_schemas(CopyDataSpec *copySpecs)
 	/*
 	 * Now prepare two specifications with only the source uri.
 	 *
-	 * We don't free() any memory here as the two CopyDataSpecs copies are
 	 * going to share pointers to memory allocated in the main copySpecs
 	 * instance.
 	 */
@@ -659,7 +656,6 @@ compare_schemas_table_hook(void *ctx, SourceTable *sourceTable)
 				  sourceTable->nspname,
 				  sourceTable->relname);
 
-		free(targetTable);
 		return false;
 	}
 
@@ -710,7 +706,6 @@ compare_schemas_table_hook(void *ctx, SourceTable *sourceTable)
 		}
 	}
 
-	free(targetTable);
 
 	log_notice("Matched table %s with %d columns ok",
 			   sourceTable->qname,
@@ -746,7 +741,6 @@ compare_schemas_index_hook(void *ctx, SourceIndex *sourceIndex)
 				  sourceIndex->indexNamespace,
 				  sourceIndex->indexRelname);
 
-		free(targetIndex);
 		return false;
 	}
 
@@ -839,7 +833,6 @@ compare_schemas_index_hook(void *ctx, SourceIndex *sourceIndex)
 				 targetIndex->constraintDef);
 	}
 
-	free(targetIndex);
 
 	log_notice("Matched index %s ok (%s, %s)",
 			   sourceIndex->indexQname,
@@ -877,7 +870,6 @@ compare_schemas_seq_hook(void *ctx, SourceSequence *sourceSeq)
 				  sourceSeq->nspname,
 				  sourceSeq->relname);
 
-		free(targetSeq);
 		return false;
 	}
 
@@ -910,7 +902,6 @@ compare_schemas_seq_hook(void *ctx, SourceSequence *sourceSeq)
 			   sourceSeq->qname,
 			   (long long) sourceSeq->lastValue);
 
-	free(targetSeq);
 
 	return true;
 }
@@ -1075,7 +1066,6 @@ compare_write_checksum(SourceTable *table, const char *filename)
 	bool success = write_file(serialized_string, len, filename);
 
 	json_free_serialized_string(serialized_string);
-	json_value_free(js);
 
 	if (!success)
 	{
@@ -1109,7 +1099,6 @@ compare_read_checksum(SourceTable *table, const char *filename)
 				  table->oid,
 				  table->qname,
 				  filename);
-		json_value_free(json);
 		return false;
 	}
 

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -306,8 +306,6 @@ bool copydb_init_table_specs(CopyTableDataSpec *tableSpecs,
 							 SourceTable *source,
 							 int partNumber);
 
-void FreeCopyTableDataSpec(CopyTableDataSpec *tableSpecs);
-
 bool copydb_export_snapshot(TransactionSnapshot *snapshot);
 
 bool copydb_fatal_exit(void);

--- a/src/bin/pgcopydb/defaults.h
+++ b/src/bin/pgcopydb/defaults.h
@@ -6,6 +6,21 @@
 #ifndef DEFAULTS_H
 #define DEFAULTS_H
 
+/*
+ * Setup Boehm-Demers-Weiser conservative garbage collector as a garbage
+ * collecting replacement for malloc. See https://www.hboehm.info/gc/
+ */
+#include <gc/gc.h>
+
+#define malloc(n) GC_malloc(n)
+#define calloc(m, n) GC_malloc((m) * (n))
+#define free(p) GC_free(p)
+#define realloc(p, n) GC_realloc((p), (n))
+#define CHECK_LEAKS() GC_gcollect()
+
+/*
+ * Now install the version string.
+ */
 #include "git-version.h"
 
 /* additional version information for printing version on CLI */

--- a/src/bin/pgcopydb/defaults.h
+++ b/src/bin/pgcopydb/defaults.h
@@ -16,6 +16,11 @@
 #define calloc(m, n) GC_malloc((m) * (n))
 #define free(p) GC_free(p)
 #define realloc(p, n) GC_realloc((p), (n))
+
+/*
+ * The GC API can also be used as leak detector, thanks to using the following
+ * macro, as per https://www.hboehm.info/gc/leak.html
+ */
 #define CHECK_LEAKS() GC_gcollect()
 
 /*

--- a/src/bin/pgcopydb/dump_restore.c
+++ b/src/bin/pgcopydb/dump_restore.c
@@ -281,8 +281,8 @@ copydb_copy_database_properties_hook(void *ctx, SourceProperty *property)
 	PGSQL *dst = context->dst;
 	PGconn *conn = dst->connection;
 
-	const char *t_dbname = specs->connStrings.safeTargetPGURI.uriParams.dbname;
-	const char *t_escaped_dbname = pgsql_escape_identifier(dst, t_dbname);
+	char *t_dbname = specs->connStrings.safeTargetPGURI.uriParams.dbname;
+	char *t_escaped_dbname = pgsql_escape_identifier(dst, t_dbname);
 
 	if (t_escaped_dbname == NULL)
 	{

--- a/src/bin/pgcopydb/dump_restore.c
+++ b/src/bin/pgcopydb/dump_restore.c
@@ -308,7 +308,6 @@ copydb_copy_database_properties_hook(void *ctx, SourceProperty *property)
 		if (!catalog_lookup_s_role_by_name(targetDB, property->rolname, role))
 		{
 			/* errors have already been logged */
-			free(role);
 			return false;
 		}
 
@@ -333,7 +332,6 @@ copydb_copy_database_properties_hook(void *ctx, SourceProperty *property)
 			if (!pgsql_execute(dst, command->data))
 			{
 				/* errors have already been logged */
-				free(role);
 				return false;
 			}
 
@@ -345,8 +343,6 @@ copydb_copy_database_properties_hook(void *ctx, SourceProperty *property)
 					 "does not exists on the target database",
 					 property->rolname);
 		}
-
-		free(role);
 	}
 
 	/*
@@ -602,7 +598,6 @@ copydb_write_restore_list(CopyDataSpec *specs, PostgresDumpSection section)
 						 &contents))
 	{
 		/* errors have already been logged */
-		FreeArchiveContentArray(&contents);
 		return false;
 	}
 
@@ -717,7 +712,6 @@ copydb_write_restore_list(CopyDataSpec *specs, PostgresDumpSection section)
 	{
 		log_error("Failed to create pg_restore list file: out of memory");
 		destroyPQExpBuffer(listContents);
-		FreeArchiveContentArray(&contents);
 		return false;
 	}
 
@@ -727,12 +721,10 @@ copydb_write_restore_list(CopyDataSpec *specs, PostgresDumpSection section)
 	{
 		/* errors have already been logged */
 		destroyPQExpBuffer(listContents);
-		FreeArchiveContentArray(&contents);
 		return false;
 	}
 
 	destroyPQExpBuffer(listContents);
-	FreeArchiveContentArray(&contents);
 
 	return true;
 }

--- a/src/bin/pgcopydb/extensions.c
+++ b/src/bin/pgcopydb/extensions.c
@@ -372,7 +372,6 @@ copydb_parse_extensions_requirements(CopyDataSpec *copySpecs, char *filename)
 		return false;
 	}
 
-	json_value_free(schema);
 
 	JSON_Array *jsReqArray = json_value_get_array(json);
 	size_t count = json_array_get_count(jsReqArray);

--- a/src/bin/pgcopydb/file_utils.c
+++ b/src/bin/pgcopydb/file_utils.c
@@ -356,14 +356,12 @@ read_file_internal(FILE *fileStream,
 	{
 		log_error("Failed to read file \"%s\": %m", filePath);
 		fclose(fileStream);
-		free(data);
 		return false;
 	}
 
 	if (fclose(fileStream) == EOF)
 	{
 		log_error("Failed to read file \"%s\"", filePath);
-		free(data);
 		return false;
 	}
 
@@ -530,12 +528,10 @@ read_from_stream(FILE *stream, ReadFromStreamContext *context)
 			if (bytes == -1)
 			{
 				log_error("Failed to read from input stream: %m");
-				free(buf);
 				return false;
 			}
 			else if (bytes == 0)
 			{
-				free(buf);
 				doneReading = true;
 				continue;
 			}
@@ -669,7 +665,6 @@ read_from_stream(FILE *stream, ReadFromStreamContext *context)
 
 					if (!(*context->callback)(context->ctx, line, &stop))
 					{
-						FreeLinesBuffer(&lbuf);
 						destroyPQExpBuffer(multiPartBuffer);
 						return false;
 					}
@@ -689,8 +684,6 @@ read_from_stream(FILE *stream, ReadFromStreamContext *context)
 					}
 				}
 			}
-
-			FreeLinesBuffer(&lbuf);
 		}
 
 		/* doneReading might have been set from the user callback already */
@@ -793,7 +786,6 @@ duplicate_file(char *sourcePath, char *destinationPath)
 
 	bool foundError = !write_file(fileContents, fileSize, destinationPath);
 
-	free(fileContents);
 
 	if (foundError)
 	{

--- a/src/bin/pgcopydb/file_utils.c
+++ b/src/bin/pgcopydb/file_utils.c
@@ -543,7 +543,7 @@ read_from_stream(FILE *stream, ReadFromStreamContext *context)
 			bool partialRead = buf[bytes - 1] != '\n';
 			LinesBuffer lbuf = { 0 };
 
-			if (!splitLines(&lbuf, buf, true))
+			if (!splitLines(&lbuf, buf))
 			{
 				/* errors have already been logged */
 				return false;

--- a/src/bin/pgcopydb/filtering.c
+++ b/src/bin/pgcopydb/filtering.c
@@ -137,7 +137,6 @@ parse_filters(const char *filename, SourceFilters *filters)
 	}
 
 	ini_t *ini = ini_load(fileContents, NULL);
-	free(fileContents);
 
 	/*
 	 * The index in the sections array matches the SourceFilterSection enum

--- a/src/bin/pgcopydb/indexes.c
+++ b/src/bin/pgcopydb/indexes.c
@@ -339,16 +339,12 @@ copydb_create_index_by_oid(CopyDataSpec *specs, PGSQL *dst, uint32_t indexOid)
 	if (!catalog_lookup_s_index(sourceDB, indexOid, index))
 	{
 		log_error("Failed to lookup index %u in our catalogs", indexOid);
-		free(index);
-		free(table);
 		return false;
 	}
 
 	if (!catalog_lookup_s_table(sourceDB, index->tableOid, 0, table))
 	{
 		log_error("Failed to lookup table %u in our catalogs", index->tableOid);
-		free(index);
-		free(table);
 		return false;
 	}
 
@@ -390,8 +386,6 @@ copydb_create_index_by_oid(CopyDataSpec *specs, PGSQL *dst, uint32_t indexOid)
 	if (!copydb_create_index(specs, dst, index, ifNotExists))
 	{
 		/* errors have already been logged */
-		free(index);
-		free(table);
 		return false;
 	}
 
@@ -410,8 +404,6 @@ copydb_create_index_by_oid(CopyDataSpec *specs, PGSQL *dst, uint32_t indexOid)
 									   &constraintsAreBeingBuilt))
 	{
 		/* errors have already been logged */
-		free(index);
-		free(table);
 		return false;
 	}
 
@@ -428,8 +420,6 @@ copydb_create_index_by_oid(CopyDataSpec *specs, PGSQL *dst, uint32_t indexOid)
 		{
 			log_error("Failed to create constraints for table %s",
 					  table->qname);
-			free(index);
-			free(table);
 			return false;
 		}
 
@@ -440,15 +430,11 @@ copydb_create_index_by_oid(CopyDataSpec *specs, PGSQL *dst, uint32_t indexOid)
 				log_error("Failed to queue VACUUM ANALYZE %s [%u]",
 						  table->qname,
 						  table->oid);
-				free(index);
-				free(table);
 				return false;
 			}
 		}
 	}
 
-	free(index);
-	free(table);
 
 	return true;
 }
@@ -1060,7 +1046,6 @@ copydb_create_constraints(CopyDataSpec *specs, PGSQL *dst, SourceTable *table)
 	{
 		log_error("Failed to count indexes for table %s in our target catalog",
 				  targetTable->qname);
-		free(targetTable);
 		return false;
 	}
 
@@ -1083,7 +1068,6 @@ copydb_create_constraints(CopyDataSpec *specs, PGSQL *dst, SourceTable *table)
 				  table->qname);
 	}
 
-	free(targetTable);
 
 	/*
 	 * Now iterate over the source database catalog list of indexes attached to

--- a/src/bin/pgcopydb/ld_apply.c
+++ b/src/bin/pgcopydb/ld_apply.c
@@ -484,8 +484,6 @@ stream_apply_file(StreamApplyContext *context)
 		if (!parseSQLAction(sql, metadata))
 		{
 			/* errors have already been logged */
-			FreeLinesBuffer(&(content.lbuf));
-
 			return false;
 		}
 
@@ -501,8 +499,6 @@ stream_apply_file(StreamApplyContext *context)
 					  content.filename,
 					  (long long) i + 1,
 					  (long long) content.lbuf.count);
-
-			FreeLinesBuffer(&(content.lbuf));
 
 			return false;
 		}
@@ -528,14 +524,9 @@ stream_apply_file(StreamApplyContext *context)
 					  "see above for details",
 					  content.filename);
 
-			FreeLinesBuffer(&(content.lbuf));
-
 			return false;
 		}
 	}
-
-	/* free dynamic memory that's not needed anymore */
-	FreeLinesBuffer(&(content.lbuf));
 
 	/*
 	 * Each time we are done applying a file, we update our progress and
@@ -1117,12 +1108,8 @@ stream_apply_sql(StreamApplyContext *context,
 					/* errors have already been logged */
 					return false;
 				}
-
-				free(paramValues);
 			}
 
-			free(metadata->jsonBuffer);
-			json_value_free(js);
 
 			break;
 		}
@@ -1443,11 +1430,9 @@ parseSQLAction(const char *query, LogicalMessageMetadata *metadata)
 		if (!parseMessageMetadata(metadata, message, json, true))
 		{
 			/* errors have already been logged */
-			json_value_free(json);
 			return false;
 		}
 
-		json_value_free(json);
 
 		return true;
 	}
@@ -1656,7 +1641,6 @@ stream_apply_find_durable_lsn(StreamApplyContext *context, uint64_t *durableLSN)
 	while (tail != NULL)
 	{
 		LSNTracking *previous = tail->previous;
-		free(tail);
 		tail = previous;
 	}
 
@@ -1746,12 +1730,9 @@ parseTxnMetadataFile(const char *filename, LogicalMessageMetadata *metadata)
 	if (!parseMessageMetadata(metadata, txnMetadataContent, json, true))
 	{
 		/* errors have already been logged */
-		json_value_free(json);
 		return false;
 	}
 
-	json_value_free(json);
-	free(txnMetadataContent);
 
 	if (metadata->txnCommitLSN == InvalidXLogRecPtr ||
 		metadata->xid != xid ||

--- a/src/bin/pgcopydb/ld_apply.c
+++ b/src/bin/pgcopydb/ld_apply.c
@@ -448,7 +448,7 @@ stream_apply_file(StreamApplyContext *context)
 		return false;
 	}
 
-	if (!splitLines(&(content.lbuf), contents, true))
+	if (!splitLines(&(content.lbuf), contents))
 	{
 		/* errors have already been logged */
 		return false;

--- a/src/bin/pgcopydb/ld_stream.c
+++ b/src/bin/pgcopydb/ld_stream.c
@@ -1938,7 +1938,7 @@ stream_read_file(StreamContent *content)
 		return false;
 	}
 
-	if (!splitLines(&(content->lbuf), contents, true))
+	if (!splitLines(&(content->lbuf), contents))
 	{
 		/* errors have already been logged */
 		return false;

--- a/src/bin/pgcopydb/ld_stream.c
+++ b/src/bin/pgcopydb/ld_stream.c
@@ -658,8 +658,6 @@ streamCheckResumePosition(StreamSpecs *specs)
 		log_notice("Resume replication from latest message: %s", latestMessage);
 	}
 
-	FreeLinesBuffer(&(latestStreamedContent.lbuf));
-
 	PGSQL src = { 0 };
 
 	if (!pgsql_init(&src, specs->connStrings->source_pguri, PGSQL_CONN_SOURCE))
@@ -863,7 +861,6 @@ stream_write_json(LogicalStreamContext *context, bool previous)
 	}
 
 	destroyPQExpBuffer(buffer);
-	free(metadata->jsonBuffer);
 
 	/*
 	 * Maintain the transaction progress based on the BEGIN and COMMIT messages
@@ -1976,11 +1973,8 @@ stream_read_file(StreamContent *content)
 		if (!parseMessageMetadata(metadata, message, json, false))
 		{
 			/* errors have already been logged */
-			json_value_free(json);
 			return false;
 		}
-
-		json_value_free(json);
 	}
 
 	return true;
@@ -2143,11 +2137,9 @@ buildReplicationURI(const char *pguri, char **repl_pguri)
 	if (!buildPostgresURIfromPieces(&params, repl_pguri))
 	{
 		log_error("Failed to produce the replication connection string");
-		freeURIParams(&params);
 		return false;
 	}
 
-	freeURIParams(&params);
 	return true;
 }
 
@@ -2760,33 +2752,21 @@ stream_read_context(CDCPaths *paths,
 	if (!stringToUInt(wal_segment_size, WalSegSz))
 	{
 		/* errors have already been logged */
-		free(wal_segment_size);
-		free(tli);
-		free(history);
 		return false;
 	}
 
 	if (!stringToUInt(tli, &(system->timeline)))
 	{
 		/* errors have already been logged */
-		free(wal_segment_size);
-		free(tli);
-		free(history);
 		return false;
 	}
 
 	if (!parseTimeLineHistory(paths->tlihistfile, history, system))
 	{
 		/* errors have already been logged */
-		free(wal_segment_size);
-		free(tli);
-		free(history);
 		return false;
 	}
 
-	free(wal_segment_size);
-	free(tli);
-	free(history);
 
 	return true;
 }

--- a/src/bin/pgcopydb/ld_stream.h
+++ b/src/bin/pgcopydb/ld_stream.h
@@ -624,11 +624,6 @@ bool parseMessage(StreamContext *privateContext, char *message, JSON_Value *json
 bool streamLogicalTransactionAppendStatement(LogicalTransaction *txn,
 											 LogicalTransactionStatement *stmt);
 
-void FreeLogicalMessage(LogicalMessage *msg);
-void FreeLogicalTransaction(LogicalTransaction *tx);
-void FreeLogicalMessageTupleArray(LogicalMessageTupleArray *tupleArray);
-void FreeLogicalMessageRelation(LogicalMessageRelation *table);
-void FreeLogicalMessageTuple(LogicalMessageTuple *tuple);
 bool AllocateLogicalMessageTuple(LogicalMessageTuple *tuple, int count);
 
 /* ld_test_decoding.c */

--- a/src/bin/pgcopydb/ld_test_decoding.c
+++ b/src/bin/pgcopydb/ld_test_decoding.c
@@ -110,7 +110,6 @@ prepareTestDecodingMessage(LogicalStreamContext *context)
 		return false;
 	}
 
-	json_value_free(js);
 	json_free_serialized_string(jsonstr);
 
 	return true;
@@ -627,21 +626,6 @@ SetColumnNamesAndValues(LogicalMessageTuple *tuple, TestDecodingHeader *header)
 		return false;
 	}
 
-	/*
-	 * Free the TestDecodingColumns memory that we allocated: only the
-	 * structure itself, the rest is just a bunch of pointers to parts of the
-	 * messages.
-	 */
-	TestDecodingColumns *c = cols;
-
-	for (; c != NULL;)
-	{
-		TestDecodingColumns *next = c->next;
-
-		free(c);
-		c = next;
-	}
-
 	return true;
 }
 
@@ -984,7 +968,6 @@ prepareUpdateTuppleArrays(StreamContext *privateContext,
 										table))
 	{
 		/* errors have already been logged */
-		free(table);
 		return false;
 	}
 
@@ -1120,8 +1103,6 @@ prepareUpdateTuppleArrays(StreamContext *privateContext,
 		/* avoid double-free now */
 		cols->values.array[0].array[c].val.str = NULL;
 	}
-
-	(void) FreeLogicalMessageTuple(cols);
 
 	return true;
 }

--- a/src/bin/pgcopydb/ld_transform.c
+++ b/src/bin/pgcopydb/ld_transform.c
@@ -456,8 +456,6 @@ stream_transform_write_message(StreamContext *privateContext,
 		return false;
 	}
 
-	(void) FreeLogicalMessage(currentMsg);
-
 	if (metadata->action == STREAM_ACTION_COMMIT ||
 		metadata->action == STREAM_ACTION_ROLLBACK)
 	{
@@ -515,7 +513,6 @@ stream_transform_message(StreamContext *privateContext, char *message)
 	if (!parseMessageMetadata(metadata, message, json, false))
 	{
 		/* errors have already been logged */
-		json_value_free(json);
 		return false;
 	}
 
@@ -524,11 +521,9 @@ stream_transform_message(StreamContext *privateContext, char *message)
 		log_error("Failed to parse JSON message: %.1024s%s",
 				  message,
 				  strlen(message) > 1024 ? "..." : "");
-		json_value_free(json);
 		return false;
 	}
 
-	json_value_free(json);
 
 	return true;
 }
@@ -941,7 +936,6 @@ stream_transform_file(StreamSpecs *specs, char *jsonfilename, char *sqlfilename)
 	if (privateContext->sqlFile == NULL)
 	{
 		log_error("Failed to open file \"%s\"", tempfilename);
-		FreeLinesBuffer(&(content.lbuf));
 		return false;
 	}
 
@@ -970,8 +964,6 @@ stream_transform_file(StreamSpecs *specs, char *jsonfilename, char *sqlfilename)
 		if (!parseMessageMetadata(metadata, message, json, false))
 		{
 			/* errors have already been logged */
-			json_value_free(json);
-			FreeLinesBuffer(&(content.lbuf));
 			return false;
 		}
 
@@ -1003,12 +995,9 @@ stream_transform_file(StreamSpecs *specs, char *jsonfilename, char *sqlfilename)
 		if (!parseMessage(privateContext, message, json))
 		{
 			log_error("Failed to parse JSON message: %s", message);
-			json_value_free(json);
-			FreeLinesBuffer(&(content.lbuf));
 			return false;
 		}
 
-		json_value_free(json);
 
 		/*
 		 * Prepare a new message when we just read the COMMIT message of an
@@ -1020,7 +1009,6 @@ stream_transform_file(StreamSpecs *specs, char *jsonfilename, char *sqlfilename)
 		{
 			log_error("Failed to transform and flush the current message, "
 					  "see above for details");
-			FreeLinesBuffer(&(content.lbuf));
 			return false;
 		}
 
@@ -1033,8 +1021,6 @@ stream_transform_file(StreamSpecs *specs, char *jsonfilename, char *sqlfilename)
 			firstMessage = false;
 		}
 	}
-
-	FreeLinesBuffer(&(content.lbuf));
 
 	if (fclose(privateContext->sqlFile) == EOF)
 	{
@@ -1244,7 +1230,6 @@ parseMessage(StreamContext *privateContext, char *message, JSON_Value *json)
 				/* copy the stmt over, then free the extra allocated memory */
 				mesg->action = metadata->action;
 				mesg->command.switchwal = stmt->stmt.switchwal;
-				free(stmt);
 			}
 
 			break;
@@ -1268,7 +1253,6 @@ parseMessage(StreamContext *privateContext, char *message, JSON_Value *json)
 				/* copy the stmt over, then free the extra allocated memory */
 				mesg->action = metadata->action;
 				mesg->command.keepalive = stmt->stmt.keepalive;
-				free(stmt);
 			}
 
 			break;
@@ -1287,7 +1271,6 @@ parseMessage(StreamContext *privateContext, char *message, JSON_Value *json)
 				/* copy the stmt over, then free the extra allocated memory */
 				mesg->action = metadata->action;
 				mesg->command.endpos = stmt->stmt.endpos;
-				free(stmt);
 			}
 
 			break;
@@ -1420,10 +1403,6 @@ coalesceLogicalTransactionStatement(LogicalTransaction *txn,
 	 */
 	lastValuesArray->array[lastValuesArray->count++] = newValuesArray->array[0];
 	newValuesArray->count = 0;
-
-	/* Deallocate the tuple and the new statement */
-	FreeLogicalMessageTupleArray(&(new->stmt.insert.new));
-	free(new);
 
 	return true;
 }
@@ -1562,151 +1541,6 @@ streamLogicalTransactionAppendStatement(LogicalTransaction *txn,
 	++txn->count;
 
 	return true;
-}
-
-
-/*
- * FreeLogicalMessage frees the malloc'ated memory areas of a LogicalMessage.
- */
-void
-FreeLogicalMessage(LogicalMessage *msg)
-{
-	if (msg->isTransaction)
-	{
-		FreeLogicalTransaction(&(msg->command.tx));
-	}
-}
-
-
-/*
- * FreeLogicalTransaction frees the malloc'ated memory areas of a
- * LogicalTransaction.
- */
-void
-FreeLogicalTransaction(LogicalTransaction *tx)
-{
-	LogicalTransactionStatement *currentStmt = tx->first;
-
-	for (; currentStmt != NULL;)
-	{
-		switch (currentStmt->action)
-		{
-			case STREAM_ACTION_INSERT:
-			{
-				FreeLogicalMessageRelation(&(currentStmt->stmt.insert.table));
-				FreeLogicalMessageTupleArray(&(currentStmt->stmt.insert.new));
-				break;
-			}
-
-			case STREAM_ACTION_UPDATE:
-			{
-				FreeLogicalMessageRelation(&(currentStmt->stmt.update.table));
-				FreeLogicalMessageTupleArray(&(currentStmt->stmt.update.old));
-				FreeLogicalMessageTupleArray(&(currentStmt->stmt.update.new));
-				break;
-			}
-
-			case STREAM_ACTION_DELETE:
-			{
-				FreeLogicalMessageRelation(&(currentStmt->stmt.delete.table));
-				FreeLogicalMessageTupleArray(&(currentStmt->stmt.delete.old));
-				break;
-			}
-
-			case STREAM_ACTION_TRUNCATE:
-			{
-				FreeLogicalMessageRelation(&(currentStmt->stmt.truncate.table));
-				break;
-			}
-
-			/* no malloc'ated area in a BEGIN, COMMIT, or TRUNCATE statement */
-			default:
-			{
-				break;
-			}
-		}
-
-		LogicalTransactionStatement *stmt = currentStmt;
-		currentStmt = currentStmt->next;
-
-		free(stmt);
-	}
-
-	tx->first = NULL;
-}
-
-
-/*
- * FreeLogicalMessageRelation frees the malloc'ated memory areas of
- * LogicalMessageRelation.
- */
-void
-FreeLogicalMessageRelation(LogicalMessageRelation *table)
-{
-	if (table->pqMemory)
-	{
-		/* use PQfreemem for memory allocated by PQescapeIdentifer */
-		PQfreemem(table->nspname);
-		PQfreemem(table->relname);
-	}
-	else
-	{
-		free(table->nspname);
-		free(table->relname);
-	}
-}
-
-
-/*
- * FreeLogicalMessageTupleArray frees the malloc'ated memory areas of a
- * LogicalMessageTupleArray.
- */
-void
-FreeLogicalMessageTupleArray(LogicalMessageTupleArray *tupleArray)
-{
-	for (int s = 0; s < tupleArray->count; s++)
-	{
-		LogicalMessageTuple *tuple = &(tupleArray->array[s]);
-
-		(void) FreeLogicalMessageTuple(tuple);
-	}
-
-	free(tupleArray->array);
-}
-
-
-/*
- * FreeLogicalMessageTuple frees the malloc'ated memory areas of a
- * LogicalMessageTuple.
- */
-void
-FreeLogicalMessageTuple(LogicalMessageTuple *tuple)
-{
-	for (int i = 0; i < tuple->cols; i++)
-	{
-		free(tuple->columns[i]);
-	}
-	free(tuple->columns);
-
-	for (int r = 0; r < tuple->values.count; r++)
-	{
-		LogicalMessageValues *values = &(tuple->values.array[r]);
-
-		for (int v = 0; v < values->cols; v++)
-		{
-			LogicalMessageValue *value = &(values->array[v]);
-
-			if ((value->oid == TEXTOID || value->oid == BYTEAOID) &&
-				!value->isNull)
-			{
-				free(value->val.str);
-			}
-		}
-
-		free(values->array);
-	}
-
-	free(tuple->values.array);
 }
 
 
@@ -2267,7 +2101,6 @@ stream_write_insert(FILE *out, LogicalMessageInsert *insert)
 		FFORMAT(out, "EXECUTE %x%s;\n", hash, serialized_string);
 
 		json_free_serialized_string(serialized_string);
-		json_value_free(js);
 	}
 
 	return true;
@@ -2457,7 +2290,6 @@ stream_write_update(FILE *out, LogicalMessageUpdate *update)
 		FFORMAT(out, "EXECUTE %x%s;\n", hash, serialized_string);
 
 		json_free_serialized_string(serialized_string);
-		json_value_free(js);
 	}
 
 	return true;
@@ -2543,7 +2375,6 @@ stream_write_delete(FILE *out, LogicalMessageDelete *delete)
 		FFORMAT(out, "EXECUTE %x%s;\n", hash, serialized_string);
 
 		json_free_serialized_string(serialized_string);
-		json_value_free(js);
 	}
 
 	return true;

--- a/src/bin/pgcopydb/ld_transform.c
+++ b/src/bin/pgcopydb/ld_transform.c
@@ -902,7 +902,7 @@ stream_transform_file(StreamSpecs *specs, char *jsonfilename, char *sqlfilename)
 		return false;
 	}
 
-	if (!splitLines(&(content.lbuf), contents, true))
+	if (!splitLines(&(content.lbuf), contents))
 	{
 		/* errors have already been logged */
 		return false;

--- a/src/bin/pgcopydb/ld_wal2json.c
+++ b/src/bin/pgcopydb/ld_wal2json.c
@@ -101,7 +101,6 @@ parseWal2jsonMessageActionAndXid(LogicalStreamContext *context)
 		metadata->xid = (uint32_t) xid;
 	}
 
-	json_value_free(json);
 
 	return true;
 }

--- a/src/bin/pgcopydb/lock_utils.c
+++ b/src/bin/pgcopydb/lock_utils.c
@@ -266,18 +266,14 @@ semaphore_cleanup(const char *pidfile)
 				  pidfile,
 				  (long long) lbuf.count,
 				  PIDFILE_LINE_SEM_ID);
-		FreeLinesBuffer(&lbuf);
 		return false;
 	}
 
 	if (!stringToInt(lbuf.lines[PIDFILE_LINE_SEM_ID], &(semaphore.semId)))
 	{
 		/* errors have already been logged */
-		FreeLinesBuffer(&lbuf);
 		return false;
 	}
-
-	FreeLinesBuffer(&lbuf);
 
 	log_trace("Read semaphore id %d from stale pidfile", semaphore.semId);
 

--- a/src/bin/pgcopydb/lock_utils.c
+++ b/src/bin/pgcopydb/lock_utils.c
@@ -253,7 +253,7 @@ semaphore_cleanup(const char *pidfile)
 
 	LinesBuffer lbuf = { 0 };
 
-	if (!splitLines(&lbuf, fileContents, true))
+	if (!splitLines(&lbuf, fileContents))
 	{
 		/* errors have already been logged */
 		return false;

--- a/src/bin/pgcopydb/lsn_tracking.c
+++ b/src/bin/pgcopydb/lsn_tracking.c
@@ -205,7 +205,6 @@ lsn_tracking_iter(DatabaseCatalog *catalog,
 	if (!lsn_tracking_iter_init(iter))
 	{
 		/* errors have already been logged */
-		free(iter);
 		return false;
 	}
 
@@ -214,7 +213,6 @@ lsn_tracking_iter(DatabaseCatalog *catalog,
 		if (!lsn_tracking_iter_next(iter))
 		{
 			/* errors have already been logged */
-			free(iter);
 			return false;
 		}
 
@@ -225,7 +223,6 @@ lsn_tracking_iter(DatabaseCatalog *catalog,
 			if (!lsn_tracking_iter_finish(iter))
 			{
 				/* errors have already been logged */
-				free(iter);
 				return false;
 			}
 
@@ -241,7 +238,6 @@ lsn_tracking_iter(DatabaseCatalog *catalog,
 		}
 	}
 
-	free(iter);
 
 	return true;
 }
@@ -299,7 +295,6 @@ lsn_tracking_iter_next(LSNTrackingIterator *iter)
 
 	if (rc == SQLITE_DONE)
 	{
-		free(iter->lsnTracking);
 		iter->lsnTracking = NULL;
 
 		return true;

--- a/src/bin/pgcopydb/main.c
+++ b/src/bin/pgcopydb/main.c
@@ -6,11 +6,15 @@
 #include <getopt.h>
 #include <unistd.h>
 
+#include <gc/gc.h>
+
 #include "postgres.h"
 
 #if (PG_VERSION_NUM >= 120000)
 #include "common/logging.h"
 #endif
+
+#include "parson.h"
 
 #include "cli_root.h"
 #include "copydb.h"
@@ -58,6 +62,9 @@ main(int argc, char **argv)
 
 	/* allows changing process title in ps/top/ptree etc */
 	(void) init_ps_buffer(argc, argv);
+
+	/* set memory allocation function for JSON parson lib to use libgc */
+	(void) json_set_allocation_functions(GC_malloc, GC_free);
 
 	/* set our logging infrastructure */
 	(void) set_logger();

--- a/src/bin/pgcopydb/parsing_utils.c
+++ b/src/bin/pgcopydb/parsing_utils.c
@@ -64,6 +64,7 @@ regexp_first_match(const char *string, const char *regex)
 		log_error("Failed to compile regex \"%s\": %s%s",
 				  regex, message, bytes < BUFSIZE ? "..." : "");
 
+		regfree(&compiledRegex);
 
 		return NULL;
 	}
@@ -73,6 +74,7 @@ regexp_first_match(const char *string, const char *regex)
 	 * returns a nonzero value.
 	 */
 	int matchStatus = regexec(&compiledRegex, string, RE_MATCH_COUNT, m, 0);
+	regfree(&compiledRegex);
 
 	/* We're interested into 1. re matches 2. captured at least one group */
 	if (matchStatus != 0 || m[0].rm_so == -1 || m[1].rm_so == -1)
@@ -84,7 +86,7 @@ regexp_first_match(const char *string, const char *regex)
 		regoff_t start = m[1].rm_so;
 		regoff_t finish = m[1].rm_eo;
 		int length = finish - start + 1;
-		char *result = (char *) malloc(length * sizeof(char));
+		char *result = (char *) calloc(length, sizeof(char));
 
 		if (result == NULL)
 		{

--- a/src/bin/pgcopydb/parsing_utils.h
+++ b/src/bin/pgcopydb/parsing_utils.h
@@ -112,8 +112,4 @@ bool parse_and_scrub_connection_string(const char *pguri, SafeURI *safeURI);
 
 bool bareConnectionString(const char *pguri, SafeURI *safeURI);
 
-void freeSafeURI(SafeURI *safeURI);
-void freeURIParams(URIParams *params);
-void freeKeyVal(KeyVal *parameters);
-
 #endif /* PARSING_UTILS_H */

--- a/src/bin/pgcopydb/pgcmd.c
+++ b/src/bin/pgcopydb/pgcmd.c
@@ -222,7 +222,7 @@ set_psql_from_config_bindir(PostgresPaths *pgPaths, const char *pg_config)
 
 	LinesBuffer lbuf = { 0 };
 
-	if (!splitLines(&lbuf, prog->stdOut, false) || lbuf.count != 1)
+	if (!splitLines(&lbuf, prog->stdOut) || lbuf.count != 1)
 	{
 		log_error("Unable to parse output from pg_config --bindir");
 		return false;
@@ -707,7 +707,7 @@ pg_restore_roles(PostgresPaths *pgPaths,
 
 	LinesBuffer lbuf = { 0 };
 
-	if (!splitLines(&lbuf, content, true))
+	if (!splitLines(&lbuf, content))
 	{
 		/* errors have already been logged */
 		return false;
@@ -1180,7 +1180,7 @@ parse_archive_list(const char *filename, ArchiveContentArray *contents)
 
 	LinesBuffer lbuf = { 0 };
 
-	if (!splitLines(&lbuf, buffer, true))
+	if (!splitLines(&lbuf, buffer))
 	{
 		/* errors have already been logged */
 		return false;

--- a/src/bin/pgcopydb/pgcmd.c
+++ b/src/bin/pgcopydb/pgcmd.c
@@ -52,6 +52,12 @@ psql_version(PostgresPaths *pgPaths)
 	char pg_version_string[PG_VERSION_STRING_MAX] = { 0 };
 	int pg_version = 0;
 
+	if (prog == NULL)
+	{
+		log_error(ALLOCATION_FAILED_ERROR);
+		return false;
+	}
+
 	if (prog->returnCode != 0)
 	{
 		errno = prog->error;
@@ -199,6 +205,12 @@ set_psql_from_config_bindir(PostgresPaths *pgPaths, const char *pg_config)
 	}
 
 	Program *prog = run_program(pg_config, "--bindir", NULL);
+
+	if (prog == NULL)
+	{
+		log_error(ALLOCATION_FAILED_ERROR);
+		return false;
+	}
 
 	if (prog->returnCode != 0)
 	{

--- a/src/bin/pgcopydb/pgcmd.c
+++ b/src/bin/pgcopydb/pgcmd.c
@@ -28,6 +28,14 @@
 #include "signals.h"
 #include "string_utils.h"
 
+/*
+ * Because we did include defaults.h previously in the same compilation unit (a
+ * .c file), then the runprogram.h code is linked to the Garbage-Collector:
+ * calls to malloc() in there are replaced by calls to GC_malloc() as per
+ * defaults.h #define instructions.
+ *
+ * As a result we never call free_program().
+ */
 #define RUN_PROGRAM_IMPLEMENTATION
 #include "runprogram.h"
 
@@ -40,29 +48,26 @@ static bool pg_dump_db_extension_namespace_hook(void *ctx, SourceExtension *ext)
 bool
 psql_version(PostgresPaths *pgPaths)
 {
-	Program prog = run_program(pgPaths->psql, "--version", NULL);
+	Program *prog = run_program(pgPaths->psql, "--version", NULL);
 	char pg_version_string[PG_VERSION_STRING_MAX] = { 0 };
 	int pg_version = 0;
 
-	if (prog.returnCode != 0)
+	if (prog->returnCode != 0)
 	{
-		errno = prog.error;
+		errno = prog->error;
 		log_error("Failed to run \"psql --version\" using program \"%s\": %m",
 				  pgPaths->psql);
-		free_program(&prog);
 		return false;
 	}
 
-	if (!parse_version_number(prog.stdOut,
+	if (!parse_version_number(prog->stdOut,
 							  pg_version_string,
 							  PG_VERSION_STRING_MAX,
 							  &pg_version))
 	{
 		/* errors have already been logged */
-		free_program(&prog);
 		return false;
 	}
-	free_program(&prog);
 
 	strlcpy(pgPaths->pg_version, pg_version_string, PG_VERSION_STRING_MAX);
 
@@ -193,44 +198,36 @@ set_psql_from_config_bindir(PostgresPaths *pgPaths, const char *pg_config)
 		return false;
 	}
 
-	Program prog = run_program(pg_config, "--bindir", NULL);
+	Program *prog = run_program(pg_config, "--bindir", NULL);
 
-	if (prog.returnCode != 0)
+	if (prog->returnCode != 0)
 	{
-		errno = prog.error;
+		errno = prog->error;
 		log_error("Failed to run \"pg_config --bindir\" using program \"%s\": %m",
 				  pg_config);
-		free_program(&prog);
 		return false;
 	}
 
 	LinesBuffer lbuf = { 0 };
 
-	if (!splitLines(&lbuf, prog.stdOut, false) || lbuf.count != 1)
+	if (!splitLines(&lbuf, prog->stdOut, false) || lbuf.count != 1)
 	{
 		log_error("Unable to parse output from pg_config --bindir");
-		free_program(&prog);
-		FreeLinesBuffer(&lbuf);
 		return false;
 	}
 
 	char *bindir = lbuf.lines[0];
 	join_path_components(psql, bindir, "psql");
 
-	/* we're now done with the Program and its output */
-	free_program(&prog);
-
 	if (!file_exists(psql))
 	{
 		log_error("Failed to find psql at \"%s\" from PG_CONFIG at \"%s\"",
 				  pgPaths->psql,
 				  pg_config);
-		FreeLinesBuffer(&lbuf);
 		return false;
 	}
 
 	strlcpy(pgPaths->psql, psql, sizeof(pgPaths->psql));
-	FreeLinesBuffer(&lbuf);
 
 	return true;
 }
@@ -500,12 +497,6 @@ pg_dump_db(PostgresPaths *pgPaths,
 	(void) initialize_program(&program, args, false);
 	program.processBuffer = &processBufferCallback;
 
-	/* free the extension namespace string values */
-	for (int i = 0; i < extNamespaceCount; i++)
-	{
-		free(extNamespaces[i]);
-	}
-
 	/* log the exact command line we're using */
 	int commandSize = snprintf_program_command_line(&program, command, BUFSIZE);
 
@@ -531,12 +522,10 @@ pg_dump_db(PostgresPaths *pgPaths,
 	if (program.returnCode != 0)
 	{
 		log_error("Failed to run pg_dump: exit code %d", program.returnCode);
-		free_program(&program);
 
 		return false;
 	}
 
-	free_program(&program);
 	return true;
 }
 
@@ -656,12 +645,10 @@ pg_dumpall_roles(PostgresPaths *pgPaths,
 	if (program.returnCode != 0)
 	{
 		log_error("Failed to run pg_dump: exit code %d", program.returnCode);
-		free_program(&program);
 
 		return false;
 	}
 
-	free_program(&program);
 	return true;
 }
 
@@ -776,7 +763,6 @@ pg_restore_roles(PostgresPaths *pgPaths,
 			{
 				log_error("Failed to parse create role statement \"%s\"",
 						  currentLine);
-				FreeLinesBuffer(&lbuf);
 				return false;
 			}
 
@@ -793,7 +779,6 @@ pg_restore_roles(PostgresPaths *pgPaths,
 			if (!pgsql_role_exists(&pgsql, roleName, &exists))
 			{
 				/* errors have already been logged */
-				FreeLinesBuffer(&lbuf);
 				return false;
 			}
 
@@ -814,7 +799,6 @@ pg_restore_roles(PostgresPaths *pgPaths,
 			if (!pgsql_execute(&pgsql, createRole))
 			{
 				/* errors have already been logged */
-				FreeLinesBuffer(&lbuf);
 				return false;
 			}
 		}
@@ -825,13 +809,10 @@ pg_restore_roles(PostgresPaths *pgPaths,
 			if (!pgsql_execute(&pgsql, currentLine))
 			{
 				/* errors have already been logged */
-				FreeLinesBuffer(&lbuf);
 				return false;
 			}
 		}
 	}
-
-	FreeLinesBuffer(&lbuf);
 
 	if (!pgsql_commit(&pgsql))
 	{
@@ -1012,12 +993,10 @@ pg_restore_db(PostgresPaths *pgPaths,
 	if (program.returnCode != 0)
 	{
 		log_error("Failed to run pg_restore: exit code %d", program.returnCode);
-		free_program(&program);
 
 		return false;
 	}
 
-	free_program(&program);
 	return true;
 }
 
@@ -1064,7 +1043,6 @@ pg_restore_list(PostgresPaths *pgPaths,
 	if (program.returnCode != 0)
 	{
 		log_error("Failed to run pg_restore: exit code %d", program.returnCode);
-		free_program(&program);
 
 		return false;
 	}
@@ -1072,11 +1050,9 @@ pg_restore_list(PostgresPaths *pgPaths,
 	if (!parse_archive_list(listFilename, archive))
 	{
 		/* errors have already been logged */
-		free_program(&program);
 		return false;
 	}
 
-	free_program(&program);
 	return true;
 }
 
@@ -1229,7 +1205,6 @@ parse_archive_list(const char *filename, ArchiveContentArray *contents)
 					  "see above for details",
 					  (long long) lineNumber,
 					  filename);
-			FreeLinesBuffer(&lbuf);
 			return false;
 		}
 
@@ -1249,8 +1224,6 @@ parse_archive_list(const char *filename, ArchiveContentArray *contents)
 
 		++contents->count;
 	}
-
-	FreeLinesBuffer(&lbuf);
 
 	return true;
 }
@@ -1646,30 +1619,6 @@ parse_archive_acl_or_comment(char *ptr, ArchiveContentItem *item)
 	log_trace("parse_archive_acl_or_comment: %s [%s]",
 			  item->description,
 			  item->restoreListName);
-
-	return true;
-}
-
-
-/*
- * FreeArchiveContentArray frees the memory allocated in the given
- * ArchiveContentArray.
- */
-bool
-FreeArchiveContentArray(ArchiveContentArray *contents)
-{
-	for (int i = 0; i < contents->count; i++)
-	{
-		ArchiveContentItem *item = &(contents->array[i]);
-
-		free(item->description);
-		free(item->restoreListName);
-	}
-
-	free(contents->array);
-
-	contents->count = 0;
-	contents->array = NULL;
 
 	return true;
 }

--- a/src/bin/pgcopydb/pgcmd.h
+++ b/src/bin/pgcopydb/pgcmd.h
@@ -239,6 +239,4 @@ bool parse_archive_acl_or_comment(char *ptr, ArchiveContentItem *item);
 bool parse_archive_list_entry(ArchiveContentItem *item, const char *line);
 bool tokenize_archive_list_entry(ArchiveToken *token);
 
-bool FreeArchiveContentArray(ArchiveContentArray *contents);
-
 #endif /* PGCMD_H */

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -440,7 +440,7 @@ log_connection_error(PGconn *connection, int logLevel)
 	char *message = PQerrorMessage(connection);
 	LinesBuffer lbuf = { 0 };
 
-	if (!splitLines(&lbuf, message, false))
+	if (!splitLines(&lbuf, message))
 	{
 		/* errors have already been logged */
 		return;
@@ -849,7 +849,7 @@ pgAutoCtlDefaultNoticeProcessor(void *arg, const char *message)
 {
 	LinesBuffer lbuf = { 0 };
 
-	if (!splitLines(&lbuf, (char *) message, false))
+	if (!splitLines(&lbuf, (char *) message))
 	{
 		/* errors have already been logged */
 		return;
@@ -871,7 +871,7 @@ pgAutoCtlDebugNoticeProcessor(void *arg, const char *message)
 {
 	LinesBuffer lbuf = { 0 };
 
-	if (!splitLines(&lbuf, (char *) message, false))
+	if (!splitLines(&lbuf, (char *) message))
 	{
 		/* errors have already been logged */
 		return;
@@ -1670,7 +1670,7 @@ pgsql_send_with_params(PGSQL *pgsql, const char *sql, int paramCount,
 
 		LinesBuffer lbuf = { 0 };
 
-		if (!splitLines(&lbuf, message, false))
+		if (!splitLines(&lbuf, message))
 		{
 			/* errors have already been logged */
 			return false;
@@ -2017,7 +2017,7 @@ pgsql_execute_log_error(PGSQL *pgsql,
 
 	LinesBuffer lbuf = { 0 };
 
-	if (!splitLines(&lbuf, message, false))
+	if (!splitLines(&lbuf, message))
 	{
 		/* errors have already been logged */
 		return;
@@ -2223,7 +2223,7 @@ clear_results(PGSQL *pgsql)
 			LinesBuffer lbuf = { 0 };
 			char *pqmessage = PQerrorMessage(connection);
 
-			if (!splitLines(&lbuf, pqmessage, false))
+			if (!splitLines(&lbuf, pqmessage))
 			{
 				/* errors have already been logged */
 				return false;
@@ -2806,7 +2806,7 @@ pgcopy_log_error(PGSQL *pgsql, PGresult *res, const char *context)
 	LinesBuffer lbuf = { 0 };
 	char *message = PQerrorMessage(pgsql->connection);
 
-	if (!splitLines(&lbuf, message, false))
+	if (!splitLines(&lbuf, message))
 	{
 		/* errors have already been logged */
 		return;
@@ -3215,7 +3215,7 @@ parseTimeLineHistory(const char *filename, const char *content,
 {
 	LinesBuffer lbuf = { 0 };
 
-	if (!splitLines(&lbuf, (char *) content, false))
+	if (!splitLines(&lbuf, (char *) content))
 	{
 		/* errors have already been logged */
 		return false;
@@ -4401,7 +4401,7 @@ pgsql_stream_log_error(PGSQL *pgsql, PGresult *res, const char *message)
 	{
 		LinesBuffer lbuf = { 0 };
 
-		if (!splitLines(&lbuf, pqmessage, false))
+		if (!splitLines(&lbuf, pqmessage))
 		{
 			/* errors have already been logged */
 			return;

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -413,9 +413,6 @@ pgsql_finish(PGSQL *pgsql)
 		pgsql->pgversion[0] = '\0';
 		pgsql->pgversion_num = 0;
 
-		/* we don't need the print-safe URL anymore */
-		freeSafeURI(&(pgsql->safeURI));
-
 		/*
 		 * When we fail to connect, on the way out we call pgsql_finish to
 		 * reset the connection to NULL. We still want the callers to be able
@@ -462,8 +459,6 @@ log_connection_error(PGconn *connection, int logLevel)
 			log_level(logLevel, "%s", line);
 		}
 	}
-
-	FreeLinesBuffer(&lbuf);
 }
 
 
@@ -864,8 +859,6 @@ pgAutoCtlDefaultNoticeProcessor(void *arg, const char *message)
 	{
 		log_warn("%s", lbuf.lines[lineNumber]);
 	}
-
-	FreeLinesBuffer(&lbuf);
 }
 
 
@@ -888,8 +881,6 @@ pgAutoCtlDebugNoticeProcessor(void *arg, const char *message)
 	{
 		log_sql("%s", lbuf.lines[lineNumber]);
 	}
-
-	FreeLinesBuffer(&lbuf);
 }
 
 
@@ -1704,7 +1695,6 @@ pgsql_send_with_params(PGSQL *pgsql, const char *sql, int paramCount,
 		}
 
 		destroyPQExpBuffer(debugParameters);
-		FreeLinesBuffer(&lbuf);
 		clear_results(pgsql);
 
 		return false;
@@ -2041,8 +2031,6 @@ pgsql_execute_log_error(PGSQL *pgsql,
 				  lbuf.lines[lineNumber]);
 	}
 
-	FreeLinesBuffer(&lbuf);
-
 	if (pgsql->logSQL)
 	{
 		/* when using send/fetch async queries, fetch doesn't have the sql */
@@ -2248,7 +2236,6 @@ clear_results(PGSQL *pgsql)
 
 			PQclear(result);
 			pgsql_finish(pgsql);
-			FreeLinesBuffer(&lbuf);
 			return false;
 		}
 
@@ -2862,8 +2849,6 @@ pgcopy_log_error(PGSQL *pgsql, PGresult *res, const char *context)
 			  PQbackendPID(pgsql->connection),
 			  context);
 
-	FreeLinesBuffer(&lbuf);
-
 	if (res != NULL)
 	{
 		PQclear(res);
@@ -3283,7 +3268,6 @@ parseTimeLineHistory(const char *filename, const char *content,
 		{
 			log_error("Failed to parse history file line %lld: \"%s\"",
 					  (long long) lineNumber, ptr);
-			FreeLinesBuffer(&lbuf);
 			return false;
 		}
 
@@ -3292,7 +3276,6 @@ parseTimeLineHistory(const char *filename, const char *content,
 		if (!stringToUInt(lbuf.lines[lineNumber], &(entry->tli)))
 		{
 			log_error("Failed to parse history timeline \"%s\"", tabptr);
-			FreeLinesBuffer(&lbuf);
 			return false;
 		}
 
@@ -3311,7 +3294,6 @@ parseTimeLineHistory(const char *filename, const char *content,
 		{
 			log_error("Failed to parse history timeline %d LSN \"%s\"",
 					  entry->tli, lsn);
-			FreeLinesBuffer(&lbuf);
 			return false;
 		}
 
@@ -3326,8 +3308,6 @@ parseTimeLineHistory(const char *filename, const char *content,
 
 		entry = &(system->timelines.history[++system->timelines.count]);
 	}
-
-	FreeLinesBuffer(&lbuf);
 
 	/*
 	 * Create one more entry for the "tip" of the timeline, which has no entry
@@ -3555,8 +3535,6 @@ pg_copy_large_object(PGSQL *src,
 
 			return false;
 		}
-
-		(void) free(buffer);
 
 		*bytesTransmitted += bytesRead;
 	} while (bytesRead > 0);
@@ -4446,8 +4424,6 @@ pgsql_stream_log_error(PGSQL *pgsql, PGresult *res, const char *message)
 				log_error("%s", lbuf.lines[lineNumber]);
 			}
 		}
-
-		FreeLinesBuffer(&lbuf);
 	}
 
 	if (res != NULL)
@@ -4879,7 +4855,6 @@ pgsql_replication_origin_progress(PGSQL *pgsql,
 					  context.strVal,
 					  nodeName,
 					  flush ? "true" : "false");
-			free(context.strVal);
 
 			return false;
 		}
@@ -4968,7 +4943,6 @@ pgsql_replication_slot_exists(PGSQL *pgsql, const char *slotName,
 						  "confirmed_flush_lsn for slot \"%s\"",
 						  context.strVal,
 						  slotName);
-				free(context.strVal);
 
 				return false;
 			}
@@ -5220,12 +5194,9 @@ pgsql_current_wal_flush_lsn(PGSQL *pgsql, uint64_t *lsn)
 			log_error("Failed to parse LSN \"%s\" returned from "
 					  "pg_current_wal_flush_lsn()",
 					  context.strVal);
-			free(context.strVal);
 
 			return false;
 		}
-
-		free(context.strVal);
 	}
 
 	return true;
@@ -5275,12 +5246,9 @@ pgsql_current_wal_insert_lsn(PGSQL *pgsql, uint64_t *lsn)
 			log_error("Failed to parse LSN \"%s\" returned from "
 					  "pg_current_wal_insert_lsn()",
 					  context.strVal);
-			free(context.strVal);
 
 			return false;
 		}
-
-		free(context.strVal);
 	}
 
 	return true;

--- a/src/bin/pgcopydb/pidfile.c
+++ b/src/bin/pgcopydb/pidfile.c
@@ -118,7 +118,7 @@ read_pidfile(const char *pidfile, pid_t *pid)
 
 	LinesBuffer lbuf = { 0 };
 
-	if (!splitLines(&lbuf, fileContents, true) || lbuf.count != 1)
+	if (!splitLines(&lbuf, fileContents) || lbuf.count != 1)
 	{
 		/* errors have already been logged */
 		return false;

--- a/src/bin/pgcopydb/pidfile.c
+++ b/src/bin/pgcopydb/pidfile.c
@@ -128,8 +128,6 @@ read_pidfile(const char *pidfile, pid_t *pid)
 
 	*pid = pidnum;
 
-	FreeLinesBuffer(&lbuf);
-
 	if (pid <= 0)
 	{
 		log_debug("Read negative pid %d in file \"%s\", removing it",

--- a/src/bin/pgcopydb/progress.c
+++ b/src/bin/pgcopydb/progress.c
@@ -119,7 +119,6 @@ copydb_prepare_schema_json_file(CopyDataSpec *copySpecs)
 	}
 
 	json_free_serialized_string(serialized_string);
-	json_value_free(js);
 
 	return true;
 }

--- a/src/bin/pgcopydb/schema.c
+++ b/src/bin/pgcopydb/schema.c
@@ -3932,12 +3932,9 @@ getSchemaList(void *ctx, PGresult *result)
 			{
 				/* errors have already been logged */
 				++errors;
-				free(schema);
 				break;
 			}
 		}
-
-		free(schema);
 	}
 
 	context->parsedOk = errors == 0;
@@ -4003,12 +4000,9 @@ getRoleList(void *ctx, PGresult *result)
 			{
 				/* errors have already been logged */
 				++errors;
-				free(role);
 				break;
 			}
 		}
-
-		free(role);
 	}
 
 	context->parsedOk = errors == 0;
@@ -4042,7 +4036,6 @@ getDatabaseList(void *ctx, PGresult *result)
 		if (!parseCurrentDatabase(result, rowNumber, database))
 		{
 			parsedOk = false;
-			free(database);
 			break;
 		}
 
@@ -4052,12 +4045,9 @@ getDatabaseList(void *ctx, PGresult *result)
 			{
 				/* errors have already been logged */
 				parsedOk = false;
-				free(database);
 				break;
 			}
 		}
-
-		free(database);
 	}
 
 	context->parsedOk = parsedOk;
@@ -4159,8 +4149,6 @@ getDatabaseProperties(void *ctx, PGresult *result)
 		if (!parseDatabaseProperty(result, rowNumber, property))
 		{
 			parsedOk = false;
-			free(property->setconfig);
-			free(property);
 			break;
 		}
 
@@ -4170,14 +4158,9 @@ getDatabaseProperties(void *ctx, PGresult *result)
 			{
 				/* errors have already been logged */
 				parsedOk = false;
-				free(property->setconfig);
-				free(property);
 				break;
 			}
 		}
-
-		free(property->setconfig);
-		free(property);
 	}
 
 	context->parsedOk = parsedOk;
@@ -4356,7 +4339,6 @@ getExtensionList(void *ctx, PGresult *result)
 			if (!parseCurrentExtensionConfig(result, rowNumber, config))
 			{
 				parsedOk = false;
-				free(config);
 				break;
 			}
 
@@ -4368,16 +4350,12 @@ getExtensionList(void *ctx, PGresult *result)
 				{
 					/* errors have already been logged */
 					parsedOk = false;
-					free(config);
 					break;
 				}
 			}
-
-			free(config);
 		}
 	}
 
-	free(extension);
 
 	context->parsedOk = parsedOk;
 }
@@ -4567,7 +4545,6 @@ getExtensionsVersions(void *ctx, PGresult *result)
 		/* issue a warning but let's try anyway */
 		log_warn("BUG? context's array is not null in getExtensionsVersions");
 
-		free(context->evArray->array);
 		context->evArray->array = NULL;
 	}
 
@@ -4729,12 +4706,9 @@ getCollationList(void *ctx, PGresult *result)
 			{
 				/* errors have already been logged */
 				++errors;
-				free(collation);
 				break;
 			}
 		}
-
-		free(collation);
 	}
 
 	context->parsedOk = errors == 0;
@@ -4767,7 +4741,6 @@ getTableArray(void *ctx, PGresult *result)
 		if (!parseCurrentSourceTable(result, rowNumber, table))
 		{
 			parsedOk = false;
-			free(table);
 			break;
 		}
 
@@ -4777,12 +4750,9 @@ getTableArray(void *ctx, PGresult *result)
 			{
 				/* errors have already been logged */
 				parsedOk = false;
-				free(table);
 				break;
 			}
 		}
-
-		free(table);
 	}
 
 	context->parsedOk = parsedOk;
@@ -5008,8 +4978,6 @@ parseCurrentSourceTable(PGresult *result, int rowNumber, SourceTable *table)
 					  value);
 			++errors;
 		}
-
-		json_value_free(json);
 	}
 
 	log_trace("parseCurrentSourceTable: %s.%s", table->nspname, table->relname);
@@ -5098,7 +5066,6 @@ getSequenceArray(void *ctx, PGresult *result)
 		if (!parseCurrentSourceSequence(result, rowNumber, seq))
 		{
 			parsedOk = false;
-			free(seq);
 			break;
 		}
 
@@ -5108,12 +5075,9 @@ getSequenceArray(void *ctx, PGresult *result)
 			{
 				/* errors have already been logged */
 				parsedOk = false;
-				free(seq);
 				break;
 			}
 		}
-
-		free(seq);
 	}
 
 	context->parsedOk = parsedOk;
@@ -5268,7 +5232,6 @@ getIndexArray(void *ctx, PGresult *result)
 		if (!parseCurrentSourceIndex(result, rowNumber, index))
 		{
 			parsedOk = false;
-			free(index);
 			break;
 		}
 
@@ -5278,7 +5241,6 @@ getIndexArray(void *ctx, PGresult *result)
 			{
 				/* errors have already been logged */
 				parsedOk = false;
-				free(index);
 				break;
 			}
 
@@ -5289,13 +5251,10 @@ getIndexArray(void *ctx, PGresult *result)
 				{
 					/* errors have already been logged */
 					parsedOk = false;
-					free(index);
 					break;
 				}
 			}
 		}
-
-		free(index);
 	}
 
 	context->parsedOk = parsedOk;
@@ -5590,12 +5549,9 @@ getDependArray(void *ctx, PGresult *result)
 			{
 				/* errors have already been logged */
 				parsedOk = false;
-				free(depend);
 				break;
 			}
 		}
-
-		free(depend);
 	}
 
 	context->parsedOk = parsedOk;

--- a/src/bin/pgcopydb/snapshot.c
+++ b/src/bin/pgcopydb/snapshot.c
@@ -517,7 +517,6 @@ snapshot_read_slot(const char *filename, ReplicationSlot *slot)
 	if (lbuf.count != 5)
 	{
 		log_error("Failed to parse replication slot file \"%s\"", filename);
-		free(contents);
 		return false;
 	}
 
@@ -532,7 +531,6 @@ snapshot_read_slot(const char *filename, ReplicationSlot *slot)
 				  filename,
 				  (long long) strlen(lbuf.lines[0]),
 				  (long long) sizeof(slot->slotName));
-		free(contents);
 		return false;
 	}
 
@@ -542,7 +540,6 @@ snapshot_read_slot(const char *filename, ReplicationSlot *slot)
 		log_error("Failed to parse LSN \"%s\" from file \"%s\"",
 				  lbuf.lines[1],
 				  filename);
-		free(contents);
 		return false;
 	}
 
@@ -557,7 +554,6 @@ snapshot_read_slot(const char *filename, ReplicationSlot *slot)
 				  filename,
 				  (long long) strlen(lbuf.lines[2]),
 				  (long long) sizeof(slot->snapshot));
-		free(contents);
 		return false;
 	}
 
@@ -569,7 +565,6 @@ snapshot_read_slot(const char *filename, ReplicationSlot *slot)
 		log_error("Failed to read plugin \"%s\" from file \"%s\"",
 				  lbuf.lines[3],
 				  filename);
-		free(contents);
 		return false;
 	}
 
@@ -585,7 +580,6 @@ snapshot_read_slot(const char *filename, ReplicationSlot *slot)
 				  filename);
 	}
 
-	free(contents);
 
 	log_notice("Read replication slot file \"%s\" with snapshot \"%s\", "
 			   "slot \"%s\", lsn %X/%X, and plugin \"%s\"",

--- a/src/bin/pgcopydb/snapshot.c
+++ b/src/bin/pgcopydb/snapshot.c
@@ -508,7 +508,7 @@ snapshot_read_slot(const char *filename, ReplicationSlot *slot)
 	/* make sure to use only the first line of the file, without \n */
 	LinesBuffer lbuf = { 0 };
 
-	if (!splitLines(&lbuf, contents, true))
+	if (!splitLines(&lbuf, contents))
 	{
 		/* errors have already been logged */
 		return false;

--- a/src/bin/pgcopydb/string_utils.c
+++ b/src/bin/pgcopydb/string_utils.c
@@ -643,21 +643,6 @@ splitLines(LinesBuffer *lbuf, char *buffer, bool ownsBuffer)
 
 
 /*
- * FreeLinesBuffer frees the allocated memory for LinesBuffer instance.
- */
-void
-FreeLinesBuffer(LinesBuffer *lbuf)
-{
-	free(lbuf->lines);
-
-	if (lbuf->ownsBuffer)
-	{
-		free(lbuf->buffer);
-	}
-}
-
-
-/*
  * processBufferCallback is a function callback to use with the subcommands.c
  * library when we want to output a command's output as it's running, such as
  * when running a pg_basebackup command.
@@ -685,8 +670,6 @@ processBufferCallback(const char *buffer, bool error)
 			log_level(logLevel, "%s", line);
 		}
 	}
-
-	FreeLinesBuffer(&lbuf);
 }
 
 

--- a/src/bin/pgcopydb/string_utils.c
+++ b/src/bin/pgcopydb/string_utils.c
@@ -589,10 +589,9 @@ countLines(char *buffer)
  * area.
  */
 bool
-splitLines(LinesBuffer *lbuf, char *buffer, bool ownsBuffer)
+splitLines(LinesBuffer *lbuf, char *buffer)
 {
 	lbuf->buffer = buffer;
-	lbuf->ownsBuffer = ownsBuffer;
 	lbuf->count = countLines(lbuf->buffer);
 
 	if (lbuf->buffer == NULL || lbuf->count == 0)
@@ -653,7 +652,7 @@ processBufferCallback(const char *buffer, bool error)
 	const char *warningPattern = "^(pg_dump: warning:|pg_restore: warning:)";
 	LinesBuffer lbuf = { 0 };
 
-	if (!splitLines(&lbuf, (char *) buffer, true))
+	if (!splitLines(&lbuf, (char *) buffer))
 	{
 		/* errors have already been logged */
 		return;

--- a/src/bin/pgcopydb/string_utils.h
+++ b/src/bin/pgcopydb/string_utils.h
@@ -46,14 +46,13 @@ bool IntervalToString(uint64_t millisecs, char *buffer, size_t size);
 
 typedef struct LinesBuffer
 {
-	bool ownsBuffer;
 	char *buffer;
 	uint64_t count;
 	char **lines;                     /* malloc'ed area */
 } LinesBuffer;
 
 uint64_t countLines(char *buffer);
-bool splitLines(LinesBuffer *lbuf, char *buffer, bool ownsBuffer);
+bool splitLines(LinesBuffer *lbuf, char *buffer);
 
 void processBufferCallback(const char *buffer, bool error);
 

--- a/src/bin/pgcopydb/string_utils.h
+++ b/src/bin/pgcopydb/string_utils.h
@@ -54,7 +54,6 @@ typedef struct LinesBuffer
 
 uint64_t countLines(char *buffer);
 bool splitLines(LinesBuffer *lbuf, char *buffer, bool ownsBuffer);
-void FreeLinesBuffer(LinesBuffer *lbuf);
 
 void processBufferCallback(const char *buffer, bool error);
 

--- a/src/bin/pgcopydb/summary.c
+++ b/src/bin/pgcopydb/summary.c
@@ -2265,7 +2265,6 @@ summary_iter_timing(DatabaseCatalog *catalog,
 	if (!summary_iter_timing_init(iter))
 	{
 		/* errors have already been logged */
-		free(iter);
 		return false;
 	}
 
@@ -2274,7 +2273,6 @@ summary_iter_timing(DatabaseCatalog *catalog,
 		if (!summary_iter_timing_next(iter))
 		{
 			/* errors have already been logged */
-			free(iter);
 			return false;
 		}
 
@@ -2285,7 +2283,6 @@ summary_iter_timing(DatabaseCatalog *catalog,
 			if (!summary_iter_timing_finish(iter))
 			{
 				/* errors have already been logged */
-				free(iter);
 				return false;
 			}
 
@@ -2301,7 +2298,6 @@ summary_iter_timing(DatabaseCatalog *catalog,
 		}
 	}
 
-	free(iter);
 
 	return true;
 }
@@ -2363,8 +2359,6 @@ summary_iter_timing_next(TimingIterator *iter)
 
 	if (rc == SQLITE_DONE)
 	{
-		free(iter->timing->label);
-		free(iter->timing);
 		iter->timing = NULL;
 
 		return true;
@@ -2442,8 +2436,6 @@ summary_iter_timing_finish(TimingIterator *iter)
 	/* in case we finish before reaching the DONE step */
 	if (iter->timing != NULL)
 	{
-		free(iter->timing->label);
-		free(iter->timing);
 		iter->timing = NULL;
 	}
 
@@ -2963,7 +2955,6 @@ print_summary_as_json(Summary *summary, const char *filename)
 	}
 
 	json_free_serialized_string(serialized_string);
-	json_value_free(js);
 }
 
 

--- a/tests/Dockerfile.pagila
+++ b/tests/Dockerfile.pagila
@@ -18,6 +18,7 @@ RUN apt-get update \
 	strace \
 	gdb \
 	sqlite3 \
+	libgc1 \
     libpq5 \
     postgresql-client-common \
     curl \


### PR DESCRIPTION
From their own documentation:

> The Boehm-Demers-Weiser conservative garbage collector can be used as a
> garbage collecting replacement for C malloc or C++ new. It allows you to
> allocate memory basically as you normally would, without explicitly
> deallocating memory that is no longer useful. The collector automatically
> recycles memory when it determines that it can no longer be otherwise
> accessed.

In pgcopydb C code base it's been hard to maintain proper malloc/free concerns while also implementing proper error-handling, which is a common problem when writing C code. In order to ease the maintenance of the code and reduce production hazards, the best way to proceed looks like automating the memory management altogether by using a Garbage Collector.

Replaces and close #613 
Should fix #609 