### PR TITLE
.env file support with retry mechanism

### DIFF
--- a/docs/include/clone.rst
+++ b/docs/include/clone.rst
@@ -43,4 +43,5 @@
      --origin                      Use this Postgres replication origin node name
      --endpos                      Stop replaying changes when reaching this LSN
      --use-copy-binary             Use the COPY BINARY format for COPY operations
+     --connection-retry-timeout    Number of seconds to retry before connection times out
    

--- a/docs/include/copy-db.rst
+++ b/docs/include/copy-db.rst
@@ -3,24 +3,25 @@
    pgcopydb copy db: Copy an entire database from source to target
    usage: pgcopydb copy db  --source ... --target ... [ --table-jobs ... --index-jobs ... ] 
    
-     --source              Postgres URI to the source database
-     --target              Postgres URI to the target database
-     --dir                 Work directory to use
-     --table-jobs          Number of concurrent COPY jobs to run
-     --index-jobs          Number of concurrent CREATE INDEX jobs to run
-     --restore-jobs        Number of concurrent jobs for pg_restore
-     --drop-if-exists      On the target database, clean-up from a previous run first
-     --roles               Also copy roles found on source to target
-     --no-owner            Do not set ownership of objects to match the original database
-     --no-acl              Prevent restoration of access privileges (grant/revoke commands).
-     --no-comments         Do not output commands to restore comments
-     --no-tablespaces      Do not output commands to select tablespaces
-     --skip-large-objects  Skip copying large objects (blobs)
-     --filters <filename>  Use the filters defined in <filename>
-     --fail-fast           Abort early in case of error
-     --restart             Allow restarting when temp files exist already
-     --resume              Allow resuming operations after a failure
-     --not-consistent      Allow taking a new snapshot on the source database
-     --snapshot            Use snapshot obtained with pg_export_snapshot
-     --use-copy-binary     Use the COPY BINARY format for COPY operations
+     --source                      Postgres URI to the source database
+     --target                      Postgres URI to the target database
+     --dir                         Work directory to use
+     --table-jobs                  Number of concurrent COPY jobs to run
+     --index-jobs                  Number of concurrent CREATE INDEX jobs to run
+     --restore-jobs                Number of concurrent jobs for pg_restore
+     --drop-if-exists              On the target database, clean-up from a previous run first
+     --roles                       Also copy roles found on source to target
+     --no-owner                    Do not set ownership of objects to match the original database
+     --no-acl                      Prevent restoration of access privileges (grant/revoke commands).
+     --no-comments                 Do not output commands to restore comments
+     --no-tablespaces              Do not output commands to select tablespaces
+     --skip-large-objects          Skip copying large objects (blobs)
+     --filters <filename>          Use the filters defined in <filename>
+     --fail-fast                   Abort early in case of error
+     --restart                     Allow restarting when temp files exist already
+     --resume                      Allow resuming operations after a failure
+     --not-consistent              Allow taking a new snapshot on the source database
+     --snapshot                    Use snapshot obtained with pg_export_snapshot
+     --use-copy-binary             Use the COPY BINARY format for COPY operations
+     --connection-retry-timeout    Number of seconds to retry before connection times out
    

--- a/docs/include/dump-roles.rst
+++ b/docs/include/dump-roles.rst
@@ -3,8 +3,9 @@
    pgcopydb dump roles: Dump source database roles as custome file in work directory
    usage: pgcopydb dump roles  --source <URI>
    
-     --source            Postgres URI to the source database
-     --target            Directory where to save the dump files
-     --dir               Work directory to use
-     --no-role-passwords Do not dump passwords for roles
+     --source                      Postgres URI to the source database
+     --target                      Directory where to save the dump files
+     --dir                         Work directory to use
+     --no-role-passwords           Do not dump passwords for roles
+     --connection-retry-timeout    Number of seconds to retry before connection times out
    

--- a/docs/include/dump-schema.rst
+++ b/docs/include/dump-schema.rst
@@ -3,10 +3,11 @@
    pgcopydb dump schema: Dump source database schema as custom files in work directory
    usage: pgcopydb dump schema  --source <URI> 
    
-     --source             Postgres URI to the source database
-     --target             Directory where to save the dump files
-     --dir                Work directory to use
-     --skip-extensions    Skip restoring extensions
-     --filters <filename> Use the filters defined in <filename>
-     --snapshot           Use snapshot obtained with pg_export_snapshot
+     --source                      Postgres URI to the source database
+     --target                      Directory where to save the dump files
+     --dir                         Work directory to use
+     --skip-extensions             Skip restoring extensions
+     --filters <filename>          Use the filters defined in <filename>
+     --snapshot                    Use snapshot obtained with pg_export_snapshot
+     --connection-retry-timeout    Number of seconds to retry before connection times out
    

--- a/docs/include/list-table-parts.rst
+++ b/docs/include/list-table-parts.rst
@@ -3,12 +3,13 @@
    pgcopydb list table-parts: List a source table copy partitions
    usage: pgcopydb list table-parts  --source ... 
    
-     --source                    Postgres URI to the source database
-     --force                     Force fetching catalogs again
-     --schema-name               Name of the schema where to find the table
-     --table-name                Name of the target table
-     --split-tables-larger-than  Size threshold to consider partitioning
-     --split-max-parts           Maximum number of jobs for Same-table concurrency 
-     --skip-split-by-ctid        Skip the ctid split
-     --estimate-table-sizes      Allow using estimates for relation sizes
+     --source                      Postgres URI to the source database
+     --force                       Force fetching catalogs again
+     --schema-name                 Name of the schema where to find the table
+     --table-name                  Name of the target table
+     --split-tables-larger-than    Size threshold to consider partitioning
+     --split-max-parts             Maximum number of jobs for Same-table concurrency 
+     --skip-split-by-ctid          Skip the ctid split
+     --estimate-table-sizes        Allow using estimates for relation sizes
+     --connection-retry-timeout    Number of seconds to retry before connection times out
    

--- a/docs/include/ping.rst
+++ b/docs/include/ping.rst
@@ -3,6 +3,7 @@
    pgcopydb ping: Attempt to connect to the source and target instances
    usage: pgcopydb ping  --source ... --target ... 
    
-     --source              Postgres URI to the source database
-     --target              Postgres URI to the target database
+     --source                      Postgres URI to the source database
+     --target                      Postgres URI to the target database
+     --connection-retry-timeout    Number of seconds to retry before connection times out
    

--- a/docs/include/restore-schema.rst
+++ b/docs/include/restore-schema.rst
@@ -3,17 +3,18 @@
    pgcopydb restore schema: Restore a database schema from custom files to target database
    usage: pgcopydb restore schema  --dir <dir> [ --source <URI> ] --target <URI> 
    
-     --source             Postgres URI to the source database
-     --target             Postgres URI to the target database
-     --dir                Work directory to use
-     --restore-jobs       Number of concurrent jobs for pg_restore
-     --drop-if-exists     On the target database, clean-up from a previous run first
-     --no-owner           Do not set ownership of objects to match the original database
-     --no-acl             Prevent restoration of access privileges (grant/revoke commands).
-     --no-comments        Do not output commands to restore comments
-     --no-tablespaces     Do not output commands to select tablespaces
-     --filters <filename> Use the filters defined in <filename>
-     --restart            Allow restarting when temp files exist already
-     --resume             Allow resuming operations after a failure
-     --not-consistent     Allow taking a new snapshot on the source database
+     --source                      Postgres URI to the source database
+     --target                      Postgres URI to the target database
+     --dir                         Work directory to use
+     --restore-jobs                Number of concurrent jobs for pg_restore
+     --drop-if-exists              On the target database, clean-up from a previous run first
+     --no-owner                    Do not set ownership of objects to match the original database
+     --no-acl                      Prevent restoration of access privileges (grant/revoke commands).
+     --no-comments                 Do not output commands to restore comments
+     --no-tablespaces              Do not output commands to select tablespaces
+     --filters <filename>          Use the filters defined in <filename>
+     --restart                     Allow restarting when temp files exist already
+     --resume                      Allow resuming operations after a failure
+     --not-consistent              Allow taking a new snapshot on the source database
+     --connection-retry-timeout    Number of seconds to retry before connection times out
    

--- a/docs/include/snapshot.rst
+++ b/docs/include/snapshot.rst
@@ -9,4 +9,5 @@
      --plugin                      Output plugin to use (test_decoding, wal2json)
      --wal2json-numeric-as-string  Print numeric data type as string when using wal2json output plugin
      --slot-name                   Use this Postgres replication slot name
+     --connection-retry-timeout    Number of seconds to retry before connection times out
    

--- a/docs/include/stream-setup.rst
+++ b/docs/include/stream-setup.rst
@@ -14,4 +14,5 @@
      --wal2json-numeric-as-string  Print numeric data type as string when using wal2json output plugin
      --slot-name                   Stream changes recorded by this slot
      --origin                      Name of the Postgres replication origin
+     --connection-retry-timeout    Number of seconds to retry before connection times out
    

--- a/docs/ref/pgcopydb_clone.rst
+++ b/docs/ref/pgcopydb_clone.rst
@@ -333,6 +333,18 @@ Here is an example implement the previous steps:
    $ kill %1
 
 
