### PR TITLE
add arm64 build for docker image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -85,6 +85,10 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          # Cache the image layers
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       # Sign the resulting Docker image digest except on PRs.
       # This will only write to the public Rekor transparency log when the Docker

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -85,7 +85,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           # Cache the image layers
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
thought it would be beneficial to have an `arm64` build of `pgcopydb`, as currently only the `amd64` version is available

![image](https://github.com/user-attachments/assets/bdecd8ab-0738-45be-9724-9e24515afeb0)

also added cache if it helps (or you can remove it. Thanks)
