### PR TITLE
Incorrect type used for `partnum` while querying summary table

### DIFF
--- a/src/bin/pgcopydb/summary.c
+++ b/src/bin/pgcopydb/summary.c
@@ -262,7 +262,7 @@ summary_lookup_table(DatabaseCatalog *catalog, CopyTableDataSpec *tableSpecs)
 	BindParam params[] = {
 		{ BIND_PARAMETER_TYPE_INT64, "tableoid", table->oid, NULL },
 
-		{ BIND_PARAMETER_TYPE_TEXT, "partnum",
+		{ BIND_PARAMETER_TYPE_INT64, "partnum",
 		  table->partition.partNumber, NULL },
 	};
 
@@ -354,7 +354,7 @@ summary_delete_table(DatabaseCatalog *catalog, CopyTableDataSpec *tableSpecs)
 		return false;
 	}
 
-	char *sql = "delete from summary where tableoid = $1 and partnumber = $2";
+	char *sql = "delete from summary where tableoid = $1 and partnum = $2";
 
 	if (!semaphore_lock(&(catalog->sema)))
 	{


### PR DESCRIPTION
This leads to considering `0` as `null` while querying and table with partnum as 0 is never matched.

Also fix typo which refers partnum as partnumber.