### PR TITLE
Get the block size from the origin.

### DIFF
--- a/src/bin/pgcopydb/defaults.h
+++ b/src/bin/pgcopydb/defaults.h
@@ -83,7 +83,6 @@
 #define POSTGRES_PING_RETRY_BASE_SLEEP_TIME 5         /* milliseconds */
 
 #define POSTGRES_PORT 5432
-#define POSTGRES_BLOCK_SIZE 8192
 
 /* default replication slot and origin for logical replication */
 #define REPLICATION_ORIGIN "pgcopydb"

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -5009,7 +5009,8 @@ RetrieveWalSegSize(LogicalStreamClient *client)
 /*
  * Get block size from the connected Postgres instance.
  */
-bool pgsql_get_block_size(PGSQL *pgsql, int *blockSize)
+bool
+pgsql_get_block_size(PGSQL *pgsql, int *blockSize)
 {
 	PGconn *conn = pgsql->connection;
 
@@ -5020,7 +5021,7 @@ bool pgsql_get_block_size(PGSQL *pgsql, int *blockSize)
 		return false;
 	}
 
-	const char* query = "SELECT current_setting('block_size')";
+	const char *query = "SELECT current_setting('block_size')";
 	PGresult *res = PQexec(conn, query);
 	if (PQresultStatus(res) != PGRES_TUPLES_OK)
 	{
@@ -5051,6 +5052,7 @@ bool pgsql_get_block_size(PGSQL *pgsql, int *blockSize)
 	log_sql("pgsql_get_block_size: %d", *blockSize);
 	return true;
 }
+
 
 /*
  * pgsql_replication_origin_oid calls pg_replication_origin_oid().

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -5020,18 +5020,11 @@ bool pgsql_get_block_size(PGSQL *pgsql, int *blockSize)
 		return false;
 	}
 
-	/* for previous versions set the default block size */
-	if (PQserverVersion(conn) < MINIMUM_VERSION_FOR_SHOW_CMD)
-	{
-		*blockSize = POSTGRES_BLOCK_SIZE;
-		return true;
-	}
-
-	PGresult *res = PQexec(conn, "SHOW block_size");
+	const char* query = "SELECT current_setting('block_size')";
+	PGresult *res = PQexec(conn, query);
 	if (PQresultStatus(res) != PGRES_TUPLES_OK)
 	{
-		log_error("could not send command \"%s\": %s",
-				  "SHOW block_size", PQerrorMessage(conn));
+		log_error("could not send command \"%s\": %s", query, PQerrorMessage(conn));
 		PQclear(res);
 		return false;
 	}

--- a/src/bin/pgcopydb/pgsql.h
+++ b/src/bin/pgcopydb/pgsql.h
@@ -532,6 +532,8 @@ bool pgsql_stream_logical(LogicalStreamClient *client,
 
 bool RetrieveWalSegSize(LogicalStreamClient *client);
 
+bool pgsql_get_block_size(PGSQL *pgsql, int *blockSize);
+
 bool pgsql_replication_origin_oid(PGSQL *pgsql, char *nodeName, uint32_t *oid);
 bool pgsql_replication_origin_create(PGSQL *pgsql, char *nodeName);
 bool pgsql_replication_origin_drop(PGSQL *pgsql, char *nodeName);

--- a/src/bin/pgcopydb/schema.c
+++ b/src/bin/pgcopydb/schema.c
@@ -3290,7 +3290,8 @@ schema_list_partitions(PGSQL *pgsql,
 		 * and then memoize it.
 		 */
 		static int blockSize = 0;
-		if (!blockSize && !pgsql_get_block_size(pgsql, &blockSize))
+		bool isBlockSizeCached = blockSize != 0;
+		if (!isBlockSizeCached && !pgsql_get_block_size(pgsql, &blockSize))
 		{
 			/* errors have already been logged */
 			return false;

--- a/src/bin/pgcopydb/schema.c
+++ b/src/bin/pgcopydb/schema.c
@@ -3285,9 +3285,12 @@ schema_list_partitions(PGSQL *pgsql,
 		min = 0;
 		max = table->relpages;
 
-		/* Get the block size from the origin */
-		int blockSize = 0;
-		if (!pgsql_get_block_size(pgsql, &blockSize))
+		/*
+		 * Get the block size from the origin in the first attempt
+		 * and then memoize it.
+		 */
+		static int blockSize = 0;
+		if (!blockSize && !pgsql_get_block_size(pgsql, &blockSize))
 		{
 			/* errors have already been logged */
 			return false;

--- a/src/bin/pgcopydb/schema.c
+++ b/src/bin/pgcopydb/schema.c
@@ -3285,8 +3285,14 @@ schema_list_partitions(PGSQL *pgsql,
 		min = 0;
 		max = table->relpages;
 
-		/* Postgres page size is static: 8192 Bytes */
-		uint64_t pagesPerPart = ceil((double) partSize / POSTGRES_BLOCK_SIZE);
+		/* Get the block size from the origin */
+		int blockSize = 0;
+		if (!pgsql_get_block_size(pgsql, &blockSize))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+		uint64_t pagesPerPart = ceil((double) partSize / blockSize);
 
 		partsCount = ceil((double) table->relpages / (double) pagesPerPart);
 		partsSize = ceil((double) table->relpages / partsCount);


### PR DESCRIPTION
## What

Get the block size from the origin.

## Why

The default value of 8192 was used before no matter what the value is on the origin.

## How

By executing `show block_size;` on the origin/source in the new `pgsql_get_block_size` function.
