### PR TITLE
Problem: Snapshot id printed on stdout doesn't appear on console

### DIFF
--- a/src/bin/pgcopydb/cli_snapshot.c
+++ b/src/bin/pgcopydb/cli_snapshot.c
@@ -357,6 +357,7 @@ cli_create_snapshot(int argc, char **argv)
 	}
 
 	fformat(stdout, "%s\n", copySpecs.sourceSnapshot.snapshot);
+	fflush(stdout);
 
 	for (;;)
 	{


### PR DESCRIPTION
Solution: fflush stdout after printing the snapshot id. By default stdout is buffered and flushed only when the buffer is full.