### PR TITLE
Problem: interrupted clone resume fails with index relation already exists error

### DIFF
--- a/src/bin/pgcopydb/table-data.c
+++ b/src/bin/pgcopydb/table-data.c
@@ -904,30 +904,36 @@ copydb_copy_data_by_oid(CopyDataSpec *specs, PGSQL *src, PGSQL *dst,
 		return false;
 	}
 
+	/*
+	 * Skip only table-data copy when it it has been done already on a previous
+	 * run. We still need to process the indexes, constraints, and vacuum.
+	 * So, signal the index and vacuum workers as usual.
+	 */
 	if (isDone)
 	{
-		log_info("Skipping table %s (%u), already done on a previous run",
+		log_info("Skipping table-data %s (%u), already done on a previous run",
 				 tableSpecs->sourceTable->qname,
 				 tableSpecs->sourceTable->oid);
-		return true;
 	}
-
-	/*
-	 * 1. Now COPY the TABLE DATA from the source to the destination.
-	 */
-	if (!table->excludeData)
+	else
 	{
-		if (!copydb_copy_table(specs, src, dst, tableSpecs))
+		/*
+		 * 1. Now COPY the TABLE DATA from the source to the destination.
+		 */
+		if (!table->excludeData)
+		{
+			if (!copydb_copy_table(specs, src, dst, tableSpecs))
+			{
+				/* errors have already been logged */
+				return false;
+			}
+		}
+
+		if (!copydb_mark_table_as_done(specs, tableSpecs))
 		{
 			/* errors have already been logged */
 			return false;
 		}
-	}
-
-	if (!copydb_mark_table_as_done(specs, tableSpecs))
-	{
-		/* errors have already been logged */
-		return false;
 	}
 
 	if (specs->section == DATA_SECTION_TABLE_DATA)


### PR DESCRIPTION
### How to produce this problem?

Run the following command on a relative large source with quite a few tables with indexes.

```
pgcopydb clone --skip-extension --no-acl --no-owner --table-jobs=1 --index-jobs=1 --notice
```

When you see index creation notice message, interrupt the clone operation using Ctrl + C. You might get log lines like below once interrupted.

```
...
05:46:11.552 3527984 INFO   Skipping sequences, already done on a previous run
05:46:11.557 3527979 NOTICE COPY public.readings
05:46:14.136 3527979 NOTICE COPY public.diagnostics
05:46:14.140 3527983 NOTICE CREATE INDEX IF NOT EXISTS readings_tags_id_time_idx ON public.readings USING btree (tags_id, "time" DESC);
05:46:15.582 3527983 NOTICE CREATE INDEX IF NOT EXISTS readings_time_idx ON public.readings USING btree ("time" DESC);
05:46:15.638 3527979 NOTICE COPY public.tags
05:46:15.681 3527979 NOTICE COPY public.metrics
05:46:15.720 3527982 NOTICE VACUUM ANALYZE public.metrics;
05:46:16.037 3527983 NOTICE CREATE INDEX IF NOT EXISTS diagnostics_tags_id_time_idx ON public.diagnostics USING btree (tags_id, "time" DESC);
^C05:46:16.580 3527983 ERROR  Postgres query was interrupted: CREATE INDEX IF NOT EXISTS diagnostics_tags_id_time_idx ON public.diagnostics USING btree (tags_id, "time" DESC);
05:46:16.580 3527983 ERROR  Failed to create index with oid 65679, see above for details
05:46:16.580 3527983 ERROR  CREATE INDEX worker has been interrupted
05:46:16.680 3527978 ERROR  Sub-process 3527983 exited with code 12
05:46:16.680 3527978 ERROR  Some INDEX worker process(es) have exited with error, see above for details
...
```

Then, try to resume the clone,

```
pgcopydb clone --skip-extension --no-acl --no-owner --table-jobs=1 --index-jobs=1 --notice --resume
```

It fails with following error logs,

```
...
05:46:40.965 3528009 INFO   Skipping table public.tags (65657), already done on a previous run
05:46:40.965 3528009 NOTICE Skipping table public.metrics, already done on a previous run
05:46:40.965 3528009 INFO   Skipping table public.metrics (65569), already done on a previous run
05:46:41.153 3528006 INFO   STEP 10: restore the post-data section to the target database
05:46:41.155 3528006 NOTICE  /usr/bin/pg_restore -f /tmp/pgcopydb/schema/post-out.list -l /tmp/pgcopydb/schema/post.dump
05:46:41.187 3528006 NOTICE Skipping already processed dumpId 6653: INDEX 65672 public readings_tags_id_time_idx tsdbadmin
05:46:41.187 3528006 NOTICE Skipping already processed dumpId 6654: INDEX 65673 public readings_time_idx tsdbadmin
05:46:41.187 3528006 NOTICE Write filtered pg_restore list file at "/tmp/pgcopydb/schema/post-filtered.list"
05:46:41.187 3528006 INFO    /usr/bin/pg_restore --dbname 'postgres://xxxx:36898/tsdb?sslmode=require&keepalives=1&keepalives_idle=10&keepalives_interval=10&keepalives_count=60' --single-transaction --no-owner --no-acl --use-list /tmp/pgcopydb/schema/post-filtered.list /tmp/pgcopydb/schema/post.dump
05:46:41.272 3528006 ERROR  pg_restore: error: could not execute query: ERROR:  relation "diagnostics_tags_id_time_idx" already exists
05:46:41.272 3528006 ERROR  Command was: CREATE INDEX diagnostics_tags_id_time_idx ON public.diagnostics USING btree (tags_id, "time" DESC);
05:46:41.273 3528006 ERROR  Failed to run pg_restore: exit code 1
05:46:41.273 3528006 ERROR  Failed to finalize schema on the target database, see above for details
05:46:41.273 3528006 ERROR  Failed to clone source database, see above for details
05:46:41.318 3528001 ERROR  clone process 3528006 has terminated [6]
...
```

### Root cause:

When we interrupt during index creation, index might have been created in the target but failed to update the done status on the sqlite source.db. Since the done status is not updated, the problematic index is not filtered and pg_restore attempts to recreate them.

### Solution:

On resume, let the table-data skip data copy if it is done but still signal the index workers to proceed with creating indexes. Index worker shall ignore if the index is already exists, else creates one.

### Alternatives

- pg_restore post-data can be called with `--clean --if-exists --jobs` which will take care of removing indexes those are created on target, but not updated to sqlite summary table. However, it might do double work and explicit vacuum is needed.
- Instead of using sys v message queue, probably we can use sqlite as a persistent message queue. Once table copy completes, it writes indexes to be created on a sqlite and index workers can pick from sqlite table. A similar approach can be used with in index worker to vacuum worker communication too.

Related to https://github.com/dimitri/pgcopydb/issues/692
