### PR TITLE
CI: test against PostgreSQL 17 and 18

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,6 +19,8 @@ jobs:
       matrix:
         PGVERSION:
           - 16
+          - 17
+          - 18
         TEST:
           - ci
           - pagila

--- a/src/bin/pgcopydb/pgcmd.c
+++ b/src/bin/pgcopydb/pgcmd.c
@@ -749,7 +749,8 @@ pg_restore_roles(PostgresPaths *pgPaths,
 		}
 
 
-		if (strncmp(currentLine, "\\restrict", 9) == 0 || strncmp(currentLine, "\\unrestrict", 11) == 0)
+		if (strncmp(currentLine, "\\restrict", 9) == 0 ||
+			strncmp(currentLine, "\\unrestrict", 11) == 0)
 		{
 			/* skip \restrict and \unrestrict meta commands */
 			continue;

--- a/src/bin/pgcopydb/pgcmd.c
+++ b/src/bin/pgcopydb/pgcmd.c
@@ -748,6 +748,13 @@ pg_restore_roles(PostgresPaths *pgPaths,
 			continue;
 		}
 
+
+		if (strncmp(currentLine, "\\restrict", 9) == 0 || strncmp(currentLine, "\\unrestrict", 11) == 0)
+		{
+			/* skip \restrict and \unrestrict meta commands */
+			continue;
+		}
+
 		char *createRole = "CREATE ROLE ";
 		int createRoleLen = strlen(createRole);
 


### PR DESCRIPTION
This builds on the fix from #925 (for green tests).

Related to #928. 

What else needs to be added for official PostgreSQL 17 and 18 support?