### PR TITLE
Problem: CDC replication/apply is slow

### DIFF
--- a/src/bin/pgcopydb/ld_replay.c
+++ b/src/bin/pgcopydb/ld_replay.c
@@ -179,9 +179,9 @@ stream_replay_line(void *ctx, const char *line, bool *stop)
 			}
 
 			/* rate limit to 1 pipeline sync per seconds */
-			if (1 < (now - context->applyPGSQL.pipelineSyncTime))
+			if (1 < (now - context->applyPgConn.pipelineSyncTime))
 			{
-				if (!pgsql_sync_pipeline(&(context->applyPGSQL)))
+				if (!pgsql_sync_pipeline(&(context->applyPgConn)))
 				{
 					log_error("Failed to sync the pipeline, see previous "
 							  "error for details");
@@ -245,7 +245,7 @@ stream_replay_line(void *ctx, const char *line, bool *stop)
 
 	if (*stop)
 	{
-		if (!pgsql_sync_pipeline(&(context->applyPGSQL)))
+		if (!pgsql_sync_pipeline(&(context->applyPgConn)))
 		{
 			log_error("Failed to sync the pipeline, see previous error for "
 					  "details");

--- a/src/bin/pgcopydb/ld_stream.c
+++ b/src/bin/pgcopydb/ld_stream.c
@@ -35,7 +35,6 @@
 static bool updateStreamCounters(StreamContext *context,
 								 LogicalMessageMetadata *metadata);
 
-
 /*
  * stream_init_specs initializes Change Data Capture streaming specifications
  * from a copyDBSpecs structure.

--- a/src/bin/pgcopydb/ld_stream.h
+++ b/src/bin/pgcopydb/ld_stream.h
@@ -365,6 +365,12 @@ typedef struct StreamApplyContext
 	/* target connection */
 	PGSQL pgsql;
 
+	/* target connection created in pipeline mode */
+	PGSQL pgsqlPipeline;
+
+	/* track the last time we synced the pipeline */
+	uint64_t pipelineSyncTime;
+
 	/* apply needs access to the catalogs to register sentinel replay_lsn */
 	DatabaseCatalog *sourceDB;
 	uint64_t sentinelSyncTime;
@@ -648,6 +654,8 @@ bool parseWal2jsonMessage(StreamContext *privateContext,
 bool stream_apply_catchup(StreamSpecs *specs);
 
 bool stream_apply_setup(StreamSpecs *specs, StreamApplyContext *context);
+
+bool stream_apply_cleanup(StreamApplyContext *context);
 
 bool stream_apply_wait_for_sentinel(StreamSpecs *specs,
 									StreamApplyContext *context);

--- a/src/bin/pgcopydb/ld_stream.h
+++ b/src/bin/pgcopydb/ld_stream.h
@@ -363,10 +363,10 @@ typedef struct StreamApplyContext
 	CDCPaths paths;
 
 	/* target connection to find current wal_lsn for replay_lsn mapping */
-	PGSQL controlPGSQL;
+	PGSQL controlPgConn;
 
 	/* target connection created in pipeline mode responsible for apply */
-	PGSQL applyPGSQL;
+	PGSQL applyPgConn;
 
 	/* apply needs access to the catalogs to register sentinel replay_lsn */
 	DatabaseCatalog *sourceDB;

--- a/src/bin/pgcopydb/ld_stream.h
+++ b/src/bin/pgcopydb/ld_stream.h
@@ -362,14 +362,11 @@ typedef struct StreamApplyContext
 {
 	CDCPaths paths;
 
-	/* target connection */
-	PGSQL pgsql;
+	/* target connection to find current wal_lsn for replay_lsn mapping */
+	PGSQL controlPGSQL;
 
-	/* target connection created in pipeline mode */
-	PGSQL pgsqlPipeline;
-
-	/* track the last time we synced the pipeline */
-	uint64_t pipelineSyncTime;
+	/* target connection created in pipeline mode responsible for apply */
+	PGSQL applyPGSQL;
 
 	/* apply needs access to the catalogs to register sentinel replay_lsn */
 	DatabaseCatalog *sourceDB;

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -1909,11 +1909,17 @@ pgsql_pipeline_enter(PGSQL *pgsql)
 	log_trace("Enabled pipeline mode");
 	return true;
 #else
-	log_warn("Pipeline mode is not available on Postgres version %d, "
-			 "need at least version 14",
-			 PG_MAJORVERSION_NUM);
+	static bool warned = false;
 
-	return false;
+	if (!warned)
+	{
+		log_warn("Pipeline mode is not available on Postgres version %d, "
+				 "need at least version 14",
+				 PG_MAJORVERSION_NUM);
+		warned = true;
+	}
+
+	return true;
 #endif
 }
 

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -1925,7 +1925,7 @@ pgsql_enable_pipeline_mode(PGSQL *pgsql)
 
 /*
  * pgsql_sync_pipeline drains the pipeline by sending a SYNC message and
- * reading until we get a PGRES_PIPELINE_SYNC result.
+ * reads results until we get a PGRES_PIPELINE_SYNC result.
  */
 bool
 pgsql_sync_pipeline(PGSQL *pgsql)

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -33,7 +33,7 @@
 #if defined(LIBPQ_HAS_PIPELINING) && LIBPQ_HAS_PIPELINING
 #define pqPipelineModeEnabled(conn) (PQpipelineStatus(conn) == PQ_PIPELINE_ON)
 #else
-#warning Pipeline mode is only available in libpq PostgreSQL 14 and later
+#warning Compiling pgcopydb without libpq pipeline mode, available from libpq 14 and later
 #define pqPipelineModeEnabled(conn) (false)
 #endif
 
@@ -1912,9 +1912,11 @@ pgsql_enable_pipeline_mode(PGSQL *pgsql)
 
 	if (!warned)
 	{
-		log_warn("libpq in Postgres version %d does not support pipeline mode, "
-				 "need at least version 14",
+		log_warn("Skipping libpq pipeline mode optimisation because pgcopydb "
+				 "was built with libpq %d, pipeline mode is available since "
+				 "libpq 14",
 				 PG_MAJORVERSION_NUM);
+
 		warned = true;
 	}
 
@@ -2068,9 +2070,11 @@ pgsql_sync_pipeline(PGSQL *pgsql)
 
 	if (!warned)
 	{
-		log_warn("libpq in Postgres version %d does not support pipeline mode, "
-				 "need at least version 14",
+		log_warn("Skipping libpq pipeline mode optimisation because pgcopydb "
+				 "was built with libpq %d, pipeline mode is available since "
+				 "libpq 14",
 				 PG_MAJORVERSION_NUM);
+
 		warned = true;
 	}
 

--- a/src/bin/pgcopydb/pgsql.h
+++ b/src/bin/pgcopydb/pgsql.h
@@ -187,6 +187,12 @@ typedef struct PGSQL
 
 	bool logSQL;
 	bool singleRowMode;
+
+	/*
+	 * Tracks the last time we synced the pipeline. Applicable only for
+	 * connections which are in pipeline mode.
+	 */
+	uint64_t pipelineSyncTime;
 } PGSQL;
 
 
@@ -297,8 +303,8 @@ bool pgsql_send_with_params(PGSQL *pgsql, const char *sql, int paramCount,
 bool pgsql_fetch_results(PGSQL *pgsql, bool *done,
 						 void *context, ParsePostgresResultCB *parseFun);
 
-bool pgsql_pipeline_enter(PGSQL *pgsql);
-bool pgsql_pipeline_sync(PGSQL *pgsql);
+bool pgsql_enable_pipeline_mode(PGSQL *pgsql);
+bool pgsql_sync_pipeline(PGSQL *pgsql);
 
 bool pgsql_prepare(PGSQL *pgsql, const char *name, const char *sql,
 				   int paramCount, const Oid *paramTypes);

--- a/src/bin/pgcopydb/pgsql.h
+++ b/src/bin/pgcopydb/pgsql.h
@@ -297,6 +297,9 @@ bool pgsql_send_with_params(PGSQL *pgsql, const char *sql, int paramCount,
 bool pgsql_fetch_results(PGSQL *pgsql, bool *done,
 						 void *context, ParsePostgresResultCB *parseFun);
 
+bool pgsql_pipeline_enter(PGSQL *pgsql);
+bool pgsql_pipeline_sync(PGSQL *pgsql);
+
 bool pgsql_prepare(PGSQL *pgsql, const char *name, const char *sql,
 				   int paramCount, const Oid *paramTypes);
 

--- a/src/bin/pgcopydb/pgsql.h
+++ b/src/bin/pgcopydb/pgsql.h
@@ -189,8 +189,8 @@ typedef struct PGSQL
 	bool singleRowMode;
 
 	/*
-	 * Tracks the last time we synced the pipeline. Applicable only for
-	 * connections which are in pipeline mode.
+	 * Keeps track of the last sync time for the pipeline. This is relevant
+	 * only for connections in pipeline mode.
 	 */
 	uint64_t pipelineSyncTime;
 } PGSQL;


### PR DESCRIPTION
Our existing implementation is basic and it will execute a statement and waits for its result to arrive before issuing next statement. We already improved DML statements targeting same table with in a transaction by coalescing them into [multi-value insert statement](https://github.com/dimitri/pgcopydb/pull/465), but it will be beneficial only for a transaction which has multiple DML statements.

However, we have encountered few cases where the transaction had only one DML statement. This kind of txn will be slower because statements are executed sequentially from the client's perspective and network round trip latency would be added for each statement. For e.g. consider a network round trip of 10ms, executing 100 statements would simply add 1000ms(1s) to the overall response time.

Here is an example of how a single statement transaction will be executed now,

1. Execute ["BEGIN"]()
2. Execute [bunch of "SET" statements]() which are related to replication session setup
3. Prepare [DML statement]()
4. Execute [prepared statement with values]()
5. Execute procedure to update [replication origin progress]()
6. Execute [COMMIT]()
7. Map [target current insert lsn to commit lsn]() for feedback reporting (i.e. sentinel replay_lsn)

**Solution**: Use [pipeline mode](https://www.postgresql.org/docs/current/libpq-pipeline-mode.html) from libpq. It would facilitate sending commands without waiting for it's result.

**The goal of this implementation is to reduce network latency as much as possible while apply logical messages.**

The proposed implementation would enter into pipeline mode as soon as a new libpq connection is created for the ld_apply/ld_replay process. All the statements would be executed on a pipeline by default except few for statements which needs response immediately(e.g. step 7). A dedicated connection would be used to serve (step 7), because it needs synchronous response.

The following functions are being called on the target PGSQL handle from ld_apply & ld_replay.

* pgsql_begin
* pgsql_set_gucs
* pgsql_execute
* pgsql_replication_origin_xact_setup
* pgsql_prepare
* pgsql_execute_prepared
* pgsql_current_wal_insert_lsn
* pgsql_current_wal_flush_lsn

Among all of the above function, only pgsql_current_wal_insert_lsn and pgsql_current_wal_flush_lsn returns values and other functions are write only.

The idea is to have 2 PGSQL connection handles, 1 for all write activity which can go through pipeline and another one could be used for reading.

Pipeline connection has to be synced/drained at some point to avoid accumulating results on the server & client which would end up eating lots of heap memory. The current implementation syncs based on the time interval(i.e. for every 1s). There are other methods like statement/txn count based sync, which may or may not be efficient.

The following command can be used to generate loads to understand the performance improvement made by this commit,

```
CREATE TABLE metrics (
    time TIMESTAMP NOT NULL,
    name TEXT,
    id NUMERIC,
    value FLOAT
);
```

```
-- insert_metric.sql
\set id random(1, 1000000)
\set value random(0,100)
INSERT INTO metrics (time, name, value) VALUES (NOW(), 'metric_' || :id, :value);
```
```
pgbench -n -c 40 -j 1 -t 10000 -f insert_metric.sql $SOURCE
```

- `-c` number of database connection to utlize (i.e. server side concurrency)
- `-j` number of threads to create on the client machine (i.e. client side concurrency)

synchronous_commit=off)
```
pgbench -n -c 1 -j 1 -t 10000 -f insert_metric.sql $TARGET
```
```
tps = 1177 (without initial connection time)
```

```
tps = 175
```

```
tps = 1652
```

**This commit improves the single statement txn throughput by 10x**

Ideally, we should aim to get performance number close to direct ingestion(i.e. 1200 txn/s). We are 40% performing better than the baseline in this iteration. However, we can aim more as in the real system there will be more than 1 connection will be utilized. We can't really race against multiple connection doing steady ingestion around 1000 txn/s per connection, but lets optimize the single connection throughput to the max!

This change will be a foundation to the future improvements which steers towards that.

1. Optimize step 2 - Instead of executing bunch of SET statements for every txn, run once in the beginning for the session
2. Optimize step 9 - Probably we can simply use pg_replication_origin_progress as replay_lsn?

TODO
- [x] Conditionally enable pipeline on libpq version >= 14 - Should we still need to do this?