+Retry mechanism
+^^^^^^^^^^^^^^^
+
+When a connection to either the source or target database fails, the command will
+attempt to reconnect several times before giving up. The maximum duration for these
+retries is determined by the ``--connection-retry-timeout`` parameter, which
+defaults to 60 seconds.
+
+Before each retry, the command will attempt to fetch updated connection strings from
+the ``.env`` file located in either ``${XDG_CONFIG_HOME}/pgcopydb/.env`` or
+``${HOME}/.config/pgcopydb/.env``.
+
 Options
 -------
 
@@ -713,6 +725,10 @@ The following options are available to ``pgcopydb clone``:
 
 Environment
 -----------
+
+Environment variables that begin with ``PGCOPYDB_`` can be set directly in the
+environment or read from the ``.env`` file located in either 
+``${XDG_CONFIG_HOME}/pgcopydb/.env`` or ``${HOME}/.config/pgcopydb/.env``.
 
 PGCOPYDB_SOURCE_PGURI
 

--- a/docs/ref/pgcopydb_compare.rst
+++ b/docs/ref/pgcopydb_compare.rst
@@ -123,6 +123,10 @@ compare data`` subcommands:
 Environment
 -----------
 
+Environment variables that begin with ``PGCOPYDB_`` can be set directly in the
+environment or read from the ``.env`` file located in either 
+``${XDG_CONFIG_HOME}/pgcopydb/.env`` or ``${HOME}/.config/pgcopydb/.env``.
+
 PGCOPYDB_SOURCE_PGURI
 
   Connection string to the source Postgres instance. When ``--source`` is

--- a/docs/ref/pgcopydb_copy.rst
+++ b/docs/ref/pgcopydb_copy.rst
@@ -386,6 +386,10 @@ The following options are available to ``pgcopydb copy`` sub-commands:
 Environment
 -----------
 
+Environment variables that begin with ``PGCOPYDB_`` can be set directly in the
+environment or read from the ``.env`` file located in either 
+``${XDG_CONFIG_HOME}/pgcopydb/.env`` or ``${HOME}/.config/pgcopydb/.env``.
+
 PGCOPYDB_SOURCE_PGURI
 
   Connection string to the source Postgres instance. When ``--source`` is

--- a/docs/ref/pgcopydb_dump.rst
+++ b/docs/ref/pgcopydb_dump.rst
@@ -118,6 +118,10 @@ The following options are available to ``pgcopydb dump schema`` subcommand:
 Environment
 -----------
 
+Environment variables that begin with ``PGCOPYDB_`` can be set directly in the
+environment or read from the ``.env`` file located in either 
+``${XDG_CONFIG_HOME}/pgcopydb/.env`` or ``${HOME}/.config/pgcopydb/.env``.
+
 PGCOPYDB_SOURCE_PGURI
 
   Connection string to the source Postgres instance. When ``--source`` is

--- a/docs/ref/pgcopydb_follow.rst
+++ b/docs/ref/pgcopydb_follow.rst
@@ -504,6 +504,10 @@ The following options are available to ``pgcopydb follow``:
 Environment
 -----------
 
+Environment variables that begin with ``PGCOPYDB_`` can be set directly in the
+environment or read from the ``.env`` file located in either 
+``${XDG_CONFIG_HOME}/pgcopydb/.env`` or ``${HOME}/.config/pgcopydb/.env``.
+
 PGCOPYDB_SOURCE_PGURI
 
   Connection string to the source Postgres instance. When ``--source`` is

--- a/docs/ref/pgcopydb_list.rst
+++ b/docs/ref/pgcopydb_list.rst
@@ -233,6 +233,10 @@ The following options are available to ``pgcopydb dump schema``:
 Environment
 -----------
 
+Environment variables that begin with ``PGCOPYDB_`` can be set directly in the
+environment or read from the ``.env`` file located in either 
+``${XDG_CONFIG_HOME}/pgcopydb/.env`` or ``${HOME}/.config/pgcopydb/.env``.
+
 PGCOPYDB_SOURCE_PGURI
 
   Connection string to the source Postgres instance. When ``--source`` is

--- a/docs/ref/pgcopydb_restore.rst
+++ b/docs/ref/pgcopydb_restore.rst
@@ -266,6 +266,10 @@ The following options are available to ``pgcopydb restore schema``:
 Environment
 -----------
 
+Environment variables that begin with ``PGCOPYDB_`` can be set directly in the
+environment or read from the ``.env`` file located in either 
+``${XDG_CONFIG_HOME}/pgcopydb/.env`` or ``${HOME}/.config/pgcopydb/.env``.
+
 PGCOPYDB_TARGET_PGURI
 
   Connection string to the target Postgres instance. When ``--target`` is

--- a/docs/ref/pgcopydb_snapshot.rst
+++ b/docs/ref/pgcopydb_snapshot.rst
@@ -95,6 +95,10 @@ The following options are available to ``pgcopydb snapshot``:
 Environment
 -----------
 
+Environment variables that begin with ``PGCOPYDB_`` can be set directly in the
+environment or read from the ``.env`` file located in either 
+``${XDG_CONFIG_HOME}/pgcopydb/.env`` or ``${HOME}/.config/pgcopydb/.env``.
+
 PGCOPYDB_SOURCE_PGURI
 
   Connection string to the source Postgres instance. When ``--source`` is

--- a/docs/ref/pgcopydb_stream.rst
+++ b/docs/ref/pgcopydb_stream.rst
@@ -366,6 +366,10 @@ The following options are available to ``pgcopydb stream`` sub-commands:
 Environment
 -----------
 
+Environment variables that begin with ``PGCOPYDB_`` can be set directly in the
+environment or read from the ``.env`` file located in either 
+``${XDG_CONFIG_HOME}/pgcopydb/.env`` or ``${HOME}/.config/pgcopydb/.env``.
+
 PGCOPYDB_SOURCE_PGURI
 
   Connection string to the source Postgres instance. When ``--source`` is

--- a/src/bin/pgcopydb/blobs.c
+++ b/src/bin/pgcopydb/blobs.c
@@ -367,7 +367,8 @@ copydb_blob_worker(CopyDataSpec *specs)
 	bool dropIfExists = specs->restoreOptions.dropIfExists;
 
 	/* initialize our connection to the target database */
-	if (!pgsql_init(&dst, specs->connStrings.target_pguri, PGSQL_CONN_TARGET))
+	if (!pgsql_init(&dst, specs->connStrings.target_pguri, PGSQL_CONN_TARGET,
+					specs->connectionRetryTimeout))
 	{
 		/* errors have already been logged */
 		return false;

--- a/src/bin/pgcopydb/cli_clone_follow.c
+++ b/src/bin/pgcopydb/cli_clone_follow.c
@@ -66,6 +66,7 @@
 	"  --origin                      Use this Postgres replication origin node name\n" \
 	"  --endpos                      Stop replaying changes when reaching this LSN\n" \
 	"  --use-copy-binary             Use the COPY BINARY format for COPY operations\n" \
+	"  --connection-retry-timeout    Number of seconds to retry before connection times out\n" \
 
 CommandLine clone_command =
 	make_command(
@@ -212,7 +213,8 @@ clone_and_follow(CopyDataSpec *copySpecs)
 						   &(copySpecs->catalogs.source),
 						   copyDBoptions.stdIn,
 						   copyDBoptions.stdOut,
-						   logSQL))
+						   logSQL,
+						   copyDBoptions.connectionRetryTimeout))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);
@@ -390,7 +392,8 @@ cli_follow(int argc, char **argv)
 						   &(copySpecs.catalogs.source),
 						   copyDBoptions.stdIn,
 						   copyDBoptions.stdOut,
