### PR TITLE
Problem: Resume after interrupted clone always fails

### DIFF
--- a/src/bin/pgcopydb/dump_restore.c
+++ b/src/bin/pgcopydb/dump_restore.c
@@ -62,6 +62,13 @@ copydb_dump_source_schema(CopyDataSpec *specs,
 {
 	DatabaseCatalog *sourceDB = &(specs->catalogs.source);
 
+	if (specs->runState.schemaDumpIsDone)
+	{
+		log_info("Skipping pg_dump for pre-data/post-data section, "
+				 "done on a previous run");
+		return true;
+	}
+
 	if (!summary_start_timing(sourceDB, TIMING_SECTION_DUMP_SCHEMA))
 	{
 		/* errors have already been logged */
@@ -133,12 +140,6 @@ copydb_target_prepare_schema(CopyDataSpec *specs)
 {
 	DatabaseCatalog *sourceDB = &(specs->catalogs.source);
 
-	if (!summary_start_timing(sourceDB, TIMING_SECTION_PREPARE_SCHEMA))
-	{
-		/* errors have already been logged */
-		return false;
-	}
-
 	if (!file_exists(specs->dumpPaths.preFilename))
 	{
 		log_fatal("File \"%s\" does not exists", specs->dumpPaths.preFilename);
@@ -150,6 +151,12 @@ copydb_target_prepare_schema(CopyDataSpec *specs)
 		log_info("Skipping pg_restore for pre-data section, "
 				 "done on a previous run");
 		return true;
+	}
+
+	if (!summary_start_timing(sourceDB, TIMING_SECTION_PREPARE_SCHEMA))
+	{
+		/* errors have already been logged */
+		return false;
 	}
 
 	/*
@@ -488,12 +495,6 @@ copydb_target_finalize_schema(CopyDataSpec *specs)
 {
 	DatabaseCatalog *sourceDB = &(specs->catalogs.source);
 
-	if (!summary_start_timing(sourceDB, TIMING_SECTION_FINALIZE_SCHEMA))
-	{
-		/* errors have already been logged */
-		return false;
-	}
-
 	if (!file_exists(specs->dumpPaths.postFilename))
 	{
 		log_fatal("File \"%s\" does not exists", specs->dumpPaths.postFilename);
@@ -505,6 +506,12 @@ copydb_target_finalize_schema(CopyDataSpec *specs)
 		log_info("Skipping pg_restore for --section=post-data, "
 				 "done on a previous run");
 		return true;
+	}
+
+	if (!summary_start_timing(sourceDB, TIMING_SECTION_FINALIZE_SCHEMA))
+	{
+		/* errors have already been logged */
+		return false;
 	}
 
 	if (!copydb_write_restore_list(specs, PG_DUMP_SECTION_POST_DATA))

--- a/src/bin/pgcopydb/summary.c
+++ b/src/bin/pgcopydb/summary.c
@@ -434,7 +434,7 @@ summary_add_table(DatabaseCatalog *catalog, CopyTableDataSpec *tableSpecs)
 	}
 
 	char *sql =
-		"insert into summary(pid, tableoid, partnum, start_time_epoch, command)"
+		"insert or replace into summary(pid, tableoid, partnum, start_time_epoch, command)"
 		"values($1, $2, $3, $4, $5)";
 
 	if (!semaphore_lock(&(catalog->sema)))

--- a/src/bin/pgcopydb/table-data.c
+++ b/src/bin/pgcopydb/table-data.c
@@ -42,12 +42,6 @@ copydb_copy_all_table_data(CopyDataSpec *specs)
 {
 	DatabaseCatalog *sourceDB = &(specs->catalogs.source);
 
-	if (!summary_start_timing(sourceDB, TIMING_SECTION_TOTAL_DATA))
-	{
-		/* errors have already been logged */
-		return false;
-	}
-
 	if (specs->runState.tableCopyIsDone &&
 		specs->runState.indexCopyIsDone &&
 		specs->runState.sequenceCopyIsDone &&
@@ -56,6 +50,12 @@ copydb_copy_all_table_data(CopyDataSpec *specs)
 		log_info("Skipping tables, indexes, and sequences, "
 				 "already done on a previous run");
 		return true;
+	}
+
+	if (!summary_start_timing(sourceDB, TIMING_SECTION_TOTAL_DATA))
+	{
+		/* errors have already been logged */
+		return false;
 	}
 
 	/* close SQLite databases before fork() */


### PR DESCRIPTION
We use `done_time_epoch` from `timings` to populate `runState`, which helps to skip already processed table sections.

However, we call `summary_start_timing` regardless of whether the section has been already done or not., which causing insertion(insert or replace) of default value to `done_time_epoch` because `summary_start_timing` won't be called for already done section.

Without this fix, while resuming after the interruption pgcopydb would do pre-data restore again leading to table already exists error.

Solution: Check whether the section is already completed using `runState` and exit early without calling `summary_start_timing` for already done section.

Related to https://github.com/dimitri/pgcopydb/issues/692