### PR TITLE
Pr 925 fix syntax error

### DIFF
--- a/src/bin/pgcopydb/pgcmd.c
+++ b/src/bin/pgcopydb/pgcmd.c
@@ -763,8 +763,8 @@ pg_restore_roles(PostgresPaths *pgPaths,
 		 * SQL client, we do not need to restrict our parsing of them with the
 		 * \restrict and \unrestrict backslash-commands.
 		 */
-		if (strncmp(currentLine, "\\restrict", 9) == 0
-			|| strncmp(currentLine, "\\unrestrict", 11) == 0)
+		if (strncmp(currentLine, "\\restrict", 9) == 0 ||
+			strncmp(currentLine, "\\unrestrict", 11) == 0)
 		{
 			/* skip \restrict and \unrestrict meta commands */
 			continue;

--- a/src/bin/pgcopydb/pgcmd.c
+++ b/src/bin/pgcopydb/pgcmd.c
@@ -748,8 +748,23 @@ pg_restore_roles(PostgresPaths *pgPaths,
 			continue;
 		}
 
-
-		if (strncmp(currentLine, "\\restrict", 9) == 0 || strncmp(currentLine, "\\unrestrict", 11) == 0)
+		/*
+		 * Postgres 17.6 (and 16.10, etc) added \restrict and \unrestrict
+		 * metacommands to pg_dump output to mitigate a security issue. This
+		 * code skips these lines when restoring roles.
+		 *
+		 * See 17.6 change notes:
+		 * https://www.postgresql.org/docs/17/release-17-6.html#RELEASE-17-6-CHANGES
+		 * CVE: https://www.postgresql.org/support/security/CVE-2025-8714/
+		 *
+		 * Because here we are implementing our own client behavior rather than
+		 * relying on psql implementation, we have to parse the new commands.
+		 * Given that we do not have backslash-commands implementation in our
+		 * SQL client, we do not need to restrict our parsing of them with the
+		 * \restrict and \unrestrict backslash-commands.
+		 */
+		if (strncmp(currentLine, "\\restrict", 9) == 0
+			|| strncmp(currentLine, "\\unrestrict", 11) == 0)
 		{
 			/* skip \restrict and \unrestrict meta commands */
 			continue;

--- a/src/bin/pgcopydb/pgcmd.c
+++ b/src/bin/pgcopydb/pgcmd.c
@@ -748,6 +748,13 @@ pg_restore_roles(PostgresPaths *pgPaths,
 			continue;
 		}
 
+
+		if (strncmp(currentLine, "\\restrict", 9) == 0 || strncmp(currentLine, "\\unrestrict", 11) == 0)
+		{
+			/* skip \restrict and \unrestrict meta commands */
+			continue;
+		}
+
 		char *createRole = "CREATE ROLE ";
 		int createRoleLen = strlen(createRole);
 


### PR DESCRIPTION
Fix our own implementation of pg_restore for roles by skipping new psql meta-commands \restrict and \unrestrict. As we do not implement any meta-command from psql, we do not need to be smart about them.

Closes #925 (replaces)