### PR TITLE
Bugfix: support filtering out only some of the partitions

### DIFF
--- a/src/bin/pgcopydb/schema.c
+++ b/src/bin/pgcopydb/schema.c
@@ -1189,7 +1189,7 @@ struct FilteringQueries listSourceTablesSQL[] = {
 		"              limit 1"
 		"         ) as pkeys on true"
 
-		"   where relkind in ('r', 'p', 'm') and c.relpersistence in ('p', 'u') "
+		"   where relkind in ('r', 'm') and c.relpersistence in ('p', 'u') "
 		"     and n.nspname !~ '^pg_' and n.nspname <> 'information_schema' "
 		"     and n.nspname !~ 'pgcopydb' "
 

--- a/tests/filtering/exclude.ini
+++ b/tests/filtering/exclude.ini
@@ -17,3 +17,4 @@ foo.matview_1_exclude_as_table
 
 [exclude-table-data]
 foo.matview_1_exclude_data
+partitioned_tables.sellers_archive

--- a/tests/filtering/extra.sql
+++ b/tests/filtering/extra.sql
@@ -107,3 +107,15 @@ select setval('seq.standalone_smallint_id_seq', 670);
 
 -- A standalone sequence with a minvalue that has not been set
 create sequence seq.standalone_minvalue_id_seq minvalue 671;
+
+create schema partitioned_tables;
+
+create table partitioned_tables.sellers (
+    id bigint,
+    archive smallint not null
+) partition by list (archive);
+
+create table partitioned_tables.sellers_active partition of partitioned_tables.sellers default;
+create table partitioned_tables.sellers_archive partition of partitioned_tables.sellers for values in ('1');
+
+insert into partitioned_tables.sellers (id, archive) values (1, 0), (2, 1), (3, 0);

--- a/tests/filtering/include/expected/3-schema-bar-does-not-exists.out
+++ b/tests/filtering/include/expected/3-schema-bar-does-not-exists.out
@@ -5,9 +5,11 @@ nspname | copy
 -[ RECORD 3 ]-----------------
 nspname | foo
 -[ RECORD 4 ]-----------------
-nspname | public
+nspname | partitioned_tables
 -[ RECORD 5 ]-----------------
-nspname | schema_name_20_chars
+nspname | public
 -[ RECORD 6 ]-----------------
+nspname | schema_name_20_chars
+-[ RECORD 7 ]-----------------
 nspname | seq
 


### PR DESCRIPTION
We have a bug when migrating some partitioned tables and some partitions are excluded from the migration.

PostgreSQL command `TRUNCATE ONLY` does not support partitioned tables, and following errors happen if the command is used on partitioned tables:

```
ERROR:  cannot truncate only a partitioned table
HINT:  Do not specify the ONLY keyword, or use TRUNCATE ONLY on the partitions directly.
ERROR:  cannot truncate only a partitioned table
SQL query: TRUNCATE ONLY partitioned_tables.sellers
```

Related: #700
Closes: #856 