### PR TITLE
Problem: Array out of bounds access during transform

### DIFF
--- a/src/bin/pgcopydb/ld_transform.c
+++ b/src/bin/pgcopydb/ld_transform.c
@@ -2194,7 +2194,7 @@ stream_write_update(FILE *out, LogicalMessageUpdate *update)
 					{
 						/* only works because old->values.count == 1 */
 						LogicalMessageValue *oldValue =
-							&(old->values.array[0].array[v]);
+							&(old->values.array[0].array[oc]);
 
 						if (LogicalMessageValueEq(oldValue, value))
 						{


### PR DESCRIPTION
The logic which removes redundant SET for columns who's value is same as in WHERE clause accesses oldValue using newValue index. Both can have varying size items causing out of bound access.

We use the correct index to access the old column name, but incorrect index has been used to access the old column value.

Original PR which avoids redundant SET if value is same as in WHERE: https://github.com/dimitri/pgcopydb/pull/333

Solution: Use old column index to access it's value