### PR TITLE
Update versions for checkout github action

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     container: citus/stylechecker:latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3 # intentionally using v3 to avoid v4 bug
 
     - name: Check C style
       run: citus_indent --check
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build docs
         uses: ammaraskar/sphinx-action@master
         with:


### PR DESCRIPTION
There is an issue with the current latest version of the checkout action that causes the action to fail with the following error:

```
/usr/bin/docker exec  affa129063e510f8a1c26695901b387829ac4453b272bbf8e36cd1ed60a961aa sh -c "cat /etc/*release | grep ^ID"
Error relocating /__e/node20_alpine/bin/node: secure_getenv: symbol not found
```

To remedy this, we downgrade our checkout action for stylechecker to the
last known working major version.

In passing I also updated one more version to the latest major.