### PR TITLE
Tests are broken after PG17 release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -118,7 +118,7 @@ RUN dpkg --add-architecture ${TARGETARCH:-arm64} && apt update \
     psmisc \
     openssl \
     postgresql-common \
-    postgresql-client \
+    postgresql-client-${PGVERSION} \
     postgresql-client-common \
     && apt clean \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
We do not pin the postgresql-client causing the test failures after PG17 release due to the issue discussed here in the PG mailing list[1].

> I think there are other issues related to b0e96f3119 (Catalog not-null
constraints) - if I dump a v16 server using v17 tools, the backup can't
be restored into the v16 server.  I'm okay ignoring a line or two like
'unrecognized configuration parameter "transaction_timeout", but not
'syntax error at or near "NO"'.

This commit pins the postgresql-client version as per the docker env variable PGVERSION.

[1] https://postgrespro.com/list/thread-id/2693550