### PR TITLE
Adding filtering flag to pgcopydb dump schema

### DIFF
--- a/docs/include/dump-schema.rst
+++ b/docs/include/dump-schema.rst
@@ -3,9 +3,10 @@
    pgcopydb dump schema: Dump source database schema as custom files in work directory
    usage: pgcopydb dump schema  --source <URI> 
    
-     --source          Postgres URI to the source database
-     --target          Directory where to save the dump files
-     --dir             Work directory to use
-     --skip-extensions Skip restoring extensions
-     --snapshot        Use snapshot obtained with pg_export_snapshot
+     --source             Postgres URI to the source database
+     --target             Directory where to save the dump files
+     --dir                Work directory to use
+     --skip-extensions    Skip restoring extensions
+     --filters <filename> Use the filters defined in <filename>
+     --snapshot           Use snapshot obtained with pg_export_snapshot
    


### PR DESCRIPTION
Following error will be seen without this fix,
```
10:46:09.943 284145 INFO   Running pgcopydb version 0.0.21.184.g8c85cce from "/home/ubuntu/dimitri/pgcopydb/src/bin/pgcopydb/pgcopydb"
10:46:09.981 284145 INFO   Using work dir "/tmp/pgcopydb"
10:46:09.981 284145 INFO   Restoring database from existing files at "/tmp/pgcopydb"
10:46:09.984 284145 INFO   Current filtering setup is: {"type":"SOURCE_FILTER_TYPE_EXCL","exclude-table-data":[{"schema":"public","name":"metrics_New"}]}
10:46:09.984 284145 INFO   Catalog filtering setup is: {"type":"SOURCE_FILTER_TYPE_NONE"}
10:46:09.984 284145 ERROR  Catalogs at "/tmp/pgcopydb/schema/source.db" have been setup for a different filtering than the current command, see above for details
10:46:09.984 284145 ERROR  Failed to initialize pgcopydb internal catalogs
```

The problem is, `pgcopydb dump schema` without filtering creates catalog with filtering type as NONE, when we supply filter for restore, it fails with filter type mismatch.