### PR TITLE
Allow exclude-index filtering when used with other filters.

### DIFF
--- a/src/bin/pgcopydb/schema.c
+++ b/src/bin/pgcopydb/schema.c
@@ -2519,9 +2519,17 @@ struct FilteringQueries listSourceIndexesSQL[] = {
 		"           on rn.nspname = inc.nspname "
 		"          and r.relname = inc.relname "
 
+		/* exclude-index */
+		"         left join pg_temp.filter_exclude_index fei "
+		"                on n.nspname = fei.nspname "
+		"               and i.relname = fei.relname "
+
 		"    where r.relkind = 'r' and r.relpersistence in ('p', 'u') "
 		"      and n.nspname !~ '^pg_' and n.nspname <> 'information_schema'"
 		"      and n.nspname !~ 'pgcopydb' "
+
+		/* WHERE clause for exclusion filters */
+		"		and fei.nspname is null "
 
 		/* avoid pg_class entries which belong to extensions */
 		"     and not exists "
@@ -2591,6 +2599,11 @@ struct FilteringQueries listSourceIndexesSQL[] = {
 		"                on rn.nspname = ftd.nspname "
 		"               and r.relname = ftd.relname "
 
+		/* exclude-index */
+		"         left join pg_temp.filter_exclude_index fei "
+		"                on n.nspname = fei.nspname "
+		"               and i.relname = fei.relname "
+
 		"    where r.relkind = 'r' and r.relpersistence in ('p', 'u') "
 		"      and n.nspname !~ '^pg_' and n.nspname <> 'information_schema'"
 		"      and n.nspname !~ 'pgcopydb' "
@@ -2599,6 +2612,7 @@ struct FilteringQueries listSourceIndexesSQL[] = {
 		"     and fn.nspname is null "
 		"     and ft.relname is null "
 		"     and ftd.relname is null "
+		"     and fei.relname is null "
 
 		/* avoid pg_class entries which belong to extensions */
 		"     and not exists "
@@ -2659,12 +2673,19 @@ struct FilteringQueries listSourceIndexesSQL[] = {
 		"           on rn.nspname = inc.nspname "
 		"          and r.relname = inc.relname "
 
+		/* exclude-index */
+		"    left join pg_temp.filter_exclude_index fei "
+		"           on n.nspname = fei.nspname "
+		"          and i.relname = fei.relname "
+
 		"    where r.relkind = 'r' and r.relpersistence in ('p', 'u') "
 		"      and n.nspname !~ '^pg_' and n.nspname <> 'information_schema'"
 		"      and n.nspname !~ 'pgcopydb' "
 
 		/* WHERE clause for exclusion filters */
-		"     and inc.relname is null "
+		"     and (  inc.relname is null "
+		"          or "
+		"            fei.relname is not null ) "
 
 		/* avoid pg_class entries which belong to extensions */
 		"     and not exists "
@@ -2729,12 +2750,18 @@ struct FilteringQueries listSourceIndexesSQL[] = {
 		"                on rn.nspname = ft.nspname "
 		"               and r.relname = ft.relname "
 
+		/* exclude-index */
+		"         left join pg_temp.filter_exclude_index fei "
+		"                on n.nspname = fei.nspname "
+		"               and i.relname = fei.relname "
+
 		"    where r.relkind = 'r' and r.relpersistence in ('p', 'u') "
 		"      and n.nspname !~ '^pg_' and n.nspname <> 'information_schema'"
 		"      and n.nspname !~ 'pgcopydb' "
 
 		/* WHERE clause for exclusion filters */
 		"     and (   fn.nspname is not null "
+		"          or fei.relname is not null "
 		"          or ft.relname is not null ) "
 
 		/* avoid pg_class entries which belong to extensions */

--- a/tests/filtering/expected/4-exclude-index.out
+++ b/tests/filtering/expected/4-exclude-index.out
@@ -1,0 +1,3 @@
+-[ RECORD 1 ]
+exists | f
+

--- a/tests/filtering/include.ini
+++ b/tests/filtering/include.ini
@@ -13,7 +13,7 @@ public.rental
 schema_name_20_chars.very______long______table______name_______50_chars
 
 [exclude-index]
-public.idx_store_id_film_id
+public.idx_actor_last_name
 
 [exclude-table-data]
 public.rental

--- a/tests/filtering/sql/4-exclude-index.sql
+++ b/tests/filtering/sql/4-exclude-index.sql
@@ -1,0 +1,6 @@
+select exists(select schemaname, tablename, indexname
+  from pg_indexes
+ where schemaname = 'public'
+  and tablename = 'actor'
+  and indexname = 'idx_actor_last_name'
+);


### PR DESCRIPTION
[exclude-index] works only when there is no other filter present.

Solution: Fix index listing query to consider exclude-index filters on all possible scenarios.