### PR TITLE
Improve formatting for pretty printed integers

### DIFF
--- a/src/bin/pgcopydb/string_utils.c
+++ b/src/bin/pgcopydb/string_utils.c
@@ -772,7 +772,7 @@ pretty_print_count(char *buffer, size_t size, uint64_t number)
 		int t = number / 1000;
 		int u = number - (t * 1000);
 
-		sformat(buffer, size, "%d %d", t, u);
+		sformat(buffer, size, "%d %03d", t, u);
 	}
 	else
 	{


### PR DESCRIPTION
During development I created a table with 1000 tuples and in the logs I saw that the format is not so easy to read and understand.

... with an estimated total of 1 0 tuples ...

For numbers with 4, 5, or 6 decimal digits, we should pad the number with zeros.