### PR TITLE
Problem: replay_lsn is not moving until the first message received

### DIFF
--- a/src/bin/pgcopydb/ld_stream.c
+++ b/src/bin/pgcopydb/ld_stream.c
@@ -1403,12 +1403,6 @@ streamFlush(LogicalStreamContext *context)
 {
 	StreamContext *privateContext = (StreamContext *) context->private;
 
-	/* when there is currently no file opened, just skip the flush operation */
-	if (privateContext->jsonFile == NULL)
-	{
-		return true;
-	}
-
 	log_debug("streamFlush: %X/%X %X/%X",
 			  LSN_FORMAT_ARGS(context->tracking->written_lsn),
 			  LSN_FORMAT_ARGS(context->cur_record_lsn));
@@ -1428,6 +1422,10 @@ streamFlush(LogicalStreamContext *context)
 			return false;
 		}
 
+		/*
+		 * streamKeepalive ensures we have a valid jsonFile by calling
+		 * streamRotateFile, so we can safely call fsync here.
+		 */
 		int fd = fileno(privateContext->jsonFile);
 
 		if (fsync(fd) != 0)


### PR DESCRIPTION
When we start with an idle source, pgcopydb doesn't send generate keep alive message until it receives message from the source.

pgsql_stream_logical calls [flushFunction](https://github.com/dimitri/pgcopydb/blob/e1dcb60b8f007179536c85a34ab5ce902d932497/src/bin/pgcopydb/pgsql.c#L4294-L4306), however it has been ignored by the implementation because there is [no jsonFile is created yet](https://github.com/dimitri/pgcopydb/blob/e1dcb60b8f007179536c85a34ab5ce902d932497/src/bin/pgcopydb/ld_stream.c#L1406-L1410).

Solution: Don't check for the existence of jsonFile, which leads to generation of keep alive messages causing replay_lsn to move forward.


Related to https://github.com/dimitri/pgcopydb/pull/703.