### PR TITLE
Fix no open transaction in clone --follow --snapshot

### DIFF
--- a/src/bin/pgcopydb/copydb_schema.c
+++ b/src/bin/pgcopydb/copydb_schema.c
@@ -81,7 +81,8 @@ copydb_fetch_schema_and_prepare_specs(CopyDataSpec *specs)
 		}
 
 		/* we might have to prepare the snapshot locally */
-		if (specs->sourceSnapshot.state == SNAPSHOT_STATE_UNKNOWN)
+		if (specs->sourceSnapshot.state == SNAPSHOT_STATE_UNKNOWN ||
+			specs->sourceSnapshot.state == SNAPSHOT_STATE_CLOSED)
 		{
 			if (!copydb_prepare_snapshot(specs))
 			{


### PR DESCRIPTION
## Problem

When using a pre-exported snapshot with \`clone --follow --snapshot\`, the
operation fails with:

```
BUG: call to pgsql_commit() without holding an open multi statement connection
```

The call chain is:

1. \`clone_and_follow\` calls \`copydb_fetch_schema_and_prepare_specs\`, which
   calls \`copydb_prepare_snapshot\` (state is \`SNAPSHOT_STATE_UNKNOWN\`) and
   later calls \`copydb_close_snapshot\`, leaving state as \`SNAPSHOT_STATE_CLOSED\`.
2. \`clone_and_follow\` then calls \`start_clone_process\` → \`cloneDB\` →
   \`copydb_fetch_schema_and_prepare_specs\` a second time. Now state is
   \`SNAPSHOT_STATE_CLOSED\`, so the guard `state == SNAPSHOT_STATE_UNKNOWN`
   does **not** fire, and no transaction is opened.
3. The code attempts to set the search path (fails with a warning) and then
   commits — which fails because no transaction was started.

## Fix

`copydb_prepare_snapshot` already handles both `SNAPSHOT_STATE_UNKNOWN` and
`SNAPSHOT_STATE_CLOSED` internally. The guard in
`copydb_fetch_schema_and_prepare_specs` was simply missing the `CLOSED` case.
One-line fix: add `|| state == SNAPSHOT_STATE_CLOSED` to the condition.

## Testing

`make tests/unit` passes locally.

Cherry-picked from ahmad-sanad/pgcopydb@14cd12c (part of PR #939 "Postgres 17
+ 18 Support + Bug fixes", extracted as a standalone fix).