### PR TITLE
Remove one double free

### DIFF
--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -1982,8 +1982,6 @@ pgsql_sync_pipeline(PGSQL *pgsql)
 			if (!is_response_ok(res))
 			{
 				(void) pgcopy_log_error(pgsql, res, "Failed to receive pipeline sync");
-				PQclear(res);
-
 				return false;
 			}
 


### PR DESCRIPTION
pgcopy_log_error contains a PQclear call, so we don't need to do it again.

Note: PQClear is smart enough to not free a null pointer, and thus this change is not really critical.