### PR TITLE
Fixes online migration with composite primary key

### DIFF
--- a/src/bin/pgcopydb/ld_apply.c
+++ b/src/bin/pgcopydb/ld_apply.c
@@ -583,6 +583,13 @@ stream_apply_sql(StreamApplyContext *context,
 {
 	PGSQL *applyPgConn = &(context->applyPgConn);
 
+	if (logical_message_metadata_should_skip_statement(metadata, context->preparedStmt))
+	{
+		context->preparedStmt = NULL;
+		log_debug("Skipping statement: %s", sql);
+		return true;
+	}
+
 	switch (metadata->action)
 	{
 		case STREAM_ACTION_SWITCH:

--- a/src/bin/pgcopydb/ld_stream.h
+++ b/src/bin/pgcopydb/ld_stream.h
@@ -777,4 +777,8 @@ bool follow_terminate_subprocesses(StreamSpecs *specs);
 
 bool follow_wait_pid(pid_t subprocess, bool *exited, int *returnCode, int *sig);
 
+bool logical_message_metadata_should_skip_statement(const
+													LogicalMessageMetadata *metadata,
+													const PreparedStmt *preparedStmt);
+
 #endif /* LD_STREAM_H */

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -2066,7 +2066,6 @@ pgsql_sync_pipeline(PGSQL *pgsql)
 		if (!is_response_ok(res))
 		{
 			(void) pgcopy_log_error(pgsql, res, "Failed to receive pipeline sync");
-			PQclear(res);
 
 			return false;
 		}

--- a/tests/follow-wal2json/Dockerfile
+++ b/tests/follow-wal2json/Dockerfile
@@ -3,6 +3,7 @@ FROM pagila
 WORKDIR /usr/src/pgcopydb
 COPY ./copydb.sh copydb.sh
 COPY ./dml.sql dml.sql
+COPY ./dml2.sql dml2.sql
 COPY ./ddl.sql ddl.sql
 
 USER docker

--- a/tests/follow-wal2json/Dockerfile.inject
+++ b/tests/follow-wal2json/Dockerfile.inject
@@ -9,6 +9,7 @@ RUN apt-get update \
 WORKDIR /usr/src/pgcopydb
 COPY ./inject.sh inject.sh
 COPY ./dml.sql dml.sql
+COPY ./dml2.sql dml2.sql
 
 USER docker
 CMD ["/usr/src/pgcopydb/inject.sh"]

--- a/tests/follow-wal2json/ddl.sql
+++ b/tests/follow-wal2json/ddl.sql
@@ -11,4 +11,12 @@ alter table payment_p2022_04 replica identity full;
 alter table payment_p2022_05 replica identity full;
 alter table payment_p2022_06 replica identity full;
 alter table payment_p2022_07 replica identity full;
+
+--- test_table_with_composite_pk is used to create the test case for the a bug in wall2json problem.
+--- For more information, see: https://github.com/dimitri/pgcopydb/issues/750
+CREATE TABLE test_table_with_composite_pk (
+    id INTEGER,
+    name TEXT,
+    CONSTRAINT test_pk PRIMARY KEY (id, name)
+);
 commit;

--- a/tests/follow-wal2json/dml2.sql
+++ b/tests/follow-wal2json/dml2.sql
@@ -1,0 +1,18 @@
+---
+--- pgcopydb test/cdc/dml2.sql
+---
+--- This file is used to create the test case for the a bug in wall2json problem.
+--- For more information, see: https://github.com/dimitri/pgcopydb/issues/750
+
+begin;
+insert into test_table_with_composite_pk (id,name) values (1,'postgres');
+insert into test_table_with_composite_pk (id,name) values (2,'oracle');
+insert into test_table_with_composite_pk (id,name) values (3,'mysql');
+insert into test_table_with_composite_pk (id,name) values (4,'couchbase');
+insert into test_table_with_composite_pk (id,name) values (5,'redis');
+commit;
+
+begin;
+update test_table_with_composite_pk set id = id where 1 = 1;
+update test_table_with_composite_pk set name = 'REDIS' where id = 5;
+commit;

--- a/tests/follow-wal2json/inject.sh
+++ b/tests/follow-wal2json/inject.sh
@@ -42,6 +42,11 @@ do
     sleep 1
 done
 
+# This psql call is used to create the test case for the a bug in wall2json problem.
+# For more information, see: https://github.com/dimitri/pgcopydb/issues/750
+psql -d ${PGCOPYDB_SOURCE_PGURI} -f /usr/src/pgcopydb/dml2.sql || true
+
+
 # grab the current LSN, it's going to be our streaming end position
 lsn=`psql -At -d ${PGCOPYDB_SOURCE_PGURI} -c 'select pg_current_wal_flush_lsn()'`
 pgcopydb stream sentinel set endpos --current


### PR DESCRIPTION
Refactor code to skip executing empty UPDATE statements

The logical_message_metadata_should_skip_statement function has been added to check if the logical message metadata should be skipped. This is necessary due to a bug in the wall2json output plugin that creates an UPDATE statement with an empty SET clause and places the actual SET clause in the WHERE clause. The function checks for this specific pattern and returns true if found, indicating that the statement should be skipped during execution.

In passing fixes a double free bug.

Fixes: dimitri/pgcopydb#750