### PR TITLE
Add ARM based OSX support to Makefile

### DIFF
--- a/src/bin/pgcopydb/Makefile
+++ b/src/bin/pgcopydb/Makefile
@@ -68,6 +68,9 @@ DEFAULT_CFLAGS += -D_WANT_SEMUN
 DEFAULT_CFLAGS += -Wno-missing-braces
 DEFAULT_CFLAGS += $(COMMON_LIBS)
 
+# Needed for ARM based OSX
+DEFAULT_CFLAGS += -I/opt/homebrew/include
+
 ifdef USE_SECURITY_FLAGS
 # Flags taken from: https://liquid.microsoft.com/Web/Object/Read/ms.security/Requirements/Microsoft.Security.SystemsADM.10203#guide
 SECURITY_CFLAGS=-fstack-protector-strong -D_FORTIFY_SOURCE=2 -O2 -z noexecstack -fpie -Wl,-pie -Wl,-z,relro -Wl,-z,now -Wformat -Wformat-security -Werror=format-security
@@ -85,6 +88,8 @@ LIBS += $(shell $(PG_CONFIG) --libs)
 LIBS += -lpq
 LIBS += -lncurses
 LIBS += -lgc
+# Needed for ARM based OSX
+LIBS += -L/opt/homebrew/lib
 
 all: $(PGCOPYDB) $(SQLITE3) ;
 


### PR DESCRIPTION
This is necessary because ARM-based macOS devices have a different default library path (ex: installing libgc via `brew install`) compared to other architectures. By including this line, the Makefile ensures that the necessary libraries are correctly linked for ARM-based macOS devices.