### PR TITLE
Remove table-data worker entry from `process` catalog on finish.

### DIFF
--- a/src/bin/pgcopydb/indexes.c
+++ b/src/bin/pgcopydb/indexes.c
@@ -296,6 +296,8 @@ copydb_index_worker(CopyDataSpec *specs)
 		}
 	}
 
+	pgsql_finish(&dst);
+
 	if (!catalog_delete_process(&(specs->catalogs.source), pid))
 	{
 		log_warn("Failed to delete catalog process entry for pid %d", pid);
@@ -304,11 +306,8 @@ copydb_index_worker(CopyDataSpec *specs)
 	if (!catalog_close_from_specs(specs))
 	{
 		/* errors have already been logged */
-		(void) pgsql_finish(&dst);
 		return false;
 	}
-
-	(void) pgsql_finish(&dst);
 
 	bool success = (stop == true && errors == 0);
 

--- a/src/bin/pgcopydb/table-data.c
+++ b/src/bin/pgcopydb/table-data.c
@@ -739,7 +739,9 @@ copydb_table_data_worker(CopyDataSpec *specs)
 		return false;
 	}
 
-	while (true)
+	bool stop = false;
+
+	while (!stop)
 	{
 		QMessage mesg = { 0 };
 		bool recv_ok = queue_receive(&(specs->copyQueue), &mesg);
@@ -761,10 +763,9 @@ copydb_table_data_worker(CopyDataSpec *specs)
 		{
 			case QMSG_TYPE_STOP:
 			{
+				stop = true;
 				log_debug("Stop message received by COPY worker");
-				(void) copydb_close_snapshot(specs);
-				pgsql_finish(&dst);
-				return true;
+				break;
 			}
 
 			case QMSG_TYPE_TABLEPOID:
@@ -826,7 +827,7 @@ copydb_table_data_worker(CopyDataSpec *specs)
 		return false;
 	}
 
-	return errors == 0;
+	return stop == true && errors == 0;
 }
 
 


### PR DESCRIPTION
This fixes the case where `copydb_table_data_worker` receives a `QMSG_TYPE_STOP` and we return within the switch statement without calling `catalog_delete_process` outside the switch body. This was causing problems in `list progress`.