### PR TITLE
Extension config tables are not copied in dependency order

### DIFF
--- a/src/bin/pgcopydb/catalog.c
+++ b/src/bin/pgcopydb/catalog.c
@@ -6735,13 +6735,19 @@ catalog_iter_s_ext_extconfig_init(SourceExtConfigIterator *iter)
 		return false;
 	}
 
+	/*
+	 * Query extension config table based on the order at which it is
+	 * inserted using sqlite's inbuilt "rowid". The insertion order ensures
+	 * that the config tables are inserted according to it's foreign key
+	 * dependency.
+	 */
 	char *sql =
-		"  select count(*) over(order by reloid) as num,  "
+		"  select count(*) over(order by rowid) as num,  "
 		"         count(*) over() as count, "
 		"         oid, reloid, nspname, relname, condition, relkind "
 		"    from s_extension_config "
 		"   where extoid = $1 "
-		"order by reloid";
+		"order by rowid";
 
 	SQLiteQuery *query = &(iter->query);
 


### PR DESCRIPTION
We ensure that extension config tables are queried from source tables based on their dependency(foreign key reference order) order in
https://github.com/dimitri/pgcopydb/pull/702, however while reading from sqlite catalog, we query config tables ordered by ext config table's oid which is not correct.

Here is a response of extension catalog query during the problematic scenario,

![image](https://github.com/user-attachments/assets/3600f95a-4e6f-4849-9387-72c90dc53a0f)

In the above result, config table named "_timescaledb_catalog.dimension"(oid:17242) has FK reference on "_timescaledb_catalog.hypertable"(oid:1097590370), but when it is ordered by it's oid, "dimension" will be copied first causing FK reference failure,

> TimescaleDB: 2024-07-12 11:10:15 UTC [19612]: [66910f17.4c9c-1] 24456 tsdbadmin@tsdb,app=pgcopydb[3821763] copy extensions [23503] ERROR: insert or update on table "dimension" violates foreign key constraint "dimension_hypertable_id_fkey"


Solution: Read extension config table based on the order at which it is inserted using sqlite's inbuilt "rowid".