### PR TITLE
Fix TRUNCATE ONLY and COPY FREEZE on partitioned target tables

### DIFF
--- a/src/bin/pgcopydb/ld_apply.c
+++ b/src/bin/pgcopydb/ld_apply.c
@@ -1164,7 +1164,51 @@ stream_apply_sql(StreamApplyContext *context,
 				*ptr = '\0';
 			}
 
-			if (!pgsql_execute(applyPgConn, sql))
+			/*
+			 * Postgres rejects TRUNCATE ONLY on partitioned tables. Mirror
+			 * the runtime fix in pgsql_truncate: when the target relation is
+			 * partitioned, drop the ONLY keyword. The lookup runs on the
+			 * non-pipeline controlPgConn because applyPgConn is in pipeline
+			 * mode (which forbids parseFun callbacks; see pgsql_execute_with_params).
+			 *
+			 * Invariant: stream_write_truncate emits exactly one relation per
+			 * statement (LogicalMessageTruncate.table is singular), so the
+			 * single-relation regclass lookup below is sufficient. If a future
+			 * change ever makes this multi-relation, the regclass cast will
+			 * fail, the rewrite will be skipped, and Postgres will surface a
+			 * loud error from the original TRUNCATE ONLY.
+			 */
+			char rewritten[BUFSIZE] = { 0 };
+			const char *truncateSQL = sql;
+			const char onlyPrefix[] = "TRUNCATE ONLY ";
+			size_t prefixLen = sizeof(onlyPrefix) - 1;
+
+			if (strncmp(sql, onlyPrefix, prefixLen) == 0)
+			{
+				char relkind = '\0';
+				const char *qname = sql + prefixLen;
+
+				if (pgsql_get_table_relkind(&(context->controlPgConn),
+											qname, &relkind))
+				{
+					if (relkind == 'p')
+					{
+						sformat(rewritten, sizeof(rewritten),
+								"TRUNCATE %s", qname);
+						truncateSQL = rewritten;
+					}
+				}
+				else
+				{
+					log_warn("Could not resolve relkind for replicated "
+							 "TRUNCATE on \"%s\"; replaying as TRUNCATE ONLY. "
+							 "If the target is partitioned, Postgres will "
+							 "reject this statement.",
+							 qname);
+				}
+			}
+
+			if (!pgsql_execute(applyPgConn, truncateSQL))
 			{
 				/* errors have already been logged */
 				return false;

--- a/src/bin/pgcopydb/ld_transform.c
+++ b/src/bin/pgcopydb/ld_transform.c
@@ -2507,6 +2507,13 @@ stream_write_delete(FILE *out, LogicalMessageDelete *delete)
 /*
  * stream_write_truncate writes an TRUNCATE statement to the already open out
  * stream.
+ *
+ * Each call emits exactly one relation per statement; the data model
+ * (LogicalMessageTruncate.table) is singular by construction. The apply path
+ * in ld_apply.c (STREAM_ACTION_TRUNCATE) relies on this invariant to detect
+ * the partitioned-target case via a single regclass lookup. If this is ever
+ * changed to emit multi-relation TRUNCATE statements, update the apply path
+ * accordingly.
  */
 bool
 stream_write_truncate(FILE *out, LogicalMessageTruncate *truncate)

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -1256,6 +1256,49 @@ pgsql_has_table_privilege(PGSQL *pgsql,
 
 
 /*
+ * pgsql_get_table_relkind queries pg_class for the relkind of the given
+ * qualified table name and copies it to the given char pointer. Callers
+ * should pass a fully-qualified schema.table to avoid search_path surprises;
+ * the regclass cast on $1 will otherwise resolve via search_path.
+ */
+bool
+pgsql_get_table_relkind(PGSQL *pgsql, const char *qname, char *relkind)
+{
+	SingleValueResultContext parseContext = { { 0 }, PGSQL_RESULT_STRING, false };
+
+	char *sql = "select relkind from pg_class where oid = $1::regclass;";
+
+	int paramCount = 1;
+	Oid paramTypes[1] = { TEXTOID };
+	const char *paramValues[1] = { qname };
+
+	if (!pgsql_execute_with_params(pgsql, sql,
+								   paramCount, paramTypes, paramValues,
+								   &parseContext, &parseSingleValueResult))
+	{
+		log_error("Failed to query pg_class for relkind of table %s "
+				  "(query failed: connection or permission error, or "
+				  "the regclass cast did not resolve a relation)", qname);
+		return false;
+	}
+
+	if (!parseContext.parsedOk)
+	{
+		log_error("Failed to parse relkind result for table %s "
+				  "(expected 1 row, got %d)",
+				  qname, parseContext.ntuples);
+		return false;
+	}
+
+	*relkind = parseContext.strVal[0];
+
+	free(parseContext.strVal);
+
+	return true;
+}
+
+
+/*
  * pgsql_get_search_path runs the query "show search_path" and copies the
  * result in the given pre-allocated string buffer.
  */
@@ -2606,13 +2649,31 @@ pgsql_lock_table(PGSQL *pgsql, const char *qname, const char *lockmode)
 /*
  * pgsql_truncate executes the TRUNCATE command on the given quoted relation
  * name qname, in the given Postgres connection.
+ *
+ * When the target relation is a partitioned table (relkind 'p') we issue
+ * TRUNCATE without ONLY: Postgres rejects TRUNCATE ONLY on partitioned tables
+ * with "cannot truncate only a partitioned table". This handles the asymmetric
+ * case where the source has a flat table but the target is partitioned. The
+ * source-side partition filter (PR #863) only handles the symmetric case where
+ * both source and target are partitioned, so this runtime check covers the gap.
+ *
+ * The caller passes the target's relkind (looked up via
+ * pgsql_get_table_relkind). Callers that don't know it look it up themselves
+ * to keep this function predictable and side-effect-free.
  */
 bool
-pgsql_truncate(PGSQL *pgsql, const char *qname)
+pgsql_truncate(PGSQL *pgsql, const char *qname, char relkind)
 {
 	char sql[BUFSIZE] = { 0 };
 
-	sformat(sql, sizeof(sql), "TRUNCATE ONLY %s", qname);
+	if (relkind == 'p')
+	{
+		sformat(sql, sizeof(sql), "TRUNCATE %s", qname);
+	}
+	else
+	{
+		sformat(sql, sizeof(sql), "TRUNCATE ONLY %s", qname);
+	}
 
 	/* this being more like a DDL operation, proper log level is NOTICE */
 	log_notice("%s", sql);
@@ -2683,9 +2744,21 @@ pg_copy_data(PGSQL *src, PGSQL *dst,
 		return false;
 	}
 
+	/*
+	 * Look up the target relkind once: TRUNCATE and COPY FREEZE both need it
+	 * to avoid Postgres errors on partitioned tables. '\0' on lookup failure
+	 * falls back to the flat-table path (TRUNCATE ONLY, freeze unchanged).
+	 */
+	char relkind = '\0';
+
+	if (args->truncate || args->freeze)
+	{
+		(void) pgsql_get_table_relkind(dst, args->dstQname, &relkind);
+	}
+
 	if (args->truncate)
 	{
-		if (!pgsql_truncate(dst, args->dstQname))
+		if (!pgsql_truncate(dst, args->dstQname, relkind))
 		{
 			/* errors have already been logged */
 			return false;
@@ -2694,9 +2767,18 @@ pg_copy_data(PGSQL *src, PGSQL *dst,
 
 	/*
 	 * COPY FREEZE is only accepted by Postgres if the table was created or
-	 * truncated in the current transaction.
+	 * truncated in the current transaction. It is also rejected on
+	 * partitioned tables ("cannot perform COPY FREEZE on a partitioned
+	 * table"), so disable it when the target relation is partitioned.
 	 */
 	args->freeze &= args->truncate;
+
+	if (args->freeze && relkind == 'p')
+	{
+		log_notice("disabling COPY FREEZE on partitioned target table %s",
+				   args->dstQname);
+		args->freeze = false;
+	}
 
 	/* make sure to log TRUNCATE before we log COPY, avoid confusion */
 	log_notice("%s", args->logCommand);

--- a/src/bin/pgcopydb/pgsql.h
+++ b/src/bin/pgcopydb/pgsql.h
@@ -287,6 +287,8 @@ bool pgsql_has_table_privilege(PGSQL *pgsql,
 							   const char *privilege,
 							   bool *granted);
 
+bool pgsql_get_table_relkind(PGSQL *pgsql, const char *qname, char *relkind);
+
 bool pgsql_get_search_path(PGSQL *pgsql, char *search_path, size_t size);
 bool pgsql_set_search_path(PGSQL *pgsql, char *search_path, bool local);
 bool pgsql_prepend_search_path(PGSQL *pgsql, const char *namespace);
@@ -319,7 +321,7 @@ bool validate_connection_string(const char *connectionString);
 
 bool pgsql_lock_table(PGSQL *pgsql, const char *qname, const char *lockmode);
 
-bool pgsql_truncate(PGSQL *pgsql, const char *qname);
+bool pgsql_truncate(PGSQL *pgsql, const char *qname, char relkind);
 
 typedef struct CopyArgs
 {

--- a/src/bin/pgcopydb/table-data.c
+++ b/src/bin/pgcopydb/table-data.c
@@ -579,7 +579,16 @@ copydb_copy_supervisor_add_table_hook(void *ctx, SourceTable *table)
 
 		if (granted)
 		{
-			if (!pgsql_truncate(dst, table->qname))
+			char relkind = '\0';
+
+			/*
+			 * Best-effort: on lookup failure relkind stays '\0' and we issue
+			 * TRUNCATE ONLY (the original behavior). pgsql_get_table_relkind
+			 * has already logged the underlying error.
+			 */
+			(void) pgsql_get_table_relkind(dst, table->qname, &relkind);
+
+			if (!pgsql_truncate(dst, table->qname, relkind))
 			{
 				/* errors have already been logged */
 				return false;

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -5,8 +5,9 @@ PGVERSION ?= 16
 BUILD_ARGS = --build-arg PGVERSION=$(PGVERSION)
 
 all: pagila pagila-multi-steps blobs unit filtering extensions \
+	 partitioned-target \
 	 cdc-wal2json cdc-test-decoding cdc-endpos-between-transaction cdc-low-level \
-	 cdc-replica-identity-index \
+	 cdc-replica-identity-index cdc-partitioned-target \
 	 follow-wal2json follow-9.6 follow-data-only \
 	 endpos-in-multi-wal-txn;
 
@@ -28,6 +29,9 @@ unit: build
 filtering: build
 	$(MAKE) -C $@
 
+partitioned-target: build
+	$(MAKE) -C $@
+
 extensions: build
 	$(MAKE) -C $@
 
@@ -44,6 +48,9 @@ cdc-low-level: build
 	$(MAKE) -C $@
 
 cdc-replica-identity-index: build
+	$(MAKE) -C $@
+
+cdc-partitioned-target: build
 	$(MAKE) -C $@
 
 follow-wal2json: build
@@ -65,7 +72,7 @@ build:
 	docker build $(BUILD_ARGS) -t pagila -f Dockerfile.pagila .
 
 .PHONY: all build
-.PHONY: pagila pagila-multi-steps blobs unit filtering extensions
-.PHONY: cdc-wal2json cdc-test-decoding cdc-low-level cdc-replica-identity-index
+.PHONY: pagila pagila-multi-steps blobs unit filtering partitioned-target extensions
+.PHONY: cdc-wal2json cdc-test-decoding cdc-low-level cdc-replica-identity-index cdc-partitioned-target
 .PHONY: follow-wal2json follow-9.6
 .PHONY: endpos-in-multi-wal-txn

--- a/tests/cdc-partitioned-target/Dockerfile
+++ b/tests/cdc-partitioned-target/Dockerfile
@@ -1,0 +1,11 @@
+FROM pagila
+
+WORKDIR /usr/src/pgcopydb
+COPY ./copydb.sh copydb.sh
+COPY ./source.sql source.sql
+COPY ./target.sql target.sql
+COPY ./dml.sql dml.sql
+COPY ./dml-truncate.sql dml-truncate.sql
+
+USER docker
+CMD ["/usr/src/pgcopydb/copydb.sh"]

--- a/tests/cdc-partitioned-target/Makefile
+++ b/tests/cdc-partitioned-target/Makefile
@@ -1,0 +1,15 @@
+# Copyright (c) 2021 The PostgreSQL Global Development Group.
+# Licensed under the PostgreSQL License.
+
+test: down run down ;
+
+run: build
+	docker compose run test
+
+down:
+	docker compose down
+
+build:
+	docker compose build --quiet
+
+.PHONY: run down build test

--- a/tests/cdc-partitioned-target/compose.yaml
+++ b/tests/cdc-partitioned-target/compose.yaml
@@ -1,0 +1,39 @@
+services:
+  source:
+    image: postgres:13-bullseye
+    expose:
+      - 5432
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: h4ckm3
+      POSTGRES_HOST_AUTH_METHOD: trust
+    command: >
+      -c wal_level=logical
+      -c ssl=on
+      -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
+      -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
+  target:
+    image: postgres:13-bullseye
+    expose:
+      - 5432
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: h4ckm3
+      POSTGRES_HOST_AUTH_METHOD: trust
+    command: >
+      -c ssl=on
+      -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
+      -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
+  test:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      PGSSLMODE: "require"
+      PGCOPYDB_SOURCE_PGURI: postgres://postgres:h4ckm3@source/postgres
+      PGCOPYDB_TARGET_PGURI: postgres://postgres:h4ckm3@target/postgres
+      PGCOPYDB_TABLE_JOBS: 2
+      PGCOPYDB_OUTPUT_PLUGIN: test_decoding
+    depends_on:
+      - source
+      - target

--- a/tests/cdc-partitioned-target/copydb.sh
+++ b/tests/cdc-partitioned-target/copydb.sh
@@ -1,0 +1,97 @@
+#! /bin/bash
+
+set -x
+set -e
+
+# Regression test for two related fixes against partitioned target tables:
+#
+#   1. pgcopydb copy table-data must use TRUNCATE (not TRUNCATE ONLY) and
+#      skip COPY FREEZE when the target is partitioned. Otherwise the
+#      initial copy errors with:
+#        ERROR: cannot truncate only a partitioned table
+#        ERROR: cannot perform COPY FREEZE on a partitioned table
+#
+#   2. CDC apply must rewrite "TRUNCATE ONLY <qname>" emitted by
+#      ld_transform to plain "TRUNCATE <qname>" when the target relation
+#      is partitioned. Otherwise stream catchup errors with the same
+#      "cannot truncate only" message and apply stops.
+#
+# Source has a flat table (relkind='r'); target has a partitioned table
+# (relkind='p') with the same qualified name.
+
+pgcopydb ping
+
+# Build the asymmetric fixture: flat on source, partitioned on target.
+psql -a -d "${PGCOPYDB_SOURCE_PGURI}" -1 -f /usr/src/pgcopydb/source.sql
+psql -a -d "${PGCOPYDB_TARGET_PGURI}" -1 -f /usr/src/pgcopydb/target.sql
+
+# Snapshot + slot for follow mode, then copy the seed rows. This step
+# exercises fix #1: copy table-data must succeed against the partitioned
+# target.
+coproc ( pgcopydb snapshot --follow --plugin test_decoding )
+
+sleep 1
+
+pgcopydb stream setup
+pgcopydb copy table-data
+
+kill -TERM ${COPROC_PID}
+wait ${COPROC_PID}
+
+# Confirm initial copy distributed the seed rows correctly into the
+# partitions. If pg_copy had silently failed, this assertion catches it.
+initial_a=$(psql -At -d "${PGCOPYDB_TARGET_PGURI}" \
+                 -c 'select count(*) from partitioned_target.events_a')
+initial_b=$(psql -At -d "${PGCOPYDB_TARGET_PGURI}" \
+                 -c 'select count(*) from partitioned_target.events_b')
+
+if [ "${initial_a}" != "2" ] || [ "${initial_b}" != "1" ]; then
+    echo "FAIL: initial copy partition counts (events_a=${initial_a}, " \
+         "events_b=${initial_b}); expected 2 and 1"
+    exit 1
+fi
+
+# Phase 1: drive INSERTs through CDC and assert they reach the
+# partitioned target with the correct routing.
+psql -a -d "${PGCOPYDB_SOURCE_PGURI}" -f /usr/src/pgcopydb/dml.sql
+
+lsn1=$(psql -At -d "${PGCOPYDB_SOURCE_PGURI}" \
+            -c 'select pg_current_wal_flush_lsn()')
+
+pgcopydb stream prefetch --resume --endpos "${lsn1}" --notice
+pgcopydb stream sentinel set apply
+pgcopydb stream catchup --resume --endpos "${lsn1}" --notice
+
+after_inserts_a=$(psql -At -d "${PGCOPYDB_TARGET_PGURI}" \
+                       -c 'select count(*) from partitioned_target.events_a')
+after_inserts_b=$(psql -At -d "${PGCOPYDB_TARGET_PGURI}" \
+                       -c 'select count(*) from partitioned_target.events_b')
+
+# Source has 5 rows: 3 seed (id 1..3) + 2 new (id 4..5).
+# bucket=0 -> events_a: ids 1,3,5 = 3 rows
+# bucket=1 -> events_b: ids 2,4   = 2 rows
+if [ "${after_inserts_a}" != "3" ] || [ "${after_inserts_b}" != "2" ]; then
+    echo "FAIL: after CDC inserts (events_a=${after_inserts_a}, " \
+         "events_b=${after_inserts_b}); expected 3 and 2"
+    exit 1
+fi
+
+# Phase 2: drive a TRUNCATE through CDC. Without fix #2 catchup errors
+# here; with the fix the target ends up empty.
+psql -a -d "${PGCOPYDB_SOURCE_PGURI}" -f /usr/src/pgcopydb/dml-truncate.sql
+
+lsn2=$(psql -At -d "${PGCOPYDB_SOURCE_PGURI}" \
+            -c 'select pg_current_wal_flush_lsn()')
+
+pgcopydb stream prefetch --resume --endpos "${lsn2}" --notice
+pgcopydb stream catchup --resume --endpos "${lsn2}" --notice
+
+pgcopydb stream cleanup
+
+final_count=$(psql -At -d "${PGCOPYDB_TARGET_PGURI}" \
+                   -c 'select count(*) from partitioned_target.events')
+
+if [ "${final_count}" != "0" ]; then
+    echo "FAIL: expected target empty after TRUNCATE replay, got ${final_count}"
+    exit 1
+fi

--- a/tests/cdc-partitioned-target/dml-truncate.sql
+++ b/tests/cdc-partitioned-target/dml-truncate.sql
@@ -1,0 +1,10 @@
+---
+--- pgcopydb tests/cdc-partitioned-target/dml-truncate.sql
+---
+--- DML phase 2: TRUNCATE the flat source. ld_transform writes this as
+--- "TRUNCATE ONLY ...", which Postgres rejects against the partitioned
+--- target unless ld_apply rewrites it. After replay the target must be
+--- empty.
+---
+
+truncate only partitioned_target.events;

--- a/tests/cdc-partitioned-target/dml.sql
+++ b/tests/cdc-partitioned-target/dml.sql
@@ -1,0 +1,16 @@
+---
+--- pgcopydb tests/cdc-partitioned-target/dml.sql
+---
+--- DML phase 1: INSERT new rows on the flat source. After replay these
+--- should land in the correct partitions on the target. Phase 2 (the
+--- TRUNCATE) is in dml-truncate.sql so the test can checkpoint between
+--- the two and assert each phase independently.
+---
+
+begin;
+
+insert into partitioned_target.events (id, bucket, payload)
+     values (4, 1, 'd'),
+            (5, 0, 'e');
+
+commit;

--- a/tests/cdc-partitioned-target/source.sql
+++ b/tests/cdc-partitioned-target/source.sql
@@ -1,0 +1,22 @@
+---
+--- pgcopydb tests/cdc-partitioned-target/source.sql
+---
+--- Source: flat (relkind='r') table. Pairs with target.sql to build the
+--- asymmetric source-flat / target-partitioned case that the apply-side
+--- TRUNCATE rewrite has to handle.
+---
+
+create schema partitioned_target;
+
+create table partitioned_target.events (
+    id bigint primary key,
+    bucket smallint not null,
+    payload text
+);
+
+-- Seed rows that exist before the snapshot, copied to the target by
+-- pgcopydb copy table-data and then wiped by the replicated TRUNCATE.
+insert into partitioned_target.events (id, bucket, payload)
+     values (1, 0, 'a'),
+            (2, 1, 'b'),
+            (3, 0, 'c');

--- a/tests/cdc-partitioned-target/target.sql
+++ b/tests/cdc-partitioned-target/target.sql
@@ -1,0 +1,23 @@
+---
+--- pgcopydb tests/cdc-partitioned-target/target.sql
+---
+--- Target: partitioned (relkind='p') table with the same qualified name as
+--- the source flat table. Postgres rejects "TRUNCATE ONLY" against a
+--- partitioned table; the apply path must rewrite the replicated
+--- statement to plain "TRUNCATE".
+---
+
+create schema partitioned_target;
+
+create table partitioned_target.events (
+    id bigint not null,
+    bucket smallint not null,
+    payload text,
+    primary key (id, bucket)
+) partition by list (bucket);
+
+create table partitioned_target.events_a
+    partition of partitioned_target.events for values in (0);
+
+create table partitioned_target.events_b
+    partition of partitioned_target.events for values in (1);

--- a/tests/partitioned-target/Dockerfile
+++ b/tests/partitioned-target/Dockerfile
@@ -1,0 +1,9 @@
+FROM pgcopydb
+
+WORKDIR /usr/src/pgcopydb
+COPY ./copydb.sh copydb.sh
+COPY ./source.sql source.sql
+COPY ./target.sql target.sql
+
+USER docker
+CMD ["/usr/src/pgcopydb/copydb.sh"]

--- a/tests/partitioned-target/Makefile
+++ b/tests/partitioned-target/Makefile
@@ -1,0 +1,15 @@
+# Copyright (c) 2021 The PostgreSQL Global Development Group.
+# Licensed under the PostgreSQL License.
+
+test: down run down ;
+
+run: build
+	docker compose run test
+
+down:
+	docker compose down
+
+build:
+	docker compose build --quiet
+
+.PHONY: run down build test

--- a/tests/partitioned-target/compose.yaml
+++ b/tests/partitioned-target/compose.yaml
@@ -1,0 +1,27 @@
+services:
+  source:
+    image: postgres:16-bullseye
+    expose:
+      - 5432
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: h4ckm3
+      POSTGRES_HOST_AUTH_METHOD: trust
+  target:
+    image: postgres:16-bullseye
+    expose:
+      - 5432
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: h4ckm3
+      POSTGRES_HOST_AUTH_METHOD: trust
+  test:
+    build: .
+    environment:
+      PGCOPYDB_SOURCE_PGURI: postgres://postgres:h4ckm3@source/postgres
+      PGCOPYDB_TARGET_PGURI: postgres://postgres:h4ckm3@target/postgres
+      PGCOPYDB_TABLE_JOBS: 4
+      PGCOPYDB_INDEX_JOBS: 2
+    depends_on:
+      - source
+      - target

--- a/tests/partitioned-target/copydb.sh
+++ b/tests/partitioned-target/copydb.sh
@@ -1,0 +1,40 @@
+#! /bin/bash
+
+set -x
+set -e
+
+# This script expects the following environment variables to be set:
+#
+#  - PGCOPYDB_SOURCE_PGURI
+#  - PGCOPYDB_TARGET_PGURI
+#  - PGCOPYDB_TABLE_JOBS
+
+# make sure source and target databases are ready
+pgcopydb ping
+
+# build the asymmetric fixture: flat on source, partitioned on target
+psql -a -d "${PGCOPYDB_SOURCE_PGURI}" -1 -f /usr/src/pgcopydb/source.sql
+psql -a -d "${PGCOPYDB_TARGET_PGURI}" -1 -f /usr/src/pgcopydb/target.sql
+
+# copy data only: target's partitioned schema must be preserved.
+# this would previously fail with:
+#   ERROR: cannot truncate only a partitioned table
+#   ERROR: cannot perform COPY FREEZE on a partitioned table
+pgcopydb copy table-data --not-consistent
+
+# verify row counts match between source and target
+src_count=$(psql -At -d "${PGCOPYDB_SOURCE_PGURI}" \
+                 -c 'select count(*) from partitioned_target.events')
+dst_count=$(psql -At -d "${PGCOPYDB_TARGET_PGURI}" \
+                 -c 'select count(*) from partitioned_target.events')
+
+echo "source rows: ${src_count}, target rows: ${dst_count}"
+
+if [ "${src_count}" != "${dst_count}" ]; then
+    echo "row count mismatch"
+    exit 1
+fi
+
+# verify the rows actually landed in the right partitions on target
+psql -d "${PGCOPYDB_TARGET_PGURI}" \
+     -c 'select bucket, count(*) from partitioned_target.events group by bucket order by bucket'

--- a/tests/partitioned-target/source.sql
+++ b/tests/partitioned-target/source.sql
@@ -1,0 +1,21 @@
+--
+-- Source schema: flat (non-partitioned) tables.
+--
+-- Pairs with target.sql to build the asymmetric-partitioning case:
+-- source has relkind 'r', target has relkind 'p' for the same qualified
+-- name. The runtime fallback in pgsql_truncate and pg_copy must detect
+-- the target's relkind and adjust TRUNCATE / COPY FREEZE accordingly.
+--
+create schema partitioned_target;
+
+create table partitioned_target.events (
+    id bigint not null,
+    bucket smallint not null,
+    payload text
+);
+
+insert into partitioned_target.events (id, bucket, payload)
+     values (1, 0, 'a'),
+            (2, 1, 'b'),
+            (3, 0, 'c'),
+            (4, 1, 'd');

--- a/tests/partitioned-target/target.sql
+++ b/tests/partitioned-target/target.sql
@@ -1,0 +1,21 @@
+--
+-- Target schema: same name, but partitioned (relkind 'p').
+--
+-- pgcopydb must:
+--   - emit TRUNCATE (not TRUNCATE ONLY), since Postgres rejects TRUNCATE
+--     ONLY on partitioned tables.
+--   - skip COPY FREEZE, since Postgres rejects FREEZE on partitioned tables.
+--
+create schema partitioned_target;
+
+create table partitioned_target.events (
+    id bigint not null,
+    bucket smallint not null,
+    payload text
+) partition by list (bucket);
+
+create table partitioned_target.events_a
+    partition of partitioned_target.events for values in (0);
+
+create table partitioned_target.events_b
+    partition of partitioned_target.events for values in (1);


### PR DESCRIPTION
## Summary

When the source has a flat (non-partitioned) table but the target is a partitioned table with the same qualified name, pgcopydb's data-copy phase fails with:

```
ERROR: cannot truncate only a partitioned table
ERROR: cannot perform COPY FREEZE on a partitioned table
```

The same symptoms recur during CDC follow-mode replay of replicated `TRUNCATE` statements.

This is the asymmetric source-flat / target-partitioned case from #700. The symmetric case (both partitioned) was handled by #863 via a source-side filter. This PR closes the asymmetric gap by querying `pg_class.relkind` on the target at runtime, along the lines of Dimitri's [May 2024 analysis on #700](https://github.com/dimitri/pgcopydb/issues/700#issuecomment-2108023769).

## Approach

- `pgsql_truncate` emits `TRUNCATE` (without `ONLY`) when the target's `relkind` is `'p'`. Postgres' own partition routing handles the cascade.
- `pg_copy` skips `COPY FREEZE` when the target is partitioned, since Postgres rejects FREEZE on partitioned tables.
- `ld_apply.c` (CDC follow) rewrites replicated `TRUNCATE ONLY <qname>` to plain `TRUNCATE <qname>` at apply time when the target is partitioned. The lookup runs on the non-pipeline `controlPgConn` because `applyPgConn` is in pipeline mode and `pgsql_execute_with_params` rejects `parseFun` callbacks there.

A new `pgsql_get_table_relkind` helper performs the lookup, following the same `SingleValueResultContext` pattern used by `pgsql_get_search_path` and `pgsql_has_table_privilege`.

## Tests

Two integration tests, both passing against real Postgres in docker-compose:

- `tests/partitioned-target/` (non-CDC) — flat source, partitioned target with the same qualified name, `pgcopydb copy table-data`. Asserts row counts match and partition routing is correct.
- `tests/cdc-partitioned-target/` (CDC follow) — same fixture, drives INSERTs and a `TRUNCATE` through `stream prefetch` / `stream catchup` in two phases. Asserts:
  - initial copy distributes seed rows correctly (`events_a=2`, `events_b=1`)
  - CDC-replicated INSERTs land in the right partitions (`events_a=3`, `events_b=2`)
  - replicated `TRUNCATE` clears the target (count = 0)

I manually reproduced the bug against the test's target schema (`TRUNCATE ONLY partitioned_target.events` → `cannot truncate only a partitioned table`) to confirm the test exercises the actual bug path rather than something incidental.

## Out of scope

This PR fixes the **copy phase**. The **post-data phase** (CREATE INDEX / ADD CONSTRAINT) still fails when source and target partition shapes differ. Concrete failure modes:

1. `CREATE UNIQUE INDEX` from the source on a column that isn't in the target's partition key — Postgres rejects (unique index on a partitioned table must include the partitioning columns).
2. `ALTER TABLE ... ADD CONSTRAINT ... PRIMARY KEY USING INDEX` — if the partitioned target was pre-created with its own (composite) PK, the index name conflicts. The symptom looks like #808 but the cause is a real schema conflict, not concurrency.
3. `CREATE INDEX` collisions when the partitioned target was pre-created with indexes. `IF NOT EXISTS` is opt-in (resume path) and Postgres has no `IF NOT EXISTS` for constraints.

The current workaround is to pre-create the target schema and use `pgcopydb copy table-data` (skips post-data), or to split the operation as described in the [pgcopydb tutorial — How to edit the schema when copying a database](https://pgcopydb.readthedocs.io/en/latest/tutorial.html#how-to-edit-the-schema-when-copying-a-database). A proper post-data fix is a separate, larger piece of work; happy to scope it next, either under #700 or in a new issue, whichever Dimitri prefers.

## Notes

- The relkind lookup is per-call (no cache). `TRUNCATE` is infrequent in typical CDC traffic, so caching felt premature; happy to add a `(qname → relkind)` cache on `StreamApplyContext` if preferred.
- On lookup failure the code falls back to the pre-PR behavior (issue `TRUNCATE ONLY`, leave `freeze` set). That produces a real Postgres error rather than silent corruption, and `ld_apply.c` emits a `log_warn` so the fallback is observable in operator logs.
- Multi-relation `TRUNCATE ONLY a, b;` is a pre-existing pgcopydb limitation in the `test_decoding` parser (the relname gets garbled at parse time) — not introduced or made worse by this PR. The one-relation-per-statement invariant is now documented on both `stream_write_truncate` (writer) and the apply-side rewrite (consumer).

Closes (partial) #700.