### PR TITLE
Set lock_timeout for replication connections

### DIFF
--- a/src/bin/pgcopydb/copydb.c
+++ b/src/bin/pgcopydb/copydb.c
@@ -80,6 +80,28 @@ KeyVal connStringDefaults = {
 	}
 };
 
+/*
+ * We add an extra parameter to the connection string for replication to reduce
+ * the waiting time for the initial CREATE_REPLICATION_SLOT command.
+ */
+KeyVal connStringDefaultsForReplication = {
+	.count = 5,
+	.keywords = {
+		"keepalives",
+		"keepalives_idle",
+		"keepalives_interval",
+		"keepalives_count",
+		"lock_timeout"
+	},
+	.values = {
+		"1",
+		"10",
+		"10",
+		"60",
+		"60000"
+	}
+};
+
 
 /*
  * copydb_init_tempdir initialises the file paths that are going to be used to

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -32,6 +32,7 @@
  * added them, allowing user-defined values to be taken into account.
  */
 extern KeyVal connStringDefaults;
+extern KeyVal connStringDefaultsForReplication;
 
 
 /*

--- a/src/bin/pgcopydb/ld_stream.c
+++ b/src/bin/pgcopydb/ld_stream.c
@@ -2151,7 +2151,7 @@ buildReplicationURI(const char *pguri, char **repl_pguri)
 
 	/* if replication is already found, we override it to value "1" */
 	if (!parse_pguri_info_key_vals(pguri,
-								   &connStringDefaults,
+								   &connStringDefaultsForReplication,
 								   &replicationParams,
 								   &params,
 								   checkForCompleteURI))


### PR DESCRIPTION
pgcopydb fails to create a replication slot on systems that have long running transactions. This is because the CREATE_REPLICATION_SLOT command waits for the lock to be released. This patch adds a new connection parameter lock_timeout to the connection string for replication connections. This parameter is set to 60 seconds by default. This will reduce the waiting time for the CREATE_REPLICATION_SLOT command to fail.

Fixes: #819