### PR TITLE
Fix pgcopydb list progress.

### DIFF
--- a/src/bin/pgcopydb/catalog.c
+++ b/src/bin/pgcopydb/catalog.c
@@ -2776,25 +2776,40 @@ catalog_s_table_fetch(SQLiteQuery *query)
 
 	table->oid = sqlite3_column_int64(query->ppStmt, 0);
 
-	strlcpy(table->qname,
-			(char *) sqlite3_column_text(query->ppStmt, 1),
-			sizeof(table->qname));
+	if (sqlite3_column_type(query->ppStmt, 1) != SQLITE_NULL)
+	{
+		strlcpy(table->qname,
+				(char *) sqlite3_column_text(query->ppStmt, 1),
+				sizeof(table->qname));
+	}
 
-	strlcpy(table->nspname,
-			(char *) sqlite3_column_text(query->ppStmt, 2),
-			sizeof(table->nspname));
+	if (sqlite3_column_type(query->ppStmt, 2) != SQLITE_NULL)
+	{
+		strlcpy(table->nspname,
+				(char *) sqlite3_column_text(query->ppStmt, 2),
+				sizeof(table->nspname));
+	}
 
-	strlcpy(table->relname,
-			(char *) sqlite3_column_text(query->ppStmt, 3),
-			sizeof(table->relname));
+	if (sqlite3_column_type(query->ppStmt, 3) != SQLITE_NULL)
+	{
+		strlcpy(table->relname,
+				(char *) sqlite3_column_text(query->ppStmt, 3),
+				sizeof(table->relname));
+	}
 
-	strlcpy(table->amname,
-			(char *) sqlite3_column_text(query->ppStmt, 4),
-			sizeof(table->amname));
+	if (sqlite3_column_type(query->ppStmt, 4) != SQLITE_NULL)
+	{
+		strlcpy(table->amname,
+				(char *) sqlite3_column_text(query->ppStmt, 4),
+				sizeof(table->amname));
+	}
 
-	strlcpy(table->restoreListName,
-			(char *) sqlite3_column_text(query->ppStmt, 5),
-			sizeof(table->restoreListName));
+	if (sqlite3_column_type(query->ppStmt, 5) != SQLITE_NULL)
+	{
+		strlcpy(table->restoreListName,
+				(char *) sqlite3_column_text(query->ppStmt, 5),
+				sizeof(table->restoreListName));
+	}
 
 	table->relpages = sqlite3_column_int64(query->ppStmt, 6);
 	table->reltuples = sqlite3_column_int64(query->ppStmt, 7);

--- a/src/bin/pgcopydb/progress.h
+++ b/src/bin/pgcopydb/progress.h
@@ -15,6 +15,7 @@
 typedef struct CopyTableSummaryArray
 {
 	int count;
+	int capacity;
 	CopyTableSummary *array;         /* malloc'ed area */
 } CopyTableSummaryArray;
 
@@ -22,6 +23,7 @@ typedef struct CopyTableSummaryArray
 typedef struct CopyIndexSummaryArray
 {
 	int count;
+	int capacity;
 	CopyIndexSummary *array;         /* malloc'ed area */
 } CopyIndexSummaryArray;
 

--- a/src/bin/pgcopydb/schema.h
+++ b/src/bin/pgcopydb/schema.h
@@ -181,9 +181,12 @@ typedef struct SourceTable
 
 
 /* still used in progress.[ch] */
+#define ARRAY_CAPACITY_INCREMENT 2
+
 typedef struct SourceTableArray
 {
 	int count;
+	int capacity;
 	SourceTable *array;         /* malloc'ed area */
 } SourceTableArray;
 
@@ -245,6 +248,7 @@ typedef struct SourceIndex
 typedef struct SourceIndexArray
 {
 	int count;
+	int capacity;
 	SourceIndex *array;         /* malloc'ed area */
 } SourceIndexArray;
 


### PR DESCRIPTION
Since the move of the summary and process information to the SQLite catalogs, we don't have a progress JSON file on-disk with parts of the setup anymore.

The code needed to be updated to behave correctly without having --table-jobs and --index-jobs information.

Fixes #650 