### PR TITLE
Update schema.h

### DIFF
--- a/src/bin/pgcopydb/schema.h
+++ b/src/bin/pgcopydb/schema.h
@@ -413,8 +413,6 @@ bool schema_list_collations(PGSQL *pgsql, DatabaseCatalog *catalog);
 bool schema_prepare_pgcopydb_table_size(PGSQL *pgsql,
 										SourceFilters *filters, DatabaseCatalog *catalog);
 
-bool schema_drop_pgcopydb_table_size(PGSQL *pgsql);
-
 bool schema_list_ordinary_tables(PGSQL *pgsql,
 								 SourceFilters *filters,
 								 DatabaseCatalog *catalog);


### PR DESCRIPTION
to compile

Commit 242fa27363a338b5eea76d57095a6320ca811823 removes schema_drop_pgcopydb_table_size function but not from header
This patch fixes it