### PR TITLE
Problem: xid is missing in test_decoding commit for a continued txn

### DIFF
--- a/tests/cdc-test-decoding/Dockerfile
+++ b/tests/cdc-test-decoding/Dockerfile
@@ -6,6 +6,8 @@ COPY ./dml.sql dml.sql
 COPY ./ddl.sql ddl.sql
 COPY ./000000010000000000000002.json 000000010000000000000002.json
 COPY ./000000010000000000000002.sql 000000010000000000000002.sql
+COPY ./continued-txn.json continued-txn.json
+COPY ./continued-txn.sql continued-txn.sql
 
 USER docker
 CMD /usr/src/pgcopydb/copydb.sh

--- a/tests/cdc-test-decoding/continued-txn.json
+++ b/tests/cdc-test-decoding/continued-txn.json
@@ -1,0 +1,3 @@
+{"action":"I","xid":"0","lsn":"6F/140005C0","timestamp":"2024-02-22 19:55:32.604734+0000","message":"table public.readings: INSERT: \"time\"[timestamp with time zone]:'2017-07-15 02:54:30+00' tags_id[integer]:48 latitude[double precision]:3.46436 longitude[double precision]:68.56976 elevation[double precision]:115 velocity[double precision]:55 heading[double precision]:30 grade[double precision]:78 fuel_consumption[double precision]:1.8 additional_tags[jsonb]:null"}
+{"action":"C","xid":"6730937","lsn":"6F/14003AD8","timestamp":"2024-02-22 19:55:32.604741+0000","message":"COMMIT 6730937"}
+{"action":"X","lsn":"6F/15004368"}

--- a/tests/cdc-test-decoding/continued-txn.sql
+++ b/tests/cdc-test-decoding/continued-txn.sql
@@ -1,0 +1,4 @@
+PREPARE c5019553 AS INSERT INTO public.readings ("time", "tags_id", "latitude", "longitude", "elevation", "velocity", "heading", "grade", "fuel_consumption", "additional_tags") overriding system value VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10);
+EXECUTE c5019553["2017-07-15 02:54:30+00","48","3.46436","68.56976","115","55","30","78","1.8",null];
+COMMIT; -- {"xid":6730937,"lsn":"6F/14003AD8","timestamp":"2024-02-22 19:55:32.604741+0000"}
+-- SWITCH WAL {"lsn":"6F/15004368"}

--- a/tests/cdc-test-decoding/copydb.sh
+++ b/tests/cdc-test-decoding/copydb.sh
@@ -87,5 +87,10 @@ pgcopydb stream catchup --resume --endpos "${lsn}" -vv
 # now apply AGAIN the SQL file to the target database, skipping transactions
 pgcopydb stream catchup --resume --endpos "${lsn}" -vv
 
+# test whether transform propertly sets xid for continued transactions.
+pgcopydb stream transform --debug /usr/src/pgcopydb/continued-txn.json /tmp/continued-txn.sql
+
+diff /usr/src/pgcopydb/continued-txn.sql /tmp/continued-txn.sql
+
 # cleanup
 pgcopydb stream cleanup


### PR DESCRIPTION
Missing xid triggers the following error during apply/replay.

"BUG: parseTxnMetadataFile is called with transaction xid: 0"

Solution: Use xid from commit message as a transaction xid.

Unlike wal2json, test_decoding don't have xid in the DML logical messages. So we use the xid from the COMMIT message to update the transaction xid.