### PR TITLE
Fix ordering of CFLAGS for sqlite

### DIFF
--- a/src/bin/lib/sqlite/Makefile
+++ b/src/bin/lib/sqlite/Makefile
@@ -25,7 +25,7 @@ SQLITE_CFLAGS += -DSQLITE_ENABLE_MATH_FUNCTIONS
 SQLITE_CFLAGS += -Wno-missing-prototypes
 SQLITE_CFLAGS += -Wno-implicit-fallthrough
 
-override CFLAGS := $(DEFAULT_CFLAGS) $(SQLITE_CFLAGS) $(CFLAGS)
+override CFLAGS := $(DEFAULT_CFLAGS) $(CFLAGS) $(SQLITE_CFLAGS)
 
 LIBS += -lm
 LIBS += -lreadline


### PR DESCRIPTION
The CFLAGS for sqlite were being overridden by the default CFLAGS, which caused a portion of the sqlite CFLAGS to be ignored. This commit fixes the ordering of the CFLAGS so that the sqlite CFLAGS are applied after the default CFLAGS.

Particularly, we need to apply the -Wno-implicit-fallthrough flag to sqlite, as it generates a lot of warnings with the default CFLAGS on many systems that use -Wimplicit-fallthrough=3.