### PR TITLE
Fix large object copy for PostgreSQL 17+ compatibility

### DIFF
--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -3503,24 +3503,58 @@ pg_copy_large_object(PGSQL *src,
 
 	/*
 	 * 3. Open the blob on the target database
+	 *
+	 *    In PostgreSQL 17+, pg_dump no longer outputs large object metadata
+	 *    in the pre-data section, so the large object may not exist yet.
+	 *    If opening fails, try creating it first.
 	 */
 	int dstfd = lo_open(dst->connection, blobOid, INV_WRITE);
 
 	if (dstfd == -1)
 	{
-		char context[BUFSIZE] = { 0 };
+		/*
+		 * Large object doesn't exist yet (PG17+ behavior or fresh target).
+		 * Create it with the same OID as the source, then try opening again.
+		 */
+		log_debug("Large object %u not found on target, creating it", blobOid);
 
-		sformat(context, sizeof(context),
-				"Failed to open new large object %u", blobOid);
+		Oid createdOid = lo_create(dst->connection, blobOid);
 
-		(void) pgcopy_log_error(dst, NULL, context);
+		if (createdOid != blobOid)
+		{
+			char context[BUFSIZE] = { 0 };
 
-		lo_close(src->connection, srcfd);
+			sformat(context, sizeof(context),
+					"Failed to create large object %u on target", blobOid);
 
-		pgsql_finish(src);
-		pgsql_finish(dst);
+			(void) pgcopy_log_error(dst, NULL, context);
 
-		return false;
+			lo_close(src->connection, srcfd);
+
+			pgsql_finish(src);
+			pgsql_finish(dst);
+
+			return false;
+		}
+
+		dstfd = lo_open(dst->connection, blobOid, INV_WRITE);
+
+		if (dstfd == -1)
+		{
+			char context[BUFSIZE] = { 0 };
+
+			sformat(context, sizeof(context),
+					"Failed to open newly created large object %u", blobOid);
+
+			(void) pgcopy_log_error(dst, NULL, context);
+
+			lo_close(src->connection, srcfd);
+
+			pgsql_finish(src);
+			pgsql_finish(dst);
+
+			return false;
+		}
 	}
 
 	/*


### PR DESCRIPTION
## Problem

`pgcopydb clone` fails when copying large objects (blobs) with PostgreSQL 17 as
the source, with errors such as:

```
Failed to open new large object 12345
```

PostgreSQL 17 changed `pg_dump` behaviour: large object metadata is no longer
emitted in the pre-data section of the dump (commit
[a45c78e](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=a45c78e3284b269085e9a0cbd0ea3b236b7180fa)).
As a result, when pgcopydb calls `pgcopydb restore pre-data` the target
database contains no large objects, and the subsequent `pg_copy_large_object`
call fails immediately at `lo_open` because the OID does not yet exist on the
target.

Closes #915.

## Fix

When `lo_open` fails on the target, attempt to create the large object with the
same OID (`lo_create(dst->connection, blobOid)`) and then retry `lo_open`.
If creation or the second open also fail, the original error path is preserved.

This handles both the PG17+ case (LO metadata absent from pre-data, so the LO
does not exist yet) and any other scenario where the target LO is unexpectedly
absent, without requiring a version check.

## Testing

`make tests/blobs` passes locally (PG13/PG16 source path, where the LO already
exists in pre-data — the new fallback is not exercised, so the happy path is
unchanged). The PG17+ regression path requires building against PG17 tooling
(`PGVERSION=17`).

Cherry-picked from jmealo/pgcopydb@2ac28721 (part of PR #939 "Postgres 17 + 18
Support + Bug fixes", extracted as a standalone fix).