### PR TITLE
Fix COPY partitioning.

### DIFF
--- a/src/bin/pgcopydb/catalog.h
+++ b/src/bin/pgcopydb/catalog.h
@@ -206,9 +206,6 @@ typedef struct SourceTableIterator
 	DatabaseCatalog *catalog;
 	SourceTable *table;
 	SQLiteQuery query;
-
-	/* optional parameters */
-	uint64_t splitTableLargerThanBytes;
 } SourceTableIterator;
 
 bool catalog_iter_s_table_init(SourceTableIterator *iter);

--- a/src/bin/pgcopydb/schema.c
+++ b/src/bin/pgcopydb/schema.c
@@ -3278,62 +3278,109 @@ schema_list_partitions(PGSQL *pgsql,
 	int64_t min = table->partmin;
 	int64_t max = table->partmax;
 
+	int64_t partsCount = 1;
+	int64_t partsSize = max - min + 1;
+
 	/*
 	 * When the partition key is set to "ctid", it means that the table will be
 	 * partitioned based on the physical location of the rows in the table.
-	 * In this case, the relpages value represents the total number of pages in the
-	 * table, which can be used as the maximum value for the partition range.
-	 * By setting min to 0 and max to table->relpages, we ensure that each partition
-	 * covers the entire range of pages in the table.
+	 *
+	 * The relpages value represents the total number of pages in the table,
+	 * which can be used as the maximum value for the partition range. By
+	 * setting min to 0 and max to table->relpages, we ensure that each
+	 * partition covers the entire range of pages in the table.
 	 */
-	if (streq(table->partKey, "ctid"))
+	bool splitByCTID = streq(table->partKey, "ctid");
+
+	if (splitByCTID)
 	{
 		min = 0;
 		max = table->relpages;
+
+		/* Postgres page size is static: 8192 Bytes */
+		uint64_t pagesPerPart = ceil((double) partSize / 8192);
+
+		partsCount = ceil((double) table->relpages / (double) pagesPerPart);
+		partsSize = ceil((double) table->relpages / partsCount);
 	}
 
 	/*
-	 * Below code block calculates the number of parts needed and assigns the minimum and
-	 * maximum values for each part. It also logs information about each partition and
-	 * adds the table part to the catalog if provided.
+	 * Below code block calculates the number of parts needed and assigns the
+	 * minimum and maximum values for each part. It also logs information about
+	 * each partition and adds the table part to the catalog if provided.
+	 *
 	 * Example:
 	 * int64_t tableSize (table->bytes) = 100;
 	 * int64_t partSize = 10;
 	 * int64_t min = 1;
 	 * int64_t max = 100;
 	 * int64_t result = partitionTable(&table, partSize, min, max, &catalog);
-	 * // Output:
-	 * // Partition table#1: 1 - 10 (10)
-	 * // Partition table#2: 11 - 20 (10)
-	 * // Partition table#3: 21 - 30 (10)
-	 * // ...
-	 * // Partition table#10: 91 - 100 (10)
+	 *
+	 * Output:
+	 *  Partition table#1: 1 - 10 (10)
+	 *  Partition table#2: 11 - 20 (10)
+	 *  Partition table#3: 21 - 30 (10)
+	 *  ...
+	 *  Partition table#10: 91 - 100 (10)
 	 */
-	int64_t partsCount = ceil((double) table->bytes / (double) partSize);
-	int64_t range = ceil((double) (max - min + 1) / (double) table->bytes *
-						 (double) partSize);
+	else
+	{
+		/* add a partition for IS NULL (first) */
+		partsCount = ceil((double) table->bytes / (double) partSize) + 1;
+		partsSize = ceil((double) (max - min + 1) / partsCount);
+	}
 
+	/*
+	 * Now add an s_table_part row per partition.
+	 */
 	for (int64_t i = 0; i < partsCount; i++)
 	{
+		int64_t partNumber = i + 1;
 		SourceTableParts *parts = &(table->partition);
 
 		bzero(parts, sizeof(SourceTableParts));
 
-		parts->partNumber = i + 1;
+		parts->partNumber = partNumber;
 		parts->partCount = partsCount;
-		parts->min = min + (i * range);
-		parts->max = min + ((i + 1) * range) - 1;
 
-		if (parts->max > max)
+		/* take care of NULL values (we accept partkey with unique indexes) */
+		if (i == 0 && !splitByCTID)
 		{
-			parts->max = max;
+			parts->min = -1;
+			parts->max = -1;
+			parts->count = -1;
+		}
+		else if (splitByCTID)
+		{
+			parts->min = min + (i * partsSize);
+			parts->max = min + ((i + 1) * partsSize) - 1;
+			parts->count = parts->max - parts->min + 1;
+		}
+		else
+		{
+			/*
+			 * partNumber == 0 is for NULL values
+			 * partNumber == 1 is for range [ 0 .. a ], etc
+			 */
+			parts->min = min + ((i - 1) * partsSize);
+			parts->max = min + (i * partsSize) - 1;
+			parts->count = parts->max - parts->min + 1;
 		}
 
-		parts->count = parts->max - parts->min + 1;
+		/* the last partition has no upper bound */
+		if (partNumber == partsCount)
+		{
+			parts->max = -1;
+			parts->count = -1;
+		}
 
-		log_debug("Partition %s#%d: %lld - %lld (%lld)", table->qname, parts->partNumber,
-				  (long long) parts->min, (long long) parts->max, (long
-																   long) parts->count);
+		log_debug("Partition %s #%d/%d: [%lld .. %lld] (%lld)",
+				  table->qname,
+				  parts->partNumber,
+				  parts->partCount,
+				  (long long) parts->min,
+				  (long long) parts->max,
+				  (long long) parts->count);
 
 		if (catalog != NULL && catalog->db != NULL)
 		{
@@ -3341,13 +3388,6 @@ schema_list_partitions(PGSQL *pgsql,
 			{
 				/* errors have already been logged */
 			}
-		}
-
-		/* if we hit max, no need to iterate  */
-		if (parts->max == max)
-		{
-			parts->partCount = i + 1;
-			break;
 		}
 	}
 
@@ -4778,20 +4818,46 @@ parsePartKeyMinMaxValue(void *ctx, PGresult *result)
 		return;
 	}
 
-	/* 1. min */
-	char *value = PQgetvalue(result, 0, 0);
-	if (!stringToInt64(value, &(context->min)))
+	/* min and max are both null on empty tables */
+	if (PQgetisnull(result, 0, 0) &&
+		PQgetisnull(result, 0, 1))
 	{
-		log_error("Invalid min value: \"%s\"", value);
-		++errors;
+		context->min = 0;
+		context->max = 0;
 	}
-
-	/* 2. max */
-	value = PQgetvalue(result, 0, 1);
-	if (!stringToInt64(value, &(context->max)))
+	else
 	{
-		log_error("Invalid max value: \"%s\"", value);
-		++errors;
+		/* 1. min */
+		if (PQgetisnull(result, 0, 0))
+		{
+			log_error("Invalid min value: NULL");
+			++errors;
+		}
+		else
+		{
+			char *value = PQgetvalue(result, 0, 0);
+			if (!stringToInt64(value, &(context->min)))
+			{
+				log_error("Invalid min value: \"%s\"", value);
+				++errors;
+			}
+		}
+
+		/* 2. max */
+		if (PQgetisnull(result, 0, 1))
+		{
+			log_error("Invalid max value: NULL");
+			++errors;
+		}
+		else
+		{
+			char *value = PQgetvalue(result, 0, 1);
+			if (!stringToInt64(value, &(context->max)))
+			{
+				log_error("Invalid max value: \"%s\"", value);
+				++errors;
+			}
+		}
 	}
 
 	context->parsedOk = errors == 0;

--- a/tests/unit/expected/4-list-table-split.out
+++ b/tests/unit/expected/4-list-table-split.out
@@ -1,30 +1,32 @@
-2023-07-31 13:58:39 96 INFO   main.c:163                Running pgcopydb version 0.13.3.g1e88091 from "/usr/local/bin/pgcopydb"
-2023-07-31 13:58:39 96 INFO   cli_list.c:1081           Listing COPY partitions for table "public"."table_1" in "postgres://postgres@source/postgres"
-2023-07-31 13:58:39 96 INFO   cli_list.c:1195           Table "public"."table_1" COPY will be split 10-ways
+2024-04-26 15:30:56.639 87 INFO   main.c:136                Running pgcopydb version 0.15.59.g9a151a6.dirty from "/usr/local/bin/pgcopydb"
+2024-04-26 15:30:56.685 87 INFO   copydb.c:105              Using work dir "/tmp/unit/split"
+2024-04-26 15:30:56.688 87 INFO   cli_list.c:1294           Table public.table_1 COPY will be split 11-ways
         Part |          Min |          Max |        Count
 -------------+--------------+--------------+-------------
-        1/10 |            1 |           11 |           11
-        2/10 |           12 |           22 |           11
-        3/10 |           23 |           33 |           11
-        4/10 |           34 |           44 |           11
-        5/10 |           45 |           55 |           11
-        6/10 |           56 |           66 |           11
-        7/10 |           67 |           77 |           11
-        8/10 |           78 |           88 |           11
-        9/10 |           89 |           99 |           11
-       10/10 |          100 |          100 |            1
+        1/11 |           -1 |           -1 |           -1
+        2/11 |            1 |           10 |           10
+        3/11 |           11 |           20 |           10
+        4/11 |           21 |           30 |           10
+        5/11 |           31 |           40 |           10
+        6/11 |           41 |           50 |           10
+        7/11 |           51 |           60 |           10
+        8/11 |           61 |           70 |           10
+        9/11 |           71 |           80 |           10
+       10/11 |           81 |           90 |           10
+       11/11 |           91 |           -1 |           -1
 
-2023-07-31 13:58:39 97 INFO   main.c:163                Running pgcopydb version 0.13.3.g1e88091 from "/usr/local/bin/pgcopydb"
-2023-07-31 13:58:39 97 INFO   cli_list.c:1081           Listing COPY partitions for table "public"."table_2" in "postgres://postgres@source/postgres"
-2023-07-31 13:58:39 97 INFO   cli_list.c:1195           Table "public"."table_2" COPY will be split 5-ways
+2024-04-26 15:30:56.695 94 INFO   main.c:136                Running pgcopydb version 0.15.59.g9a151a6.dirty from "/usr/local/bin/pgcopydb"
+2024-04-26 15:30:56.741 94 INFO   copydb.c:105              Using work dir "/tmp/unit/split"
+2024-04-26 15:30:56.744 94 INFO   cli_list.c:1294           Table public.table_2 COPY will be split 6-ways
         Part |          Min |          Max |        Count
 -------------+--------------+--------------+-------------
-         1/5 |            1 |           21 |           21
-         2/5 |           22 |           42 |           21
-         3/5 |           43 |           63 |           21
-         4/5 |           64 |           84 |           21
-         5/5 |           85 |          100 |           16
+         1/6 |           -1 |           -1 |           -1
+         2/6 |            1 |           17 |           17
+         3/6 |           18 |           34 |           17
+         4/6 |           35 |           51 |           17
+         5/6 |           52 |           68 |           17
+         6/6 |           69 |           -1 |           -1
 
-2023-07-31 13:58:39 98 INFO   main.c:163                Running pgcopydb version 0.13.3.g1e88091 from "/usr/local/bin/pgcopydb"
-2023-07-31 13:58:39 98 INFO   cli_list.c:1081           Listing COPY partitions for table "public"."table_3" in "postgres://postgres@source/postgres"
-2023-07-31 13:58:39 98 INFO   cli_list.c:1188           Table "public"."table_3" () will not be split
+2024-04-26 15:30:56.753 101 INFO   main.c:136                Running pgcopydb version 0.15.59.g9a151a6.dirty from "/usr/local/bin/pgcopydb"
+2024-04-26 15:30:56.812 101 INFO   copydb.c:105              Using work dir "/tmp/unit/split"
+2024-04-26 15:30:56.815 101 INFO   cli_list.c:1275           Table public.table_3 (8192 bytes) will not be split


### PR DESCRIPTION
First, the per-table part count was computed incorrectly, leading to the COPY supervisor adding unknown partitions in the COPY processing queue.

Second, we support both PRIMARY KEYS and also UNIQUE indexes without a NOT NULL constraint, which means we should add a partition for the WHERE IS NULL clause.

Fixes #755 
Fixes #756 