### PR TITLE
Fix --skip-extensions OID collision filtering out unrelated tables

### DIFF
--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -405,7 +405,8 @@ bool copydb_prepare_sequence_specs(CopyDataSpec *specs, PGSQL *pgsql, bool reset
 bool copydb_fetch_schema_and_prepare_specs(CopyDataSpec *specs);
 bool copydb_objectid_is_filtered_out(CopyDataSpec *specs,
 									 uint32_t oid,
-									 char *restoreListName);
+									 char *restoreListName,
+									 const char *archiveDesc);
 bool copydb_matview_refresh_is_filtered_out(CopyDataSpec *specs,
 											uint32_t oid);
 

--- a/src/bin/pgcopydb/copydb_schema.c
+++ b/src/bin/pgcopydb/copydb_schema.c
@@ -1012,13 +1012,51 @@ copydb_matview_refresh_is_filtered_out(CopyDataSpec *specs, uint32_t oid)
 
 
 /*
+ * filter_kind_matches_archive_desc returns true when a filter entry's kind
+ * is compatible with the archive item description being checked. This prevents
+ * OID collisions between different catalog types (e.g., pg_extension and
+ * pg_class can have the same OID value) from incorrectly filtering out
+ * unrelated objects.
+ *
+ * Filter kinds whose OIDs come from non-pg_class catalogs (extension from
+ * pg_extension, coll from pg_collation) must only match their own archive
+ * item type. Other kinds (table, index, sequence, etc.) use pg_class OIDs
+ * and match freely since they share the same OID namespace.
+ */
+static bool
+filter_kind_matches_archive_desc(const char *kind, const char *archiveDesc)
+{
+	/* if no archive description or no kind, assume match (backwards compat) */
+	if (archiveDesc == NULL || IS_EMPTY_STRING_BUFFER(kind))
+	{
+		return true;
+	}
+
+	/* extension OIDs come from pg_extension, not pg_class */
+	if (strcmp(kind, "extension") == 0)
+	{
+		return strcmp(archiveDesc, "EXTENSION") == 0;
+	}
+
+	/* collation OIDs come from pg_collation, not pg_class */
+	if (strcmp(kind, "coll") == 0)
+	{
+		return strcmp(archiveDesc, "COLLATION") == 0;
+	}
+
+	return true;
+}
+
+
+/*
  * copydb_objectid_is_filtered_out returns true when the given oid belongs to a
  * database object that's been filtered out by the filtering setup.
  */
 bool
 copydb_objectid_is_filtered_out(CopyDataSpec *specs,
 								uint32_t oid,
-								char *restoreListName)
+								char *restoreListName,
+								const char *archiveDesc)
 {
 	DatabaseCatalog *filtersDB = &(specs->catalogs.filter);
 	CatalogFilter result = { 0 };
@@ -1031,7 +1069,8 @@ copydb_objectid_is_filtered_out(CopyDataSpec *specs,
 			return false;
 		}
 
-		if (result.oid != 0)
+		if (result.oid != 0 &&
+			filter_kind_matches_archive_desc(result.kind, archiveDesc))
 		{
 			return true;
 		}
@@ -1045,7 +1084,8 @@ copydb_objectid_is_filtered_out(CopyDataSpec *specs,
 			return false;
 		}
 
-		if (!IS_EMPTY_STRING_BUFFER(result.restoreListName))
+		if (!IS_EMPTY_STRING_BUFFER(result.restoreListName) &&
+			filter_kind_matches_archive_desc(result.kind, archiveDesc))
 		{
 			return true;
 		}

--- a/src/bin/pgcopydb/dump_restore.c
+++ b/src/bin/pgcopydb/dump_restore.c
@@ -800,7 +800,8 @@ copydb_write_restore_list_hook(void *ctx, ArchiveContentItem *item)
 				   item->restoreListName);
 	}
 
-	if (!skip && copydb_objectid_is_filtered_out(specs, oid, name))
+	if (!skip && copydb_objectid_is_filtered_out(specs, oid, name,
+											   item->description))
 	{
 		skip = true;
 

--- a/src/bin/pgcopydb/dump_restore.c
+++ b/src/bin/pgcopydb/dump_restore.c
@@ -801,7 +801,7 @@ copydb_write_restore_list_hook(void *ctx, ArchiveContentItem *item)
 	}
 
 	if (!skip && copydb_objectid_is_filtered_out(specs, oid, name,
-											   item->description))
+												 item->description))
 	{
 		skip = true;
 


### PR DESCRIPTION
## Summary

- Fixes `--skip-extensions` incorrectly excluding tables/sequences from `pg_restore` when their OID collides with an extension OID
- Also fixes the same potential issue with `--skip-collations`
- Guards both the OID and `restoreListName` lookup paths

## Problem

PostgreSQL uses independent OID sequences for different catalog tables (`pg_extension`, `pg_class`, `pg_collation`). The same OID value can appear in multiple catalogs. When `--skip-extensions` inserts extension OIDs into pgcopydb's filter table, `copydb_objectid_is_filtered_out()` would match any archive item with that OID — including TABLE and SEQUENCE items from `pg_class` that happen to share the OID.

This causes `pg_restore` to fail because dependent objects (SEQUENCE OWNED BY, DEFAULT, constraints, indexes, GRANTs) are still included in the restore list, but the table they reference was incorrectly excluded.

Reproduces on real-world databases where early-created extensions get low OIDs that overlap with user tables. See #772 for a prior report of this bug.

## Fix

Added `filter_kind_matches_archive_desc()` which checks the filter entry's `kind` against the archive item's `description` before filtering:
- `kind = 'extension'` only matches `EXTENSION` archive items
- `kind = 'coll'` only matches `COLLATION` archive items  
- All other kinds (table, index, sequence, etc.) match freely since they use `pg_class` OIDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)