### PR TITLE
Allow identity based sequences to be found and reset

### DIFF
--- a/src/bin/pgcopydb/schema.c
+++ b/src/bin/pgcopydb/schema.c
@@ -1897,8 +1897,8 @@ struct FilteringQueries listSourceSequencesSQL[] = {
 		"       left join pg_depend d2 on d2.refobjid = s.seqoid "
 		"        and d2.refclassid = 'pg_class'::regclass "
 		"        and d2.classid = 'pg_attrdef'::regclass "
-		"       join pg_attrdef a on a.oid = d2.objid "
-		"       join pg_attribute at "
+		"       left join pg_attrdef a on a.oid = d2.objid "
+		"       left join pg_attribute at "
 		"         on at.attrelid = a.adrelid "
 		"        and at.attnum = a.adnum "
 
@@ -1976,16 +1976,16 @@ struct FilteringQueries listSourceSequencesSQL[] = {
 		"       left join pg_depend d2 on d2.refobjid = s.seqoid "
 		"        and d2.refclassid = 'pg_class'::regclass "
 		"        and d2.classid = 'pg_attrdef'::regclass "
-		"       join pg_attrdef a on a.oid = d2.objid "
-		"       join pg_attribute at "
+		"       left join pg_attrdef a on a.oid = d2.objid "
+		"       left join pg_attribute at "
 		"         on at.attrelid = a.adrelid "
 		"        and at.attnum = a.adnum "
 
 		"       left join pg_class r1 on r1.oid = d1.refobjid "
-		"       join pg_namespace rn1 on rn1.oid = r1.relnamespace "
+		"       left join pg_namespace rn1 on rn1.oid = r1.relnamespace "
 
 		"       left join pg_class r2 on r2.oid = at.attrelid  "
-		"       join pg_namespace rn2 on rn2.oid = r2.relnamespace "
+		"       left join pg_namespace rn2 on rn2.oid = r2.relnamespace "
 
 		/* exclude-schema */
 		"      left join pg_temp.filter_exclude_schema fn1 "
@@ -2013,7 +2013,7 @@ struct FilteringQueries listSourceSequencesSQL[] = {
 		"            and r2.relname = ftd2.relname "
 
 		/* WHERE clause for exclusion filters */
-		"     where case when r1.oid = r2.oid "
+		"     where case when r2.oid is null or r1.oid = r2.oid"
 		"           then rn1.nspname is not null and fn1.nspname is null "
 		"            and r1.relname is not null and ft1.relname is null "
 		"            and r1.relname is not null and ftd1.relname is null "
@@ -2079,8 +2079,8 @@ struct FilteringQueries listSourceSequencesSQL[] = {
 		"       left join pg_depend d2 on d2.refobjid = s.seqoid "
 		"        and d2.refclassid = 'pg_class'::regclass "
 		"        and d2.classid = 'pg_attrdef'::regclass "
-		"       join pg_attrdef a on a.oid = d2.objid "
-		"       join pg_attribute at "
+		"       left join pg_attrdef a on a.oid = d2.objid "
+		"       left join pg_attribute at "
 		"         on at.attrelid = a.adrelid "
 		"        and at.attnum = a.adnum "
 
@@ -2158,16 +2158,16 @@ struct FilteringQueries listSourceSequencesSQL[] = {
 		"       left join pg_depend d2 on d2.refobjid = s.seqoid "
 		"        and d2.refclassid = 'pg_class'::regclass "
 		"        and d2.classid = 'pg_attrdef'::regclass "
-		"       join pg_attrdef a on a.oid = d2.objid "
-		"       join pg_attribute at "
+		"       left join pg_attrdef a on a.oid = d2.objid "
+		"       left join pg_attribute at "
 		"         on at.attrelid = a.adrelid "
 		"        and at.attnum = a.adnum "
 
 		"       left join pg_class r1 on r1.oid = d1.refobjid "
-		"       join pg_namespace rn1 on rn1.oid = r1.relnamespace "
+		"       left join pg_namespace rn1 on rn1.oid = r1.relnamespace "
 
 		"       left join pg_class r2 on r2.oid = at.attrelid  "
-		"       join pg_namespace rn2 on rn2.oid = r2.relnamespace "
+		"       left join pg_namespace rn2 on rn2.oid = r2.relnamespace "
 
 		/* exclude-schema */
 		"      left join pg_temp.filter_exclude_schema fn "

--- a/tests/pagila/copydb.sh
+++ b/tests/pagila/copydb.sh
@@ -45,15 +45,6 @@ create schema "With a space";
 create extension seg schema "With a space" cascade;
 EOF
 
-# Create sequences and tables to ensure they get reset.
-psql -d ${PAGILA_SOURCE_PGURI} <<EOF
-create sequence normal_table_id_seq;
-create table normal_table (id integer primary key default nextval('normal_table_id_seq'));
-create table identity_table (id integer primary key generated always as identity);
-select setval('identity_table_id_seq', 667);
-select setval('normal_table_id_seq', 667);
-EOF
-
 # Create a couple of schemas in the target database
 # to ensure they get skipped during the clone
 psql -d ${PAGILA_TARGET_PGURI} <<EOF
@@ -79,6 +70,3 @@ pgcopydb compare schema \
 pgcopydb compare data \
          --source ${PAGILA_SOURCE_PGURI} \
          --target ${PAGILA_TARGET_PGURI}
-
-psql -d ${PAGILA_TARGET_PGURI} -c "select last_value from identity_table_id_seq;" | grep -q 667
-psql -d ${PAGILA_TARGET_PGURI} -c "select last_value from normal_table_id_seq;" | grep -q 667

--- a/tests/pagila/copydb.sh
+++ b/tests/pagila/copydb.sh
@@ -80,10 +80,5 @@ pgcopydb compare data \
          --source ${PAGILA_SOURCE_PGURI} \
          --target ${PAGILA_TARGET_PGURI}
 
-psql -d ${PAGILA_TARGET_PGURI} <<EOF
-select last_value from identity_table_id_seq;
-EOF | grep -q 667
-
-psql -d ${PAGILA_TARGET_PGURI} <<EOF
-select last_value from normal_table_id_seq;
-EOF | grep -q 667
+psql -d ${PAGILA_TARGET_PGURI} -c "select last_value from identity_table_id_seq;" | grep -q 667
+psql -d ${PAGILA_TARGET_PGURI} -c "select last_value from normal_table_id_seq;" | grep -q 667

--- a/tests/pagila/copydb.sh
+++ b/tests/pagila/copydb.sh
@@ -45,6 +45,15 @@ create schema "With a space";
 create extension seg schema "With a space" cascade;
 EOF
 
+# Create sequences and tables to ensure they get reset.
+psql -d ${PAGILA_SOURCE_PGURI} <<EOF
+create sequence normal_table_id_seq;
+create table normal_table (id integer primary key default nextval('normal_table_id_seq'));
+create table identity_table (id integer primary key generated always as identity);
+select setval('identity_table_id_seq', 667);
+select setval('normal_table_id_seq', 667);
+EOF
+
 # Create a couple of schemas in the target database
 # to ensure they get skipped during the clone
 psql -d ${PAGILA_TARGET_PGURI} <<EOF
@@ -70,3 +79,11 @@ pgcopydb compare schema \
 pgcopydb compare data \
          --source ${PAGILA_SOURCE_PGURI} \
          --target ${PAGILA_TARGET_PGURI}
+
+psql -d ${PAGILA_TARGET_PGURI} <<EOF
+select last_value from identity_table_id_seq;
+EOF | grep -q 667
+
+psql -d ${PAGILA_TARGET_PGURI} <<EOF
+select last_value from normal_table_id_seq;
+EOF | grep -q 667

--- a/tests/unit/expected/6-sequences.out
+++ b/tests/unit/expected/6-sequences.out
@@ -1,4 +1,6 @@
--[ RECORD 1 ]
+-[ RECORD 1 ]---
 last_value | 667
--[ RECORD 1 ]
+
+-[ RECORD 1 ]---
 last_value | 667
+

--- a/tests/unit/expected/6-sequences.out
+++ b/tests/unit/expected/6-sequences.out
@@ -1,0 +1,4 @@
+-[ RECORD 1 ]
+last_value | 667
+-[ RECORD 1 ]
+last_value | 667

--- a/tests/unit/setup/16-sequences.sql
+++ b/tests/unit/setup/16-sequences.sql
@@ -1,0 +1,9 @@
+---
+--- See https://github.com/dimitri/pgcopydb/issues/777
+---
+
+create sequence normal_table_id_seq;
+create table normal_table (id integer primary key default nextval('normal_table_id_seq'));
+create table identity_table (id integer primary key generated always as identity);
+select setval('identity_table_id_seq', 667);
+select setval('normal_table_id_seq', 667);

--- a/tests/unit/setup/setup.sql
+++ b/tests/unit/setup/setup.sql
@@ -12,3 +12,4 @@
 \ir 12-generated-column.sql
 \ir 14-uuid.sql
 \ir 15-attgenerated.sql
+\ir 16-sequences.sql

--- a/tests/unit/sql/6-sequences.sql
+++ b/tests/unit/sql/6-sequences.sql
@@ -1,0 +1,2 @@
+select last_value from identity_table_id_seq;
+select last_value from normal_table_id_seq;


### PR DESCRIPTION
Fixes: https://github.com/dimitri/pgcopydb/issues/777

I put this up as a fix and a regression test for #777. With some changes to the query I've managed to get it discovering identity + normal sequences:

```
create sequence kbgood_id_seq;
create table kbgood (id integer primary key default nextval('kbgood_id_seq'));

create table kbbad (id integer generated always as identity);
-- implies kbbad_id_seq is created
```

```
12:46:12.370 624 INFO   sequences.c:78            Fetching information for 2 sequences
```

```
12:49:30.865 650 SQL    pgsql.c:1572              [TARGET 308053] 'public.kbbad_id_seq', '1', 'false'
12:49:32.412 650 SQL    pgsql.c:1559              [TARGET 308053] select pg_catalog.setval($1::regclass, $2, $3);
12:49:32.412 650 SQL    pgsql.c:1572              [TARGET 308053] 'public.kbgood_id_seq', '1', 'false'
12:49:32.926 650 SQL    pgsql.c:1559              [TARGET 308053] select pg_catalog.setval($1::regclass, $2, $3);
```