### PR TITLE
Fix out-of-memory issue in creating our pg_restore list file.

### DIFF
--- a/src/bin/pgcopydb/cli_restore.c
+++ b/src/bin/pgcopydb/cli_restore.c
@@ -550,6 +550,24 @@ cli_restore_roles(int argc, char **argv)
 
 
 /*
+ * print_archive_toc_item_hook is an iterator callback function.
+ */
+static bool
+print_archive_toc_item_hook(void *context, ArchiveContentItem *item)
+{
+	fformat(stdout,
+			"%d; %u %u %s %s\n",
+			item->dumpId,
+			item->catalogOid,
+			item->objectOid,
+			item->description ? item->description : "",
+			item->restoreListName ? item->restoreListName : "");
+
+	return true;
+}
+
+
+/*
  * cli_restore_schema implements the command: pgcopydb restore parse-list
  */
 static void
@@ -561,27 +579,10 @@ cli_restore_schema_parse_list(int argc, char **argv)
 
 		log_info("Parsing Archive Content pre.list file: \"%s\"", filename);
 
-		ArchiveContentArray contents = { 0 };
-
-		if (!parse_archive_list(filename, &contents))
+		if (!archive_iter_toc(filename, NULL, print_archive_toc_item_hook))
 		{
 			/* errors have already been logged */
 			exit(EXIT_CODE_INTERNAL_ERROR);
-		}
-
-		log_notice("Read %d archive items in \"%s\"", contents.count, filename);
-
-		for (int i = 0; i < contents.count; i++)
-		{
-			ArchiveContentItem *item = &(contents.array[i]);
-
-			fformat(stdout,
-					"%d; %u %u %s %s\n",
-					item->dumpId,
-					item->catalogOid,
-					item->objectOid,
-					item->description ? item->description : "",
-					item->restoreListName ? item->restoreListName : "");
 		}
 
 		exit(EXIT_CODE_QUIT);

--- a/src/bin/pgcopydb/file_utils.h
+++ b/src/bin/pgcopydb/file_utils.h
@@ -54,6 +54,26 @@ bool write_file(char *data, long fileSize, const char *filePath);
 bool append_to_file(char *data, long fileSize, const char *filePath);
 bool read_file(const char *filePath, char **contents, long *fileSize);
 bool read_file_if_exists(const char *filePath, char **contents, long *fileSize);
+
+/* iterate over a file one line at a time */
+typedef bool (FileIterLinesFun)(void *context, char *line);
+
+bool file_iter_lines(const char *filename, size_t bufsize,
+					 void *context,
+					 FileIterLinesFun *callback);
+
+typedef struct FileLinesIterator
+{
+	const char *filename;
+	FILE *stream;
+	size_t bufsize;
+	char *line;                 /* malloc'ed area */
+} FileLinesIterator;
+
+bool file_iter_lines_init(FileLinesIterator *iter);
+bool file_iter_lines_next(FileLinesIterator *iter);
+bool file_iter_lines_finish(FileLinesIterator *iter);
+
 bool move_file(char *sourcePath, char *destinationPath);
 bool duplicate_file(char *sourcePath, char *destinationPath);
 bool create_symbolic_link(char *sourcePath, char *targetPath);

--- a/src/bin/pgcopydb/pgcmd.h
+++ b/src/bin/pgcopydb/pgcmd.h
@@ -283,8 +283,25 @@ bool pg_restore_db(PostgresPaths *pgPaths,
 
 bool pg_restore_list(PostgresPaths *pgPaths,
 					 const char *restoreFilename,
-					 const char *listFilename,
-					 ArchiveContentArray *archive);
+					 const char *listFilename);
+
+/* iterate over a file one line at a time */
+typedef bool (ArchiveTOCFun)(void *context, ArchiveContentItem *item);
+
+bool archive_iter_toc(const char *filename,
+					  void *context,
+					  ArchiveTOCFun *callback);
+
+typedef struct ArchiveTOCIterator
+{
+	const char *filename;
+	FileLinesIterator *fileIterator;
+	ArchiveContentItem *item;
+} ArchiveTOCIterator;
+
+bool archive_iter_toc_init(ArchiveTOCIterator *iter);
+bool archive_iter_toc_next(ArchiveTOCIterator *iter);
+bool archive_iter_toc_finish(ArchiveTOCIterator *iter);
 
 bool parse_archive_list(const char *filename, ArchiveContentArray *archive);
 


### PR DESCRIPTION
Instead of creating the whole contents of the file in-memory, write it to disk one line at a time, keeping only that line in-memory during the whole operation.

Also arrange to code to only read the pg_restore --list output one line at a time, no context is needed to be able to parse this file format (pg_dump archive Table Of Contents).

Fixes #811 
Replaces and closes #818 