### PR TITLE
fix skip extensions oid collision

### DIFF
--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -406,7 +406,8 @@ bool copydb_prepare_sequence_specs(CopyDataSpec *specs, PGSQL *pgsql, bool reset
 bool copydb_fetch_schema_and_prepare_specs(CopyDataSpec *specs);
 bool copydb_objectid_is_filtered_out(CopyDataSpec *specs,
 									 uint32_t oid,
-									 char *restoreListName);
+									 char *restoreListName,
+									 const char *archiveDesc);
 bool copydb_matview_refresh_is_filtered_out(CopyDataSpec *specs,
 											uint32_t oid);
 

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -405,9 +405,7 @@ bool copydb_prepare_sequence_specs(CopyDataSpec *specs, PGSQL *pgsql, bool reset
 /* copydb_schema.c */
 bool copydb_fetch_schema_and_prepare_specs(CopyDataSpec *specs);
 bool copydb_objectid_is_filtered_out(CopyDataSpec *specs,
-									 uint32_t oid,
-									 char *restoreListName,
-									 const char *archiveDesc);
+									 ArchiveContentItem *item);
 bool copydb_matview_refresh_is_filtered_out(CopyDataSpec *specs,
 											uint32_t oid);
 

--- a/src/bin/pgcopydb/copydb_schema.c
+++ b/src/bin/pgcopydb/copydb_schema.c
@@ -1012,13 +1012,51 @@ copydb_matview_refresh_is_filtered_out(CopyDataSpec *specs, uint32_t oid)
 
 
 /*
+ * filter_kind_matches_archive_desc returns true when a filter entry's kind
+ * is compatible with the archive item description being checked. This prevents
+ * OID collisions between different catalog types (e.g., pg_extension and
+ * pg_class can have the same OID value) from incorrectly filtering out
+ * unrelated objects.
+ *
+ * Filter kinds whose OIDs come from non-pg_class catalogs (extension from
+ * pg_extension, coll from pg_collation) must only match their own archive
+ * item type. Other kinds (table, index, sequence, etc.) use pg_class OIDs
+ * and match freely since they share the same OID namespace.
+ */
+static bool
+filter_kind_matches_archive_desc(const char *kind, const char *archiveDesc)
+{
+	/* if no archive description or no kind, assume match (backwards compat) */
+	if (archiveDesc == NULL || IS_EMPTY_STRING_BUFFER(kind))
+	{
+		return true;
+	}
+
+	/* extension OIDs come from pg_extension, not pg_class */
+	if (strcmp(kind, "extension") == 0)
+	{
+		return strcmp(archiveDesc, "EXTENSION") == 0;
+	}
+
+	/* collation OIDs come from pg_collation, not pg_class */
+	if (strcmp(kind, "coll") == 0)
+	{
+		return strcmp(archiveDesc, "COLLATION") == 0;
+	}
+
+	return true;
+}
+
+
+/*
  * copydb_objectid_is_filtered_out returns true when the given oid belongs to a
  * database object that's been filtered out by the filtering setup.
  */
 bool
 copydb_objectid_is_filtered_out(CopyDataSpec *specs,
 								uint32_t oid,
-								char *restoreListName)
+								char *restoreListName,
+								const char *archiveDesc)
 {
 	DatabaseCatalog *filtersDB = &(specs->catalogs.filter);
 	CatalogFilter result = { 0 };
@@ -1031,7 +1069,8 @@ copydb_objectid_is_filtered_out(CopyDataSpec *specs,
 			return false;
 		}
 
-		if (result.oid != 0)
+		if (result.oid != 0 &&
+			filter_kind_matches_archive_desc(result.kind, archiveDesc))
 		{
 			return true;
 		}
@@ -1045,7 +1084,8 @@ copydb_objectid_is_filtered_out(CopyDataSpec *specs,
 			return false;
 		}
 
-		if (!IS_EMPTY_STRING_BUFFER(result.restoreListName))
+		if (!IS_EMPTY_STRING_BUFFER(result.restoreListName) &&
+			filter_kind_matches_archive_desc(result.kind, archiveDesc))
 		{
 			return true;
 		}

--- a/src/bin/pgcopydb/copydb_schema.c
+++ b/src/bin/pgcopydb/copydb_schema.c
@@ -987,6 +987,7 @@ copydb_matview_refresh_is_filtered_out(CopyDataSpec *specs, uint32_t oid)
 	 * to find out if the materialized view refresh has been filtered out.
 	 *
 	 * The filtering of materialized view as a whole handled by the
+
 	 * existing filtering setup(i.e. copydb_objectid_is_filtered_out).
 	 */
 	DatabaseCatalog *sourceDB = &(specs->catalogs.source);
@@ -1033,15 +1034,15 @@ filter_kind_matches_archive_desc(const char *kind, const char *archiveDesc)
 	}
 
 	/* extension OIDs come from pg_extension, not pg_class */
