### PR TITLE
Extension config tables are not copied in dependency order

### DIFF
--- a/src/bin/pgcopydb/schema.c
+++ b/src/bin/pgcopydb/schema.c
@@ -4264,6 +4264,7 @@ getExtensionList(void *ctx, PGresult *result)
 			if (context->catalog != NULL && context->catalog->db != NULL)
 			{
 				config->extoid = extension->oid;
+				config->index = confIndex;
 
 				if (!catalog_add_s_extension_config(context->catalog, config))
 				{

--- a/src/bin/pgcopydb/schema.h
+++ b/src/bin/pgcopydb/schema.h
@@ -56,6 +56,7 @@ typedef struct SourceExtensionConfig
 {
 	uint32_t extoid;               /* extension's oid */
 	uint32_t reloid;               /* pg_class.oid */
+	uint32_t index;                /* extension config index */
 	char nspname[PG_NAMEDATALEN];
 	char relname[PG_NAMEDATALEN];
 	char *condition;            /* strdup from PQresult: malloc'ed area */


### PR DESCRIPTION
We ensure that extension config tables are queried from source tables based on their dependency order in
https://github.com/dimitri/pgcopydb/pull/702/files, however while reading from sqlite catalog inorder to copy, we query config tables order by ext config oid which is not correct.

Solution: Read extension config table based on the configuration array index