### PR TITLE
Use compose plugin of docker

### DIFF
--- a/tests/blobs/Makefile
+++ b/tests/blobs/Makefile
@@ -4,13 +4,13 @@
 test: down run down ;
 
 run: build
-	docker-compose run test
+	docker compose run test
 
 down:
-	docker-compose down
+	docker compose down
 
 build:
-	docker-compose build --quiet
+	docker compose build --quiet
 
 import:
 	psql --single-transaction --no-psqlrc -f import.sql

--- a/tests/cdc-endpos-between-transaction/Makefile
+++ b/tests/cdc-endpos-between-transaction/Makefile
@@ -4,12 +4,12 @@
 test: down run down ;
 
 run: build
-	docker-compose run test
+	docker compose run test
 
 down:
-	docker-compose down
+	docker compose down
 
 build:
-	docker-compose build --quiet
+	docker compose build --quiet
 
 .PHONY: run down build test

--- a/tests/cdc-low-level/Makefile
+++ b/tests/cdc-low-level/Makefile
@@ -4,12 +4,12 @@
 test: down run down ;
 
 run: build
-	docker-compose run test
+	docker compose run test
 
 down:
-	docker-compose down
+	docker compose down
 
 build:
-	docker-compose build --quiet
+	docker compose build --quiet
 
 .PHONY: run down build test

--- a/tests/cdc-test-decoding/Makefile
+++ b/tests/cdc-test-decoding/Makefile
@@ -4,12 +4,12 @@
 test: down run down ;
 
 run: build
-	docker-compose run test
+	docker compose run test
 
 down:
-	docker-compose down
+	docker compose down
 
 build:
-	docker-compose build --quiet
+	docker compose build --quiet
 
 .PHONY: run down build test

--- a/tests/cdc-wal2json/Makefile
+++ b/tests/cdc-wal2json/Makefile
@@ -6,15 +6,15 @@ COMPOSE_EXIT = --exit-code-from=test --abort-on-container-exit
 test: down run down ;
 
 up: down build
-	docker-compose up $(COMPOSE_EXIT)
+	docker compose up $(COMPOSE_EXIT)
 
 run: build
-	docker-compose run test
+	docker compose run test
 
 down:
-	docker-compose down
+	docker compose down
 
 build:
-	docker-compose build --quiet
+	docker compose build --quiet
 
 .PHONY: run down build test

--- a/tests/endpos-in-multi-wal-txn/Makefile
+++ b/tests/endpos-in-multi-wal-txn/Makefile
@@ -4,12 +4,12 @@
 test: down run down ;
 
 run: build
-	docker-compose run test
+	docker compose run test
 
 down:
-	docker-compose down
+	docker compose down
 
 build:
-	docker-compose build --quiet
+	docker compose build --quiet
 
 .PHONY: run down build test

--- a/tests/extensions/Makefile
+++ b/tests/extensions/Makefile
@@ -4,12 +4,12 @@
 test: down run down ;
 
 run: build
-	docker-compose run test
+	docker compose run test
 
 down:
-	docker-compose down
+	docker compose down
 
 build:
-	docker-compose build --quiet
+	docker compose build --quiet
 
 .PHONY: run down build test

--- a/tests/filtering/Makefile
+++ b/tests/filtering/Makefile
@@ -4,12 +4,12 @@
 test: down run down ;
 
 run: build
-	docker-compose run test
+	docker compose run test
 
 down:
-	docker-compose down
+	docker compose down
 
 build:
-	docker-compose build --quiet
+	docker compose build --quiet
 
 .PHONY: run down build test

--- a/tests/follow-9.6/Makefile
+++ b/tests/follow-9.6/Makefile
@@ -7,16 +7,16 @@ COMPOSE_EXIT = --exit-code-from=test --abort-on-container-exit
 test: down run down ;
 
 up: down build
-	PGVERSION=$(PGVERSION) docker-compose up $(COMPOSE_EXIT)
+	PGVERSION=$(PGVERSION) docker compose up $(COMPOSE_EXIT)
 
 run: build
-	PGVERSION=$(PGVERSION) docker-compose run test
+	PGVERSION=$(PGVERSION) docker compose run test
 
 down:
-	docker-compose down
+	docker compose down
 	rm -rf workdir/pgcopydb
 
 build:
-	PGVERSION=$(PGVERSION) docker-compose build
+	PGVERSION=$(PGVERSION) docker compose build
 
 .PHONY: run down build test

--- a/tests/follow-9.6/inject.sh
+++ b/tests/follow-9.6/inject.sh
@@ -66,7 +66,7 @@ pgcopydb stream sentinel set endpos --current
 pgcopydb stream sentinel get
 
 #
-# Becaure we're using docker-compose --abort-on-container-exit make sure
+# Becaure we're using docker compose --abort-on-container-exit make sure
 # that the other process in the pgcopydb service is done before exiting
 # here.
 #

--- a/tests/follow-data-only/Makefile
+++ b/tests/follow-data-only/Makefile
@@ -6,16 +6,16 @@ COMPOSE_EXIT = --exit-code-from=test --abort-on-container-exit
 test: down run down ;
 
 up: down build