-	if (strcmp(kind, "extension") == 0)
+	if (streq(kind, "extension"))
 	{
-		return strcmp(archiveDesc, "EXTENSION") == 0;
+		return streq(archiveDesc, "EXTENSION");
 	}
 
 	/* collation OIDs come from pg_collation, not pg_class */
-	if (strcmp(kind, "coll") == 0)
+	if (streq(kind, "coll"))
 	{
-		return strcmp(archiveDesc, "COLLATION") == 0;
+		return streq(archiveDesc, "COLLATION");
 	}
 
 	return true;
@@ -1054,38 +1055,39 @@ filter_kind_matches_archive_desc(const char *kind, const char *archiveDesc)
  */
 bool
 copydb_objectid_is_filtered_out(CopyDataSpec *specs,
-								uint32_t oid,
-								char *restoreListName,
-								const char *archiveDesc)
+								ArchiveContentItem *item)
 {
 	DatabaseCatalog *filtersDB = &(specs->catalogs.filter);
 	CatalogFilter result = { 0 };
 
-	if (oid != 0)
+	if (item->objectOid != 0)
 	{
-		if (!catalog_lookup_filter_by_oid(filtersDB, &result, oid))
+		if (!catalog_lookup_filter_by_oid(filtersDB, &result, item->objectOid))
 		{
 			/* errors have already been logged */
 			return false;
 		}
 
 		if (result.oid != 0 &&
-			filter_kind_matches_archive_desc(result.kind, archiveDesc))
+			filter_kind_matches_archive_desc(result.kind, item->description))
 		{
 			return true;
 		}
 	}
 
-	if (restoreListName != NULL && !IS_EMPTY_STRING_BUFFER(restoreListName))
+	if (item->restoreListName != NULL &&
+		!IS_EMPTY_STRING_BUFFER(item->restoreListName))
 	{
-		if (!catalog_lookup_filter_by_rlname(filtersDB, &result, restoreListName))
+		if (!catalog_lookup_filter_by_rlname(filtersDB,
+											 &result,
+											 item->restoreListName))
 		{
 			/* errors have already been logged */
 			return false;
 		}
 
 		if (!IS_EMPTY_STRING_BUFFER(result.restoreListName) &&
-			filter_kind_matches_archive_desc(result.kind, archiveDesc))
+			filter_kind_matches_archive_desc(result.kind, item->description))
 		{
 			return true;
 		}

--- a/src/bin/pgcopydb/copydb_schema.c
+++ b/src/bin/pgcopydb/copydb_schema.c
@@ -987,7 +987,6 @@ copydb_matview_refresh_is_filtered_out(CopyDataSpec *specs, uint32_t oid)
 	 * to find out if the materialized view refresh has been filtered out.
 	 *
 	 * The filtering of materialized view as a whole handled by the
-
 	 * existing filtering setup(i.e. copydb_objectid_is_filtered_out).
 	 */
 	DatabaseCatalog *sourceDB = &(specs->catalogs.source);
@@ -1043,6 +1042,23 @@ filter_kind_matches_archive_desc(const char *kind, const char *archiveDesc)
 	if (streq(kind, "coll"))
 	{
 		return streq(archiveDesc, "COLLATION");
+	}
+
+	/*
+	 * DEFAULT filter entries carry the sequence's restore_list_name to filter
+	 * out DEFAULT constraints, not the sequence definition itself. Without
+	 * this check a SEQUENCE archive item whose restore_list_name matches a
+	 * DEFAULT filter entry would be incorrectly excluded from the restore.
+	 */
+	if (streq(kind, "default"))
+	{
+		return streq(archiveDesc, "DEFAULT");
+	}
+
+	/* SEQUENCE OWNED BY entries only apply to ownership statements */
+	if (streq(kind, "sequence owned by"))
+	{
+		return streq(archiveDesc, "SEQUENCE OWNED BY");
 	}
 
 	return true;

