### PR TITLE
Copy schemas/namespaces as a separate sub-command

### DIFF
--- a/docs/include/copy-schemas.rst
+++ b/docs/include/copy-schemas.rst
@@ -1,0 +1,13 @@
+::
+
+   pgcopydb copy schemas: Create all the schemas found in the source database in the target
+   usage: pgcopydb copy schemas  --source ... --target ... [ --table-jobs ... --index-jobs ... ] 
+   
+     --source             Postgres URI to the source database
+     --target             Postgres URI to the target database
+     --dir                Work directory to use
+     --filters <filename> Use the filters defined in <filename>
+     --restart            Allow restarting when temp files exist already
+     --resume             Allow resuming operations after a failure
+     --not-consistent     Allow taking a new snapshot on the source database
+   

--- a/docs/include/copy.rst
+++ b/docs/include/copy.rst
@@ -14,4 +14,5 @@
        sequences    Copy the current value from all sequences in database from source to target
        indexes      Create all the indexes found in the source database in the target
        constraints  Create all the constraints found in the source database in the target
+       schemas      Create all the schemas found in the source database in the target
    

--- a/docs/include/help.rst
+++ b/docs/include/help.rst
@@ -30,6 +30,7 @@
        sequences    Copy the current value from all sequences in database from source to target
        indexes      Create all the indexes found in the source database in the target
        constraints  Create all the constraints found in the source database in the target
+       schemas      Create all the schemas found in the source database in the target
    
      pgcopydb dump
        schema     Dump source database schema as custom files in work directory

--- a/docs/ref/pgcopydb_copy.rst
+++ b/docs/ref/pgcopydb_copy.rst
@@ -198,6 +198,15 @@ is found existing already on the target database.
 
 .. include:: ../include/copy-constraints.rst
 
+pgcopydb copy schemas
+---------------------
+
+pgcopydb copy schemas - Creates all the schemas found in the source database in the target
+
+The command ``pgcopydb copy schemas`` fetches all the CREATE SCHEMA commands from the pre-data section of pg_dump. Ownership and ACLs can also be restored if they pre-exist, or the ``pgcopydb copy roles`` command can be used beforehand.
+
+.. include:: ../include/copy-schemas.rst
+
 Description
 -----------
 

--- a/src/bin/pgcopydb/extensions.c
+++ b/src/bin/pgcopydb/extensions.c
@@ -233,8 +233,8 @@ copydb_copy_extensions_hook(void *ctx, SourceExtension *ext)
 		HASH_FIND(hh, context->reqs, extname, strlen(extname), req);
 
 		appendPQExpBuffer(sql,
-						  "create extension if not exists \"%s\" with schema \"%s\" cascade",
-						  ext->extname, ext->extnamespace);
+						  "create extension if not exists \"%s\" cascade",
+						  ext->extname);
 
 		if (req != NULL)
 		{
@@ -248,7 +248,6 @@ copydb_copy_extensions_hook(void *ctx, SourceExtension *ext)
 			log_error("Failed to build CREATE EXTENSION sql buffer: "
 					  "Out of Memory");
 			(void) destroyPQExpBuffer(sql);
-			return false;
 		}
 
 		log_info("Creating extension \"%s\"", ext->extname);
@@ -256,8 +255,6 @@ copydb_copy_extensions_hook(void *ctx, SourceExtension *ext)
 		if (!pgsql_execute(dst, sql->data))
 		{
 			log_error("Failed to create extension \"%s\"", ext->extname);
-			(void) destroyPQExpBuffer(sql);
-			return false;
 		}
 
 		(void) destroyPQExpBuffer(sql);

--- a/tests/extensions/copydb.sh
+++ b/tests/extensions/copydb.sh
@@ -31,6 +31,8 @@ EOF
 psql -a -1 ${PGCOPYDB_SOURCE_PGURI_SU} <<EOF
 create extension intarray cascade;
 create extension postgis cascade;
+create schema foo;
+create extension hstore with schema foo cascade;
 EOF
 
 #
@@ -56,6 +58,14 @@ psql -o /tmp/c.out -d ${PGCOPYDB_SOURCE_PGURI} -1 -f /usr/src/pgcopydb/countries
 coproc ( pgcopydb snapshot --debug )
 
 sleep 1
+
+# copy the schemas to the target database
+# before we copy the extensions
+pgcopydb copy schemas \
+         --source ${PGCOPYDB_SOURCE_PGURI_SU} \
+         --target ${PGCOPYDB_TARGET_PGURI_SU} \
+         --resume \
+         --debug
 
 # copy the extensions separately, needs superuser (both on source and target)
 pgcopydb list extensions --source ${PGCOPYDB_SOURCE_PGURI_SU}


### PR DESCRIPTION
This adds a new sub-command for copying schemas. Split from: https://github.com/dimitri/pgcopydb/pull/711