### PR TITLE
Add byte-level progress to pgcopydb list progress

### DIFF
--- a/src/bin/pgcopydb/catalog.c
+++ b/src/bin/pgcopydb/catalog.c
@@ -2989,7 +2989,7 @@ catalog_iter_s_table_init(SourceTableIterator *iter)
 
 
 /*
- * catalog_iter_s_table_init initializes an Interator over our catalog of
+ * catalog_iter_s_table_nopk_init initializes an Interator over our catalog of
  * SourceTable entries.
  */
 bool

--- a/src/bin/pgcopydb/catalog.c
+++ b/src/bin/pgcopydb/catalog.c
@@ -151,8 +151,7 @@ static char *sourceDBcreateDDLs[] = {
 	"  id integer primary key,"
 	"  label text,"
 	"  start_time_epoch integer, done_time_epoch integer, duration integer, "
-	"  duration_pretty, "
-	"  count integer, bytes integer, bytes_pretty text"
+	"  count integer, bytes integer"
 	")",
 
 	"create table summary("

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -448,7 +448,6 @@ bool copydb_table_create_lockfile(CopyDataSpec *specs,
 								  bool *isDone);
 
 bool copydb_save_copy_progress(CopyDataSpec *specs,
-							   CopyTableDataSpec *tableSpecs,
 							   uint64_t count,
 							   uint64_t bytes,
 							   instr_time lastSavingTime);

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -436,7 +436,9 @@ bool copydb_process_table_data_worker(CopyDataSpec *specs);
 bool copydb_process_table_data_with_workers(CopyDataSpec *specs);
 
 bool copydb_copy_table(CopyDataSpec *specs, PGSQL *src, PGSQL *dst,
-					   CopyTableDataSpec *tableSpecs);
+					   CopyTableDataSpec *tableSpecs,
+					   CopyProgressCallback onCopyProgress,
+					   void *onCopyProgressContext);
 
 
 bool copydb_table_create_lockfile(CopyDataSpec *specs,
@@ -444,7 +446,7 @@ bool copydb_table_create_lockfile(CopyDataSpec *specs,
 								  PGSQL *dst,
 								  bool *isDone);
 
-bool copydb_mark_table_as_done(CopyDataSpec *specs,
+bool copydb_save_copy_progress(CopyDataSpec *specs,
 							   CopyTableDataSpec *tableSpecs);
 
 bool copydb_table_parts_are_all_done(CopyDataSpec *specs,

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -533,6 +533,9 @@ bool summary_add_table(DatabaseCatalog *catalog,
 bool summary_finish_table(DatabaseCatalog *catalog,
 						  CopyTableDataSpec *tableSpecs);
 
+bool summary_update_table(DatabaseCatalog *catalog,
+						  CopyTableDataSpec *tableSpecs);
+
 bool summary_delete_table(DatabaseCatalog *catalog,
 						  CopyTableDataSpec *tableSpecs);
 

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -10,6 +10,7 @@
 #include "copydb_paths.h"
 #include "filtering.h"
 #include "lock_utils.h"
+#include "portability/instr_time.h"
 #include "queue_utils.h"
 #include "pgcmd.h"
 #include "pgsql.h"
@@ -437,8 +438,8 @@ bool copydb_process_table_data_with_workers(CopyDataSpec *specs);
 
 bool copydb_copy_table(CopyDataSpec *specs, PGSQL *src, PGSQL *dst,
 					   CopyTableDataSpec *tableSpecs,
-					   CopyProgressCallback onCopyProgress,
-					   void *onCopyProgressContext);
+					   void *onCopyProgressContext,
+					   CopyProgressCallback onCopyProgress);
 
 
 bool copydb_table_create_lockfile(CopyDataSpec *specs,
@@ -447,7 +448,10 @@ bool copydb_table_create_lockfile(CopyDataSpec *specs,
 								  bool *isDone);
 
 bool copydb_save_copy_progress(CopyDataSpec *specs,
-							   CopyTableDataSpec *tableSpecs);
+							   CopyTableDataSpec *tableSpecs,
+							   uint64_t count,
+							   uint64_t bytes,
+							   instr_time lastSavingTime);
 
 bool copydb_table_parts_are_all_done(CopyDataSpec *specs,
 									 CopyTableDataSpec *tableSpecs,

--- a/src/bin/pgcopydb/extensions.c
+++ b/src/bin/pgcopydb/extensions.c
@@ -7,6 +7,7 @@
 #include <getopt.h>
 #include <inttypes.h>
 #include <sys/wait.h>
+#include <time.h>
 #include <unistd.h>
 
 #include "catalog.h"
@@ -173,10 +174,12 @@ copydb_copy_ext_table(PGSQL *src, PGSQL *dst, char *qname, char *condition)
 		.srcWhereClause = condition,
 		.dstQname = qname,
 		.dstAttrList = "",
-		.bytesTransmitted = 0
+		.bytesTransmitted = 0,
+		.bytesTransmittedBeforeSavingProgress = 0,
+		.lastSavingTimeMs = time(NULL),
 	};
 
-	if (!pg_copy(src, dst, &args))
+	if (!pg_copy(src, dst, &args, NULL, NULL))
 	{
 		/* errors have already been logged */
 		return false;

--- a/src/bin/pgcopydb/extensions.c
+++ b/src/bin/pgcopydb/extensions.c
@@ -174,7 +174,6 @@ copydb_copy_ext_table(PGSQL *src, PGSQL *dst, char *qname, char *condition)
 		.srcWhereClause = condition,
 		.dstQname = qname,
 		.dstAttrList = "",
-		.bytesTransmitted = 0,
 	};
 
 	if (!pg_copy(src, dst, &args, NULL, NULL))

--- a/src/bin/pgcopydb/extensions.c
+++ b/src/bin/pgcopydb/extensions.c
@@ -175,8 +175,6 @@ copydb_copy_ext_table(PGSQL *src, PGSQL *dst, char *qname, char *condition)
 		.dstQname = qname,
 		.dstAttrList = "",
 		.bytesTransmitted = 0,
-		.bytesTransmittedBeforeSavingProgress = 0,
-		.lastSavingTimeMs = time(NULL),
 	};
 
 	if (!pg_copy(src, dst, &args, NULL, NULL))

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -2748,7 +2748,6 @@ pg_copy_data(PGSQL *src, PGSQL *dst, CopyArgs *args, void *context, CopyProgress
 	char *copybuf;
 	bool failedOnSrc = false;
 	bool failedOnDst = false;
-	args->bytesTransmitted = 0;
 
 	for (;;)
 	{

--- a/src/bin/pgcopydb/pgsql.h
+++ b/src/bin/pgcopydb/pgsql.h
@@ -337,16 +337,14 @@ typedef struct CopyArgs
 	bool truncate;
 	bool freeze;
 	uint64_t bytesTransmitted;
-	uint64_t bytesTransmittedBeforeSavingProgress; /* the bytes transmitted before saving the progress to DB */
-	uint64_t lastSavingTimeMs; /* the last saving time of the progress to the DB */
 } CopyArgs;
 
 /* Callback type to be called during the copy data operation */
 typedef bool (*CopyProgressCallback)(int bytesTransmitted, void *context);
 
 
-bool pg_copy(PGSQL *src, PGSQL *dst, CopyArgs *args, CopyProgressCallback
-			 on_copy_progress_hook, void *context);
+bool pg_copy(PGSQL *src, PGSQL *dst, CopyArgs *args, void *context, CopyProgressCallback
+			 on_copy_progress_hook);
 
 bool pg_copy_from_stdin(PGSQL *pgsql, const char *qname);
 bool pg_copy_row_from_stdin(PGSQL *pgsql, char *fmt, ...);

--- a/src/bin/pgcopydb/pgsql.h
+++ b/src/bin/pgcopydb/pgsql.h
@@ -337,9 +337,16 @@ typedef struct CopyArgs
 	bool truncate;
 	bool freeze;
 	uint64_t bytesTransmitted;
+	uint64_t bytesTransmittedBeforeSavingProgress; /* the bytes transmitted before saving the progress to DB */
+	uint64_t lastSavingTimeMs; /* the last saving time of the progress to the DB */
 } CopyArgs;
 
-bool pg_copy(PGSQL *src, PGSQL *dst, CopyArgs *args);
+/* Callback type to be called during the copy data operation */
+typedef bool (*CopyProgressCallback)(int bytesTransmitted, void *context);
+
+
+bool pg_copy(PGSQL *src, PGSQL *dst, CopyArgs *args, CopyProgressCallback
+			 on_copy_progress_hook, void *context);
 
 bool pg_copy_from_stdin(PGSQL *pgsql, const char *qname);
 bool pg_copy_row_from_stdin(PGSQL *pgsql, char *fmt, ...);

--- a/src/bin/pgcopydb/pgsql.h
+++ b/src/bin/pgcopydb/pgsql.h
@@ -336,7 +336,6 @@ typedef struct CopyArgs
 	char *logCommand;
 	bool truncate;
 	bool freeze;
-	uint64_t bytesTransmitted;
 } CopyArgs;
 
 /* Callback type to be called during the copy data operation */

--- a/src/bin/pgcopydb/summary.c
+++ b/src/bin/pgcopydb/summary.c
@@ -2322,6 +2322,10 @@ catalog_timing_fetch(SQLiteQuery *query)
 	timing->doneTime = sqlite3_column_int64(query->ppStmt, 3);
 	timing->durationMs = sqlite3_column_int64(query->ppStmt, 4);
 
+	/*
+	 * Skip reading `ppDuration` from DB and create it from `durationMs`
+	 * in accordance with the single source of truth
+	 */
 	if (timing->durationMs > 0)
 	{
 		IntervalToString(timing->durationMs,
@@ -2332,6 +2336,10 @@ catalog_timing_fetch(SQLiteQuery *query)
 	timing->count = sqlite3_column_int64(query->ppStmt, 5);
 	timing->bytes = sqlite3_column_int64(query->ppStmt, 6);
 
+	/*
+	 * Skip reading `ppBytes` from DB and create it from `bytes`
+	 * in accordance with the single source of truth
+	 */
 	if (timing->bytes > 0)
 	{
 		pretty_print_bytes(timing->ppBytes,

--- a/src/bin/pgcopydb/summary.c
+++ b/src/bin/pgcopydb/summary.c
@@ -1866,12 +1866,6 @@ summary_stop_timing(DatabaseCatalog *catalog, TimingSection section)
 			return false;
 		}
 
-		if (!summary_pretty_print_timing(catalog, timing))
-		{
-			/* errors have already been logged */
-			return false;
-		}
-
 		const char *sql =
 			"update timings "
 			"set done_time_epoch = $1, bytes_pretty = $2, duration_pretty = $3 "
@@ -2096,25 +2090,6 @@ summary_set_timing_count(DatabaseCatalog *catalog,
 
 
 /*
- * summary_pretty_print_timing computes the pretty-printed versions of the
- * bytes and duration values in a given Top-Level Timing section.
- */
-bool
-summary_pretty_print_timing(DatabaseCatalog *catalog, TopLevelTiming *timing)
-{
-	pretty_print_bytes(timing->ppBytes,
-					   sizeof(timing->ppBytes),
-					   timing->bytes);
-
-	IntervalToString(timing->durationMs,
-					 timing->ppDuration,
-					 INTSTRING_MAX_DIGITS);
-
-	return true;
-}
-
-
-/*
  * catalog_lookup_timing fetches a TopLevelTiming entry from our catalogs.
  */
 bool
@@ -2143,7 +2118,7 @@ summary_lookup_timing(DatabaseCatalog *catalog,
 
 	char *sql =
 		"  select id, label, start_time_epoch, done_time_epoch, duration, "
-		"         duration_pretty, count, bytes, bytes_pretty "
+		"         count, bytes "
 		"    from timings "
 		"   where id = $1";
 
@@ -2272,7 +2247,7 @@ summary_iter_timing_init(TimingIterator *iter)
 
 	char *sql =
 		"  select id, label, start_time_epoch, done_time_epoch, duration, "
-		"         duration_pretty, count, bytes, bytes_pretty "
+		"         count, bytes "
 		"    from timings "
 		"order by id";
 
@@ -2354,8 +2329,8 @@ catalog_timing_fetch(SQLiteQuery *query)
 						 INTSTRING_MAX_DIGITS);
 	}
 
-	timing->count = sqlite3_column_int64(query->ppStmt, 6);
-	timing->bytes = sqlite3_column_int64(query->ppStmt, 7);
+	timing->count = sqlite3_column_int64(query->ppStmt, 5);
+	timing->bytes = sqlite3_column_int64(query->ppStmt, 6);
 
 	if (timing->bytes > 0)
 	{

--- a/src/bin/pgcopydb/summary.c
+++ b/src/bin/pgcopydb/summary.c
@@ -1989,8 +1989,8 @@ summary_stop_timing(DatabaseCatalog *catalog, TimingSection section)
 
 		const char *sql =
 			"update timings "
-			"set done_time_epoch = $1, bytes_pretty = $2, duration_pretty = $3 "
-			"where id = $4";
+			"set done_time_epoch = $1 "
+			"where id = $2";
 
 		if (!catalog_sql_prepare(db, sql, &query))
 		{
@@ -2001,8 +2001,6 @@ summary_stop_timing(DatabaseCatalog *catalog, TimingSection section)
 
 		BindParam params[] = {
 			{ BIND_PARAMETER_TYPE_INT64, "done", doneTime, NULL },
-			{ BIND_PARAMETER_TYPE_TEXT, "ppBytes", 0, timing->ppBytes },
-			{ BIND_PARAMETER_TYPE_TEXT, "ppDuration", 0, timing->ppDuration },
 			{ BIND_PARAMETER_TYPE_INT, "id", timing->section, NULL }
 		};
 
@@ -2019,8 +2017,8 @@ summary_stop_timing(DatabaseCatalog *catalog, TimingSection section)
 	{
 		char *sql =
 			"update timings "
-			"set done_time_epoch = $1, duration = $2, duration_pretty = $3 "
-			"where id = $4";
+			"set done_time_epoch = $1, duration = $2 "
+			"where id = $3";
 
 		if (!catalog_sql_prepare(db, sql, &query))
 		{
@@ -2032,7 +2030,6 @@ summary_stop_timing(DatabaseCatalog *catalog, TimingSection section)
 		BindParam params[] = {
 			{ BIND_PARAMETER_TYPE_INT64, "done", timing->doneTime, NULL },
 			{ BIND_PARAMETER_TYPE_INT64, "duration", timing->durationMs, NULL },
-			{ BIND_PARAMETER_TYPE_TEXT, "d_pretty", 0, timing->ppDuration },
 			{ BIND_PARAMETER_TYPE_INT, "id", timing->section, NULL }
 		};
 
@@ -2443,10 +2440,6 @@ catalog_timing_fetch(SQLiteQuery *query)
 	timing->doneTime = sqlite3_column_int64(query->ppStmt, 3);
 	timing->durationMs = sqlite3_column_int64(query->ppStmt, 4);
 
-	/*
-	 * Skip reading `ppDuration` from DB and create it from `durationMs`
-	 * in accordance with the single source of truth principle.
-	 */
 	if (timing->durationMs > 0)
 	{
 		IntervalToString(timing->durationMs,
@@ -2457,10 +2450,6 @@ catalog_timing_fetch(SQLiteQuery *query)
 	timing->count = sqlite3_column_int64(query->ppStmt, 5);
 	timing->bytes = sqlite3_column_int64(query->ppStmt, 6);
 
-	/*
-	 * Skip reading `ppBytes` from DB and create it from `bytes`
-	 * in accordance with the single source of truth principle.
-	 */
 	if (timing->bytes > 0)
 	{
 		pretty_print_bytes(timing->ppBytes,

--- a/src/bin/pgcopydb/summary.c
+++ b/src/bin/pgcopydb/summary.c
@@ -833,7 +833,7 @@ summary_finish_vacuum(DatabaseCatalog *catalog, CopyTableDataSpec *tableSpecs)
 
 	if (db == NULL)
 	{
-		log_error("BUG: summary_finish_table: db is NULL");
+		log_error("BUG: summary_finish_vacuum: db is NULL");
 		return false;
 	}
 
@@ -2347,21 +2347,21 @@ catalog_timing_fetch(SQLiteQuery *query)
 	timing->doneTime = sqlite3_column_int64(query->ppStmt, 3);
 	timing->durationMs = sqlite3_column_int64(query->ppStmt, 4);
 
-	if (sqlite3_column_type(query->ppStmt, 5) != SQLITE_NULL)
+	if (timing->durationMs > 0)
 	{
-		strlcpy(timing->ppDuration,
-				(char *) sqlite3_column_text(query->ppStmt, 5),
-				sizeof(timing->ppDuration));
+		IntervalToString(timing->durationMs,
+						 timing->ppDuration,
+						 INTSTRING_MAX_DIGITS);
 	}
 
 	timing->count = sqlite3_column_int64(query->ppStmt, 6);
 	timing->bytes = sqlite3_column_int64(query->ppStmt, 7);
 
-	if (sqlite3_column_type(query->ppStmt, 8) != SQLITE_NULL)
+	if (timing->bytes > 0)
 	{
-		strlcpy(timing->ppBytes,
-				(char *) sqlite3_column_text(query->ppStmt, 8),
-				sizeof(timing->ppBytes));
+		pretty_print_bytes(timing->ppBytes,
+						   sizeof(timing->ppBytes),
+						   timing->bytes);
 	}
 
 	return true;

--- a/src/bin/pgcopydb/summary.c
+++ b/src/bin/pgcopydb/summary.c
@@ -2869,6 +2869,9 @@ print_summary_table(SummaryTable *summary)
 }
 
 
+/*
+ * summary_index_array_as_json converts a SummaryIndexArray to a JSON array.
+ */
 static JSON_Value *
 summary_index_array_as_json(SummaryIndexArray *indexArray)
 {

--- a/src/bin/pgcopydb/summary.c
+++ b/src/bin/pgcopydb/summary.c
@@ -2324,7 +2324,7 @@ catalog_timing_fetch(SQLiteQuery *query)
 
 	/*
 	 * Skip reading `ppDuration` from DB and create it from `durationMs`
-	 * in accordance with the single source of truth
+	 * in accordance with the single source of truth principle.
 	 */
 	if (timing->durationMs > 0)
 	{
@@ -2338,7 +2338,7 @@ catalog_timing_fetch(SQLiteQuery *query)
 
 	/*
 	 * Skip reading `ppBytes` from DB and create it from `bytes`
-	 * in accordance with the single source of truth
+	 * in accordance with the single source of truth principle.
 	 */
 	if (timing->bytes > 0)
 	{

--- a/src/bin/pgcopydb/summary.h
+++ b/src/bin/pgcopydb/summary.h
@@ -22,6 +22,14 @@
 #include "string_utils.h"
 #include "schema.h"
 
+typedef struct CopyStats
+{
+	uint64_t bytes; /* total number of bytes copied */
+	char bytesStr[INTSTRING_MAX_DIGITS];
+	char transmitRate[INTSTRING_MAX_DIGITS];
+} CopyStats;
+
+
 typedef struct CopyTableSummary
 {
 	pid_t pid;                  /* pid */
@@ -31,7 +39,7 @@ typedef struct CopyTableSummary
 	uint64_t durationMs;        /* instr_time duration in milliseconds */
 	instr_time startTimeInstr;  /* internal instr_time tracker */
 	instr_time durationInstr;   /* internal instr_time tracker */
-	uint64_t bytesTransmitted;  /* total number of bytes copied */
+	CopyStats copyStats;
 	char *command;              /* malloc'ed area */
 } CopyTableSummary;
 
@@ -135,9 +143,7 @@ typedef struct SummaryTableEntry
 	char relname[PG_NAMEDATALEN];
 	char partCount[INTSTRING_MAX_DIGITS];
 	char tableMs[INTERVAL_MAXLEN];
-	uint64_t bytes;
-	char bytesStr[INTSTRING_MAX_DIGITS];
-	char transmitRate[INTSTRING_MAX_DIGITS];
+	CopyStats copyStats;
 	char indexCount[INTSTRING_MAX_DIGITS];
 	char indexMs[INTERVAL_MAXLEN];
 	uint64_t durationTableMs;
@@ -170,6 +176,8 @@ typedef struct Summary
 	int restoreJobs;
 } Summary;
 
+
+void copy_stats_update(CopyStats *stats, uint64_t bytes, uint64_t durationMs);
 
 bool summary_start_timing(DatabaseCatalog *catalog, TimingSection section);
 bool summary_stop_timing(DatabaseCatalog *catalog, TimingSection section);

--- a/src/bin/pgcopydb/table-data.c
+++ b/src/bin/pgcopydb/table-data.c
@@ -849,6 +849,20 @@ typedef struct CopyProgressContext
 } CopyProgressContext;
 
 /*
+ * copy_progress_context_init initializes the copy progress context with the given specifications.
+ */
+static void
+copy_progress_context_init(CopyProgressContext *ctx, CopyDataSpec *specs,
+						   CopyTableDataSpec *tableSpecs)
+{
+	ctx->specs = specs;
+	ctx->tableSpecs = tableSpecs;
+	ctx->bytesTransmitted = 0;
+	INSTR_TIME_SET_CURRENT(ctx->lastSavingTimeMs);
+}
+
+
+/*
  * on_copy_progress_hook saves the copy progress into the catalog.
  * It writes to the DB within at an arbitrary interval.
  */
@@ -998,13 +1012,8 @@ copydb_copy_data_by_oid(CopyDataSpec *specs, PGSQL *src, PGSQL *dst,
 		/*
 		 * 1. Now COPY the TABLE DATA from the source to the destination.
 		 */
-		CopyProgressContext context = {
-			.specs = specs,
-			.tableSpecs = tableSpecs,
-			.bytesTransmitted = 0,
-			.lastSavingTimeMs = 0
-		};
-		INSTR_TIME_SET_CURRENT(context.lastSavingTimeMs);
+		CopyProgressContext context = { 0 };
+		copy_progress_context_init(&context, specs, tableSpecs);
 		if (!table->excludeData)
 		{
 			if (!copydb_copy_table(specs, src, dst, tableSpecs, &context,


### PR DESCRIPTION
Fixes: #388

Allows the user to see the progress of the copy operation by executing the `pgcopydb list progress` command. The user will see that the duration and the bytes transferred will be increasing.