### PR TITLE
Dockerfile: make pg_dump more interoperable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM --platform=${TARGETPLATFORM} debian:11-slim as build
 ARG TARGETPLATFORM
 ARG TARGETOS
 ARG TARGETARCH
-ARG PGVERSION=14
+ARG PGVERSION=16
 
 RUN dpkg --add-architecture ${TARGETARCH:-arm64} && apt update \
   && apt install -qqy --no-install-recommends \
@@ -37,6 +37,7 @@ RUN dpkg --add-architecture ${TARGETARCH:-arm64} && apt update \
     libselinux1-dev \
     libssl-dev \
     libxslt1-dev \
+    libzstd-dev \
     lsof \
     psmisc \
     gdb \
@@ -64,7 +65,7 @@ FROM --platform=${TARGETPLATFORM} debian:11-slim as run
 ARG TARGETPLATFORM
 ARG TARGETOS
 ARG TARGETARCH
-ARG PGVERSION=14
+ARG PGVERSION=16
 
 # used to configure Github Packages
 LABEL org.opencontainers.image.source https://github.com/dimitri/pgcopydb


### PR DESCRIPTION
Before, `pg_dump` would refuse to talk to Postgres versions higher than version 14 because it allows only equal or lower major versions. Therefore, we have bumped the Postgres version to 16 to allow `pg_dump` to connect to all available Postgres versions.

@DimCitus [wrote](https://github.com/dimitri/pgcopydb/issues/666#issuecomment-1980917660):
> We could improve the main Dockerfile to use that trick and publish docker images with Postgres 16 by default I suppose.