### PR TITLE
Fix Syntax error at or near "\"

### DIFF
--- a/src/bin/pgcopydb/pgcmd.c
+++ b/src/bin/pgcopydb/pgcmd.c
@@ -748,6 +748,13 @@ pg_restore_roles(PostgresPaths *pgPaths,
 			continue;
 		}
 
+
+		if (strncmp(currentLine, "\\restrict", 9) == 0 || strncmp(currentLine, "\\unrestrict", 11) == 0)
+		{
+			/* skip \restrict and \unrestrict meta commands */
+			continue;
+		}
+
 		char *createRole = "CREATE ROLE ";
 		int createRoleLen = strlen(createRole);
 


### PR DESCRIPTION
Fixes https://github.com/dimitri/pgcopydb/issues/922 and tests

Postgres 17.6 (and 16.10, etc) added `\restrict` and `\unrestrict` metacommands to pg_dump output to mitigate a security issue. This code skips these lines when restoring roles.

17.6 change notes: https://www.postgresql.org/docs/17/release-17-6.html#RELEASE-17-6-CHANGES
CVE: https://www.postgresql.org/support/security/CVE-2025-8714/