--- a/src/bin/pgcopydb/copydb_schema.c
+++ b/src/bin/pgcopydb/copydb_schema.c
@@ -1044,23 +1044,6 @@ filter_kind_matches_archive_desc(const char *kind, const char *archiveDesc)
 		return streq(archiveDesc, "COLLATION");
 	}
 
-	/*
-	 * DEFAULT filter entries carry the sequence's restore_list_name to filter
-	 * out DEFAULT constraints, not the sequence definition itself. Without
-	 * this check a SEQUENCE archive item whose restore_list_name matches a
-	 * DEFAULT filter entry would be incorrectly excluded from the restore.
-	 */
-	if (streq(kind, "default"))
-	{
-		return streq(archiveDesc, "DEFAULT");
-	}
-
-	/* SEQUENCE OWNED BY entries only apply to ownership statements */
-	if (streq(kind, "sequence owned by"))
-	{
-		return streq(archiveDesc, "SEQUENCE OWNED BY");
-	}
-
 	return true;
 }
 
@@ -1089,6 +1072,22 @@ copydb_objectid_is_filtered_out(CopyDataSpec *specs,
 		{
 			return true;
 		}
+	}
+
+	/*
+	 * For SEQUENCE items, skip name-based lookup. The 'default' filter entry
+	 * for a sequence owned by an excluded table carries the sequence's own
+	 * restore_list_name so it can filter DEFAULT constraints and SEQUENCE
+	 * OWNED BY statements — but it must not filter the SEQUENCE definition
+	 * itself, which is needed when the sequence is referenced by an included
+	 * table (e.g. copy.foo shares app.foo_id_seq via LIKE ... INCLUDING ALL).
+	 *
+	 * SEQUENCE OWNED BY and DEFAULT items are not ARCHIVE_TAG_SEQUENCE, so
+	 * they still reach the name-based lookup below and are filtered correctly.
+	 */
+	if (item->desc == ARCHIVE_TAG_SEQUENCE)
+	{
+		return false;
 	}
 
 	if (item->restoreListName != NULL &&

--- a/src/bin/pgcopydb/dump_restore.c
+++ b/src/bin/pgcopydb/dump_restore.c
@@ -800,7 +800,8 @@ copydb_write_restore_list_hook(void *ctx, ArchiveContentItem *item)
 				   item->restoreListName);
 	}
 
-	if (!skip && copydb_objectid_is_filtered_out(specs, oid, name))
+	if (!skip && copydb_objectid_is_filtered_out(specs, oid, name,
+											   item->description))
 	{
 		skip = true;
 

--- a/src/bin/pgcopydb/dump_restore.c
+++ b/src/bin/pgcopydb/dump_restore.c
@@ -800,8 +800,7 @@ copydb_write_restore_list_hook(void *ctx, ArchiveContentItem *item)
 				   item->restoreListName);
 	}
 
-	if (!skip && copydb_objectid_is_filtered_out(specs, oid, name,
-												 item->description))
+	if (!skip && copydb_objectid_is_filtered_out(specs, item))
 	{
 		skip = true;
 

--- a/src/bin/pgcopydb/dump_restore.c
+++ b/src/bin/pgcopydb/dump_restore.c
@@ -776,11 +776,11 @@ copydb_write_restore_list_hook(void *ctx, ArchiveContentItem *item)
 	 * table a and used as a default value in table b, where table a has
 	 * been filtered-out from pgcopydb scope of operations, but not table
 	 * b.
+	 *
+	 * The kind-based matching in filter_kind_matches_archive_desc ensures
+	 * that 'default' and 'sequence owned by' filter entries do not match
+	 * SEQUENCE archive items, so no name override is needed here.
 	 */
-	if (item->desc == ARCHIVE_TAG_SEQUENCE)
-	{
-		name = NULL;
-	}
 
 	/*
 	 * There could be a case where the materalized view is included in the

--- a/src/bin/pgcopydb/dump_restore.c
+++ b/src/bin/pgcopydb/dump_restore.c
@@ -801,7 +801,7 @@ copydb_write_restore_list_hook(void *ctx, ArchiveContentItem *item)
 	}
 
 	if (!skip && copydb_objectid_is_filtered_out(specs, oid, name,
-											   item->description))
+												 item->description))
 	{
 		skip = true;
 


### PR DESCRIPTION
- **Fix --skip-extensions OID collision filtering out unrelated tables**
- **style: apply citus_indent to schema.c and dump_restore.c**
- **Review.**
