### PR TITLE
Fix pipe done read condition.

### DIFF
--- a/src/bin/lib/subcommands.c/runprogram.h
+++ b/src/bin/lib/subcommands.c/runprogram.h
@@ -565,7 +565,7 @@ read_from_pipes(Program *prog, pid_t childPid, int *outpipe, int *errpipe)
 					prog->error = errno;
 				}
 			}
-			doneReading = (bytes_out < BUFSIZE && bytes_err < BUFSIZE);
+			doneReading = (bytes_out == 0 && bytes_err == 0);
 		}
 	}
 


### PR DESCRIPTION
man page for the read() function

```
RETURN VALUE
      On success, the number of bytes read is returned (zero indicates end of file), and the file position is
      advanced by this number.  It is not an error if this number is smaller than the number  of  bytes  requested;
      this  may  happen  for  example because fewer bytes are actually available right now (maybe because we were
      close to end-of-file, or because we are reading from a pipe, or from a terminal), or because read() was
      interrupted by a signal.
```

**Scenario**

pgcopydb exits prematurely without reading the stdout/stderr buffers. vacuumdb tries to write to stdout/stderr but the output is not being read by pgcopydb, and the data accumulates in the pipe buffer. vacuumdb gets blocked once the pipe buffers are full.

```
(gdb) bt
#0  0x000072466fe95c7f in wait4 () from target:/lib/x86_64-linux-gnu/libc.so.6
#1  0x00005fb17839dca0 in waitprogram (childPid=childPid@entry=51, prog=<optimized out>, prog=<optimized out>)
    at /usr/src/pgcopydb/src/bin/pgcopydb/../lib/subcommands.c/runprogram.h:610
#2  0x00005fb17839e390 in **read_from_pipes** (errpipe=0x7ffd5f70ad28, outpipe=0x7ffd5f70ad20, childPid=51, prog=0x7ffd5f70ae10)
    at /usr/src/pgcopydb/src/bin/pgcopydb/../lib/subcommands.c/runprogram.h:585
#3  execute_subprogram (prog=prog@entry=0x7ffd5f70ae10) at /usr/src/pgcopydb/src/bin/pgcopydb/../lib/subcommands.c/runprogram.h:313
#4  0x00005fb17839f67d in **pg_vacuumdb_analyze_only** (pgPaths=pgPaths@entry=0x7ffd5f718f10,
    connStrings=connStrings@entry=0x7ffd5f71a798, jobs=<optimized out>) at pgcmd.c:629
#5  0x00005fb1783a7bc6 in copydb_prepare_table_specs (pgsql=0x7ffd5f70b880, specs=0x7ffd5f713b10) at copydb_schema.c:662
#6  copydb_fetch_source_schema (src=0x7ffd5f70b880, specs=0x7ffd5f713b10) at copydb_schema.c:541
#7  copydb_fetch_schema_and_prepare_specs (specs=specs@entry=0x7ffd5f713b10) at copydb_schema.c:112
```