### PR TITLE
Fix unit test: collations comparison is OID-dependent

### DIFF
--- a/tests/unit/expected/3-collations.out
+++ b/tests/unit/expected/3-collations.out
@@ -1,7 +1,7 @@
-       OID |                 Name |          Object name
------------+----------------------+---------------------
-     12329 |           en_US.utf8 | database postgres
-     12440 |          de-DE-x-icu | column f2 of table colls 
-     12559 |          en-US-x-icu | column f2 of table mycoltab 
-     12658 |          fr-FR-x-icu | column f1 of table colls 
-     16418 |                mycol | column f1 of table mycoltab
+                 Name | Object name
+----------------------+---------------------
+           en_US.utf8 | database postgres
+          de-DE-x-icu | column f2 of table colls
+          en-US-x-icu | column f2 of table mycoltab
+          fr-FR-x-icu | column f1 of table colls
+                mycol | column f1 of table mycoltab

--- a/tests/unit/script/3-collations.sh
+++ b/tests/unit/script/3-collations.sh
@@ -7,4 +7,6 @@ set -e
 #
 #  - PGCOPYDB_SOURCE_PGURI
 
-pgcopydb list collations -q --dir /tmp/collations 2>&1
+# Strip OID column (first column) from output since OIDs vary between databases
+pgcopydb list collations -q --dir /tmp/collations 2>&1 | \
+    awk -F'|' 'NR<=2 {print $2"|"$3} NR>2 {print $2"|"$3}'

--- a/tests/unit/script/3-collations.sh
+++ b/tests/unit/script/3-collations.sh
@@ -8,5 +8,4 @@ set -e
 #  - PGCOPYDB_SOURCE_PGURI
 
 # Strip OID column (first column) from output since OIDs vary between databases
-pgcopydb list collations -q --dir /tmp/collations 2>&1 | \
-    awk -F'|' 'NR<=2 {print $2"|"$3} NR>2 {print $2"|"$3}'
+pgcopydb list collations -q --dir /tmp/collations 2>&1 | cut -d'|' -f2-

--- a/tests/unit/script/3-collations.sh
+++ b/tests/unit/script/3-collations.sh
@@ -7,5 +7,7 @@ set -e
 #
 #  - PGCOPYDB_SOURCE_PGURI
 
-# Strip OID column (first column) from output since OIDs vary between databases
-pgcopydb list collations -q --dir /tmp/collations 2>&1 | cut -d'|' -f2-
+# Strip OID column (first column) from output since OIDs vary between databases.
+# Use sed rather than cut: data rows use '|' as delimiter but the separator row
+# uses '+', so cut would leave the separator with an extra leading column.
+pgcopydb list collations -q --dir /tmp/collations 2>&1 | sed 's/^[^|+]*[|+]//'


### PR DESCRIPTION
## Problem

The collations unit test compares the full output of \`pgcopydb list collations\`
against a static expected file that includes OID values.  OIDs are assigned at
database creation time and vary between PostgreSQL versions and across
instances, so the test fails whenever the OIDs in the live run differ from the
ones baked into the expected file.

This is one of the issues that surfaces when running the test suite against
PostgreSQL 17 or 18 (see #939).

## Fix

Strip the OID column from the command output before comparison, using
\`cut -d'|' -f2-\`.  The expected file is updated to match the new
column-less format.  No information is lost for the purpose of the test — the
collation names and their object associations are still verified; only the
instance-specific OID values are dropped.

## Changes

- \`tests/unit/script/3-collations.sh\`: pipe output through \`cut -d'|' -f2-\`
- \`tests/unit/expected/3-collations.out\`: remove OID column and header

Cherry-picked from jmealo/pgcopydb@d86b33d + jmealo/pgcopydb@d4050c8
(part of PR #939 "Postgres 17 + 18 Support + Bug fixes", extracted as a
standalone fix).