### PR TITLE
Support pg 11 and 12

### DIFF
--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -1913,9 +1913,8 @@ pgsql_enable_pipeline_mode(PGSQL *pgsql)
 	if (!warned)
 	{
 		log_warn("Skipping libpq pipeline mode optimisation because pgcopydb "
-				 "was built with libpq %d, pipeline mode is available since "
-				 "libpq 14",
-				 PG_MAJORVERSION);
+				 "was built with libpq " PG_MAJORVERSION
+				 ", pipeline mode is available since libpq 14");
 
 		warned = true;
 	}
@@ -2071,9 +2070,8 @@ pgsql_sync_pipeline(PGSQL *pgsql)
 	if (!warned)
 	{
 		log_warn("Skipping libpq pipeline mode optimisation because pgcopydb "
-				 "was built with libpq %d, pipeline mode is available since "
-				 "libpq 14",
-				 PG_MAJORVERSION);
+				 "was built with libpq " PG_MAJORVERSION
+				 ", pipeline mode is available since libpq 14");
 
 		warned = true;
 	}

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -1915,7 +1915,7 @@ pgsql_enable_pipeline_mode(PGSQL *pgsql)
 		log_warn("Skipping libpq pipeline mode optimisation because pgcopydb "
 				 "was built with libpq %d, pipeline mode is available since "
 				 "libpq 14",
-				 PG_MAJORVERSION_NUM);
+				 PG_MAJORVERSION);
 
 		warned = true;
 	}
@@ -2073,7 +2073,7 @@ pgsql_sync_pipeline(PGSQL *pgsql)
 		log_warn("Skipping libpq pipeline mode optimisation because pgcopydb "
 				 "was built with libpq %d, pipeline mode is available since "
 				 "libpq 14",
-				 PG_MAJORVERSION_NUM);
+				 PG_MAJORVERSION);
 
 		warned = true;
 	}


### PR DESCRIPTION
Support pg 11 and 12

Postgres 11 and 12 has not PG_MAJORVERSION_NUM macro,
so this patch replaces it by PG_MAJORVERSION