### PR TITLE
Use our own memory area for editing libpq static error messages

### DIFF
--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -2278,7 +2278,11 @@ pgsql_execute_log_error(PGSQL *pgsql,
 	{
 		/* make sure message is writable by splitLines */
 		message = strdup(message);
-		/* Because we link with the libc Garbage Collector, we don't need to call free later */
+
+		/* 
+		 * Because we link with the libc Garbage Collector, 
+		 * we don't need to call free later 
+		 */
 	}
 
 	if (!splitLines(&lbuf, message))

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -2274,9 +2274,11 @@ pgsql_execute_log_error(PGSQL *pgsql,
 
 	LinesBuffer lbuf = { 0 };
 
-	if (message != NULL){
-		// make sure message is writable by splitLines
+	if (message != NULL)
+	{
+		/* make sure message is writable by splitLines */
 		message = strdup(message);
+		/* Because we link with the libc Garbage Collector, we don't need to call free later */
 	}
 
 	if (!splitLines(&lbuf, message))
@@ -2292,7 +2294,6 @@ pgsql_execute_log_error(PGSQL *pgsql,
 				  PQbackendPID(pgsql->connection),
 				  lbuf.lines[lineNumber]);
 	}
-	free(message); // free copy of message we created above
 
 	if (pgsql->logSQL)
 	{

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -2273,11 +2273,11 @@ pgsql_execute_log_error(PGSQL *pgsql,
 	LinesBuffer lbuf = { 0 };
 
 	/*
-     * PostgreSQL error message could be a static memory area in the
+	 * PostgreSQL error message could be a static memory area in the
 	 * code, in which case we are not allowed to edit the text and inject
-     * newlines. Duplicate the memory area before manipulating it.
+	 * newlines. Duplicate the memory area before manipulating it.
 	 *
-     * Also, because we use the Boehm GC lib, refrain from manually calling
+	 * Also, because we use the Boehm GC lib, refrain from manually calling
 	 * free() on the newly allocated memory area.
 	 */
 	if (message != NULL)

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -2274,6 +2274,11 @@ pgsql_execute_log_error(PGSQL *pgsql,
 
 	LinesBuffer lbuf = { 0 };
 
+	if (message != NULL){
+		// make sure message is writable by splitLines
+		message = strdup(message);
+	}
+
 	if (!splitLines(&lbuf, message))
 	{
 		/* errors have already been logged */
@@ -2287,6 +2292,7 @@ pgsql_execute_log_error(PGSQL *pgsql,
 				  PQbackendPID(pgsql->connection),
 				  lbuf.lines[lineNumber]);
 	}
+	free(message); // free copy of message we created above
 
 	if (pgsql->logSQL)
 	{

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -2272,15 +2272,18 @@ pgsql_execute_log_error(PGSQL *pgsql,
 
 	LinesBuffer lbuf = { 0 };
 
+	/*
+     * PostgreSQL error message could be a static memory area in the
+	 * code, in which case we are not allowed to edit the text and inject
+     * newlines. Duplicate the memory area before manipulating it.
+	 *
+     * Also, because we use the Boehm GC lib, refrain from manually calling
+	 * free() on the newly allocated memory area.
+	 */
 	if (message != NULL)
 	{
 		/* make sure message is writable by splitLines */
 		message = strdup(message);
-
-		/* 
-		 * Because we link with the libc Garbage Collector, 
-		 * we don't need to call free later 
-		 */
 	}
 
 	if (!splitLines(&lbuf, message))


### PR DESCRIPTION
see segmentation fault described in https://github.com/neondatabase/neon/pull/10706