### PR TITLE
Fixes literalWithCharPtrCompare cppcheck warnings

### DIFF
--- a/src/bin/pgcopydb/string_utils.h
+++ b/src/bin/pgcopydb/string_utils.h
@@ -11,9 +11,11 @@
 
 #define NULL_AS_EMPTY_STRING(str) (str == NULL ? "" : str)
 
+/* casting to const char * is necessary to avoid literalWithCharPtrCompare cppcheck finding */
 #define streq(a, b) \
 	(((const char *) a != NULL) && ((const char *) b != NULL) && (strcmp(a, b) == 0))
 
+/* casting to const char * is necessary to avoid literalWithCharPtrCompare cppcheck finding */
 #define strneq(a, b) \
 	(((const char *) a != NULL) && ((const char *) b != NULL) && (strcmp(a, b) != 0))
 

--- a/src/bin/pgcopydb/string_utils.h
+++ b/src/bin/pgcopydb/string_utils.h
@@ -11,10 +11,11 @@
 
 #define NULL_AS_EMPTY_STRING(str) (str == NULL ? "" : str)
 
-#define streq(a, b) (a != NULL && b != NULL && strcmp(a, b) == 0)
+#define streq(a, b) \
+	(((const char *) a != NULL) && ((const char *) b != NULL) && (strcmp(a, b) == 0))
 
-#define strneq(x, y) \
-	((x != NULL) && (y != NULL) && (strcmp(x, y) != 0))
+#define strneq(a, b) \
+	(((const char *) a != NULL) && ((const char *) b != NULL) && (strcmp(a, b) != 0))
 
 /* maximum decimal int64 length with minus and NUL */
 #define INTSTRING_MAX_DIGITS 21

--- a/src/bin/pgcopydb/string_utils.h
+++ b/src/bin/pgcopydb/string_utils.h
@@ -11,11 +11,14 @@
 
 #define NULL_AS_EMPTY_STRING(str) (str == NULL ? "" : str)
 
-/* casting to const char * is necessary to avoid literalWithCharPtrCompare cppcheck finding */
+/* 
+ * Casting to const char * is necessary when comparing a C-string (char *)
+ * with a C string buffer (char[]), as reported by the cppcheck warning:
+ * literalWithCharPtrCompare
+ */
 #define streq(a, b) \
 	(((const char *) a != NULL) && ((const char *) b != NULL) && (strcmp(a, b) == 0))
 
-/* casting to const char * is necessary to avoid literalWithCharPtrCompare cppcheck finding */
 #define strneq(a, b) \
 	(((const char *) a != NULL) && ((const char *) b != NULL) && (strcmp(a, b) != 0))
 


### PR DESCRIPTION
The reason for the warning is the comparison of string literals like "ctid" with NULL, which appeared at 23 points as follows:
```bash
src/bin/pgcopydb/cli_list.c:1385:6: warning: String literal compared with variable 'NULL'. Did you intend to use strcmp() instead? [literalWithCharPtrCompare]
 if (streq(table->partKey, "ctid"))
     ^
```