### PR TITLE
Compute COPY attribute list using SQL.

### DIFF
--- a/src/bin/pgcopydb/catalog.h
+++ b/src/bin/pgcopydb/catalog.h
@@ -248,7 +248,10 @@ bool catalog_iter_s_table_part_init(SourceTablePartsIterator *iter);
 bool catalog_iter_s_table_part_next(SourceTablePartsIterator *iter);
 bool catalog_iter_s_table_part_finish(SourceTablePartsIterator *iter);
 
+bool catalog_s_table_attrlist(DatabaseCatalog *catalog, SourceTable *table);
 bool catalog_s_table_part_fetch(SQLiteQuery *query);
+
+bool catalog_s_table_fetch_attrlist(SQLiteQuery *query);
 
 typedef struct SourceTableAttrsIterator
 {

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -457,9 +457,6 @@ bool copydb_table_parts_are_all_done(CopyDataSpec *specs,
 
 bool copydb_prepare_copy_query(CopyTableDataSpec *tableSpecs, CopyArgs *args);
 
-bool copydb_prepare_copy_query_attrlist(CopyTableDataSpec *tableSpecs,
-										PQExpBuffer attrList);
-
 bool copydb_prepare_summary_command(CopyTableDataSpec *tableSpecs);
 
 

--- a/src/bin/pgcopydb/schema.h
+++ b/src/bin/pgcopydb/schema.h
@@ -169,6 +169,7 @@ typedef struct SourceTable
 	char partKey[PG_NAMEDATALEN];
 	SourceTableParts partition;
 
+	char *attrList;             /* malloc'ed area */
 	SourceTableAttributeArray attributes;
 
 	uint64_t indexCount;


### PR DESCRIPTION
Before embedding SQLite we could not depend on aggregates FILTER clause to be available, and as a result we had to aggregate the attribute list in our own C code. Turns out we had strange bugs around that, that hopefully the very simple SQL query will not have.

Should fix #657
Should fix #634 