### PR TITLE
Fix SQL syntax error in group_concat.

### DIFF
--- a/src/bin/pgcopydb/catalog.c
+++ b/src/bin/pgcopydb/catalog.c
@@ -3184,7 +3184,7 @@ catalog_s_table_attrlist(DatabaseCatalog *catalog, SourceTable *table)
 	}
 
 	char *sql =
-		"select group_concat(attname, ', ' order by attnum) "
+		" select group_concat(attname order by attnum, ', ') "
 		"       filter (where not attisgenerated) "
 		"  from s_attr "
 		" where oid = $1";


### PR DESCRIPTION
Without this fix the migrations would fail with this error when hit this code path,
```
2024-03-13 09:56:42.303 14231 ERROR  catalog.c:7286            Failed to prepare SQLite statement: select group_concat(attname, ', ' order by attnum)        filter (where not attisgenerated)   from s_attr  where oid = $1
2024-03-13 09:56:42.303 14231 ERROR  catalog.c:7287            [SQLite] near "order": syntax error
```