-						   logSQL))
+						   logSQL,
+						   copyDBoptions.connectionRetryTimeout))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);
@@ -562,7 +565,8 @@ cloneDB(CopyDataSpec *copySpecs)
 		if (!pg_copy_roles(&(copySpecs->pgPaths),
 						   &(copySpecs->connStrings),
 						   copySpecs->dumpPaths.rolesFilename,
-						   copySpecs->noRolesPasswords))
+						   copySpecs->noRolesPasswords,
+						   copySpecs->connectionRetryTimeout))
 		{
 			/* errors have already been logged */
 			return false;

--- a/src/bin/pgcopydb/cli_common.c
+++ b/src/bin/pgcopydb/cli_common.c
@@ -148,26 +148,6 @@ cli_pprint_json(JSON_Value *js)
 
 
 /*
- * cli_copydb_getenv_source_pguri reads the PGCOPYDB_SOURCE_PGURI environment
- * variable and duplicates its value at the given place.
- */
-bool
-cli_copydb_getenv_source_pguri(char **pguri)
-{
-	if (env_exists(PGCOPYDB_SOURCE_PGURI))
-	{
-		if (!get_env_dup(PGCOPYDB_SOURCE_PGURI, pguri))
-		{
-			/* errors have already been logged */
-			return false;
-		}
-	}
-
-	return true;
-}
-
-
-/*
  * cli_copydb_getenv_split reads the PGCOPYDB_SPLIT_TABLES_LARGER_THAN
  * environment variable and fills in the given SplitTableLargerThan instance.
  */
@@ -204,6 +184,67 @@ cli_copydb_getenv_split(SplitTableLargerThan *splitTablesLargerThan)
 
 
 /*
+ * cli_copydb_getenv_file reads the .env file and fills-in the command line options
+ */
+bool
+cli_copydb_getenv_file(CopyDBOptions *options)
+{
+	int errors = 0;
+
+	EnvParser parsers[] = {
+		{ PGCOPYDB_SOURCE_PGURI, ENV_TYPE_STR_PTR,
+		  &(options->connStrings.source_pguri) },
+		{ PGCOPYDB_TARGET_PGURI, ENV_TYPE_STR_PTR,
+		  &(options->connStrings.target_pguri) },
+		{ PGCOPYDB_TABLE_JOBS, ENV_TYPE_INT,
+		  &(options->tableJobs), 0, true, 1, true, 128 },
+		{ PGCOPYDB_INDEX_JOBS, ENV_TYPE_INT,
+		  &(options->indexJobs), 0, true, 1, true, 128 },
+		{ PGCOPYDB_RESTORE_JOBS, ENV_TYPE_INT,
+		  &(options->restoreOptions.jobs), 0, true, 1, true, 128 },
+		{ PGCOPYDB_LARGE_OBJECTS_JOBS, ENV_TYPE_INT,
+		  &(options->lObjectJobs), 0, true, 1, true, 128 },
+		{ PGCOPYDB_SPLIT_MAX_PARTS, ENV_TYPE_INT,
+		  &(options->splitMaxParts), 0, true, 1 },
+		{ PGCOPYDB_ESTIMATE_TABLE_SIZES, ENV_TYPE_BOOL,
+		  &(options->estimateTableSizes) },
+		{ PGCOPYDB_SNAPSHOT, ENV_TYPE_STRING,
+		  &(options->snapshot), sizeof(options->snapshot) },
+		{ PGCOPYDB_WAL2JSON_NUMERIC_AS_STRING, ENV_TYPE_BOOL,
+		  &(options->slot.wal2jsonNumericAsString) },
+		{ PGCOPYDB_DROP_IF_EXISTS, ENV_TYPE_BOOL,
+		  &(options->restoreOptions.dropIfExists) },
+		{ PGCOPYDB_FAIL_FAST, ENV_TYPE_BOOL,
+		  &(options->failFast) },
+		{ PGCOPYDB_SKIP_VACUUM, ENV_TYPE_BOOL,
+		  &(options->skipVacuum) },
+		{ PGCOPYDB_SKIP_ANALYZE, ENV_TYPE_BOOL,
+		  &(options->skipAnalyze) },
+		{ PGCOPYDB_SKIP_DB_PROPERTIES, ENV_TYPE_BOOL,
+		  &(options->skipDBproperties) },
+		{ PGCOPYDB_SKIP_CTID_SPLIT, ENV_TYPE_BOOL,
+		  &(options->skipCtidSplit) },
+		{ PGCOPYDB_SKIP_TABLESPACES, ENV_TYPE_BOOL,
+		  &(options->restoreOptions.noTableSpaces) },
+		{ PGCOPYDB_USE_COPY_BINARY, ENV_TYPE_BOOL,
+		  &(options->useCopyBinary) }
+	};
+
+	int parserCount = sizeof(parsers) / sizeof(parsers[0]);
+
+	EnvParserArray parserArray = { .count = parserCount, .array = parsers };
+
+	if (!get_env_using_parsers_from_file(&parserArray))
+	{
+		/* errors have already been logged */
+		++errors;
+	}
+
+	return errors == 0;
+}
+
+
+/*
  * cli_copydb_getenv reads from the environment variables and fills-in the
  * command line options.
  */
@@ -220,6 +261,10 @@ cli_copydb_getenv(CopyDBOptions *options)
 	options->splitTablesLargerThan.bytes = DEFAULT_SPLIT_TABLES_LARGER_THAN;
 
 	EnvParser parsers[] = {
+		{ PGCOPYDB_SOURCE_PGURI, ENV_TYPE_STR_PTR,
+		  &(options->connStrings.source_pguri) },
+		{ PGCOPYDB_TARGET_PGURI, ENV_TYPE_STR_PTR,
+		  &(options->connStrings.target_pguri) },
 		{ PGCOPYDB_TABLE_JOBS, ENV_TYPE_INT,
 		  &(options->tableJobs), 0, true, 1, true, 128 },
 		{ PGCOPYDB_INDEX_JOBS, ENV_TYPE_INT,
@@ -262,22 +307,6 @@ cli_copydb_getenv(CopyDBOptions *options)
 	{
 		/* errors have already been logged */
 		++errors;
-	}
-
-	if (!cli_copydb_getenv_source_pguri(&(options->connStrings.source_pguri)))
-	{
-		/* errors have already been logged */
-		++errors;
-	}
-
-	if (env_exists(PGCOPYDB_TARGET_PGURI))
-	{
-		if (!get_env_dup(PGCOPYDB_TARGET_PGURI,
-						 &(options->connStrings.target_pguri)))
-		{
-			/* errors have already been logged */
-			++errors;
-		}
 	}
 
 	if (!cli_copydb_getenv_split(&(options->splitTablesLargerThan)))
@@ -634,6 +663,7 @@ cli_copy_db_getopts(int argc, char **argv)
 		{ "origin", required_argument, NULL, 'o' },
 		{ "create-slot", no_argument, NULL, 't' },
 		{ "endpos", required_argument, NULL, 'E' },
+		{ "connection-retry-timeout", required_argument, NULL, 'W' },
 		{ "version", no_argument, NULL, 'V' },
 		{ "verbose", no_argument, NULL, 'v' },
 		{ "notice", no_argument, NULL, 'v' },
@@ -653,8 +683,15 @@ cli_copy_db_getopts(int argc, char **argv)
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 
+	/* read values from .env file */
+	if (!cli_copydb_getenv_file(&options))
+	{
+		log_fatal("Failed to read default values from .env file");
+		exit(EXIT_CODE_BAD_ARGS);
+	}
+
 	const char *optstring =
-		"S:T:D:J:I:b:L:u:mcAPOXj:xBeMlUagkynF:F:Q:irRCN:fp:ws:o:tE:Vvdzqh";
+		"S:T:D:J:I:b:L:u:mcAPOXj:xBeMlUagkynF:F:Q:irRCN:fp:ws:o:tE:VvdzqhW:"; /* YZ left, can use any char afterwards */
 
 	while ((c = getopt_long(argc, argv,
 							optstring, long_options, &option_index)) != -1)
@@ -1091,6 +1128,18 @@ cli_copy_db_getopts(int argc, char **argv)
 			{
 				options.useCopyBinary = true;
 				log_trace("--use-copy-binary");
+				break;
+			}
+
+			case 'W':
+			{
+				if (!stringToInt(optarg, &options.connectionRetryTimeout) ||
+					options.connectionRetryTimeout < 1)
+				{
+					log_fatal("Failed to parse --connection-retry-timeout: \"%s\"",
+							  optarg);
+					++errors;
+				}
 				break;
 			}
 

--- a/src/bin/pgcopydb/cli_common.h
+++ b/src/bin/pgcopydb/cli_common.h
@@ -53,6 +53,7 @@ typedef struct CopyDBOptions
 	int tableJobs;
 	int indexJobs;
 	int lObjectJobs;
+	int connectionRetryTimeout;
 
 	SplitTableLargerThan splitTablesLargerThan;
 	int splitMaxParts;
@@ -106,12 +107,10 @@ int cli_print_version_getopts(int argc, char **argv);
 void cli_print_version(int argc, char **argv);
 
 void cli_pprint_json(JSON_Value *js);
-char * logLevelToString(int logLevel);
-
-bool cli_copydb_getenv_source_pguri(char **pguri);
 bool cli_copydb_getenv_split(SplitTableLargerThan *splitTablesLargerThan);
 
 bool cli_copydb_getenv(CopyDBOptions *options);
+bool cli_copydb_getenv_file(CopyDBOptions *options);
 bool cli_copydb_is_consistent(CopyDBOptions *options);
 bool cli_read_previous_options(CopyDBOptions *options, CopyFilePaths *cfPaths);
 

--- a/src/bin/pgcopydb/cli_compare.c
+++ b/src/bin/pgcopydb/cli_compare.c
@@ -87,6 +87,7 @@ cli_compare_getopts(int argc, char **argv)
 		{ "trace", no_argument, NULL, 'z' },
 		{ "quiet", no_argument, NULL, 'q' },
 		{ "help", no_argument, NULL, 'h' },
+		{ "connection-retry-timeout", required_argument, NULL, 'W' },
 		{ NULL, 0, NULL, 0 }
 	};
 
@@ -99,11 +100,18 @@ cli_compare_getopts(int argc, char **argv)
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 
+	/* read values from .env file */
+	if (!cli_copydb_getenv_file(&options))
+	{
+		log_fatal("Failed to read default values from .env file");
+		exit(EXIT_CODE_BAD_ARGS);
+	}
+
 	/* bypass computing partitioning specs */
 	SplitTableLargerThan empty = { 0 };
 	options.splitTablesLargerThan = empty;
 
-	while ((c = getopt_long(argc, argv, "S:T:D:j:JVvdzqh",
+	while ((c = getopt_long(argc, argv, "S:T:D:j:JVvdzqhW:",
 							long_options, &option_index)) != -1)
 	{
 		switch (c)
@@ -224,6 +232,18 @@ cli_compare_getopts(int argc, char **argv)
 			{
 				commandline_help(stderr);
 				exit(EXIT_CODE_QUIT);
+				break;
+			}
+
+			case 'W':
+			{
+				if (!stringToInt(optarg, &options.connectionRetryTimeout) ||
+					options.connectionRetryTimeout < 1)
+				{
+					log_fatal("Failed to parse --connection-retry-timeout: \"%s\"",
+							  optarg);
+					++errors;
+				}
 				break;
 			}
 

--- a/src/bin/pgcopydb/cli_copy.c
+++ b/src/bin/pgcopydb/cli_copy.c
@@ -34,26 +34,27 @@ static CommandLine copy_db_command =
 		"db",
 		"Copy an entire database from source to target",
 		" --source ... --target ... [ --table-jobs ... --index-jobs ... ] ",
-		"  --source              Postgres URI to the source database\n"
-		"  --target              Postgres URI to the target database\n"
-		"  --dir                 Work directory to use\n"
-		"  --table-jobs          Number of concurrent COPY jobs to run\n"
-		"  --index-jobs          Number of concurrent CREATE INDEX jobs to run\n"
-		"  --restore-jobs        Number of concurrent jobs for pg_restore\n"
-		"  --drop-if-exists      On the target database, clean-up from a previous run first\n"
-		"  --roles               Also copy roles found on source to target\n"
-		"  --no-owner            Do not set ownership of objects to match the original database\n"
-		"  --no-acl              Prevent restoration of access privileges (grant/revoke commands).\n"
-		"  --no-comments         Do not output commands to restore comments\n"
-		"  --no-tablespaces      Do not output commands to select tablespaces\n"
-		"  --skip-large-objects  Skip copying large objects (blobs)\n"
-		"  --filters <filename>  Use the filters defined in <filename>\n"
-		"  --fail-fast           Abort early in case of error\n"
-		"  --restart             Allow restarting when temp files exist already\n"
-		"  --resume              Allow resuming operations after a failure\n"
-		"  --not-consistent      Allow taking a new snapshot on the source database\n"
-		"  --snapshot            Use snapshot obtained with pg_export_snapshot\n"
-		"  --use-copy-binary     Use the COPY BINARY format for COPY operations\n",
+		"  --source                      Postgres URI to the source database\n"
+		"  --target                      Postgres URI to the target database\n"
+		"  --dir                         Work directory to use\n"
+		"  --table-jobs                  Number of concurrent COPY jobs to run\n"
+		"  --index-jobs                  Number of concurrent CREATE INDEX jobs to run\n"
+		"  --restore-jobs                Number of concurrent jobs for pg_restore\n"
+		"  --drop-if-exists              On the target database, clean-up from a previous run first\n"
+		"  --roles                       Also copy roles found on source to target\n"
+		"  --no-owner                    Do not set ownership of objects to match the original database\n"
+		"  --no-acl                      Prevent restoration of access privileges (grant/revoke commands).\n"
+		"  --no-comments                 Do not output commands to restore comments\n"
+		"  --no-tablespaces              Do not output commands to select tablespaces\n"
+		"  --skip-large-objects          Skip copying large objects (blobs)\n"
+		"  --filters <filename>          Use the filters defined in <filename>\n"
+		"  --fail-fast                   Abort early in case of error\n"
+		"  --restart                     Allow restarting when temp files exist already\n"
+		"  --resume                      Allow resuming operations after a failure\n"
+		"  --not-consistent              Allow taking a new snapshot on the source database\n"
+		"  --snapshot                    Use snapshot obtained with pg_export_snapshot\n"
+		"  --use-copy-binary             Use the COPY BINARY format for COPY operations\n"
+		"  --connection-retry-timeout    Number of seconds to retry before connection times out\n",
 		cli_copy_db_getopts,
 		cli_clone);
 
@@ -589,7 +590,8 @@ cli_copy_roles(int argc, char **argv)
 	if (!pg_copy_roles(&(copySpecs.pgPaths),
 					   &(copySpecs.connStrings),
 					   copySpecs.dumpPaths.rolesFilename,
-					   copySpecs.noRolesPasswords))
+					   copySpecs.noRolesPasswords,
+					   copySpecs.connectionRetryTimeout))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_TARGET);

--- a/src/bin/pgcopydb/cli_list.c
+++ b/src/bin/pgcopydb/cli_list.c
@@ -106,14 +106,15 @@ static CommandLine list_table_parts_command =
 		"table-parts",
 		"List a source table copy partitions",
 		" --source ... ",
-		"  --source                    Postgres URI to the source database\n"
-		"  --force                     Force fetching catalogs again\n"
-		"  --schema-name               Name of the schema where to find the table\n"
-		"  --table-name                Name of the target table\n"
-		"  --split-tables-larger-than  Size threshold to consider partitioning\n"
-		"  --split-max-parts           Maximum number of jobs for Same-table concurrency \n" \
-		"  --skip-split-by-ctid        Skip the ctid split\n"
-		"  --estimate-table-sizes      Allow using estimates for relation sizes\n",
+		"  --source                      Postgres URI to the source database\n"
+		"  --force                       Force fetching catalogs again\n"
+		"  --schema-name                 Name of the schema where to find the table\n"
+		"  --table-name                  Name of the target table\n"
+		"  --split-tables-larger-than    Size threshold to consider partitioning\n"
+		"  --split-max-parts             Maximum number of jobs for Same-table concurrency \n" \
+		"  --skip-split-by-ctid          Skip the ctid split\n"
+		"  --estimate-table-sizes        Allow using estimates for relation sizes\n"
+		"  --connection-retry-timeout    Number of seconds to retry before connection times out\n",
 		cli_list_db_getopts,
 		cli_list_table_parts);
 
@@ -211,6 +212,8 @@ cli_list_getenv(ListDBOptions *options)
 	int errors = 0;
 
 	EnvParser parsers[] = {
+		{ PGCOPYDB_SOURCE_PGURI, ENV_TYPE_STR_PTR,
+		  &(options->connStrings.source_pguri) },
 		{ PGCOPYDB_SPLIT_MAX_PARTS, ENV_TYPE_INT,
 		  &(options->splitMaxParts), 0, true, 1 },
 		{ PGCOPYDB_ESTIMATE_TABLE_SIZES, ENV_TYPE_BOOL,
@@ -227,13 +230,38 @@ cli_list_getenv(ListDBOptions *options)
 		++errors;
 	}
 
-	if (!cli_copydb_getenv_source_pguri(&(options->connStrings.source_pguri)))
+	if (!cli_copydb_getenv_split(&(options->splitTablesLargerThan)))
 	{
 		/* errors have already been logged */
 		++errors;
 	}
 
-	if (!cli_copydb_getenv_split(&(options->splitTablesLargerThan)))
+	return errors == 0;
+}
+
+
+/*
+ * cli_list_getenv_file reads the .env file and fills-in the command line options
+ */
+static bool
+cli_list_getenv_file(ListDBOptions *options)
+{
+	int errors = 0;
+
+	EnvParser parsers[] = {
+		{ PGCOPYDB_SOURCE_PGURI, ENV_TYPE_STR_PTR,
+		  &(options->connStrings.source_pguri) },
+		{ PGCOPYDB_SPLIT_MAX_PARTS, ENV_TYPE_INT,
+		  &(options->splitMaxParts), 0, true, 1 },
+		{ PGCOPYDB_ESTIMATE_TABLE_SIZES, ENV_TYPE_BOOL,
+		  &(options->estimateTableSizes) },
+	};
+
+	int parserCount = sizeof(parsers) / sizeof(parsers[0]);
+
+	EnvParserArray parserArray = { .count = parserCount, .array = parsers };
+
+	if (!get_env_using_parsers_from_file(&parserArray))
 	{
 		/* errors have already been logged */
 		++errors;
@@ -282,6 +310,7 @@ cli_list_db_getopts(int argc, char **argv)
 		{ "notice", no_argument, NULL, 'v' },
 		{ "quiet", no_argument, NULL, 'q' },
 		{ "help", no_argument, NULL, 'h' },
+		{ "connection-retry-timeout", required_argument, NULL, 'W' },
 		{ NULL, 0, NULL, 0 }
 	};
 
@@ -294,7 +323,15 @@ cli_list_db_getopts(int argc, char **argv)
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 
-	const char *optstring = "S:D:s:t:F:xPL:u:k:mfyarJRIN:Vdzvqh";
+	/* read values from the .env file */
+	if (!cli_list_getenv_file(&options))
+	{
+		log_fatal("Failed to read default values from .env file");
+		exit(EXIT_CODE_BAD_ARGS);
+	}
+
+
+	const char *optstring = "S:D:s:t:F:xPL:u:k:mfyarJRIN:VdzvqhW:";
 
 	while ((c = getopt_long(argc, argv, optstring,
 							long_options, &option_index)) != -1)
@@ -531,6 +568,18 @@ cli_list_db_getopts(int argc, char **argv)
 				break;
 			}
 
+			case 'W':
+			{
+				if (!stringToInt(optarg, &options.connectionRetryTimeout) ||
+					options.connectionRetryTimeout < 1)
+				{
+					log_fatal("Failed to parse --connection-retry-timeout: \"%s\"",
+							  optarg);
+					exit(EXIT_CODE_QUIT);
+				}
+				break;
+			}
+
 			case '?':
 			default:
 			{
@@ -606,7 +655,8 @@ cli_list_databases(int argc, char **argv)
 	PGSQL pgsql = { 0 };
 	ConnStrings *dsn = &(listDBoptions.connStrings);
 
-	if (!pgsql_init(&pgsql, dsn->source_pguri, PGSQL_CONN_SOURCE))
+	if (!pgsql_init(&pgsql, dsn->source_pguri, PGSQL_CONN_SOURCE,
+					copySpecs.connectionRetryTimeout))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_SOURCE);
@@ -870,7 +920,8 @@ cli_list_extension_versions(int argc, char **argv)
 
 	ConnStrings *dsn = &(listDBoptions.connStrings);
 
-	if (!pgsql_init(&pgsql, dsn->source_pguri, PGSQL_CONN_SOURCE))
+	if (!pgsql_init(&pgsql, dsn->source_pguri, PGSQL_CONN_SOURCE,
+					listDBoptions.connectionRetryTimeout))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_SOURCE);
@@ -951,7 +1002,8 @@ cli_list_extension_requirements(int argc, char **argv)
 	PGSQL pgsql = { 0 };
 	ConnStrings *dsn = &(listDBoptions.connStrings);
 
