### PR TITLE
Create extensions in the schema of the original extension

### DIFF
--- a/tests/extensions/copydb.sh
+++ b/tests/extensions/copydb.sh
@@ -31,6 +31,13 @@ EOF
 psql -a -1 ${PGCOPYDB_SOURCE_PGURI_SU} <<EOF
 create extension intarray cascade;
 create extension postgis cascade;
+create schema foo;
+create extension hstore with schema foo cascade;
+EOF
+
+# create schemas for extensions on the target pagila database (needs superuser)
+psql -a -1 ${PGCOPYDB_TARGET_PGURI_SU} <<EOF
+create schema foo;
 EOF
 
 #


### PR DESCRIPTION
Related to this one: https://github.com/dimitri/pgcopydb/issues/694 and this: https://github.com/dimitri/pgcopydb/pull/717

The `pgcopydb copy extensions` command doesn't create the extension in the original scheme from the source. This patch attempts to fix that by using the `with schema XXX` clause during `create extension`.