### PR TITLE
Sentinel is updated for every commit

### DIFF
--- a/src/bin/pgcopydb/ld_apply.c
+++ b/src/bin/pgcopydb/ld_apply.c
@@ -415,6 +415,7 @@ stream_apply_sync_sentinel(StreamApplyContext *context, bool findDurableLSN)
 	context->apply = sentinel.apply;
 	context->endpos = sentinel.endpos;
 	context->startpos = sentinel.startpos;
+	context->sentinelSyncTime = time(NULL);
 
 	log_debug("stream_apply_sync_sentinel: "
 			  "write_lsn %X/%X flush_lsn %X/%X replay_lsn %X/%X "


### PR DESCRIPTION
We used to track last sentinel sync time and update sentinel for every 1 sec. However, the change[1] which adopted sqlite to track sentinel removed the last updated time assignment[2] leading to sentinel write
for every commit message causes replay slowness by almost 6 times.

Solution: Track last sentinel update time

Without the fix, the following snippet will be always executed because `1 < (now - context->sentinelSyncTime)` will be always true!

https://github.com/dimitri/pgcopydb/blob/812a108976b43738ac81dd4fce060851d55076f8/src/bin/pgcopydb/ld_replay.c#L170-L179

[1] https://github.com/dimitri/pgcopydb/pull/601
[2] https://github.com/dimitri/pgcopydb/pull/601/files#diff-481cd5fcd15742c022e2a18916c7a508cc7c7d46c264084daab85200e1b10004L477


### Before this PR, 
```
cat ~/dimitri/bench_new.sql | time pgcopydb stream apply --resume --not-consistent -
14:24:27.034 1550353 INFO   Running pgcopydb version 0.0.13.5.g6a1c2f8.dirty from "/home/ubuntu/dimitri/pgcopydb/src/bin/pgcopydb/pgcopydb"
14:24:27.082 1550353 INFO   Using work dir "/tmp/pgcopydb"
14:24:27.155 1550353 INFO   Setting up previous LSN from replication origin "pgcopydb" progress at 0/0, overriding previous value D8/959B48C0
14:24:27.156 1550353 INFO   Catchup-up with changes from LSN 0/0
pgcopydb stream apply --resume --not-consistent -  7.93s user 6.78s system 9% cpu 2:30.66 total
```

### After this PR,

```
cat ~/dimitri/bench_new.sql | time pgcopydb stream apply --resume --not-consistent -
14:47:05.704 1551251 INFO   Running pgcopydb version 0.0.13.5.g6a1c2f8.dirty from "/home/ubuntu/dimitri/pgcopydb/src/bin/pgcopydb/pgcopydb"
14:47:05.752 1551251 INFO   Using work dir "/tmp/pgcopydb"
14:47:05.824 1551251 INFO   Setting up previous LSN from replication origin "pgcopydb" progress at 0/0, overriding previous value D8/95A663C8
14:47:05.825 1551251 INFO   Catchup-up with changes from LSN 0/0
pgcopydb stream apply --resume --not-consistent -  8.76s user 3.24s system 57% cpu 20.883 total
```

### Gain:

(2m, 30 sec - 21 sec) / 21 sec =  ~6.1 times
