### PR TITLE
SAST Bad-copy-paste

### DIFF
--- a/src/bin/pgcopydb/compare.c
+++ b/src/bin/pgcopydb/compare.c
@@ -1007,7 +1007,7 @@ compare_fetch_schemas(CopyDataSpec *copySpecs,
 		{ NULL, NULL }
 	};
 
-	for (int i = 0; dbs[i].name != NULL; i++)
+	for (int i = 0; dbt[i].name != NULL; i++)
 	{
 		struct db *d = &(dbt[i]);
 		sformat(d->db->dbfile, MAXPGPATH, "%s/%s.db", targetDir, d->name);


### PR DESCRIPTION
In function 'compare_fetch_schemas': Value 'dbs' might be 'dbt

fix #934 