### PR TITLE
Problem: Still old variant of strdup has been used

### DIFF
--- a/src/bin/pgcopydb/defaults.h
+++ b/src/bin/pgcopydb/defaults.h
@@ -16,6 +16,8 @@
 #define calloc(m, n) GC_malloc((m) * (n))
 #define free(p) GC_free(p)
 #define realloc(p, n) GC_realloc((p), (n))
+#define strdup(p) GC_strdup(p)
+#define strndup(p, n) GC_strndup(p, n)
 
 /*
  * The GC API can also be used as leak detector, thanks to using the following


### PR DESCRIPTION
pgcopydb recently switched to Boehm-Demers-Weiser Garbage Collector[1] and replaced malloc family with GC_malloc and friends. However, strdup is not replaced to GC_strdup.

Solution: Use macros to replace strdup/strndup with it's GC variant.

[1] https://github.com/dimitri/pgcopydb/pull/647