### PR TITLE
Bump to Postgres 14 to use libpq pipeline mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,16 @@ FROM --platform=${TARGETPLATFORM} debian:11-slim as build
 ARG TARGETPLATFORM
 ARG TARGETOS
 ARG TARGETARCH
+ARG PGVERSION=14
+
+RUN dpkg --add-architecture ${TARGETARCH:-arm64} && apt update \
+  && apt install -qqy --no-install-recommends \
+	curl \
+	ca-certificates \
+	gnupg
+
+RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt bullseye-pgdg main ${PGVERSION}" > /etc/apt/sources.list.d/pgdg.list
 
 RUN dpkg --add-architecture ${TARGETARCH:-arm64} && apt update \
   && apt install -qqy --no-install-recommends \
@@ -35,9 +45,7 @@ RUN dpkg --add-architecture ${TARGETARCH:-arm64} && apt update \
     watch \
     make \
     openssl \
-    postgresql-common \
-    postgresql-client-common \
-    postgresql-server-dev-all \
+    postgresql-server-dev-${PGVERSION} \
     psutils \
     tmux \
     watch \
@@ -56,9 +64,19 @@ FROM --platform=${TARGETPLATFORM} debian:11-slim as run
 ARG TARGETPLATFORM
 ARG TARGETOS
 ARG TARGETARCH
+ARG PGVERSION=14
 
 # used to configure Github Packages
 LABEL org.opencontainers.image.source https://github.com/dimitri/pgcopydb
+
+RUN dpkg --add-architecture ${TARGETARCH:-arm64} && apt update \
+  && apt install -qqy --no-install-recommends \
+	curl \
+	ca-certificates \
+	gnupg
+
+RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt bullseye-pgdg main ${PGVERSION}" > /etc/apt/sources.list.d/pgdg.list
 
 RUN dpkg --add-architecture ${TARGETARCH:-arm64} && apt update \
   && apt install -qqy --no-install-suggests --no-install-recommends \
@@ -82,7 +100,7 @@ RUN dpkg --add-architecture ${TARGETARCH:-arm64} && apt update \
 RUN useradd -rm -d /var/lib/postgres -s /bin/bash -g postgres -G sudo docker
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
-COPY --from=build --chmod=755 /usr/lib/postgresql/13/bin/pgcopydb /usr/local/bin
+COPY --from=build --chmod=755 /usr/lib/postgresql/${PGVERSION}/bin/pgcopydb /usr/local/bin
 
 USER docker
 


### PR DESCRIPTION
We have implemented pipeline mode in
https://github.com/dimitri/pgcopydb/pull/704, but it is not yet enabled by default as the current docker image has PG13.