### PR TITLE
Check that a table still exists before running COPY.

### DIFF
--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -461,6 +461,7 @@ bool copydb_prepare_copy_query(CopyTableDataSpec *tableSpecs, CopyArgs *args);
 
 bool copydb_prepare_summary_command(CopyTableDataSpec *tableSpecs);
 
+bool copydb_check_table_exists(PGSQL *pgsql, SourceTable *table, bool *exists);
 
 /* blobs.c */
 bool copydb_start_blob_process(CopyDataSpec *specs);

--- a/src/bin/pgcopydb/dump_restore.c
+++ b/src/bin/pgcopydb/dump_restore.c
@@ -456,6 +456,8 @@ copydb_target_drop_tables(CopyDataSpec *specs)
 		return false;
 	}
 
+	log_notice("%s", query->data);
+
 	PGSQL dst = { 0 };
 
 	if (!pgsql_init(&dst, specs->connStrings.target_pguri, PGSQL_CONN_TARGET))

--- a/src/bin/pgcopydb/pgsql.h
+++ b/src/bin/pgcopydb/pgsql.h
@@ -322,6 +322,8 @@ void pgAutoCtlDebugNoticeProcessor(void *arg, const char *message);
 
 bool validate_connection_string(const char *connectionString);
 
+bool pgsql_lock_table(PGSQL *pgsql, const char *qname, const char *lockmode);
+
 bool pgsql_truncate(PGSQL *pgsql, const char *qname);
 
 typedef struct CopyArgs
@@ -563,6 +565,7 @@ bool pgsql_role_exists(PGSQL *pgsql, const char *roleName, bool *exists);
 bool pgsql_configuration_exists(PGSQL *pgsql, const char *setconfig, bool *exists);
 
 bool pgsql_table_exists(PGSQL *pgsql,
+						uint32_t oid,
 						const char *relname,
 						const char *nspname,
 						bool *exists);


### PR DESCRIPTION
In Postgres pg_dump, the situation of a DROP TABLE happening concurrently to the backup operation is prevented by taking an explicit ACCESS SHARE lock on all the tables early.

This approach is limited to max_locks_per_transaction and can be problematic to operate given large schemas.

In the context of pgcopydb though, we do not need to forbid DROP TABLE happening on the source server while the migration is running, we need to be able to skip a table that has been dropped before we get to COPY it.