### PR TITLE
Cleanup schema_drop_pgcopydb_table_size.

### DIFF
--- a/src/bin/pgcopydb/copydb_schema.c
+++ b/src/bin/pgcopydb/copydb_schema.c
@@ -494,16 +494,6 @@ copydb_fetch_source_schema(CopyDataSpec *specs, PGSQL *src)
 		}
 	}
 
-	/*
-	 * First, if it doesn't exist yet, create the pgcopydb.table_size table.
-	 * Keep track of whether we had to create that table, if we did, it is
-	 * expected that we DROP it before the end of this transaction.
-	 *
-	 * In order to allow for users to prepare that table in advance, we do not
-	 * use a TEMP table here.
-	 */
-	bool createdTableSizeTable = false;
-
 	if (!catalog_begin(sourceDB, false))
 	{
 		/* errors have already been logged */
@@ -567,15 +557,6 @@ copydb_fetch_source_schema(CopyDataSpec *specs, PGSQL *src)
 	if (specs->fetchFilteredOids)
 	{
 		if (!copydb_fetch_filtered_oids(specs, src))
-		{
-			/* errors have already been logged */
-			return false;
-		}
-	}
-
-	if (createdTableSizeTable)
-	{
-		if (!schema_drop_pgcopydb_table_size(src))
 		{
 			/* errors have already been logged */
 			return false;

--- a/src/bin/pgcopydb/schema.h
+++ b/src/bin/pgcopydb/schema.h
@@ -413,8 +413,6 @@ bool schema_list_collations(PGSQL *pgsql, DatabaseCatalog *catalog);
 bool schema_prepare_pgcopydb_table_size(PGSQL *pgsql,
 										SourceFilters *filters, DatabaseCatalog *catalog);
 
-bool schema_drop_pgcopydb_table_size(PGSQL *pgsql);
-
 bool schema_list_ordinary_tables(PGSQL *pgsql,
 								 SourceFilters *filters,
 								 DatabaseCatalog *catalog);


### PR DESCRIPTION
This function does not exists anymore, but the header was still defined and the call site was not removed yet.

Closes #688
See #684 