### PR TITLE
Fix issues with CFLAGS

### DIFF
--- a/src/bin/pgcopydb/Makefile
+++ b/src/bin/pgcopydb/Makefile
@@ -76,15 +76,13 @@ ifeq ($(shell uname -s),Darwin)
 endif
 
 
-ifdef USE_SECURITY_FLAGS
 # Flags taken from: https://liquid.microsoft.com/Web/Object/Read/ms.security/Requirements/Microsoft.Security.SystemsADM.10203#guide
 SECURITY_CFLAGS=-fstack-protector-strong -D_FORTIFY_SOURCE=2 -O2 -z noexecstack -fpie -Wl,-pie -Wl,-z,relro -Wl,-z,now -Wformat -Wformat-security -Werror=format-security
 DEFAULT_CFLAGS += $(SECURITY_CFLAGS)
-endif
 
 override CFLAGS := $(DEFAULT_CFLAGS) $(CFLAGS)
 
-JENKINS_CFLAGS = $(CFAGS) -Wno-implicit-fallthrough -Wno-format
+JENKINS_CFLAGS = $(CFLAGS) -Wno-implicit-fallthrough
 
 LIBS  = -L $(shell $(PG_CONFIG) --pkglibdir)
 LIBS += -L $(shell $(PG_CONFIG) --libdir)


### PR DESCRIPTION
There were several issues with the CFLAGS in the pgcopydb Makefile. This patch fixes them.

1. Removal of conditional logic for USE_SECURITY_FLAGS

Historically, we needed to support some linux distros such as RHEL6 that did not support the subset of security flags that are required for Microsoft Compliance. However, we are now at a point where we can remove this conditional logic and always use those security flags. This patch removes the conditional logic and always uses the security flags.

2. Fix typo in JENKINS_CFLAGS

The JENKINS_CFLAGS variable was misspelled as CFAGS. This patch fixes the typo.

3. Remove unnecessary override of CFLAGS

The override of CFLAGS was unnecessary and was causing the security flags to be overridden. This patch removes the override. If we do not have -Wformat option, -Wformat-security which is a required compiler flag for compliance is ignored.

Relevant error message:
cc1: error: -Wformat-security ignored without -Wformat [-Werror=format-security]

Fixes: #672 