### PR TITLE
Check configuration on target before applying db properties.

### DIFF
--- a/src/bin/pgcopydb/copydb_schema.c
+++ b/src/bin/pgcopydb/copydb_schema.c
@@ -180,7 +180,7 @@ copydb_fetch_schema_and_prepare_specs(CopyDataSpec *specs)
 
 /*
  * copydb_fetch_source_catalog_setup initializes our local catalog cache and
- * checks th setup and cache state.
+ * checks the setup and cache state.
  */
 static bool
 copydb_fetch_source_catalog_setup(CopyDataSpec *specs)

--- a/src/bin/pgcopydb/dump_restore.c
+++ b/src/bin/pgcopydb/dump_restore.c
@@ -350,6 +350,22 @@ copydb_copy_database_properties_hook(void *ctx, SourceProperty *property)
 	 */
 	else
 	{
+		bool exists = false;
+
+		if (!pgsql_configuration_exists(dst, property->setconfig, &exists))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+
+		if (!exists)
+		{
+			log_warn("Skipping database property %s which "
+					 "does not exists on the target database",
+					 property->setconfig);
+			return true;
+		}
+
 		PQExpBuffer command = createPQExpBuffer();
 
 		makeAlterConfigCommand(conn, property->setconfig,

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -5152,6 +5152,47 @@ pgsql_role_exists(PGSQL *pgsql, const char *roleName, bool *exists)
 
 
 /*
+ * pgsql_configuration_exists checks that a configuration exists on the
+ * Postgres server.
+ */
+bool
+pgsql_configuration_exists(PGSQL *pgsql, const char *setconfig, bool *exists)
+{
+	char *sql = "select exists(select name from pg_settings WHERE name = $1)";
+
+	char *configName = strdup(setconfig);
+	char *equalsSign = strchr(configName, '=');
+	if (equalsSign != NULL)
+	{
+		*equalsSign = '\0';
+	}
+
+	int paramCount = 1;
+	Oid paramTypes[1] = { TEXTOID };
+	const char *paramValues[1] = { configName };
+
+	SingleValueResultContext context = { { 0 }, PGSQL_RESULT_BOOL, false };
+
+	if (!pgsql_execute_with_params(pgsql, sql, paramCount, paramTypes, paramValues,
+								   &context, &parseSingleValueResult))
+	{
+		return false;
+	}
+
+	if (!context.parsedOk)
+	{
+		log_error(
+			"Failed to check if target database contains the configuration, see above for details");
+		return false;
+	}
+
+	*exists = context.boolVal;
+
+	return true;
+}
+
+
+/*
  * pgsql_current_wal_flush_lsn calls pg_current_wal_flush_lsn().
  */
 bool

--- a/src/bin/pgcopydb/pgsql.h
+++ b/src/bin/pgcopydb/pgsql.h
@@ -537,6 +537,8 @@ bool pgsql_drop_replication_slot(PGSQL *pgsql, const char *slotName);
 
 bool pgsql_role_exists(PGSQL *pgsql, const char *roleName, bool *exists);
 
+bool pgsql_configuration_exists(PGSQL *pgsql, const char *setconfig, bool *exists);
+
 bool pgsql_table_exists(PGSQL *pgsql,
 						const char *relname,
 						const char *nspname,

--- a/src/bin/pgcopydb/table-data.c
+++ b/src/bin/pgcopydb/table-data.c
@@ -168,7 +168,7 @@ copydb_process_table_data(CopyDataSpec *specs)
 	}
 
 	/*
-	 * Are blobs table data? well pg_dump --section sayth yes.
+	 * Are blobs table data? well pg_dump --section says yes.
 	 */
 	if (errors == 0 && !copydb_start_blob_process(specs))
 	{


### PR DESCRIPTION
Certain configurations on source might not exist in the target server. Before applying the configuration we need to check if it exists.

**before**
```
2024-03-27 18:43:21 64 ERROR pgsql.c:1978 [TARGET 29176] ERROR: unrecognized configuration parameter "sql_inheritance"
2024-03-27 18:43:21 64 ERROR pgsql.c:1989 [TARGET 29176] SQL query: ALTER DATABASE postgres SET "sql_inheritance" TO 'off';
```
**after**
```
12:16:53.589 16592 SQL    pgsql.c:1504              [TARGET 12718] select exists(select name from pg_settings WHERE name = $1);
12:16:53.589 16592 SQL    pgsql.c:1517              [TARGET 12718] 'sql_inheritance'
12:16:53.810 16592 WARN   dump_restore.c:363        Skipping database property sql_inheritance=off which does not exists on the target database
```