-	if (!pgsql_init(&pgsql, dsn->source_pguri, PGSQL_CONN_SOURCE))
+	if (!pgsql_init(&pgsql, dsn->source_pguri, PGSQL_CONN_SOURCE,
+					listDBoptions.connectionRetryTimeout))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_SOURCE);

--- a/src/bin/pgcopydb/cli_list.h
+++ b/src/bin/pgcopydb/cli_list.h
@@ -21,6 +21,7 @@ typedef struct ListDBOptions
 	char dir[MAXPGPATH];
 
 	ConnStrings connStrings;
+	int connectionRetryTimeout;
 
 	char schema_name[PG_NAMEDATALEN];
 	char table_name[PG_NAMEDATALEN];

--- a/src/bin/pgcopydb/cli_ping.c
+++ b/src/bin/pgcopydb/cli_ping.c
@@ -25,8 +25,9 @@ CommandLine ping_command =
 		"ping",
 		"Attempt to connect to the source and target instances",
 		" --source ... --target ... ",
-		"  --source              Postgres URI to the source database\n"
-		"  --target              Postgres URI to the target database\n",
+		"  --source                      Postgres URI to the source database\n"
+		"  --target                      Postgres URI to the target database\n"
+		"  --connection-retry-timeout    Number of seconds to retry before connection times out\n",
 		cli_ping_getopts,
 		cli_ping);
 
