### PR TITLE
Review pgcopydb stream sentinel CLI.

### DIFF
--- a/docs/include/stream-sentinel-get.rst
+++ b/docs/include/stream-sentinel-get.rst
@@ -1,8 +1,13 @@
 ::
 
    pgcopydb stream sentinel get: Get the sentinel table values
-   usage: pgcopydb stream sentinel get  --source ... 
+   usage: pgcopydb stream sentinel get 
    
-     --source      Postgres URI to the source database
-     --json        Format the output using JSON
+     --json           Format the output using JSON
+     --startpos       Get only the startpos value
+     --endpos         Get only the endpos value
+     --apply          Get only the apply value
+     --write-lsn      Get only the write LSN value
+     --flush-lsn      Get only the flush LSN value
+     --replay-lsn     Get only the replay LSN value
    

--- a/docs/include/stream-sentinel-set-apply.rst
+++ b/docs/include/stream-sentinel-set-apply.rst
@@ -3,5 +3,4 @@
    pgcopydb stream sentinel set apply: Set the sentinel apply mode
    usage: pgcopydb stream sentinel set apply 
    
-     --source      Postgres URI to the source database
    

--- a/docs/include/stream-sentinel-set-endpos.rst
+++ b/docs/include/stream-sentinel-set-endpos.rst
@@ -1,7 +1,7 @@
 ::
 
    pgcopydb stream sentinel set endpos: Set the sentinel end position LSN
-   usage: pgcopydb stream sentinel set endpos  --source ... <end LSN>
+   usage: pgcopydb stream sentinel set endpos [ --source ... ] [ <end lsn> | --current ]
    
      --source      Postgres URI to the source database
      --current     Use pg_current_wal_flush_lsn() as the endpos

--- a/docs/include/stream-sentinel-set-prefetch.rst
+++ b/docs/include/stream-sentinel-set-prefetch.rst
@@ -3,5 +3,4 @@
    pgcopydb stream sentinel set prefetch: Set the sentinel prefetch mode
    usage: pgcopydb stream sentinel set prefetch 
    
-     --source      Postgres URI to the source database
    

--- a/docs/include/stream-sentinel-set-startpos.rst
+++ b/docs/include/stream-sentinel-set-startpos.rst
@@ -1,7 +1,6 @@
 ::
 
    pgcopydb stream sentinel set startpos: Set the sentinel start position LSN
-   usage: pgcopydb stream sentinel set startpos  --source ... <start LSN>
+   usage: pgcopydb stream sentinel set startpos <start lsn>
    
-     --source      Postgres URI to the source database
    

--- a/docs/include/stream-sentinel-setup.rst
+++ b/docs/include/stream-sentinel-setup.rst
@@ -1,8 +1,6 @@
 ::
 
    pgcopydb stream sentinel setup: Setup the sentinel table
-   usage: pgcopydb stream sentinel setup 
+   usage: pgcopydb stream sentinel setup <start lsn> <end lsn>
    
-     --startpos    Start replaying changes when reaching this LSN
-     --endpos      Stop replaying changes when reaching this LSN
    

--- a/docs/ref/pgcopydb_stream.rst
+++ b/docs/ref/pgcopydb_stream.rst
@@ -151,6 +151,14 @@ pgcopydb stream sentinel set startpos - Set the sentinel start position LSN
 
 .. include:: ../include/stream-sentinel-set-startpos.rst
 
+This is an advanced API used for unit-testing and debugging, the operation
+is automatically covered in normal pgcopydb operations.
+             
+Logical replication target system registers progress by assigning a current
+LSN to the ``--origin`` node name. When creating an origin on the target
+database system, it is required to provide the current LSN from the source
+database system, in order to properly bootstrap pgcopydb logical decoding.
+
 .. _pgcopydb_stream_sentinel_set_endpos:
 
 pgcopydb stream sentinel set endpos
@@ -160,6 +168,19 @@ pgcopydb stream sentinel set endpos - Set the sentinel end position LSN
 
 .. include:: ../include/stream-sentinel-set-endpos.rst
 
+Logical replication target LSN to use. Automatically stop replication and
+exit with normal exit status 0 when receiving reaches the specified LSN. If
+there's a record with LSN exactly equal to lsn, the record will be output.
+
+The ``--endpos`` option is not aware of transaction boundaries and may
+truncate output partway through a transaction. Any partially output
+transaction will not be consumed and will be replayed again when the slot is
+next read from. Individual messages are never truncated.
+
+See also documentation for `pg_recvlogical`__.
+
+__ https://www.postgresql.org/docs/current/app-pgrecvlogical.html
+             
 .. _pgcopydb_stream_sentinel_set_apply:
 
 pgcopydb stream sentinel set apply
@@ -310,22 +331,6 @@ The following options are available to ``pgcopydb stream`` sub-commands:
 
   Logical decoding slot name to use.
 
---endpos
-
-  Logical replication target LSN to use. Automatically stop replication and
-  exit with normal exit status 0 when receiving reaches the specified LSN.
-  If there's a record with LSN exactly equal to lsn, the record will be
-  output.
-
-  The ``--endpos`` option is not aware of transaction boundaries and may
-  truncate output partway through a transaction. Any partially output
-  transaction will not be consumed and will be replayed again when the slot
-  is next read from. Individual messages are never truncated.
-
-  See also documentation for `pg_recvlogical`__.
-
-  __ https://www.postgresql.org/docs/current/app-pgrecvlogical.html
-
 --origin
 
   Logical replication target system needs to track the transactions that
@@ -339,14 +344,6 @@ The following options are available to ``pgcopydb stream`` sub-commands:
   target, where each source should have their own unique origin node name.
 
   __ https://www.postgresql.org/docs/current/replication-origins.html
-
---startpos
-
-  Logical replication target system registers progress by assigning a
-  current LSN to the ``--origin`` node name. When creating an origin on the
-  target database system, it is required to provide the current LSN from the
-  source database system, in order to properly bootstrap pgcopydb logical
-  decoding.
 
 --verbose
 

--- a/src/bin/pgcopydb/cli_common.h
+++ b/src/bin/pgcopydb/cli_common.h
@@ -28,6 +28,22 @@ typedef struct SplitTableLargerThan
 } SplitTableLargerThan;
 
 
+typedef struct SentinelOptions
+{
+	/* pgcopydb stream sentinel get --flush-lsn */
+	bool startpos;
+	bool endpos;
+	bool apply;
+	bool writeLSN;
+	bool transformLSN;
+	bool flushLSN;
+	bool replayLSN;
+
+	/* pgcopydb stream sentinel set endpos --current */
+	bool currentLSN;
+} SentinelOptions;
+
+
 typedef struct CopyDBOptions
 {
 	char dir[MAXPGPATH];
@@ -69,9 +85,12 @@ typedef struct CopyDBOptions
 
 	bool follow;
 	bool createSlot;
-	bool currentpos;
+
+	/* pgcopydb stream sentinel get --flush-lsn and friends */
+	SentinelOptions sentinelOptions;
+
+	/* pgcopydb stream receive|transform|apply --endpos %X%X */
 	uint64_t endpos;
-	uint64_t startpos;
 
 	char filterFileName[MAXPGPATH];
 	char requirementsFileName[MAXPGPATH];


### PR DESCRIPTION
Add new options to `pgcopydb stream sentinel get` allowing to fetch a single LSN value, avoiding the need to use `awk`, `jq`, or something equivalent to then parse a single entry in the command output.