### PR TITLE
Fix cache invalidation of zero --split-tables-larger-than setup.

### DIFF
--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -326,6 +326,7 @@ bool catalog_init_from_specs(CopyDataSpec *copySpecs);
 bool catalog_open_from_specs(CopyDataSpec *copySpecs);
 bool catalog_close_from_specs(CopyDataSpec *copySpecs);
 bool catalog_register_setup_from_specs(CopyDataSpec *copySpecs);
+bool catalog_update_setup(CopyDataSpec *copySpecs);
 
 /* snapshot.c */
 bool copydb_copy_snapshot(CopyDataSpec *specs, TransactionSnapshot *snapshot);

--- a/src/bin/pgcopydb/copydb_schema.c
+++ b/src/bin/pgcopydb/copydb_schema.c
@@ -559,6 +559,13 @@ copydb_fetch_source_schema(CopyDataSpec *specs, PGSQL *src)
 		}
 	}
 
+	/* now update --split-tables-larger-than and target pguri */
+	if (!catalog_update_setup(specs))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
 	/* prepare the Oids of objects that are filtered out */
 	if (specs->fetchFilteredOids)
 	{

--- a/tests/cdc-wal2json/copydb.sh
+++ b/tests/cdc-wal2json/copydb.sh
@@ -30,7 +30,7 @@ sleep 1
 pgcopydb stream setup
 
 # pgcopydb clone uses the environment variables
-pgcopydb clone
+pgcopydb clone --split-tables-larger-than 200kB
 
 kill -TERM ${COPROC_PID}
 wait ${COPROC_PID}


### PR DESCRIPTION
When registering the catalog setup, which includes the same-table concurrency threshold, only consider that value when the table partitions have been populated in the cache already. Otherwise the table partitions are going to be computed again anyway.

Fixes #644 