### PR TITLE
Fix pgsql_escape_identifier memory leak

### DIFF
--- a/src/bin/pgcopydb/ld_stream.h
+++ b/src/bin/pgcopydb/ld_stream.h
@@ -140,7 +140,6 @@ typedef struct LogicalMessageRelation
 {
 	char *nspname;  /* malloc'ed area */
 	char *relname;  /* malloc'ed area */
-	bool pqMemory;
 } LogicalMessageRelation;
 
 typedef struct LogicalMessageInsert

--- a/src/bin/pgcopydb/ld_test_decoding.c
+++ b/src/bin/pgcopydb/ld_test_decoding.c
@@ -351,7 +351,6 @@ parseTestDecodingMessageHeader(TestDecodingHeader *header, const char *message)
 	 */
 	header->table.nspname = strndup(idp, dot - idp);
 	header->table.relname = strndup(dot + 1, sep - dot - 1);
-	header->table.pqMemory = false;
 
 	sformat(header->qname, sizeof(header->qname), "%s.%s",
 			header->table.nspname,

--- a/src/bin/pgcopydb/ld_wal2json.c
+++ b/src/bin/pgcopydb/ld_wal2json.c
@@ -11,7 +11,6 @@
 
 #include "postgres.h"
 #include "postgres_fe.h"
-#include "libpq-fe.h"
 #include "access/xlog_internal.h"
 #include "access/xlogdefs.h"
 
@@ -294,19 +293,18 @@ SetMessageRelation(JSON_Object *jsobj,
 	}
 
 	table->nspname = pgsql_escape_identifier(pgsql, schema);
+
 	if (table->nspname == NULL)
 	{
 		return false;
 	}
 
 	table->relname = pgsql_escape_identifier(pgsql, relname);
+
 	if (table->relname == NULL)
 	{
-		PQfreemem(table->nspname);
 		return false;
 	}
-
-	table->pqMemory = true;
 
 	return true;
 }


### PR DESCRIPTION
The utility function pgsql_escape_identifier uses libpq's PQescapeIdentifier which allocates string using C's malloc which requires explicit memory deallocation using PQifreemem. However, we use libgc to auto manage memory with in pgcopydb and we never free the string returned by pgsql_escape_identifier anywhere in the code and causes memory leak.

Solution: Copy the string returned by PQescapeIdentifier into a memory space managed by libgc.