-	docker-compose up $(COMPOSE_EXIT)
+	docker compose up $(COMPOSE_EXIT)
 
 run: build
-	docker-compose run test
+	docker compose run test
 
 down:
-	docker-compose down
+	docker compose down
 	rm -rf workdir/pgcopydb
 
 build:
-	docker-compose build --quiet
+	docker compose build --quiet
 
 .PHONY: run down build test

--- a/tests/follow-data-only/inject.sh
+++ b/tests/follow-data-only/inject.sh
@@ -72,7 +72,7 @@ pgcopydb stream sentinel set endpos --current
 pgcopydb stream sentinel get
 
 #
-# Becaure we're using docker-compose --abort-on-container-exit make sure
+# Becaure we're using docker compose --abort-on-container-exit make sure
 # that the other process in the pgcopydb service is done before exiting
 # here.
 #

--- a/tests/follow-wal2json/Makefile
+++ b/tests/follow-wal2json/Makefile
@@ -6,16 +6,16 @@ COMPOSE_EXIT = --exit-code-from=test --abort-on-container-exit
 test: down run down ;
 
 up: down build
-	docker-compose up $(COMPOSE_EXIT)
+	docker compose up $(COMPOSE_EXIT)
 
 run: build
-	docker-compose run test
+	docker compose run test
 
 down:
-	docker-compose down
+	docker compose down
 	rm -rf workdir/pgcopydb
 
 build:
-	docker-compose build --quiet
+	docker compose build --quiet
 
 .PHONY: run down build test

--- a/tests/follow-wal2json/inject.sh
+++ b/tests/follow-wal2json/inject.sh
@@ -48,7 +48,7 @@ pgcopydb stream sentinel set endpos --current
 pgcopydb stream sentinel get
 
 #
-# Becaure we're using docker-compose --abort-on-container-exit make sure
+# Becaure we're using docker compose --abort-on-container-exit make sure
 # that the other process in the pgcopydb service is done before exiting
 # here.
 #

--- a/tests/pagila-multi-steps/Makefile
+++ b/tests/pagila-multi-steps/Makefile
@@ -4,12 +4,12 @@
 test: down run down ;
 
 run: build
-	docker-compose run test
+	docker compose run test
 
 down:
-	docker-compose down
+	docker compose down
 
 build:
-	docker-compose build --quiet
+	docker compose build --quiet
 
 .PHONY: run down build test

--- a/tests/pagila-standby/Dockerfile
+++ b/tests/pagila-standby/Dockerfile
@@ -1,4 +1,4 @@
-# that image is built by docker-compose build: project-service
+# that image is built by docker compose build: project-service
 FROM pagila
 
 COPY --from=pgcopydb /usr/local/bin/pgcopydb /usr/local/bin

--- a/tests/pagila-standby/Makefile
+++ b/tests/pagila-standby/Makefile
@@ -4,12 +4,12 @@
 test: down run down ;
 
 run: build
-	docker-compose run test
+	docker compose run test
 
 down:
-	docker-compose down
+	docker compose down
 
 build:
-	docker-compose build --quiet
+	docker compose build --quiet
 
 .PHONY: down build test

--- a/tests/pagila/Dockerfile
+++ b/tests/pagila/Dockerfile
@@ -1,4 +1,4 @@
-# that image is built by docker-compose build: project-service
+# that image is built by docker compose build: project-service
 FROM pagila
 
 COPY --from=pgcopydb /usr/local/bin/pgcopydb /usr/local/bin

--- a/tests/pagila/Makefile
+++ b/tests/pagila/Makefile
@@ -4,12 +4,12 @@
 test: down run down ;
 
 run: build
-	docker-compose run test
+	docker compose run test
 
 down:
-	docker-compose down
+	docker compose down
 
 build:
-	docker-compose build --quiet
+	docker compose build --quiet
 
 .PHONY: down build test

--- a/tests/unit/Dockerfile
+++ b/tests/unit/Dockerfile
@@ -1,4 +1,4 @@
-# that image is built by docker-compose build: project-service
+# that image is built by docker compose build: project-service
 FROM pagila
 
 WORKDIR /usr/src/pgcopydb

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -4,12 +4,12 @@
 test: down run down ;
 
 run: build
-	docker-compose run test
+	docker compose run test
 
 down:
-	docker-compose down
+	docker compose down
 
 build:
-	docker-compose build --quiet
+	docker compose build --quiet
 
 .PHONY: run down build test


### PR DESCRIPTION
`docker-compose`` is an external tool written in python and is deprecated for a while. Github actions also removed support for that recently.

docker cli has a plugin named compose that is available as a command of the cli as in `docker compose`.

`docker-compose` and `docker compose` do not have same specifcations and it is not always a trivial task to migrate from one to another. This commit will only change all the references to the `docker-compose` to `docker compose` in our codebase.

Github Actions removed support for `docker-compose` in https://github.com/actions/runner-images/pull/10368

More details available at https://docs.docker.com/compose/intro/history/

Closes: #847 