### PR TITLE
Remove redundant identifier escaping from transform

### DIFF
--- a/src/bin/pgcopydb/ld_transform.c
+++ b/src/bin/pgcopydb/ld_transform.c
@@ -2034,14 +2034,7 @@ stream_write_insert(FILE *out, LogicalMessageInsert *insert)
 
 		for (int c = 0; c < stmt->cols; c++)
 		{
-			/*
-			 * In the case of the test_decoding plugin, it already escapes
-			 * keywords using double quotes, so we should avoid double quoting
-			 * again.
-			 */
-			const char *quoteFormatStr = (stmt->columns[c][0] == '"') ? "%s%s" :
-										 "%s\"%s\"";
-			appendPQExpBuffer(buf, quoteFormatStr,
+			appendPQExpBuffer(buf, "%s%s",
 							  c > 0 ? ", " : "",
 							  stmt->columns[c]);
 		}
@@ -2213,14 +2206,7 @@ stream_write_update(FILE *out, LogicalMessageUpdate *update)
 
 				if (!skip)
 				{
-					/*
-					 * In the case of the test_decoding plugin, it already escapes
-					 * keywords using double quotes, so we should avoid double quoting
-					 * again.
-					 */
-					const char *quoteFormatStr = (colname[0] == '"') ? "%s%s = $%d" :
-												 "%s\"%s\" = $%d";
-					appendPQExpBuffer(buf, quoteFormatStr,
+					appendPQExpBuffer(buf, "%s%s = $%d",
 									  first ? "" : ", ",
 									  colname,
 									  ++pos);
@@ -2261,30 +2247,19 @@ stream_write_update(FILE *out, LogicalMessageUpdate *update)
 					return false;
 				}
 
-				/*
-				 * In the case of the test_decoding plugin, it already escapes
-				 * keywords using double quotes, so we should avoid double quoting
-				 * again.
-				 */
 				if (value->isNull)
 				{
 					/*
 					 * Attributes with the value `NULL` require `IS NULL` instead of `=`
 					 * in the WHERE clause.
 					 */
-					const char *quoteFormatStr = (old->columns[v][0] == '"') ?
-												 "%s%s IS NULL" :
-												 "%s\"%s\" IS NULL";
-					appendPQExpBuffer(buf, quoteFormatStr,
+					appendPQExpBuffer(buf, "%s%s IS NULL",
 									  v > 0 ? " and " : "",
 									  old->columns[v]);
 				}
 				else
 				{
-					const char *quoteFormatStr = (old->columns[v][0] == '"') ?
-												 "%s%s = $%d" :
-												 "%s\"%s\" = $%d";
-					appendPQExpBuffer(buf, quoteFormatStr,
+					appendPQExpBuffer(buf, "%s%s = $%d",
 									  v > 0 ? " and " : "",
 									  old->columns[v],
 									  ++pos);
@@ -2370,30 +2345,19 @@ stream_write_delete(FILE *out, LogicalMessageDelete *delete)
 					return false;
 				}
 
-				/*
-				 * In the case of the test_decoding plugin, it already escapes
-				 * keywords using double quotes, so we should avoid double quoting
-				 * again.
-				 */
 				if (value->isNull)
 				{
 					/*
 					 * Attributes with the value `NULL` require `IS NULL` instead of `=`
 					 * in the WHERE clause.
 					 */
-					const char *quoteFormatStr = (old->columns[v][0] == '"') ?
-												 "%s%s IS NULL" :
-												 "%s\"%s\" IS NULL";
-					appendPQExpBuffer(buf, quoteFormatStr,
+					appendPQExpBuffer(buf, "%s%s IS NULL",
 									  v > 0 ? " and " : "",
 									  old->columns[v]);
 				}
 				else
 				{
-					const char *quoteFormatStr = (old->columns[v][0] == '"') ?
-												 "%s%s = $%d" :
-												 "%s\"%s\" = $%d";
-					appendPQExpBuffer(buf, quoteFormatStr,
+					appendPQExpBuffer(buf, "%s%s = $%d",
 									  v > 0 ? " and " : "",
 									  old->columns[v],
 									  ++pos);

--- a/tests/cdc-low-level/000000010000000000000002.sql
+++ b/tests/cdc-low-level/000000010000000000000002.sql
@@ -1,63 +1,62 @@
--- KEEPALIVE {"lsn":"0/24489B0","timestamp":"2023-12-21 17:23:21.330234+0000"}
-BEGIN; -- {"xid":491,"lsn":"0/244B698","timestamp":"2023-12-21 17:23:21.348819+0000","commit_lsn":"0/244DA18"}
-PREPARE d33a643f AS INSERT INTO public.rental ("rental_id", "rental_date", "inventory_id", "customer_id", "return_date", "staff_id", "last_update") overriding system value VALUES ($1, $2, $3, $4, $5, $6, $7), ($8, $9, $10, $11, $12, $13, $14);
-EXECUTE d33a643f["16050","2022-06-01 00:00:00+00","371","291",null,"1","2022-06-01 00:00:00+00","16051","2022-06-01 00:00:00+00","373","293",null,"2","2022-06-01 00:00:00+00"];
-PREPARE b05a8353 AS INSERT INTO public.payment_p2022_06 ("payment_id", "customer_id", "staff_id", "rental_id", "amount", "payment_date") overriding system value VALUES ($1, $2, $3, $4, $5, $6), ($7, $8, $9, $10, $11, $12);
-EXECUTE b05a8353["32099","291","1","16050","5.99","2022-06-01 00:00:00+00","32100","293","2","16051","5.99","2022-06-01 00:00:00+00"];
-COMMIT; -- {"xid":491,"lsn":"0/244DA18","timestamp":"2023-12-21 17:23:21.348819+0000"}
-BEGIN; -- {"xid":492,"lsn":"0/244DA18","timestamp":"2023-12-21 17:23:21.349405+0000","commit_lsn":"0/244EB00"}
-PREPARE 32de52b9 AS UPDATE public.payment_p2022_02 SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
-EXECUTE 32de52b9["11.95","23757","116","2","14763","11.99","2022-02-11 03:52:25.634006+00"];
-PREPARE 32de52b9 AS UPDATE public.payment_p2022_02 SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
-EXECUTE 32de52b9["11.95","24866","237","2","11479","11.99","2022-02-07 18:37:34.579143+00"];
-PREPARE a5d9c563 AS UPDATE public.payment_p2022_03 SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
-EXECUTE a5d9c563["11.95","17055","196","2","106","11.99","2022-03-18 18:50:39.243747+00"];
-PREPARE a5d9c563 AS UPDATE public.payment_p2022_03 SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
-EXECUTE a5d9c563["11.95","28799","591","2","4383","11.99","2022-03-08 16:41:23.911522+00"];
-PREPARE 1d7c9a4f AS UPDATE public.payment_p2022_04 SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
-EXECUTE 1d7c9a4f["11.95","20403","362","1","14759","11.99","2022-04-16 04:35:36.904758+00"];
-PREPARE 7978edcc AS UPDATE public.payment_p2022_05 SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
-EXECUTE 7978edcc["11.95","17354","305","1","2166","11.99","2022-05-12 11:28:17.949049+00"];
-PREPARE 72ebfeff AS UPDATE public.payment_p2022_06 SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
-EXECUTE 72ebfeff["11.95","22650","204","2","15415","11.99","2022-06-11 11:17:22.428079+00"];
-PREPARE 72ebfeff AS UPDATE public.payment_p2022_06 SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
-EXECUTE 72ebfeff["11.95","24553","195","2","16040","11.99","2022-06-15 02:21:00.279776+00"];
-PREPARE 3b977bd8 AS UPDATE public.payment_p2022_07 SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
-EXECUTE 3b977bd8["11.95","28814","592","1","3973","11.99","2022-07-06 12:15:38.928947+00"];
-PREPARE 3b977bd8 AS UPDATE public.payment_p2022_07 SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
-EXECUTE 3b977bd8["11.95","29136","13","2","8831","11.99","2022-07-22 16:15:40.797771+00"];
-COMMIT; -- {"xid":492,"lsn":"0/244EB00","timestamp":"2023-12-21 17:23:21.349405+0000"}
-BEGIN; -- {"xid":493,"lsn":"0/244ECC0","timestamp":"2023-12-21 17:23:21.349496+0000","commit_lsn":"0/244EE70"}
-PREPARE 2fa3c9c9 AS DELETE FROM public.payment_p2022_06 WHERE "payment_id" = $1 and "customer_id" = $2 and "staff_id" = $3 and "rental_id" = $4 and "amount" = $5 and "payment_date" = $6;
-EXECUTE 2fa3c9c9["32099","291","1","16050","5.99","2022-06-01 00:00:00+00"];
-PREPARE 2fa3c9c9 AS DELETE FROM public.payment_p2022_06 WHERE "payment_id" = $1 and "customer_id" = $2 and "staff_id" = $3 and "rental_id" = $4 and "amount" = $5 and "payment_date" = $6;
-EXECUTE 2fa3c9c9["32100","293","2","16051","5.99","2022-06-01 00:00:00+00"];
-PREPARE 4f0082a0 AS DELETE FROM public.rental WHERE "rental_id" = $1;
-EXECUTE 4f0082a0["16050"];
-PREPARE 4f0082a0 AS DELETE FROM public.rental WHERE "rental_id" = $1;
-EXECUTE 4f0082a0["16051"];
-COMMIT; -- {"xid":493,"lsn":"0/244EE70","timestamp":"2023-12-21 17:23:21.349496+0000"}
-BEGIN; -- {"xid":494,"lsn":"0/244EE70","timestamp":"2023-12-21 17:23:21.349657+0000","commit_lsn":"0/244F3F0"}
-PREPARE 32de52b9 AS UPDATE public.payment_p2022_02 SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
-EXECUTE 32de52b9["11.99","23757","116","2","14763","11.95","2022-02-11 03:52:25.634006+00"];
-PREPARE 32de52b9 AS UPDATE public.payment_p2022_02 SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
-EXECUTE 32de52b9["11.99","24866","237","2","11479","11.95","2022-02-07 18:37:34.579143+00"];
-PREPARE a5d9c563 AS UPDATE public.payment_p2022_03 SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
-EXECUTE a5d9c563["11.99","17055","196","2","106","11.95","2022-03-18 18:50:39.243747+00"];
-PREPARE a5d9c563 AS UPDATE public.payment_p2022_03 SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
-EXECUTE a5d9c563["11.99","28799","591","2","4383","11.95","2022-03-08 16:41:23.911522+00"];
-PREPARE 1d7c9a4f AS UPDATE public.payment_p2022_04 SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
-EXECUTE 1d7c9a4f["11.99","20403","362","1","14759","11.95","2022-04-16 04:35:36.904758+00"];
-PREPARE 7978edcc AS UPDATE public.payment_p2022_05 SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
-EXECUTE 7978edcc["11.99","17354","305","1","2166","11.95","2022-05-12 11:28:17.949049+00"];
-PREPARE 72ebfeff AS UPDATE public.payment_p2022_06 SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
-EXECUTE 72ebfeff["11.99","22650","204","2","15415","11.95","2022-06-11 11:17:22.428079+00"];
-PREPARE 72ebfeff AS UPDATE public.payment_p2022_06 SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
-EXECUTE 72ebfeff["11.99","24553","195","2","16040","11.95","2022-06-15 02:21:00.279776+00"];
-PREPARE 3b977bd8 AS UPDATE public.payment_p2022_07 SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
-EXECUTE 3b977bd8["11.99","28814","592","1","3973","11.95","2022-07-06 12:15:38.928947+00"];
-PREPARE 3b977bd8 AS UPDATE public.payment_p2022_07 SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
-EXECUTE 3b977bd8["11.99","29136","13","2","8831","11.95","2022-07-22 16:15:40.797771+00"];
-COMMIT; -- {"xid":494,"lsn":"0/244F3F0","timestamp":"2023-12-21 17:23:21.349657+0000"}
--- KEEPALIVE {"lsn":"0/244F3F0","timestamp":"2023-12-21 17:23:21.349789+0000"}
--- ENDPOS {"lsn":"0/244F3F0"}
+BEGIN; -- {"xid":489,"lsn":"0/24D2208","timestamp":"2024-05-08 11:10:09.242465+0000","commit_lsn":"0/24D4588"}
+PREPARE 58013803 AS INSERT INTO public.rental (rental_id, rental_date, inventory_id, customer_id, return_date, staff_id, last_update) overriding system value VALUES ($1, $2, $3, $4, $5, $6, $7), ($8, $9, $10, $11, $12, $13, $14);
+EXECUTE 58013803["16050","2022-06-01 00:00:00+00","371","291",null,"1","2022-06-01 00:00:00+00","16051","2022-06-01 00:00:00+00","373","293",null,"2","2022-06-01 00:00:00+00"];
+PREPARE dd147129 AS INSERT INTO public.payment_p2022_06 (payment_id, customer_id, staff_id, rental_id, amount, payment_date) overriding system value VALUES ($1, $2, $3, $4, $5, $6), ($7, $8, $9, $10, $11, $12);
+EXECUTE dd147129["32099","291","1","16050","5.99","2022-06-01 00:00:00+00","32100","293","2","16051","5.99","2022-06-01 00:00:00+00"];
+COMMIT; -- {"xid":489,"lsn":"0/24D4588","timestamp":"2024-05-08 11:10:09.242465+0000"}
+BEGIN; -- {"xid":490,"lsn":"0/24D4588","timestamp":"2024-05-08 11:10:09.242871+0000","commit_lsn":"0/24D5658"}
+PREPARE b44633db AS UPDATE public.payment_p2022_02 SET amount = $1 WHERE payment_id = $2 and customer_id = $3 and staff_id = $4 and rental_id = $5 and amount = $6 and payment_date = $7;
+EXECUTE b44633db["11.95","23757","116","2","14763","11.99","2022-02-11 03:52:25.634006+00"];
+PREPARE b44633db AS UPDATE public.payment_p2022_02 SET amount = $1 WHERE payment_id = $2 and customer_id = $3 and staff_id = $4 and rental_id = $5 and amount = $6 and payment_date = $7;
+EXECUTE b44633db["11.95","24866","237","2","11479","11.99","2022-02-07 18:37:34.579143+00"];
+PREPARE a7ce2dc4 AS UPDATE public.payment_p2022_03 SET amount = $1 WHERE payment_id = $2 and customer_id = $3 and staff_id = $4 and rental_id = $5 and amount = $6 and payment_date = $7;
+EXECUTE a7ce2dc4["11.95","17055","196","2","106","11.99","2022-03-18 18:50:39.243747+00"];
+PREPARE a7ce2dc4 AS UPDATE public.payment_p2022_03 SET amount = $1 WHERE payment_id = $2 and customer_id = $3 and staff_id = $4 and rental_id = $5 and amount = $6 and payment_date = $7;
+EXECUTE a7ce2dc4["11.95","28799","591","2","4383","11.99","2022-03-08 16:41:23.911522+00"];
+PREPARE a368a817 AS UPDATE public.payment_p2022_04 SET amount = $1 WHERE payment_id = $2 and customer_id = $3 and staff_id = $4 and rental_id = $5 and amount = $6 and payment_date = $7;
+EXECUTE a368a817["11.95","20403","362","1","14759","11.99","2022-04-16 04:35:36.904758+00"];
+PREPARE f53be34c AS UPDATE public.payment_p2022_05 SET amount = $1 WHERE payment_id = $2 and customer_id = $3 and staff_id = $4 and rental_id = $5 and amount = $6 and payment_date = $7;
+EXECUTE f53be34c["11.95","17354","305","1","2166","11.99","2022-05-12 11:28:17.949049+00"];
+PREPARE e6404448 AS UPDATE public.payment_p2022_06 SET amount = $1 WHERE payment_id = $2 and customer_id = $3 and staff_id = $4 and rental_id = $5 and amount = $6 and payment_date = $7;
+EXECUTE e6404448["11.95","22650","204","2","15415","11.99","2022-06-11 11:17:22.428079+00"];
+PREPARE e6404448 AS UPDATE public.payment_p2022_06 SET amount = $1 WHERE payment_id = $2 and customer_id = $3 and staff_id = $4 and rental_id = $5 and amount = $6 and payment_date = $7;
+EXECUTE e6404448["11.95","24553","195","2","16040","11.99","2022-06-15 02:21:00.279776+00"];
+PREPARE 4b3d4a5b AS UPDATE public.payment_p2022_07 SET amount = $1 WHERE payment_id = $2 and customer_id = $3 and staff_id = $4 and rental_id = $5 and amount = $6 and payment_date = $7;
+EXECUTE 4b3d4a5b["11.95","28814","592","1","3973","11.99","2022-07-06 12:15:38.928947+00"];
+PREPARE 4b3d4a5b AS UPDATE public.payment_p2022_07 SET amount = $1 WHERE payment_id = $2 and customer_id = $3 and staff_id = $4 and rental_id = $5 and amount = $6 and payment_date = $7;
+EXECUTE 4b3d4a5b["11.95","29136","13","2","8831","11.99","2022-07-22 16:15:40.797771+00"];
+COMMIT; -- {"xid":490,"lsn":"0/24D5658","timestamp":"2024-05-08 11:10:09.242871+0000"}
+BEGIN; -- {"xid":491,"lsn":"0/24D5818","timestamp":"2024-05-08 11:10:09.242917+0000","commit_lsn":"0/24D59C8"}
+PREPARE e1d51ac7 AS DELETE FROM public.payment_p2022_06 WHERE payment_id = $1 and customer_id = $2 and staff_id = $3 and rental_id = $4 and amount = $5 and payment_date = $6;
+EXECUTE e1d51ac7["32099","291","1","16050","5.99","2022-06-01 00:00:00+00"];
+PREPARE e1d51ac7 AS DELETE FROM public.payment_p2022_06 WHERE payment_id = $1 and customer_id = $2 and staff_id = $3 and rental_id = $4 and amount = $5 and payment_date = $6;
+EXECUTE e1d51ac7["32100","293","2","16051","5.99","2022-06-01 00:00:00+00"];
+PREPARE 3f2797d9 AS DELETE FROM public.rental WHERE rental_id = $1;
+EXECUTE 3f2797d9["16050"];
+PREPARE 3f2797d9 AS DELETE FROM public.rental WHERE rental_id = $1;
+EXECUTE 3f2797d9["16051"];
+COMMIT; -- {"xid":491,"lsn":"0/24D59C8","timestamp":"2024-05-08 11:10:09.242917+0000"}
+BEGIN; -- {"xid":492,"lsn":"0/24D59C8","timestamp":"2024-05-08 11:10:09.243006+0000","commit_lsn":"0/24D5F48"}
+PREPARE b44633db AS UPDATE public.payment_p2022_02 SET amount = $1 WHERE payment_id = $2 and customer_id = $3 and staff_id = $4 and rental_id = $5 and amount = $6 and payment_date = $7;
+EXECUTE b44633db["11.99","23757","116","2","14763","11.95","2022-02-11 03:52:25.634006+00"];
+PREPARE b44633db AS UPDATE public.payment_p2022_02 SET amount = $1 WHERE payment_id = $2 and customer_id = $3 and staff_id = $4 and rental_id = $5 and amount = $6 and payment_date = $7;
+EXECUTE b44633db["11.99","24866","237","2","11479","11.95","2022-02-07 18:37:34.579143+00"];
+PREPARE a7ce2dc4 AS UPDATE public.payment_p2022_03 SET amount = $1 WHERE payment_id = $2 and customer_id = $3 and staff_id = $4 and rental_id = $5 and amount = $6 and payment_date = $7;
+EXECUTE a7ce2dc4["11.99","17055","196","2","106","11.95","2022-03-18 18:50:39.243747+00"];
+PREPARE a7ce2dc4 AS UPDATE public.payment_p2022_03 SET amount = $1 WHERE payment_id = $2 and customer_id = $3 and staff_id = $4 and rental_id = $5 and amount = $6 and payment_date = $7;
+EXECUTE a7ce2dc4["11.99","28799","591","2","4383","11.95","2022-03-08 16:41:23.911522+00"];
+PREPARE a368a817 AS UPDATE public.payment_p2022_04 SET amount = $1 WHERE payment_id = $2 and customer_id = $3 and staff_id = $4 and rental_id = $5 and amount = $6 and payment_date = $7;
+EXECUTE a368a817["11.99","20403","362","1","14759","11.95","2022-04-16 04:35:36.904758+00"];
+PREPARE f53be34c AS UPDATE public.payment_p2022_05 SET amount = $1 WHERE payment_id = $2 and customer_id = $3 and staff_id = $4 and rental_id = $5 and amount = $6 and payment_date = $7;
+EXECUTE f53be34c["11.99","17354","305","1","2166","11.95","2022-05-12 11:28:17.949049+00"];
+PREPARE e6404448 AS UPDATE public.payment_p2022_06 SET amount = $1 WHERE payment_id = $2 and customer_id = $3 and staff_id = $4 and rental_id = $5 and amount = $6 and payment_date = $7;
+EXECUTE e6404448["11.99","22650","204","2","15415","11.95","2022-06-11 11:17:22.428079+00"];
+PREPARE e6404448 AS UPDATE public.payment_p2022_06 SET amount = $1 WHERE payment_id = $2 and customer_id = $3 and staff_id = $4 and rental_id = $5 and amount = $6 and payment_date = $7;
+EXECUTE e6404448["11.99","24553","195","2","16040","11.95","2022-06-15 02:21:00.279776+00"];
+PREPARE 4b3d4a5b AS UPDATE public.payment_p2022_07 SET amount = $1 WHERE payment_id = $2 and customer_id = $3 and staff_id = $4 and rental_id = $5 and amount = $6 and payment_date = $7;
+EXECUTE 4b3d4a5b["11.99","28814","592","1","3973","11.95","2022-07-06 12:15:38.928947+00"];
+PREPARE 4b3d4a5b AS UPDATE public.payment_p2022_07 SET amount = $1 WHERE payment_id = $2 and customer_id = $3 and staff_id = $4 and rental_id = $5 and amount = $6 and payment_date = $7;
+EXECUTE 4b3d4a5b["11.99","29136","13","2","8831","11.95","2022-07-22 16:15:40.797771+00"];
+COMMIT; -- {"xid":492,"lsn":"0/24D5F48","timestamp":"2024-05-08 11:10:09.243006+0000"}
+-- KEEPALIVE {"lsn":"0/24D5F48","timestamp":"2024-05-08 11:10:09.243014+0000"}
+-- ENDPOS {"lsn":"0/24D5F48"}

--- a/tests/cdc-test-decoding/000000010000000000000002.sql
+++ b/tests/cdc-test-decoding/000000010000000000000002.sql
@@ -1,76 +1,76 @@
-BEGIN; -- {"xid":492,"lsn":"0/24DD738","timestamp":"2024-04-17 12:28:50.815089+0000","commit_lsn":"0/24DDBA0"}
-PREPARE 8ffad89d AS INSERT INTO public.rental ("rental_id", "rental_date", "inventory_id", "customer_id", "return_date", "staff_id", "last_update") overriding system value VALUES ($1, $2, $3, $4, $5, $6, $7);
-EXECUTE 8ffad89d["16050","2022-06-01 00:00:00+00","371","291",null,"1","2022-06-01 00:00:00+00"];
-PREPARE 1825441d AS INSERT INTO public.payment_p2022_06 ("payment_id", "customer_id", "staff_id", "rental_id", "amount", "payment_date") overriding system value VALUES ($1, $2, $3, $4, $5, $6);
-EXECUTE 1825441d["32099","291","1","16050","5.99","2022-06-01 00:00:00+00"];
-COMMIT; -- {"xid":492,"lsn":"0/24DDBA0","timestamp":"2024-04-17 12:28:50.815089+0000"}
-BEGIN; -- {"xid":493,"lsn":"0/24DDBA0","timestamp":"2024-04-17 12:28:50.815524+0000","commit_lsn":"0/24DEC88"}
-PREPARE 32de52b9 AS UPDATE public.payment_p2022_02 SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
-EXECUTE 32de52b9["11.95","23757","116","2","14763","11.99","2022-02-11 03:52:25.634006+00"];
-PREPARE 32de52b9 AS UPDATE public.payment_p2022_02 SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
-EXECUTE 32de52b9["11.95","24866","237","2","11479","11.99","2022-02-07 18:37:34.579143+00"];
-PREPARE a5d9c563 AS UPDATE public.payment_p2022_03 SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
-EXECUTE a5d9c563["11.95","17055","196","2","106","11.99","2022-03-18 18:50:39.243747+00"];
-PREPARE a5d9c563 AS UPDATE public.payment_p2022_03 SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
-EXECUTE a5d9c563["11.95","28799","591","2","4383","11.99","2022-03-08 16:41:23.911522+00"];
-PREPARE 1d7c9a4f AS UPDATE public.payment_p2022_04 SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
-EXECUTE 1d7c9a4f["11.95","20403","362","1","14759","11.99","2022-04-16 04:35:36.904758+00"];
-PREPARE 7978edcc AS UPDATE public.payment_p2022_05 SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
-EXECUTE 7978edcc["11.95","17354","305","1","2166","11.99","2022-05-12 11:28:17.949049+00"];
-PREPARE 72ebfeff AS UPDATE public.payment_p2022_06 SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
-EXECUTE 72ebfeff["11.95","22650","204","2","15415","11.99","2022-06-11 11:17:22.428079+00"];
-PREPARE 72ebfeff AS UPDATE public.payment_p2022_06 SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
-EXECUTE 72ebfeff["11.95","24553","195","2","16040","11.99","2022-06-15 02:21:00.279776+00"];
-PREPARE 3b977bd8 AS UPDATE public.payment_p2022_07 SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
-EXECUTE 3b977bd8["11.95","28814","592","1","3973","11.99","2022-07-06 12:15:38.928947+00"];
-PREPARE 3b977bd8 AS UPDATE public.payment_p2022_07 SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
-EXECUTE 3b977bd8["11.95","29136","13","2","8831","11.99","2022-07-22 16:15:40.797771+00"];
-COMMIT; -- {"xid":493,"lsn":"0/24DEC88","timestamp":"2024-04-17 12:28:50.815524+0000"}
-BEGIN; -- {"xid":494,"lsn":"0/24DEE48","timestamp":"2024-04-17 12:28:50.815594+0000","commit_lsn":"0/24DEF58"}
-PREPARE 2fa3c9c9 AS DELETE FROM public.payment_p2022_06 WHERE "payment_id" = $1 and "customer_id" = $2 and "staff_id" = $3 and "rental_id" = $4 and "amount" = $5 and "payment_date" = $6;
-EXECUTE 2fa3c9c9["32099","291","1","16050","5.99","2022-06-01 00:00:00+00"];
-PREPARE 4f0082a0 AS DELETE FROM public.rental WHERE "rental_id" = $1;
-EXECUTE 4f0082a0["16050"];
-COMMIT; -- {"xid":494,"lsn":"0/24DEF58","timestamp":"2024-04-17 12:28:50.815594+0000"}
-BEGIN; -- {"xid":495,"lsn":"0/24DEF58","timestamp":"2024-04-17 12:28:50.815773+0000","commit_lsn":"0/24DF4D8"}
-PREPARE 32de52b9 AS UPDATE public.payment_p2022_02 SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
-EXECUTE 32de52b9["11.99","23757","116","2","14763","11.95","2022-02-11 03:52:25.634006+00"];
-PREPARE 32de52b9 AS UPDATE public.payment_p2022_02 SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
-EXECUTE 32de52b9["11.99","24866","237","2","11479","11.95","2022-02-07 18:37:34.579143+00"];
-PREPARE a5d9c563 AS UPDATE public.payment_p2022_03 SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
-EXECUTE a5d9c563["11.99","17055","196","2","106","11.95","2022-03-18 18:50:39.243747+00"];
-PREPARE a5d9c563 AS UPDATE public.payment_p2022_03 SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
-EXECUTE a5d9c563["11.99","28799","591","2","4383","11.95","2022-03-08 16:41:23.911522+00"];
-PREPARE 1d7c9a4f AS UPDATE public.payment_p2022_04 SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
-EXECUTE 1d7c9a4f["11.99","20403","362","1","14759","11.95","2022-04-16 04:35:36.904758+00"];
-PREPARE 7978edcc AS UPDATE public.payment_p2022_05 SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
-EXECUTE 7978edcc["11.99","17354","305","1","2166","11.95","2022-05-12 11:28:17.949049+00"];
-PREPARE 72ebfeff AS UPDATE public.payment_p2022_06 SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
-EXECUTE 72ebfeff["11.99","22650","204","2","15415","11.95","2022-06-11 11:17:22.428079+00"];
-PREPARE 72ebfeff AS UPDATE public.payment_p2022_06 SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
-EXECUTE 72ebfeff["11.99","24553","195","2","16040","11.95","2022-06-15 02:21:00.279776+00"];
-PREPARE 3b977bd8 AS UPDATE public.payment_p2022_07 SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
-EXECUTE 3b977bd8["11.99","28814","592","1","3973","11.95","2022-07-06 12:15:38.928947+00"];
-PREPARE 3b977bd8 AS UPDATE public.payment_p2022_07 SET "amount" = $1 WHERE "payment_id" = $2 and "customer_id" = $3 and "staff_id" = $4 and "rental_id" = $5 and "amount" = $6 and "payment_date" = $7;
-EXECUTE 3b977bd8["11.99","29136","13","2","8831","11.95","2022-07-22 16:15:40.797771+00"];
-COMMIT; -- {"xid":495,"lsn":"0/24DF4D8","timestamp":"2024-04-17 12:28:50.815773+0000"}
-BEGIN; -- {"xid":496,"lsn":"0/24DF4D8","timestamp":"2024-04-17 12:28:50.815898+0000","commit_lsn":"0/24DF688"}
-PREPARE 87f8bc56 AS UPDATE public.staff SET "first_name" = $1, "last_name" = $2, "address_id" = $3, "email" = $4, "store_id" = $5, "active" = $6, "username" = $7, "password" = $8, "last_update" = $9, "picture" = $10 WHERE "staff_id" = $11;
-EXECUTE 87f8bc56["Warner","Hudson","45","hartmann1448@ratkehaley.com","25","true","fay.kub","8cb2237d0679ca88db6464eac60da96345513964","2024-04-17 12:28:50.695367+00",null,"1"];
-COMMIT; -- {"xid":496,"lsn":"0/24DF688","timestamp":"2024-04-17 12:28:50.815898+0000"}
-BEGIN; -- {"xid":497,"lsn":"0/24DF688","timestamp":"2024-04-17 12:28:50.815962+0000","commit_lsn":"0/24DF760"}
-PREPARE 5eff0dcd AS INSERT INTO public."""dqname""" ("id") overriding system value VALUES ($1);
-EXECUTE 5eff0dcd["1"];
-COMMIT; -- {"xid":497,"lsn":"0/24DF760","timestamp":"2024-04-17 12:28:50.815962+0000"}
-BEGIN; -- {"xid":498,"lsn":"0/24DF760","timestamp":"2024-04-17 12:28:50.816023+0000","commit_lsn":"0/24DF880"}
+BEGIN; -- {"xid":492,"lsn":"0/24DDF80","timestamp":"2024-05-08 11:10:15.239495+0000","commit_lsn":"0/24DE400"}
+PREPARE d003ca15 AS INSERT INTO public.rental (rental_id, rental_date, inventory_id, customer_id, return_date, staff_id, last_update) overriding system value VALUES ($1, $2, $3, $4, $5, $6, $7);
+EXECUTE d003ca15["16050","2022-06-01 00:00:00+00","371","291",null,"1","2022-06-01 00:00:00+00"];
+PREPARE eba75101 AS INSERT INTO public.payment_p2022_06 (payment_id, customer_id, staff_id, rental_id, amount, payment_date) overriding system value VALUES ($1, $2, $3, $4, $5, $6);
+EXECUTE eba75101["32099","291","1","16050","5.99","2022-06-01 00:00:00+00"];
+COMMIT; -- {"xid":492,"lsn":"0/24DE400","timestamp":"2024-05-08 11:10:15.239495+0000"}
+BEGIN; -- {"xid":493,"lsn":"0/24DE400","timestamp":"2024-05-08 11:10:15.239859+0000","commit_lsn":"0/24DF4D0"}
+PREPARE b44633db AS UPDATE public.payment_p2022_02 SET amount = $1 WHERE payment_id = $2 and customer_id = $3 and staff_id = $4 and rental_id = $5 and amount = $6 and payment_date = $7;
+EXECUTE b44633db["11.95","23757","116","2","14763","11.99","2022-02-11 03:52:25.634006+00"];
+PREPARE b44633db AS UPDATE public.payment_p2022_02 SET amount = $1 WHERE payment_id = $2 and customer_id = $3 and staff_id = $4 and rental_id = $5 and amount = $6 and payment_date = $7;
+EXECUTE b44633db["11.95","24866","237","2","11479","11.99","2022-02-07 18:37:34.579143+00"];
+PREPARE a7ce2dc4 AS UPDATE public.payment_p2022_03 SET amount = $1 WHERE payment_id = $2 and customer_id = $3 and staff_id = $4 and rental_id = $5 and amount = $6 and payment_date = $7;
+EXECUTE a7ce2dc4["11.95","17055","196","2","106","11.99","2022-03-18 18:50:39.243747+00"];
+PREPARE a7ce2dc4 AS UPDATE public.payment_p2022_03 SET amount = $1 WHERE payment_id = $2 and customer_id = $3 and staff_id = $4 and rental_id = $5 and amount = $6 and payment_date = $7;
+EXECUTE a7ce2dc4["11.95","28799","591","2","4383","11.99","2022-03-08 16:41:23.911522+00"];
+PREPARE a368a817 AS UPDATE public.payment_p2022_04 SET amount = $1 WHERE payment_id = $2 and customer_id = $3 and staff_id = $4 and rental_id = $5 and amount = $6 and payment_date = $7;
+EXECUTE a368a817["11.95","20403","362","1","14759","11.99","2022-04-16 04:35:36.904758+00"];
+PREPARE f53be34c AS UPDATE public.payment_p2022_05 SET amount = $1 WHERE payment_id = $2 and customer_id = $3 and staff_id = $4 and rental_id = $5 and amount = $6 and payment_date = $7;
+EXECUTE f53be34c["11.95","17354","305","1","2166","11.99","2022-05-12 11:28:17.949049+00"];
+PREPARE e6404448 AS UPDATE public.payment_p2022_06 SET amount = $1 WHERE payment_id = $2 and customer_id = $3 and staff_id = $4 and rental_id = $5 and amount = $6 and payment_date = $7;
+EXECUTE e6404448["11.95","22650","204","2","15415","11.99","2022-06-11 11:17:22.428079+00"];
+PREPARE e6404448 AS UPDATE public.payment_p2022_06 SET amount = $1 WHERE payment_id = $2 and customer_id = $3 and staff_id = $4 and rental_id = $5 and amount = $6 and payment_date = $7;
+EXECUTE e6404448["11.95","24553","195","2","16040","11.99","2022-06-15 02:21:00.279776+00"];
+PREPARE 4b3d4a5b AS UPDATE public.payment_p2022_07 SET amount = $1 WHERE payment_id = $2 and customer_id = $3 and staff_id = $4 and rental_id = $5 and amount = $6 and payment_date = $7;
+EXECUTE 4b3d4a5b["11.95","28814","592","1","3973","11.99","2022-07-06 12:15:38.928947+00"];
+PREPARE 4b3d4a5b AS UPDATE public.payment_p2022_07 SET amount = $1 WHERE payment_id = $2 and customer_id = $3 and staff_id = $4 and rental_id = $5 and amount = $6 and payment_date = $7;
+EXECUTE 4b3d4a5b["11.95","29136","13","2","8831","11.99","2022-07-22 16:15:40.797771+00"];
+COMMIT; -- {"xid":493,"lsn":"0/24DF4D0","timestamp":"2024-05-08 11:10:15.239859+0000"}
+BEGIN; -- {"xid":494,"lsn":"0/24DF690","timestamp":"2024-05-08 11:10:15.239919+0000","commit_lsn":"0/24DF7A0"}
+PREPARE e1d51ac7 AS DELETE FROM public.payment_p2022_06 WHERE payment_id = $1 and customer_id = $2 and staff_id = $3 and rental_id = $4 and amount = $5 and payment_date = $6;
+EXECUTE e1d51ac7["32099","291","1","16050","5.99","2022-06-01 00:00:00+00"];
+PREPARE 3f2797d9 AS DELETE FROM public.rental WHERE rental_id = $1;
+EXECUTE 3f2797d9["16050"];
+COMMIT; -- {"xid":494,"lsn":"0/24DF7A0","timestamp":"2024-05-08 11:10:15.239919+0000"}
+BEGIN; -- {"xid":495,"lsn":"0/24DF7A0","timestamp":"2024-05-08 11:10:15.240058+0000","commit_lsn":"0/24DFD20"}
+PREPARE b44633db AS UPDATE public.payment_p2022_02 SET amount = $1 WHERE payment_id = $2 and customer_id = $3 and staff_id = $4 and rental_id = $5 and amount = $6 and payment_date = $7;
+EXECUTE b44633db["11.99","23757","116","2","14763","11.95","2022-02-11 03:52:25.634006+00"];
+PREPARE b44633db AS UPDATE public.payment_p2022_02 SET amount = $1 WHERE payment_id = $2 and customer_id = $3 and staff_id = $4 and rental_id = $5 and amount = $6 and payment_date = $7;
+EXECUTE b44633db["11.99","24866","237","2","11479","11.95","2022-02-07 18:37:34.579143+00"];
+PREPARE a7ce2dc4 AS UPDATE public.payment_p2022_03 SET amount = $1 WHERE payment_id = $2 and customer_id = $3 and staff_id = $4 and rental_id = $5 and amount = $6 and payment_date = $7;
+EXECUTE a7ce2dc4["11.99","17055","196","2","106","11.95","2022-03-18 18:50:39.243747+00"];
+PREPARE a7ce2dc4 AS UPDATE public.payment_p2022_03 SET amount = $1 WHERE payment_id = $2 and customer_id = $3 and staff_id = $4 and rental_id = $5 and amount = $6 and payment_date = $7;
+EXECUTE a7ce2dc4["11.99","28799","591","2","4383","11.95","2022-03-08 16:41:23.911522+00"];
+PREPARE a368a817 AS UPDATE public.payment_p2022_04 SET amount = $1 WHERE payment_id = $2 and customer_id = $3 and staff_id = $4 and rental_id = $5 and amount = $6 and payment_date = $7;
+EXECUTE a368a817["11.99","20403","362","1","14759","11.95","2022-04-16 04:35:36.904758+00"];
+PREPARE f53be34c AS UPDATE public.payment_p2022_05 SET amount = $1 WHERE payment_id = $2 and customer_id = $3 and staff_id = $4 and rental_id = $5 and amount = $6 and payment_date = $7;
+EXECUTE f53be34c["11.99","17354","305","1","2166","11.95","2022-05-12 11:28:17.949049+00"];
+PREPARE e6404448 AS UPDATE public.payment_p2022_06 SET amount = $1 WHERE payment_id = $2 and customer_id = $3 and staff_id = $4 and rental_id = $5 and amount = $6 and payment_date = $7;
+EXECUTE e6404448["11.99","22650","204","2","15415","11.95","2022-06-11 11:17:22.428079+00"];
+PREPARE e6404448 AS UPDATE public.payment_p2022_06 SET amount = $1 WHERE payment_id = $2 and customer_id = $3 and staff_id = $4 and rental_id = $5 and amount = $6 and payment_date = $7;
+EXECUTE e6404448["11.99","24553","195","2","16040","11.95","2022-06-15 02:21:00.279776+00"];
+PREPARE 4b3d4a5b AS UPDATE public.payment_p2022_07 SET amount = $1 WHERE payment_id = $2 and customer_id = $3 and staff_id = $4 and rental_id = $5 and amount = $6 and payment_date = $7;
+EXECUTE 4b3d4a5b["11.99","28814","592","1","3973","11.95","2022-07-06 12:15:38.928947+00"];
+PREPARE 4b3d4a5b AS UPDATE public.payment_p2022_07 SET amount = $1 WHERE payment_id = $2 and customer_id = $3 and staff_id = $4 and rental_id = $5 and amount = $6 and payment_date = $7;
+EXECUTE 4b3d4a5b["11.99","29136","13","2","8831","11.95","2022-07-22 16:15:40.797771+00"];
+COMMIT; -- {"xid":495,"lsn":"0/24DFD20","timestamp":"2024-05-08 11:10:15.240058+0000"}
+BEGIN; -- {"xid":496,"lsn":"0/24DFD20","timestamp":"2024-05-08 11:10:15.240218+0000","commit_lsn":"0/24DFED0"}
+PREPARE 65b94c7d AS UPDATE public.staff SET first_name = $1, last_name = $2, address_id = $3, email = $4, store_id = $5, active = $6, username = $7, password = $8, last_update = $9, picture = $10 WHERE staff_id = $11;
+EXECUTE 65b94c7d["Warner","Hudson","45","hartmann1448@ratkehaley.com","25","true","fay.kub","8cb2237d0679ca88db6464eac60da96345513964","2024-05-08 11:10:15.147146+00",null,"1"];
+COMMIT; -- {"xid":496,"lsn":"0/24DFED0","timestamp":"2024-05-08 11:10:15.240218+0000"}
+BEGIN; -- {"xid":497,"lsn":"0/24DFED0","timestamp":"2024-05-08 11:10:15.240285+0000","commit_lsn":"0/24DFFA8"}
+PREPARE 4835081e AS INSERT INTO public."""dqname""" (id) overriding system value VALUES ($1);
+EXECUTE 4835081e["1"];
+COMMIT; -- {"xid":497,"lsn":"0/24DFFA8","timestamp":"2024-05-08 11:10:15.240285+0000"}
+BEGIN; -- {"xid":498,"lsn":"0/24DFFA8","timestamp":"2024-05-08 11:10:15.240338+0000","commit_lsn":"0/24E00E0"}
 PREPARE 7a201c42 AS INSERT INTO public.identifer_as_column ("time") overriding system value VALUES ($1);
 EXECUTE 7a201c42["1"];
 PREPARE df296f92 AS DELETE FROM public.identifer_as_column WHERE "time" = $1;
 EXECUTE df296f92["1"];
-COMMIT; -- {"xid":498,"lsn":"0/24DF880","timestamp":"2024-04-17 12:28:50.816023+0000"}
-BEGIN; -- {"xid":499,"lsn":"0/24DF880","timestamp":"2024-04-17 12:28:50.816094+0000","commit_lsn":"0/24DF938"}
-PREPARE 757be8dc AS INSERT INTO public.t_bit_types ("id", "a", "b") overriding system value VALUES ($1, $2, $3);
-EXECUTE 757be8dc["2","100","101"];
-COMMIT; -- {"xid":499,"lsn":"0/24DF938","timestamp":"2024-04-17 12:28:50.816094+0000"}
--- KEEPALIVE {"lsn":"0/24DF938","timestamp":"2024-04-17 12:28:50.816107+0000"}
--- ENDPOS {"lsn":"0/24DF938"}
+COMMIT; -- {"xid":498,"lsn":"0/24E00E0","timestamp":"2024-05-08 11:10:15.240338+0000"}
+BEGIN; -- {"xid":499,"lsn":"0/24E00E0","timestamp":"2024-05-08 11:10:15.240400+0000","commit_lsn":"0/24E0198"}
+PREPARE 15aec07e AS INSERT INTO public.t_bit_types (id, a, b) overriding system value VALUES ($1, $2, $3);
+EXECUTE 15aec07e["2","100","101"];
+COMMIT; -- {"xid":499,"lsn":"0/24E0198","timestamp":"2024-05-08 11:10:15.240400+0000"}
+-- KEEPALIVE {"lsn":"0/24E0198","timestamp":"2024-05-08 11:10:15.240411+0000"}
+-- ENDPOS {"lsn":"0/24E0198"}

--- a/tests/cdc-test-decoding/continued-txn.sql
+++ b/tests/cdc-test-decoding/continued-txn.sql
@@ -1,4 +1,4 @@
-PREPARE c5019553 AS INSERT INTO public.readings ("time", "tags_id", "latitude", "longitude", "elevation", "velocity", "heading", "grade", "fuel_consumption", "additional_tags") overriding system value VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10);
-EXECUTE c5019553["2017-07-15 02:54:30+00","48","3.46436","68.56976","115","55","30","78","1.8",null];
+PREPARE b286b954 AS INSERT INTO public.readings ("time", tags_id, latitude, longitude, elevation, velocity, heading, grade, fuel_consumption, additional_tags) overriding system value VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10);
+EXECUTE b286b954["2017-07-15 02:54:30+00","48","3.46436","68.56976","115","55","30","78","1.8",null];
 COMMIT; -- {"xid":6730937,"lsn":"6F/14003AD8","timestamp":"2024-02-22 19:55:32.604741+0000"}
 -- SWITCH WAL {"lsn":"6F/15004368"}


### PR DESCRIPTION
Reverts https://github.com/dimitri/pgcopydb/pull/482

Previously, identifiers coming from the wal2json plugin weren't escaped, and we applied escaping to them while transforming to SQL. However, we recently added proper escaping for all identifiers coming from wal2json [1] using PQescapeIdentifier, which obsoletes the need for escaping in ld_transform.c.

[1] https://github.com/dimitri/pgcopydb/pull/663