@@ -51,6 +52,7 @@ cli_ping_getopts(int argc, char **argv)
 		{ "trace", no_argument, NULL, 'z' },
 		{ "quiet", no_argument, NULL, 'q' },
 		{ "help", no_argument, NULL, 'h' },
+		{ "connection-retry-timeout", required_argument, NULL, 'W' },
 		{ NULL, 0, NULL, 0 }
 	};
 	optind = 0;
@@ -62,7 +64,14 @@ cli_ping_getopts(int argc, char **argv)
 		exit(EXIT_CODE_BAD_ARGS);
 	}
 
-	while ((c = getopt_long(argc, argv, "S:T:Vvdzqh",
+	/* read values from .env file */
+	if (!cli_copydb_getenv_file(&options))
+	{
+		log_fatal("Failed to read default values from .env file");
+		exit(EXIT_CODE_BAD_ARGS);
+	}
+
+	while ((c = getopt_long(argc, argv, "S:T:VvdzqhW:",
 							long_options, &option_index)) != -1)
 	{
 		switch (c)
@@ -153,6 +162,18 @@ cli_ping_getopts(int argc, char **argv)
 				break;
 			}
 
+			case 'W':
+			{
+				if (!stringToInt(optarg, &options.connectionRetryTimeout) ||
+					options.connectionRetryTimeout < 1)
+				{
+					log_fatal("Failed to parse --connection-retry-timeout: \"%s\"",
+							  optarg);
+					++errors;
+				}
+				break;
+			}
+
 			case '?':
 			default:
 			{
@@ -201,8 +222,11 @@ cli_ping(int argc, char **argv)
 	char *source = dsn->source_pguri;
 	char *target = dsn->target_pguri;
 
+	int connectionRetryTimeout = copyDBoptions.connectionRetryTimeout;
+
 	/* ping both source and target databases concurrently */
 	pid_t sPid = fork();
+
 
 	switch (sPid)
 	{
@@ -218,7 +242,7 @@ cli_ping(int argc, char **argv)
 			/* child process runs the command */
 			PGSQL src = { 0 };
 
-			if (!pgsql_init(&src, source, PGSQL_CONN_SOURCE))
+			if (!pgsql_init(&src, source, PGSQL_CONN_SOURCE, connectionRetryTimeout))
 			{
 				/* errors have already been logged */
 				exit(EXIT_CODE_SOURCE);
@@ -276,7 +300,7 @@ cli_ping(int argc, char **argv)
 			/* child process runs the command */
 			PGSQL dst = { 0 };
 
-			if (!pgsql_init(&dst, target, PGSQL_CONN_TARGET))
+			if (!pgsql_init(&dst, target, PGSQL_CONN_TARGET, connectionRetryTimeout))
 			{
 				/* errors have already been logged */
 				exit(EXIT_CODE_TARGET);

--- a/src/bin/pgcopydb/compare.c
+++ b/src/bin/pgcopydb/compare.c
@@ -405,7 +405,8 @@ compare_table(CopyDataSpec *copySpecs, SourceTable *source)
 	PGSQL src = { 0 };
 	PGSQL dst = { 0 };
 
-	if (!pgsql_init(&src, dsn->source_pguri, PGSQL_CONN_SOURCE))
+	if (!pgsql_init(&src, dsn->source_pguri, PGSQL_CONN_SOURCE,
+					copySpecs->connectionRetryTimeout))
 	{
 		/* errors have already been logged */
 		return false;
@@ -417,7 +418,8 @@ compare_table(CopyDataSpec *copySpecs, SourceTable *source)
 		return false;
 	}
 
-	if (!pgsql_init(&dst, dsn->target_pguri, PGSQL_CONN_TARGET))
+	if (!pgsql_init(&dst, dsn->target_pguri, PGSQL_CONN_TARGET,
+					copySpecs->connectionRetryTimeout))
 	{
 		/* errors have already been logged */
 		(void) pgsql_finish(&src);

--- a/src/bin/pgcopydb/copydb.c
+++ b/src/bin/pgcopydb/copydb.c
@@ -518,6 +518,7 @@ copydb_init_specs(CopyDataSpec *specs,
 		.noRolesPasswords = options->noRolesPasswords,
 		.failFast = options->failFast,
 		.useCopyBinary = options->useCopyBinary,
+		.connectionRetryTimeout = options->connectionRetryTimeout,
 
 		.restart = options->restart,
 		.resume = options->resume,

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -247,6 +247,7 @@ typedef struct CopyDataSpec
 	int indexJobs;
 	int vacuumJobs;
 	int lObjectJobs;
+	int connectionRetryTimeout;
 
 	SplitTableLargerThan splitTablesLargerThan;
 	int splitMaxParts;
@@ -299,8 +300,6 @@ bool copydb_init_table_specs(CopyTableDataSpec *tableSpecs,
 							 CopyDataSpec *specs,
 							 SourceTable *source,
 							 int partNumber);
-
-bool copydb_export_snapshot(TransactionSnapshot *snapshot);
 
 bool copydb_fatal_exit(void);
 bool copydb_wait_for_subprocesses(bool failFast);

--- a/src/bin/pgcopydb/copydb_schema.c
+++ b/src/bin/pgcopydb/copydb_schema.c
@@ -98,7 +98,8 @@ copydb_fetch_schema_and_prepare_specs(CopyDataSpec *specs)
 	else
 	{
 		log_debug("--not-consistent, create a fresh connection");
-		if (!pgsql_init(&pgsql, specs->connStrings.source_pguri, PGSQL_CONN_SOURCE))
+		if (!pgsql_init(&pgsql, specs->connStrings.source_pguri, PGSQL_CONN_SOURCE,
+						specs->connectionRetryTimeout))
 		{
 			/* errors have already been logged */
 			return false;
@@ -1437,7 +1438,8 @@ copydb_prepare_target_catalog(CopyDataSpec *specs)
 		return false;
 	}
 
-	if (!pgsql_init(&dst, specs->connStrings.target_pguri, PGSQL_CONN_TARGET))
+	if (!pgsql_init(&dst, specs->connStrings.target_pguri, PGSQL_CONN_TARGET,
+					specs->connectionRetryTimeout))
 	{
 		/* errors have already been logged */
 		(void) semaphore_unlock(&(targetDB->sema));

--- a/src/bin/pgcopydb/dump_restore.c
+++ b/src/bin/pgcopydb/dump_restore.c
@@ -32,6 +32,7 @@ static bool copydb_copy_database_properties_hook(void *ctx,
 
 static bool copydb_write_restore_list_hook(void *ctx,
 										   ArchiveContentItem *item);
+static void try_update_connection_string();
 
 
 /*
@@ -91,6 +92,45 @@ copydb_objectid_has_been_processed_already(CopyDataSpec *specs,
 
 
 /*
+ * try_update_connection_string tries to connect to given connection,
+ * updating copyDataSpec if pgsql automatically changes its connection string.
+ */
+static void
+try_update_connection_string(CopyDataSpec *specs, ConnectionType connType)
+{
+	/* Check if we still can connect to given connection type */
+	PGSQL conn = { 0 };
+
+	char *old_pguri = connType == PGSQL_CONN_TARGET ? specs->connStrings.target_pguri :
+					  specs->connStrings.source_pguri;
+
+	pgsql_init(&conn, old_pguri, connType, specs->connectionRetryTimeout);
+
+	if (!pgsql_server_version(&conn))
+	{
+		log_error("Failed to connect to %s database, "
+				  "see above for details",
+				  connType == PGSQL_CONN_TARGET ? "target" : "source");
+	}
+
+	/* If url changed in pgsql, update specs */
+	if (strcmp(conn.connectionString, old_pguri) != 0)
+	{
+		if (connType == PGSQL_CONN_TARGET)
+		{
+			specs->connStrings.target_pguri = strdup(conn.connectionString);
+			specs->connStrings.safeTargetPGURI = conn.safeURI;
+		}
+		else
+		{
+			specs->connStrings.source_pguri = strdup(conn.connectionString);
+			specs->connStrings.safeSourcePGURI = conn.safeURI;
+		}
+	}
+}
+
+
+/*
  * copydb_dump_source_schema uses pg_dump -Fc --schema --schema-only
  * to dump the source database schema to file.
  */
@@ -119,15 +159,19 @@ copydb_dump_source_schema(CopyDataSpec *specs,
 				 "as \"%s\" already exists",
 				 specs->dumpPaths.dumpFilename);
 	}
-	else if (!pg_dump_db(&(specs->pgPaths),
-						 &(specs->connStrings),
-						 snapshot,
-						 &(specs->filters),
-						 &(specs->catalogs.filter),
-						 specs->dumpPaths.dumpFilename))
+	else
 	{
-		/* errors have already been logged */
-		return false;
+		try_update_connection_string(specs, PGSQL_CONN_SOURCE);
+		if (!pg_dump_db(&(specs->pgPaths),
+						&(specs->connStrings),
+						snapshot,
+						&(specs->filters),
+						&(specs->catalogs.filter),
+						specs->dumpPaths.dumpFilename))
+		{
+			/* errors have already been logged */
+			return false;
+		}
 	}
 
 	if (!summary_stop_timing(sourceDB, TIMING_SECTION_DUMP_SCHEMA))
@@ -205,6 +249,8 @@ copydb_target_prepare_schema(CopyDataSpec *specs)
 		}
 	}
 
+	try_update_connection_string(specs, PGSQL_CONN_TARGET);
+
 	specs->restoreOptions.section = PG_RESTORE_SECTION_PRE_DATA;
 	if (!pg_restore_db(&(specs->pgPaths),
 					   &(specs->connStrings),
@@ -256,7 +302,8 @@ copydb_copy_database_properties(CopyDataSpec *specs)
 
 	PGSQL dst = { 0 };
 
-	if (!pgsql_init(&dst, specs->connStrings.target_pguri, PGSQL_CONN_TARGET))
+	if (!pgsql_init(&dst, specs->connStrings.target_pguri, PGSQL_CONN_TARGET,
+					specs->connectionRetryTimeout))
 	{
 		/* errors have already been logged */
 		return false;
@@ -480,7 +527,8 @@ copydb_target_drop_tables(CopyDataSpec *specs)
 
 	PGSQL dst = { 0 };
 
-	if (!pgsql_init(&dst, specs->connStrings.target_pguri, PGSQL_CONN_TARGET))
+	if (!pgsql_init(&dst, specs->connStrings.target_pguri, PGSQL_CONN_TARGET,
+					specs->connectionRetryTimeout))
 	{
 		/* errors have already been logged */
 		destroyPQExpBuffer(query);
@@ -558,6 +606,8 @@ copydb_target_finalize_schema(CopyDataSpec *specs)
 				  "see above for details");
 		return false;
 	}
+
+	try_update_connection_string(specs, PGSQL_CONN_TARGET);
 
 	specs->restoreOptions.section = PG_RESTORE_SECTION_POST_DATA;
 	if (!pg_restore_db(&(specs->pgPaths),

--- a/src/bin/pgcopydb/env_utils.h
+++ b/src/bin/pgcopydb/env_utils.h
@@ -10,6 +10,7 @@
 
 enum EnvType
 {
+	ENV_TYPE_STR_PTR,
 	ENV_TYPE_STRING,
 	ENV_TYPE_INT,
 	ENV_TYPE_BOOL
@@ -40,5 +41,6 @@ bool get_env_copy_with_fallback(const char *name, char *result, int maxLength,
 bool get_env_dup(const char *name, char **result);
 bool get_env_dup_with_fallback(const char *name, char **result, const char *fallback);
 bool get_env_using_parsers(EnvParserArray *parsers);
+bool get_env_using_parsers_from_file(EnvParserArray *parsers);
 
 #endif /* ENV_UTILS_H */

--- a/src/bin/pgcopydb/extensions.c
+++ b/src/bin/pgcopydb/extensions.c
@@ -125,7 +125,8 @@ copydb_copy_extensions(CopyDataSpec *copySpecs, bool createExtensions)
 	}
 
 	/* also connect to the target database  */
-	if (!pgsql_init(&dst, copySpecs->connStrings.target_pguri, PGSQL_CONN_TARGET))
+	if (!pgsql_init(&dst, copySpecs->connStrings.target_pguri, PGSQL_CONN_TARGET,
+					copySpecs->connectionRetryTimeout))
 	{
 		/* errors have already been logged */
 		return false;
@@ -501,7 +502,8 @@ timescaledb_pre_restore(CopyDataSpec *copySpecs, SourceExtension *extension)
 {
 	PGSQL dst = { 0 };
 
-	if (!pgsql_init(&dst, copySpecs->connStrings.target_pguri, PGSQL_CONN_TARGET))
+	if (!pgsql_init(&dst, copySpecs->connStrings.target_pguri, PGSQL_CONN_TARGET,
+					copySpecs->connectionRetryTimeout))
 	{
 		/* errors have already been logged */
 		return false;
@@ -530,7 +532,8 @@ timescaledb_post_restore(CopyDataSpec *copySpecs, SourceExtension *extension)
 {
 	PGSQL dst = { 0 };
 
-	if (!pgsql_init(&dst, copySpecs->connStrings.target_pguri, PGSQL_CONN_TARGET))
+	if (!pgsql_init(&dst, copySpecs->connStrings.target_pguri, PGSQL_CONN_TARGET,
+					copySpecs->connectionRetryTimeout))
 	{
 		/* errors have already been logged */
 		return false;

--- a/src/bin/pgcopydb/indexes.c
+++ b/src/bin/pgcopydb/indexes.c
@@ -249,7 +249,8 @@ copydb_index_worker(CopyDataSpec *specs)
 	PGSQL dst = { 0 };
 	char *pguri = specs->connStrings.target_pguri;
 
-	if (!pgsql_init(&dst, (char *) pguri, PGSQL_CONN_TARGET))
+	if (!pgsql_init(&dst, (char *) pguri, PGSQL_CONN_TARGET,
+					specs->connectionRetryTimeout))
 	{
 		return false;
 	}

--- a/src/bin/pgcopydb/ld_apply.c
+++ b/src/bin/pgcopydb/ld_apply.c
@@ -1194,7 +1194,8 @@ setupConnection(PGSQL *pgsql, StreamApplyContext *context)
 {
 	if (!pgsql_init(pgsql,
 					context->connStrings->target_pguri,
-					PGSQL_CONN_TARGET))
+					PGSQL_CONN_TARGET,
+					context->connectionRetryTimeout))
 	{
 		/* errors have already been logged */
 		return false;

--- a/src/bin/pgcopydb/ld_stream.h
+++ b/src/bin/pgcopydb/ld_stream.h
@@ -431,6 +431,7 @@ typedef struct StreamApplyContext
 	uint64_t sentinelSyncTime;
 
 	ConnStrings *connStrings;
+	int connectionRetryTimeout;
 	char origin[BUFSIZE];
 
 	IdentifySystem system;      /* information about source database */
@@ -495,6 +496,7 @@ struct StreamSpecs
 	CDCPaths paths;
 
 	ConnStrings *connStrings;
+	int connectionRetryTimeout;
 
 	uint32_t WalSegSz;
 	IdentifySystem system;
@@ -552,7 +554,8 @@ bool stream_init_specs(StreamSpecs *specs,
 					   DatabaseCatalog *sourceDB,
 					   bool stdIn,
 					   bool stdOut,
-					   bool logSQL);
+					   bool logSQL,
+					   int connectionRetryTimeout);
 
 bool stream_init_for_mode(StreamSpecs *specs, LogicalStreamMode mode);
 
@@ -614,7 +617,8 @@ bool stream_create_sentinel(CopyDataSpec *copySpecs,
 
 bool stream_fetch_current_lsn(uint64_t *lsn,
 							  const char *pguri,
-							  ConnectionType connectionType);
+							  ConnectionType connectionType,
+							  int connectionRetryTimeout);
 
 bool stream_write_context(StreamSpecs *specs, LogicalStreamClient *stream);
 bool stream_cleanup_context(StreamSpecs *specs);

--- a/src/bin/pgcopydb/ld_transform.c
+++ b/src/bin/pgcopydb/ld_transform.c
@@ -83,7 +83,8 @@ stream_transform_context_init(StreamSpecs *specs)
 	/* initialize our connection to the target database */
 	if (!pgsql_init(privateContext->transformPGSQL,
 					specs->connStrings->target_pguri,
-					PGSQL_CONN_TARGET))
+					PGSQL_CONN_TARGET,
+					specs->connectionRetryTimeout))
 	{
 		/* errors have already been logged */
 		return false;

--- a/src/bin/pgcopydb/pgcmd.c
+++ b/src/bin/pgcopydb/pgcmd.c
@@ -665,7 +665,8 @@ pg_dumpall_roles(PostgresPaths *pgPaths,
 bool
 pg_restore_roles(PostgresPaths *pgPaths,
 				 const char *pguri,
-				 const char *filename)
+				 const char *filename,
+				 int connectionRetryTimeout)
 {
 	char *content = NULL;
 	long size = 0L;
@@ -708,7 +709,7 @@ pg_restore_roles(PostgresPaths *pgPaths,
 
 	PGSQL pgsql = { 0 };
 
-	if (!pgsql_init(&pgsql, (char *) pguri, PGSQL_CONN_TARGET))
+	if (!pgsql_init(&pgsql, (char *) pguri, PGSQL_CONN_TARGET, connectionRetryTimeout))
 	{
 		/* errors have already been logged */
 		return false;
@@ -838,7 +839,8 @@ bool
 pg_copy_roles(PostgresPaths *pgPaths,
 			  ConnStrings *connStrings,
 			  const char *filename,
-			  bool noRolesPasswords)
+			  bool noRolesPasswords,
+			  int connectionRetryTimeout)
 {
 	if (!pg_dumpall_roles(pgPaths, connStrings, filename, noRolesPasswords))
 	{
@@ -846,7 +848,8 @@ pg_copy_roles(PostgresPaths *pgPaths,
 		return false;
 	}
 
-	if (!pg_restore_roles(pgPaths, connStrings->target_pguri, filename))
+	if (!pg_restore_roles(pgPaths, connStrings->target_pguri, filename,
+						  connectionRetryTimeout))
 	{
 		/* errors have already been logged */
 		return false;

--- a/src/bin/pgcopydb/pgcmd.h
+++ b/src/bin/pgcopydb/pgcmd.h
@@ -267,12 +267,14 @@ bool pg_dumpall_roles(PostgresPaths *pgPaths,
 
 bool pg_restore_roles(PostgresPaths *pgPaths,
 					  const char *pguri,
-					  const char *filename);
+					  const char *filename,
+					  int connectionRetryTimeout);
 
 bool pg_copy_roles(PostgresPaths *pgPaths,
 				   ConnStrings *connStrings,
 				   const char *filename,
-				   bool noRolesPasswords);
+				   bool noRolesPasswords,
+				   int connectionRetryTimeout);
 
 bool pg_restore_db(PostgresPaths *pgPaths,
 				   ConnStrings *connStrings,

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -39,10 +39,14 @@
 #define pqPipelineModeEnabled(conn) (false)
 #endif
 
+static void pgsql_set_connection_retry_timeout(PGSQL *pgsql, int connectionRetryTimeout);
+
 static char * ConnectionTypeToString(ConnectionType connectionType);
 static void log_connection_error(PGconn *connection, int logLevel);
 static void pgAutoCtlDefaultNoticeProcessor(void *arg, const char *message);
 static bool pgsql_retry_open_connection(PGSQL *pgsql);
+
+static void pgsql_fetch_connection_string(PGSQL *pgsql);
 
 static void pgsql_handle_notifications(PGSQL *pgsql);
 
@@ -169,13 +173,20 @@ fetchedRows(void *ctx, PGresult *result)
  * URL or connection string.
  */
 bool
-pgsql_init(PGSQL *pgsql, char *url, ConnectionType connectionType)
+pgsql_init(PGSQL *pgsql, char *url, ConnectionType connectionType, int
+		   connectionRetryTimeout)
 {
 	pgsql->connectionType = connectionType;
 	pgsql->connection = NULL;
 
 	/* set our default retry policy for interactive commands */
-	(void) pgsql_set_interactive_retry_policy(&(pgsql->retryPolicy));
+	pgsql_set_interactive_retry_policy(&pgsql->retryPolicy);
+
+	if (connectionRetryTimeout > 0)
+	{
+		pgsql_set_connection_retry_timeout(pgsql, connectionRetryTimeout);
+	}
+
 	if (validate_connection_string(url))
 	{
 		pgsql->connectionString = url;
@@ -216,6 +227,17 @@ pgsql_set_retry_policy(ConnectionRetryPolicy *retryPolicy,
 #else
 	pg_prng_seed(&(retryPolicy->prng_state), (uint64) (getpid() ^ time(NULL)));
 #endif
+}
+
+
+/*
+ * pgsql_set_connection_retry_timeout updates the retry policy timeout
+ * to given number of seconds
+ */
+static void
+pgsql_set_connection_retry_timeout(PGSQL *pgsql, int connectionRetryTimeout)
+{
+	pgsql->retryPolicy.maxT = connectionRetryTimeout;
 }
 
 
@@ -597,6 +619,40 @@ pgsql_open_connection(PGSQL *pgsql)
 
 
 /*
+ * pgsql_fetch_connection_string tries to update the connection string
+ * from the .env file, if it exists.
+ */
+void
+pgsql_fetch_connection_string(PGSQL *pgsql)
+{
+	const char *oldUrl = pgsql->connectionString;
+
+	EnvParser parsers[] = {
+		{
+			pgsql->connectionType == PGSQL_CONN_SOURCE
+			? PGCOPYDB_SOURCE_PGURI
+			: PGCOPYDB_TARGET_PGURI,
+			ENV_TYPE_STR_PTR,
+			&(pgsql->connectionString)
+		}
+	};
+	EnvParserArray parserArray = { .array = parsers, count: 1 };
+
+	if (!get_env_using_parsers_from_file(&parserArray))
+	{
+		log_error("Failed to read .env file for new connection string");
+		return;
+	}
+
+	if (strcmp(oldUrl, pgsql->connectionString) != 0)
+	{
+		(void) parse_and_scrub_connection_string(pgsql->connectionString,
+												 &(pgsql->safeURI));
+	}
+}
+
+
+/*
  * Refrain from warning too often. The user certainly wants to know that we are
  * still trying to connect, though warning several times a second is not going
  * to help anyone. A good trade-off seems to be a warning every 30s.
@@ -664,6 +720,9 @@ pgsql_retry_open_connection(PGSQL *pgsql)
 
 		/* we have milliseconds, pg_usleep() wants microseconds */
 		(void) pg_usleep(sleep * 1000);
+
+		/* fetch the connection string from the .env file */
+		pgsql_fetch_connection_string(pgsql);
 
 		log_sql("PQping(%s): slept %d ms on attempt %d",
 				pgsql->safeURI.pguri,
@@ -3519,11 +3578,12 @@ pgsql_init_stream(LogicalStreamClient *client,
 				  StreamOutputPlugin plugin,
 				  const char *slotName,
 				  XLogRecPtr startpos,
-				  XLogRecPtr endpos)
+				  XLogRecPtr endpos,
+				  int connectionRetryTimeout)
 {
 	PGSQL *pgsql = &(client->pgsql);
 
-	if (!pgsql_init(pgsql, (char *) pguri, PGSQL_CONN_SOURCE))
+	if (!pgsql_init(pgsql, (char *) pguri, PGSQL_CONN_SOURCE, connectionRetryTimeout))
 	{
 		/* errors have already been logged */
 		return false;

--- a/src/bin/pgcopydb/pgsql.h
+++ b/src/bin/pgcopydb/pgsql.h
@@ -242,7 +242,8 @@ typedef struct GUC
 	char *value;
 } GUC;
 
-bool pgsql_init(PGSQL *pgsql, char *url, ConnectionType connectionType);
+bool pgsql_init(PGSQL *pgsql, char *url, ConnectionType connectionType,
+				int connectionRetryTimeout);
 
 PGconn * pgsql_open_connection(PGSQL *pgsql);
 
@@ -497,7 +498,8 @@ bool pgsql_init_stream(LogicalStreamClient *client,
 					   StreamOutputPlugin plugin,
 					   const char *slotName,
 					   XLogRecPtr startpos,
-					   XLogRecPtr endpos);
+					   XLogRecPtr endpos,
+					   int connectionRetryTimeout);
 
 StreamOutputPlugin OutputPluginFromString(char *plugin);
 char * OutputPluginToString(StreamOutputPlugin plugin);

--- a/src/bin/pgcopydb/sequences.c
+++ b/src/bin/pgcopydb/sequences.c
@@ -260,7 +260,8 @@ copydb_copy_all_sequences(CopyDataSpec *specs, bool reset)
 
 	if (reset)
 	{
-		if (!pgsql_init(&src, specs->connStrings.source_pguri, PGSQL_CONN_SOURCE))
+		if (!pgsql_init(&src, specs->connStrings.source_pguri, PGSQL_CONN_SOURCE,
+						specs->connectionRetryTimeout))
 		{
 			/* errors have already been logged */
 			return false;
@@ -318,7 +319,8 @@ copydb_copy_all_sequences(CopyDataSpec *specs, bool reset)
 
 	PGSQL dst = { 0 };
 
-	if (!pgsql_init(&dst, specs->connStrings.target_pguri, PGSQL_CONN_TARGET))
+	if (!pgsql_init(&dst, specs->connStrings.target_pguri, PGSQL_CONN_TARGET,
+					specs->connectionRetryTimeout))
 	{
 		/* errors have already been logged */
 		return false;

--- a/src/bin/pgcopydb/table-data.c
+++ b/src/bin/pgcopydb/table-data.c
@@ -493,7 +493,7 @@ copydb_copy_worker_queue_tables(CopyDataSpec *specs)
 	{
 		char *pguri = specs->connStrings.target_pguri;
 
-		if (!pgsql_init(&dst, pguri, PGSQL_CONN_TARGET))
+		if (!pgsql_init(&dst, pguri, PGSQL_CONN_TARGET, specs->connectionRetryTimeout))
 		{
 			/* errors have already been logged */
 			return false;
@@ -724,7 +724,8 @@ copydb_table_data_worker(CopyDataSpec *specs)
 	PGSQL dst = { 0 };
 
 	/* initialize our connection to the target database */
-	if (!pgsql_init(&dst, specs->connStrings.target_pguri, PGSQL_CONN_TARGET))
+	if (!pgsql_init(&dst, specs->connStrings.target_pguri, PGSQL_CONN_TARGET,
+					specs->connectionRetryTimeout))
 	{
 		/* errors have already been logged */
 		return false;

--- a/src/bin/pgcopydb/vacuum.c
+++ b/src/bin/pgcopydb/vacuum.c
@@ -321,7 +321,8 @@ vacuum_analyze_table_by_oid(CopyDataSpec *specs, uint32_t oid)
 	PGSQL dst = { 0 };
 
 	/* initialize our connection to the target database */
-	if (!pgsql_init(&dst, specs->connStrings.target_pguri, PGSQL_CONN_TARGET))
+	if (!pgsql_init(&dst, specs->connStrings.target_pguri, PGSQL_CONN_TARGET,
+					specs->connectionRetryTimeout))
 	{
 		/* errors have already been logged */
 		return false;

--- a/tests/pagila-multi-steps/.env
+++ b/tests/pagila-multi-steps/.env
@@ -1,0 +1,2 @@
+PGCOPYDB_TARGET_PGURI=postgres://postgres:h4ckm3@target/postgres
+PGCOPYDB_SOURCE_PGURI=postgres://postgres:h4ckm3@source/postgres

--- a/tests/pagila-multi-steps/Dockerfile
+++ b/tests/pagila-multi-steps/Dockerfile
@@ -2,6 +2,7 @@ FROM pagila
 
 WORKDIR /usr/src/pgcopydb
 COPY ./copydb.sh copydb.sh
+COPY .env /usr/src/pgcopydb/.config/pgcopydb/.env
 
 USER docker
 CMD ["/usr/src/pgcopydb/copydb.sh"]

--- a/tests/pagila-multi-steps/compose.yaml
+++ b/tests/pagila-multi-steps/compose.yaml
@@ -6,7 +6,6 @@ services:
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: h4ckm3
-      POSTGRES_HOST_AUTH_METHOD: trust
   target:
     image: postgres:13-bullseye
     expose:
@@ -14,12 +13,12 @@ services:
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: h4ckm3
-      POSTGRES_HOST_AUTH_METHOD: trust
   test:
     build: .
     environment:
-      PGCOPYDB_SOURCE_PGURI: postgres://postgres:h4ckm3@source/postgres
-      PGCOPYDB_TARGET_PGURI: postgres://postgres:h4ckm3@target/postgres
+      XDG_CONFIG_HOME: /usr/src/pgcopydb/.config
+      SCRIPT_PGCOPYDB_SOURCE_PGURI: postgres://postgres:h4ckm3@source/postgres
+      SCRIPT_PGCOPYDB_TARGET_PGURI: postgres://postgres:h4ckm3@target/postgres
       PGCOPYDB_TABLE_JOBS: 2
       PGCOPYDB_INDEX_JOBS: 2
     depends_on:

--- a/tests/pagila-multi-steps/copydb.sh
+++ b/tests/pagila-multi-steps/copydb.sh
@@ -13,10 +13,10 @@ set -e
 # make sure source and target databases are ready
 pgcopydb ping
 
-psql -o /tmp/d.out -d ${PGCOPYDB_SOURCE_PGURI} -1 -f /usr/src/pagila/pagila-schema.sql
-psql -o /tmp/s.out -d ${PGCOPYDB_SOURCE_PGURI} -1 -f /usr/src/pagila/pagila-data.sql
+psql -o /tmp/d.out -d ${SCRIPT_PGCOPYDB_SOURCE_PGURI} -1 -f /usr/src/pagila/pagila-schema.sql
+psql -o /tmp/s.out -d ${SCRIPT_PGCOPYDB_SOURCE_PGURI} -1 -f /usr/src/pagila/pagila-data.sql
 
-psql -d ${PGCOPYDB_TARGET_PGURI} <<EOF
+psql -d ${SCRIPT_PGCOPYDB_TARGET_PGURI} <<EOF
 alter database postgres connection limit 2;
 EOF
 

--- a/tests/pagila/compose.yaml
+++ b/tests/pagila/compose.yaml
@@ -6,7 +6,6 @@ services:
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: h4ckm3
-      POSTGRES_HOST_AUTH_METHOD: trust
     command: >
       -c ssl=on
       -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
@@ -18,7 +17,6 @@ services:
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: h4ckm3
-      POSTGRES_HOST_AUTH_METHOD: trust
     command: >
       -c ssl=on
       -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem

--- a/tests/pagila/copydb.sh
+++ b/tests/pagila/copydb.sh
@@ -21,10 +21,11 @@ create role pagila NOSUPERUSER CREATEDB NOCREATEROLE LOGIN PASSWORD '0wn3d';
 create database pagila owner pagila connection limit 8;
 EOF
 
-pgcopydb copy roles
+pgcopydb copy roles --no-role-passwords
 
 psql -a ${PGCOPYDB_TARGET_PGURI} <<EOF
 create database pagila owner pagila connection limit 10;
+alter role pagila with password '0wn3d';
 EOF
 
 PAGILA_SOURCE_PGURI="postgres://pagila:0wn3d@source/pagila"


### PR DESCRIPTION
With this change, pgcopydb will read the connection strings from .env file on retrying connections. This allows users to change the connection strings in .env file while pgcopydb is running.

This particular change is useful for users who are using managed identities or other similar solutions, where the connection strings might change during the execution of pgcopydb. On such systems, the passwords are not stored in the environment variables, but managed in the .env file.

--------------------

Changes Made

* Added `--connection-retry-timeout` parameter to stop retrying after N seconds (60 default)

* Added .env file support that will be fetched from ($XDG_CONFIG_HOME OR $HOME/.config)/pgcopydb/.env

* following parameters will be read from .env file on init, overriding environment variables, but have lower priority than cli parameters: PGCOPYDB_SOURCE_PGURI PGCOPYDB_TARGET_PGURI PGCOPYDB_TABLE_JOBS PGCOPYDB_INDEX_JOBS PGCOPYDB_RESTORE_JOBS PGCOPYDB_LARGE_OBJECTS_JOBS PGCOPYDB_SPLIT_MAX_PARTS PGCOPYDB_ESTIMATE_TABLE_SIZES PGCOPYDB_SNAPSHOT PGCOPYDB_WAL2JSON_NUMERIC_AS_STRING PGCOPYDB_DROP_IF_EXISTS PGCOPYDB_FAIL_FAST PGCOPYDB_SKIP_VACUUM

* Added mechanism to re-read .env file and retry with new connection string in pgsql connections.

--------------------

Description

* param > .env file > environment variable on init, .env file on retry

* ($XDG_CONFIG_HOME OR $HOME/.config)/pgcopydb/.env

* Retry only will fetch connection strings (PGCOPYDB_SOURCE_PGURI, PGCOPYDB_TARGET_PGURI) from .env file

--------------------

Testing

* I have a url with a wrong password in my env variable, but my .env file have the correct one. The clone works without problem.

* I run the clone with timeout variable set to 5, with wrong url in both env file and env variable, after 5 seconds of trying to connect, the process stops retrying.

* I have a url with a wrong password in my env variable, my .env file also have the wrong password. I run the clone, while it's retrying, I edit the .env file with correct password. In the next try, the clone continues to work as expected.