### PR TITLE
Add missing args for skip-db-properties option

### DIFF
--- a/src/bin/pgcopydb/cli_common.c
+++ b/src/bin/pgcopydb/cli_common.c
@@ -855,7 +855,7 @@ cli_copy_db_getopts(int argc, char **argv)
 	}
 
 	const char *optstring =
-		"S:T:D:J:I:b:L:cAPOXj:xBeMlUdyF:F:Q:irRCN:fp:ws:o:tE:Vvdzqh";
+		"S:T:D:J:I:b:L:cAPOXj:xBeMlUgyF:F:Q:irRCN:fp:ws:o:tE:Vvdzqh";
 
 	while ((c = getopt_long(argc, argv,
 							optstring, long_options, &option_index)) != -1)


### PR DESCRIPTION
On #779 we forgot to add short option -g for skip-db-properties.

See https://github.com/dimitri/pgcopydb/pull/779/files#r1601520982