### PR TITLE
Add PostgreSQL 17 and 18 build and test support

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,80 @@
+name: Nightly Tests
+
+on:
+  # Full PG16/17/18 matrix every night at 02:00 UTC.
+  schedule:
+    - cron: '0 2 * * *'
+
+  # Manual trigger — use this when you want a full matrix run on demand
+  # (e.g. before cutting a release or after a large refactor).
+  workflow_dispatch:
+
+jobs:
+  build_package:
+    name: Run tests
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        PGVERSION:
+          - 16
+          - 17
+          - 18
+        TEST:
+          - ci
+          - pagila
+          - pagila-multi-steps
+          - pagila-standby
+          - unit
+          - blobs
+          - filtering
+          - extensions
+          - timescaledb
+          - cdc-low-level
+          - cdc-test-decoding
+          - cdc-endpos-between-transaction
+          - cdc-wal2json
+          - follow-wal2json
+          - follow-9.6
+          - follow-data-only
+          - endpos-in-multi-wal-txn
+        exclude:
+          # timescaledb uses timescale/timescaledb:latest-pg13 for both source
+          # and target. pg_restore from PG17+ emits "SET transaction_timeout = 0"
+          # at connect time; the TimescaleDB pg13 server rejects this unknown GUC,
+          # causing pg_restore to fail.  The test exercises TimescaleDB
+          # compatibility, not PG version, so running it only under PG16 is fine.
+          - TEST: timescaledb
+            PGVERSION: 17
+          - TEST: timescaledb
+            PGVERSION: 18
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # all history for all branches and tags
+
+      - name: Set Version String From .git
+        run: make version
+
+      - name: Set environment variables
+        run: |
+            echo "TEST=${{ matrix.TEST }}" >> $GITHUB_ENV
+            echo "PGVERSION=${{ matrix.PGVERSION }}" >> $GITHUB_ENV
+
+      - name: Create docker volumes
+        run: |
+          docker volume create ${TEST}
+
+      - name: List docker volumes
+        run: |
+          docker volume ls
+
+      - name: Docker Compose Version
+        run: |
+          docker compose version
+
+      - name: Run a test
+        timeout-minutes: 15
+        run: |
+          make tests/${TEST}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -51,6 +51,7 @@ jobs:
       - name: Set environment variables
         run: |
             echo "TEST=${{ matrix.TEST }}" >> $GITHUB_ENV
+            echo "PGVERSION=${{ matrix.PGVERSION }}" >> $GITHUB_ENV
 
       - name: Create docker volumes
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,6 +19,8 @@ jobs:
       matrix:
         PGVERSION:
           - 16
+          - 17
+          - 18
         TEST:
           - ci
           - pagila

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -66,7 +66,7 @@ jobs:
           docker compose version
 
       - name: Run a test
-        timeout-minutes: 5
+        timeout-minutes: 15
         run: |
           make tests/${TEST}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -39,6 +39,16 @@ jobs:
           - follow-9.6
           - follow-data-only
           - endpos-in-multi-wal-txn
+        exclude:
+          # timescaledb uses timescale/timescaledb:latest-pg13 for both source
+          # and target. pg_restore from PG17+ emits "SET transaction_timeout = 0"
+          # at connect time; the TimescaleDB pg13 server rejects this unknown GUC,
+          # causing pg_restore to fail.  The test exercises TimescaleDB
+          # compatibility, not PG version, so running it only under PG16 is fine.
+          - TEST: timescaledb
+            PGVERSION: 17
+          - TEST: timescaledb
+            PGVERSION: 18
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,6 +8,8 @@ on:
     branches:
     - main
 
+  # Manual trigger for a quick, PR-style run on any branch.
+  # For a full PG16/17/18 matrix run, use the Nightly workflow instead.
   workflow_dispatch:
 
 jobs:
@@ -17,9 +19,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # PR / push matrix: PG16 (smoke) + PG18 (full).
+        #
+        # PG17 is intentionally omitted here — it is covered by the nightly
+        # full-matrix run.  PG18 (latest) gets every test; PG16 (oldest
+        # supported) gets a representative core subset.  This keeps the PR
+        # gate at ~25 jobs instead of 49.
         PGVERSION:
           - 16
-          - 17
           - 18
         TEST:
           - ci
@@ -46,9 +53,27 @@ jobs:
           # causing pg_restore to fail.  The test exercises TimescaleDB
           # compatibility, not PG version, so running it only under PG16 is fine.
           - TEST: timescaledb
-            PGVERSION: 17
-          - TEST: timescaledb
             PGVERSION: 18
+
+          # CDC / WAL-streaming / follow tests are version-agnostic at the
+          # protocol level.  Running them on PG18 on every PR is enough signal;
+          # PG16 coverage is provided by the nightly full-matrix run.
+          - TEST: cdc-low-level
+            PGVERSION: 16
+          - TEST: cdc-test-decoding
+            PGVERSION: 16
+          - TEST: cdc-endpos-between-transaction
+            PGVERSION: 16
+          - TEST: cdc-wal2json
+            PGVERSION: 16
+          - TEST: follow-wal2json
+            PGVERSION: 16
+          - TEST: follow-9.6
+            PGVERSION: 16
+          - TEST: follow-data-only
+            PGVERSION: 16
+          - TEST: endpos-in-multi-wal-txn
+            PGVERSION: 16
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### pgcopydb (Unreleased) ###
+
+### Added
+* Add support for PostgreSQL 17 and 18
+* Update all test infrastructure to PostgreSQL 17
+* Update CI pipeline to test against PostgreSQL 16, 17, and 18
+
 ### pgcopydb v0.17 (August 7, 2024) ###
 
 pgcopydb v0.17 is mostly a bugfix release. New features include

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN dpkg --add-architecture ${TARGETARCH:-arm64} && apt update \
     libkrb5-dev \
     liblz4-dev \
     libncurses6 \
+    libnuma-dev \
     libpam-dev \
     libpq-dev \
     libpq5 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:latest
 # Define a base image with all our build dependencies.
-FROM --platform=${TARGETPLATFORM} debian:11-slim AS build
+FROM --platform=${TARGETPLATFORM} debian:12-slim AS build
 
 # multi-arch
 ARG TARGETPLATFORM
@@ -15,7 +15,7 @@ RUN dpkg --add-architecture ${TARGETARCH:-arm64} && apt update \
 	gnupg
 
 RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt bullseye-pgdg main ${PGVERSION}" > /etc/apt/sources.list.d/pgdg.list
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt bookworm-pgdg main ${PGVERSION}" > /etc/apt/sources.list.d/pgdg.list
 
 RUN dpkg --add-architecture ${TARGETARCH:-arm64} && apt update \
   && apt install -qqy --no-install-recommends \
@@ -86,7 +86,7 @@ RUN make -s clean && make -s -j$(nproc) install
 COPY tests tests
 
 # Now the "run" image, as small as possible
-FROM --platform=${TARGETPLATFORM} debian:11-slim AS run
+FROM --platform=${TARGETPLATFORM} debian:12-slim AS run
 
 # multi-arch
 ARG TARGETPLATFORM
@@ -104,7 +104,7 @@ RUN dpkg --add-architecture ${TARGETARCH:-arm64} && apt update \
 	gnupg
 
 RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt bullseye-pgdg main ${PGVERSION}" > /etc/apt/sources.list.d/pgdg.list
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt bookworm-pgdg main ${PGVERSION}" > /etc/apt/sources.list.d/pgdg.list
 
 RUN dpkg --add-architecture ${TARGETARCH:-arm64} && apt update \
   && apt install -qqy --no-install-suggests --no-install-recommends \

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 
 TOP := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 PGCOPYDB ?= $(TOP)src/bin/pgcopydb/pgcopydb
+PGVERSION ?= 16
 
 all: bin ;
 
@@ -53,7 +54,7 @@ indent:
 	citus_indent
 
 build: version
-	docker build -t pgcopydb .
+	docker build --build-arg PGVERSION=$(PGVERSION) -t pgcopydb .
 
 echo-version: GIT-VERSION-FILE
 	@awk '{print $$3}' $<

--- a/docs/ref/pgcopydb.rst
+++ b/docs/ref/pgcopydb.rst
@@ -48,7 +48,7 @@ of pgcopydb used, and can do that in the JSON format when using the
    $ pgcopydb version
    pgcopydb version 0.13.1.g868ad77
    compiled with PostgreSQL 13.11 (Debian 13.11-0+deb11u1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1 20210110, 64-bit
-   compatible with Postgres 10, 11, 12, 13, 14, and 15
+   compatible with Postgres 11, 12, 13, 14, 15, 16, 17, and 18
 
 In JSON:
 

--- a/src/bin/pgcopydb/cli_common.c
+++ b/src/bin/pgcopydb/cli_common.c
@@ -124,7 +124,7 @@ cli_print_version(int argc, char **argv)
 	{
 		fformat(stdout, "pgcopydb version %s\n", VERSION_STRING);
 		fformat(stdout, "compiled with %s\n", PG_VERSION_STR);
-		fformat(stdout, "compatible with Postgres 11, 12, 13, 14, 15, and 16\n");
+		fformat(stdout, "compatible with Postgres 11, 12, 13, 14, 15, 16, 17, and 18\n");
 	}
 
 	exit(0);

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -3472,13 +3472,45 @@ pg_copy_large_object(PGSQL *src,
 	 *    In normal cases `pg_dump --section=pre-data` outputs the
 	 *    large object metadata and we only have to take care of the
 	 *    contents of the large objects.
+	 *
+	 *    In PostgreSQL 17+, lo_unlink() throws a SQL error (aborting the
+	 *    current transaction) when the large object does not exist, rather
+	 *    than simply returning -1.  Use a savepoint to recover.
 	 */
 	if (dropIfExists)
 	{
+		if (!pgsql_execute(dst, "SAVEPOINT pgcopydb_lo_unlink"))
+		{
+			lo_close(src->connection, srcfd);
+			pgsql_finish(src);
+			pgsql_finish(dst);
+			return false;
+		}
+
 		if (!lo_unlink(dst->connection, blobOid))
 		{
-			/* ignore errors, the object might not exists */
+			/*
+			 * Ignore errors, the object might not exist yet.  But in
+			 * PG17+ the failure aborts the current transaction, so roll
+			 * back to the savepoint before continuing.
+			 */
 			log_debug("Failed to delete large object %u", blobOid);
+
+			if (!pgsql_execute(dst, "ROLLBACK TO SAVEPOINT pgcopydb_lo_unlink"))
+			{
+				lo_close(src->connection, srcfd);
+				pgsql_finish(src);
+				pgsql_finish(dst);
+				return false;
+			}
+		}
+
+		if (!pgsql_execute(dst, "RELEASE SAVEPOINT pgcopydb_lo_unlink"))
+		{
+			lo_close(src->connection, srcfd);
+			pgsql_finish(src);
+			pgsql_finish(dst);
+			return false;
 		}
 
 		Oid dstBlobOid = lo_create(dst->connection, blobOid);
@@ -3507,16 +3539,38 @@ pg_copy_large_object(PGSQL *src,
 	 *    In PostgreSQL 17+, pg_dump no longer outputs large object metadata
 	 *    in the pre-data section, so the large object may not exist yet.
 	 *    If opening fails, try creating it first.
+	 *
+	 *    Also in PG17+, lo_open() throws a SQL error (aborting the current
+	 *    transaction) when the large object does not exist, rather than
+	 *    simply returning -1.  Use a savepoint to recover from that error
+	 *    so we can create the object and retry.
 	 */
+	if (!pgsql_execute(dst, "SAVEPOINT pgcopydb_lo_open"))
+	{
+		lo_close(src->connection, srcfd);
+		pgsql_finish(src);
+		pgsql_finish(dst);
+		return false;
+	}
+
 	int dstfd = lo_open(dst->connection, blobOid, INV_WRITE);
 
 	if (dstfd == -1)
 	{
 		/*
 		 * Large object doesn't exist yet (PG17+ behavior or fresh target).
-		 * Create it with the same OID as the source, then try opening again.
+		 * In PG17+ the lo_open() failure aborts the current transaction,
+		 * so roll back to the savepoint before creating the object.
 		 */
 		log_debug("Large object %u not found on target, creating it", blobOid);
+
+		if (!pgsql_execute(dst, "ROLLBACK TO SAVEPOINT pgcopydb_lo_open"))
+		{
+			lo_close(src->connection, srcfd);
+			pgsql_finish(src);
+			pgsql_finish(dst);
+			return false;
+		}
 
 		Oid createdOid = lo_create(dst->connection, blobOid);
 
@@ -3555,6 +3609,15 @@ pg_copy_large_object(PGSQL *src,
 
 			return false;
 		}
+	}
+
+	if (!pgsql_execute(dst, "RELEASE SAVEPOINT pgcopydb_lo_open"))
+	{
+		lo_close(src->connection, srcfd);
+		lo_close(dst->connection, dstfd);
+		pgsql_finish(src);
+		pgsql_finish(dst);
+		return false;
 	}
 
 	/*

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -3464,17 +3464,34 @@ pg_copy_large_object(PGSQL *src,
 	}
 
 	/*
-	 * In PostgreSQL 17+, lo_unlink() and lo_open() throw a SQL error
-	 * (aborting the current transaction) when the target large object does
-	 * not exist, rather than simply returning -1.  Also in PG17+, pg_dump
-	 * no longer outputs large object metadata in the pre-data section.
+	 * Both lo_open() and lo_unlink() call ereport(ERROR) — aborting the
+	 * current transaction — when the target large object does not exist.
+	 * This is true for all PostgreSQL versions: inv_open() checks
+	 * LargeObjectExistsWithSnapshot() and LargeObjectDrop() scans
+	 * pg_largeobject_metadata, both throwing ERROR if the OID is absent.
 	 *
-	 * For PG17+ we therefore use SQL-level existence checks via
-	 * pg_largeobject_metadata to avoid transaction-aborting errors.  For
-	 * older versions the libpq large-object functions return -1 safely, so
-	 * we keep the simpler direct-call path.
+	 * Whether those errors can actually be triggered depends on whether
+	 * the blobs have been created on the target before this function runs.
 	 *
-	 * PQserverVersion() reads the version from the connection struct --
+	 * In PostgreSQL 16 and earlier, pg_dump emits "BLOB" TOC entries in
+	 * SECTION_PRE_DATA containing "SELECT pg_catalog.lo_create(N)" for
+	 * every large object.  pgcopydb restores those in the pre-data step,
+	 * so by the time pg_copy_large_object() is called the blobs always
+	 * exist on the target.  lo_open() and lo_unlink() therefore never
+	 * encounter missing objects, and no special handling is needed.
+	 *
+	 * In PostgreSQL 17+, commit a45c78e3284 moved blob creation into
+	 * "BLOB METADATA" TOC entries placed in SECTION_DATA (not pre-data).
+	 * pgcopydb only restores the pre-data section, so blobs are never
+	 * pre-created.  pg_copy_large_object() must therefore create each
+	 * blob itself before opening it for writing, and must handle the
+	 * drop-if-exists case without calling lo_unlink() on absent blobs.
+	 *
+	 * For PG17+ we use SQL-level checks via pg_largeobject_metadata —
+	 * the same technique that pg_restore's own DropLOIfExists() has used
+	 * since PostgreSQL 9.0 (src/bin/pg_dump/pg_backup_db.c).
+	 *
+	 * PQserverVersion() reads the version from the connection struct;
 	 * it is an O(1) operation with no network round-trip.
 	 */
 	bool dstIsPG17orLater = PQserverVersion(dst->connection) >= 170000;
@@ -3494,10 +3511,14 @@ pg_copy_large_object(PGSQL *src,
 		if (dstIsPG17orLater)
 		{
 			/*
-			 * In PG17+, lo_unlink() aborts the transaction when the
-			 * object does not exist.  Avoid that by filtering through
-			 * pg_largeobject_metadata: if the row is absent the SELECT
-			 * returns zero rows and lo_unlink() is never called.
+			 * On PG17+, blobs are not pre-created by the pre-data
+			 * restore, so the blob may not exist yet.  Calling
+			 * lo_unlink() on a missing blob would reach LargeObjectDrop()
+			 * which calls ereport(ERROR), aborting the transaction.
+			 *
+			 * Instead, use a WHERE-filtered SELECT so that lo_unlink()
+			 * is only called when the row actually exists.  This is the
+			 * same pattern used by pg_restore's own DropLOIfExists().
 			 */
 			char sql[BUFSIZE] = { 0 };
 
@@ -3518,9 +3539,10 @@ pg_copy_large_object(PGSQL *src,
 		else
 		{
 			/*
-			 * On PG16 and earlier lo_unlink() returns -1 (does not abort
-			 * the transaction) when the object is absent, so we can call
-			 * it unconditionally and ignore the return value.
+			 * On PG16 and earlier, pg_dump places blob creation in the
+			 * pre-data section, so blobs are always present on the target
+			 * before this function runs.  lo_unlink() therefore always
+			 * finds the blob and succeeds.
 			 */
 			if (!lo_unlink(dst->connection, blobOid))
 			{
@@ -3551,17 +3573,16 @@ pg_copy_large_object(PGSQL *src,
 	/*
 	 * 3. Open the blob on the target database.
 	 *
-	 *    In PostgreSQL 17+, pg_dump no longer outputs large object metadata
-	 *    in the pre-data section, so the large object may not exist yet on
-	 *    the target.  Also in PG17+, lo_open() throws a SQL error (aborting
-	 *    the current transaction) when the large object does not exist.
+	 *    On PG17+, blobs are not pre-created by the pre-data restore (see
+	 *    comment above), so we must create the blob here if it does not
+	 *    exist yet.  We check via pg_largeobject_metadata first because
+	 *    calling lo_open() on an absent blob would call ereport(ERROR) in
+	 *    inv_open() and abort the current transaction.
 	 *
-	 *    For PG17+ we therefore check existence via pg_largeobject_metadata
-	 *    before opening, creating the object when it is absent.
-	 *
-	 *    For PG16 and earlier lo_open() safely returns -1 when the object
-	 *    is absent (no transaction abort), so we try to open first and only
-	 *    create when the open fails.
+	 *    On PG16 and earlier, blob creation happens in the pre-data
+	 *    section, so the blob always exists on the target by the time we
+	 *    reach this point.  lo_open() succeeds directly and the fallback
+	 *    create path is never exercised.
 	 */
 	int dstfd = -1;
 
@@ -3642,9 +3663,10 @@ pg_copy_large_object(PGSQL *src,
 	else
 	{
 		/*
-		 * PG16 and earlier: lo_open() returns -1 when the object is absent
-		 * without aborting the transaction.  Try to open; if it fails,
-		 * create the object and retry.
+		 * PG16 and earlier: blobs are always pre-created by the pre-data
+		 * restore, so lo_open() succeeds directly.  The fallback create
+		 * path below is a safety net that is not expected to be reached
+		 * in normal operation.
 		 */
 		dstfd = lo_open(dst->connection, blobOid, INV_WRITE);
 

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -3464,6 +3464,22 @@ pg_copy_large_object(PGSQL *src,
 	}
 
 	/*
+	 * In PostgreSQL 17+, lo_unlink() and lo_open() throw a SQL error
+	 * (aborting the current transaction) when the target large object does
+	 * not exist, rather than simply returning -1.  Also in PG17+, pg_dump
+	 * no longer outputs large object metadata in the pre-data section.
+	 *
+	 * For PG17+ we therefore use SQL-level existence checks via
+	 * pg_largeobject_metadata to avoid transaction-aborting errors.  For
+	 * older versions the libpq large-object functions return -1 safely, so
+	 * we keep the simpler direct-call path.
+	 *
+	 * PQserverVersion() reads the version from the connection struct --
+	 * it is an O(1) operation with no network round-trip.
+	 */
+	bool dstIsPG17orLater = PQserverVersion(dst->connection) >= 170000;
+
+	/*
 	 * 2. Drop/Create the blob on the target database.
 	 *
 	 *    When using --drop-if-exists, we first try to unlink the
@@ -3472,31 +3488,26 @@ pg_copy_large_object(PGSQL *src,
 	 *    In normal cases `pg_dump --section=pre-data` outputs the
 	 *    large object metadata and we only have to take care of the
 	 *    contents of the large objects.
-	 *
-	 *    In PostgreSQL 17+, lo_unlink() throws a SQL error (aborting the
-	 *    current transaction) when the large object does not exist, rather
-	 *    than simply returning -1.  Use a savepoint to recover.
 	 */
 	if (dropIfExists)
 	{
-		if (!pgsql_execute(dst, "SAVEPOINT pgcopydb_lo_unlink"))
-		{
-			lo_close(src->connection, srcfd);
-			pgsql_finish(src);
-			pgsql_finish(dst);
-			return false;
-		}
-
-		if (!lo_unlink(dst->connection, blobOid))
+		if (dstIsPG17orLater)
 		{
 			/*
-			 * Ignore errors, the object might not exist yet.  But in
-			 * PG17+ the failure aborts the current transaction, so roll
-			 * back to the savepoint before continuing.
+			 * In PG17+, lo_unlink() aborts the transaction when the
+			 * object does not exist.  Avoid that by filtering through
+			 * pg_largeobject_metadata: if the row is absent the SELECT
+			 * returns zero rows and lo_unlink() is never called.
 			 */
-			log_debug("Failed to delete large object %u", blobOid);
+			char sql[BUFSIZE] = { 0 };
 
-			if (!pgsql_execute(dst, "ROLLBACK TO SAVEPOINT pgcopydb_lo_unlink"))
+			sformat(sql, sizeof(sql),
+					"SELECT lo_unlink(oid) "
+					"FROM pg_largeobject_metadata "
+					"WHERE oid = %u",
+					blobOid);
+
+			if (!pgsql_execute(dst, sql))
 			{
 				lo_close(src->connection, srcfd);
 				pgsql_finish(src);
@@ -3504,13 +3515,17 @@ pg_copy_large_object(PGSQL *src,
 				return false;
 			}
 		}
-
-		if (!pgsql_execute(dst, "RELEASE SAVEPOINT pgcopydb_lo_unlink"))
+		else
 		{
-			lo_close(src->connection, srcfd);
-			pgsql_finish(src);
-			pgsql_finish(dst);
-			return false;
+			/*
+			 * On PG16 and earlier lo_unlink() returns -1 (does not abort
+			 * the transaction) when the object is absent, so we can call
+			 * it unconditionally and ignore the return value.
+			 */
+			if (!lo_unlink(dst->connection, blobOid))
+			{
+				log_debug("Failed to delete large object %u", blobOid);
+			}
 		}
 
 		Oid dstBlobOid = lo_create(dst->connection, blobOid);
@@ -3534,37 +3549,35 @@ pg_copy_large_object(PGSQL *src,
 	}
 
 	/*
-	 * 3. Open the blob on the target database
+	 * 3. Open the blob on the target database.
 	 *
 	 *    In PostgreSQL 17+, pg_dump no longer outputs large object metadata
-	 *    in the pre-data section, so the large object may not exist yet.
-	 *    If opening fails, try creating it first.
+	 *    in the pre-data section, so the large object may not exist yet on
+	 *    the target.  Also in PG17+, lo_open() throws a SQL error (aborting
+	 *    the current transaction) when the large object does not exist.
 	 *
-	 *    Also in PG17+, lo_open() throws a SQL error (aborting the current
-	 *    transaction) when the large object does not exist, rather than
-	 *    simply returning -1.  Use a savepoint to recover from that error
-	 *    so we can create the object and retry.
+	 *    For PG17+ we therefore check existence via pg_largeobject_metadata
+	 *    before opening, creating the object when it is absent.
+	 *
+	 *    For PG16 and earlier lo_open() safely returns -1 when the object
+	 *    is absent (no transaction abort), so we try to open first and only
+	 *    create when the open fails.
 	 */
-	if (!pgsql_execute(dst, "SAVEPOINT pgcopydb_lo_open"))
+	int dstfd = -1;
+
+	if (dstIsPG17orLater)
 	{
-		lo_close(src->connection, srcfd);
-		pgsql_finish(src);
-		pgsql_finish(dst);
-		return false;
-	}
+		SingleValueResultContext context = { { 0 }, PGSQL_RESULT_BOOL, false };
+		char sql[BUFSIZE] = { 0 };
 
-	int dstfd = lo_open(dst->connection, blobOid, INV_WRITE);
+		sformat(sql, sizeof(sql),
+				"SELECT EXISTS("
+				"SELECT 1 FROM pg_largeobject_metadata WHERE oid = %u"
+				")",
+				blobOid);
 
-	if (dstfd == -1)
-	{
-		/*
-		 * Large object doesn't exist yet (PG17+ behavior or fresh target).
-		 * In PG17+ the lo_open() failure aborts the current transaction,
-		 * so roll back to the savepoint before creating the object.
-		 */
-		log_debug("Large object %u not found on target, creating it", blobOid);
-
-		if (!pgsql_execute(dst, "ROLLBACK TO SAVEPOINT pgcopydb_lo_open"))
+		if (!pgsql_execute_with_params(dst, sql, 0, NULL, NULL,
+									   &context, &parseSingleValueResult))
 		{
 			lo_close(src->connection, srcfd);
 			pgsql_finish(src);
@@ -3572,35 +3585,51 @@ pg_copy_large_object(PGSQL *src,
 			return false;
 		}
 
-		Oid createdOid = lo_create(dst->connection, blobOid);
-
-		if (createdOid != blobOid)
+		if (!context.parsedOk)
 		{
-			char context[BUFSIZE] = { 0 };
-
-			sformat(context, sizeof(context),
-					"Failed to create large object %u on target", blobOid);
-
-			(void) pgcopy_log_error(dst, NULL, context);
+			log_error("Failed to check existence of large object %u on target",
+					  blobOid);
 
 			lo_close(src->connection, srcfd);
-
 			pgsql_finish(src);
 			pgsql_finish(dst);
-
 			return false;
+		}
+
+		if (!context.boolVal)
+		{
+			log_debug("Large object %u not found on target, creating it", blobOid);
+
+			Oid createdOid = lo_create(dst->connection, blobOid);
+
+			if (createdOid != blobOid)
+			{
+				char ctx[BUFSIZE] = { 0 };
+
+				sformat(ctx, sizeof(ctx),
+						"Failed to create large object %u on target", blobOid);
+
+				(void) pgcopy_log_error(dst, NULL, ctx);
+
+				lo_close(src->connection, srcfd);
+
+				pgsql_finish(src);
+				pgsql_finish(dst);
+
+				return false;
+			}
 		}
 
 		dstfd = lo_open(dst->connection, blobOid, INV_WRITE);
 
 		if (dstfd == -1)
 		{
-			char context[BUFSIZE] = { 0 };
+			char ctx[BUFSIZE] = { 0 };
 
-			sformat(context, sizeof(context),
-					"Failed to open newly created large object %u", blobOid);
+			sformat(ctx, sizeof(ctx),
+					"Failed to open large object %u on target", blobOid);
 
-			(void) pgcopy_log_error(dst, NULL, context);
+			(void) pgcopy_log_error(dst, NULL, ctx);
 
 			lo_close(src->connection, srcfd);
 
@@ -3610,14 +3639,57 @@ pg_copy_large_object(PGSQL *src,
 			return false;
 		}
 	}
-
-	if (!pgsql_execute(dst, "RELEASE SAVEPOINT pgcopydb_lo_open"))
+	else
 	{
-		lo_close(src->connection, srcfd);
-		lo_close(dst->connection, dstfd);
-		pgsql_finish(src);
-		pgsql_finish(dst);
-		return false;
+		/*
+		 * PG16 and earlier: lo_open() returns -1 when the object is absent
+		 * without aborting the transaction.  Try to open; if it fails,
+		 * create the object and retry.
+		 */
+		dstfd = lo_open(dst->connection, blobOid, INV_WRITE);
+
+		if (dstfd == -1)
+		{
+			log_debug("Large object %u not found on target, creating it", blobOid);
+
+			Oid createdOid = lo_create(dst->connection, blobOid);
+
+			if (createdOid != blobOid)
+			{
+				char ctx[BUFSIZE] = { 0 };
+
+				sformat(ctx, sizeof(ctx),
+						"Failed to create large object %u on target", blobOid);
+
+				(void) pgcopy_log_error(dst, NULL, ctx);
+
+				lo_close(src->connection, srcfd);
+
+				pgsql_finish(src);
+				pgsql_finish(dst);
+
+				return false;
+			}
+
+			dstfd = lo_open(dst->connection, blobOid, INV_WRITE);
+
+			if (dstfd == -1)
+			{
+				char ctx[BUFSIZE] = { 0 };
+
+				sformat(ctx, sizeof(ctx),
+						"Failed to open newly created large object %u", blobOid);
+
+				(void) pgcopy_log_error(dst, NULL, ctx);
+
+				lo_close(src->connection, srcfd);
+
+				pgsql_finish(src);
+				pgsql_finish(dst);
+
+				return false;
+			}
+		}
 	}
 
 	/*

--- a/tests/Dockerfile.pagila
+++ b/tests/Dockerfile.pagila
@@ -1,6 +1,6 @@
-ARG PGVERSION=16
+ARG PGVERSION=17
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 ARG PGVERSION
 
@@ -27,7 +27,7 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt bullseye-pgdg main ${PGVERSION}" > /etc/apt/sources.list.d/pgdg.list
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt bookworm-pgdg main ${PGVERSION}" > /etc/apt/sources.list.d/pgdg.list
 
 # bypass initdb of a "main" cluster
 RUN echo 'create_main_cluster = false' | sudo tee -a /etc/postgresql-common/createcluster.conf

--- a/tests/Dockerfile.pagila
+++ b/tests/Dockerfile.pagila
@@ -1,4 +1,4 @@
-ARG PGVERSION=17
+ARG PGVERSION=16
 
 FROM debian:bookworm-slim
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -2,6 +2,7 @@
 # Licensed under the PostgreSQL License.
 
 PGVERSION ?= 16
+export PGVERSION
 BUILD_ARGS = --build-arg PGVERSION=$(PGVERSION)
 
 all: pagila pagila-multi-steps blobs unit filtering extensions \

--- a/tests/blobs/compose.yaml
+++ b/tests/blobs/compose.yaml
@@ -1,6 +1,6 @@
 services:
   source:
-    image: postgres:13-bullseye
+    image: postgres:17-bookworm
     expose:
       - 5432
     environment:
@@ -8,7 +8,7 @@ services:
       POSTGRES_PASSWORD: h4ckm3
       POSTGRES_HOST_AUTH_METHOD: trust
   target:
-    image: postgres:13-bullseye
+    image: postgres:17-bookworm
     expose:
       - 5432
     environment:

--- a/tests/blobs/compose.yaml
+++ b/tests/blobs/compose.yaml
@@ -1,6 +1,6 @@
 services:
   source:
-    image: postgres:17-bookworm
+    image: postgres:${PGVERSION:-16}-bookworm
     expose:
       - 5432
     environment:
@@ -8,7 +8,7 @@ services:
       POSTGRES_PASSWORD: h4ckm3
       POSTGRES_HOST_AUTH_METHOD: trust
   target:
-    image: postgres:17-bookworm
+    image: postgres:${PGVERSION:-16}-bookworm
     expose:
       - 5432
     environment:

--- a/tests/blobs/compose.yaml
+++ b/tests/blobs/compose.yaml
@@ -1,6 +1,6 @@
 services:
   source:
-    image: postgres:${PGVERSION:-16}-bookworm
+    image: postgres:${PGVERSION:-16}
     expose:
       - 5432
     environment:
@@ -8,7 +8,7 @@ services:
       POSTGRES_PASSWORD: h4ckm3
       POSTGRES_HOST_AUTH_METHOD: trust
   target:
-    image: postgres:${PGVERSION:-16}-bookworm
+    image: postgres:${PGVERSION:-16}
     expose:
       - 5432
     environment:

--- a/tests/blobs/compose.yaml
+++ b/tests/blobs/compose.yaml
@@ -7,6 +7,11 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: h4ckm3
       POSTGRES_HOST_AUTH_METHOD: trust
+    healthcheck:
+      test: 'pg_isready -U postgres'
+      interval: 5s
+      timeout: 5s
+      retries: 10
   target:
     image: postgres:${PGVERSION:-16}
     expose:
@@ -15,6 +20,11 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: h4ckm3
       POSTGRES_HOST_AUTH_METHOD: trust
+    healthcheck:
+      test: 'pg_isready -U postgres'
+      interval: 5s
+      timeout: 5s
+      retries: 10
   test:
     build: .
     environment:
@@ -23,5 +33,7 @@ services:
       PGCOPYDB_TABLE_JOBS: 4
       PGCOPYDB_INDEX_JOBS: 2
     depends_on:
-      - source
-      - target
+      source:
+        condition: service_healthy
+      target:
+        condition: service_healthy

--- a/tests/cdc-endpos-between-transaction/Dockerfile.pg
+++ b/tests/cdc-endpos-between-transaction/Dockerfile.pg
@@ -1,6 +1,7 @@
 ARG PGVERSION=16
-FROM postgres:${PGVERSION}-bookworm
+FROM postgres:${PGVERSION}
 
+ARG PGVERSION=16
 RUN apt-get update \
     && apt-get install -y --no-install-recommends postgresql-${PGVERSION}-wal2json \
     && rm -rf /var/lib/apt/lists/*

--- a/tests/cdc-endpos-between-transaction/Dockerfile.pg
+++ b/tests/cdc-endpos-between-transaction/Dockerfile.pg
@@ -1,5 +1,5 @@
-FROM postgres:13-bullseye
+FROM postgres:17-bookworm
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends postgresql-13-wal2json \
+    && apt-get install -y --no-install-recommends postgresql-17-wal2json \
     && rm -rf /var/lib/apt/lists/*

--- a/tests/cdc-endpos-between-transaction/Dockerfile.pg
+++ b/tests/cdc-endpos-between-transaction/Dockerfile.pg
@@ -1,5 +1,6 @@
-FROM postgres:17-bookworm
+ARG PGVERSION=16
+FROM postgres:${PGVERSION}-bookworm
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends postgresql-17-wal2json \
+    && apt-get install -y --no-install-recommends postgresql-${PGVERSION}-wal2json \
     && rm -rf /var/lib/apt/lists/*

--- a/tests/cdc-endpos-between-transaction/compose.yaml
+++ b/tests/cdc-endpos-between-transaction/compose.yaml
@@ -15,7 +15,7 @@ services:
       -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
   target:
-    image: postgres:${PGVERSION:-16}-bookworm
+    image: postgres:${PGVERSION:-16}
     expose:
       - 5432
     environment:

--- a/tests/cdc-endpos-between-transaction/compose.yaml
+++ b/tests/cdc-endpos-between-transaction/compose.yaml
@@ -15,7 +15,7 @@ services:
       -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
   target:
-    image: postgres:17-bookworm
+    image: postgres:${PGVERSION:-16}-bookworm
     expose:
       - 5432
     environment:

--- a/tests/cdc-endpos-between-transaction/compose.yaml
+++ b/tests/cdc-endpos-between-transaction/compose.yaml
@@ -15,7 +15,7 @@ services:
       -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
   target:
-    image: postgres:13-bullseye
+    image: postgres:17-bookworm
     expose:
       - 5432
     environment:

--- a/tests/cdc-low-level/compose.yaml
+++ b/tests/cdc-low-level/compose.yaml
@@ -1,6 +1,6 @@
 services:
   source:
-    image: postgres:${PGVERSION:-16}-bookworm
+    image: postgres:${PGVERSION:-16}
     expose:
       - 5432
     environment:
@@ -13,7 +13,7 @@ services:
       -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
   target:
-    image: postgres:${PGVERSION:-16}-bookworm
+    image: postgres:${PGVERSION:-16}
     expose:
       - 5432
     environment:

--- a/tests/cdc-low-level/compose.yaml
+++ b/tests/cdc-low-level/compose.yaml
@@ -1,6 +1,6 @@
 services:
   source:
-    image: postgres:17-bookworm
+    image: postgres:${PGVERSION:-16}-bookworm
     expose:
       - 5432
     environment:
@@ -13,7 +13,7 @@ services:
       -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
   target:
-    image: postgres:17-bookworm
+    image: postgres:${PGVERSION:-16}-bookworm
     expose:
       - 5432
     environment:

--- a/tests/cdc-low-level/compose.yaml
+++ b/tests/cdc-low-level/compose.yaml
@@ -1,6 +1,6 @@
 services:
   source:
-    image: postgres:13-bullseye
+    image: postgres:17-bookworm
     expose:
       - 5432
     environment:
@@ -13,7 +13,7 @@ services:
       -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
   target:
-    image: postgres:13-bullseye
+    image: postgres:17-bookworm
     expose:
       - 5432
     environment:

--- a/tests/cdc-test-decoding/compose.yaml
+++ b/tests/cdc-test-decoding/compose.yaml
@@ -1,6 +1,6 @@
 services:
   source:
-    image: postgres:${PGVERSION:-16}-bookworm
+    image: postgres:${PGVERSION:-16}
     expose:
       - 5432
     environment:
@@ -13,7 +13,7 @@ services:
       -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
   target:
-    image: postgres:${PGVERSION:-16}-bookworm
+    image: postgres:${PGVERSION:-16}
     expose:
       - 5432
     environment:

--- a/tests/cdc-test-decoding/compose.yaml
+++ b/tests/cdc-test-decoding/compose.yaml
@@ -1,6 +1,6 @@
 services:
   source:
-    image: postgres:17-bookworm
+    image: postgres:${PGVERSION:-16}-bookworm
     expose:
       - 5432
     environment:
@@ -13,7 +13,7 @@ services:
       -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
   target:
-    image: postgres:17-bookworm
+    image: postgres:${PGVERSION:-16}-bookworm
     expose:
       - 5432
     environment:

--- a/tests/cdc-test-decoding/compose.yaml
+++ b/tests/cdc-test-decoding/compose.yaml
@@ -1,6 +1,6 @@
 services:
   source:
-    image: postgres:13-bullseye
+    image: postgres:17-bookworm
     expose:
       - 5432
     environment:
@@ -13,7 +13,7 @@ services:
       -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
   target:
-    image: postgres:13-bullseye
+    image: postgres:17-bookworm
     expose:
       - 5432
     environment:

--- a/tests/cdc-wal2json/Dockerfile.pg
+++ b/tests/cdc-wal2json/Dockerfile.pg
@@ -1,6 +1,7 @@
 ARG PGVERSION=16
-FROM postgres:${PGVERSION}-bookworm
+FROM postgres:${PGVERSION}
 
+ARG PGVERSION=16
 RUN apt-get update \
     && apt-get install -y --no-install-recommends postgresql-${PGVERSION}-wal2json \
     && rm -rf /var/lib/apt/lists/*

--- a/tests/cdc-wal2json/Dockerfile.pg
+++ b/tests/cdc-wal2json/Dockerfile.pg
@@ -1,5 +1,5 @@
-FROM postgres:13-bullseye
+FROM postgres:17-bookworm
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends postgresql-13-wal2json \
+    && apt-get install -y --no-install-recommends postgresql-17-wal2json \
     && rm -rf /var/lib/apt/lists/*

--- a/tests/cdc-wal2json/Dockerfile.pg
+++ b/tests/cdc-wal2json/Dockerfile.pg
@@ -1,5 +1,6 @@
-FROM postgres:17-bookworm
+ARG PGVERSION=16
+FROM postgres:${PGVERSION}-bookworm
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends postgresql-17-wal2json \
+    && apt-get install -y --no-install-recommends postgresql-${PGVERSION}-wal2json \
     && rm -rf /var/lib/apt/lists/*

--- a/tests/cdc-wal2json/compose.yaml
+++ b/tests/cdc-wal2json/compose.yaml
@@ -15,7 +15,7 @@ services:
       -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
   target:
-    image: postgres:${PGVERSION:-16}-bookworm
+    image: postgres:${PGVERSION:-16}
     expose:
       - 5432
     environment:

--- a/tests/cdc-wal2json/compose.yaml
+++ b/tests/cdc-wal2json/compose.yaml
@@ -15,7 +15,7 @@ services:
       -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
   target:
-    image: postgres:17-bookworm
+    image: postgres:${PGVERSION:-16}-bookworm
     expose:
       - 5432
     environment:

--- a/tests/cdc-wal2json/compose.yaml
+++ b/tests/cdc-wal2json/compose.yaml
@@ -15,7 +15,7 @@ services:
       -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
   target:
-    image: postgres:13-bullseye
+    image: postgres:17-bookworm
     expose:
       - 5432
     environment:

--- a/tests/endpos-in-multi-wal-txn/Dockerfile.pg
+++ b/tests/endpos-in-multi-wal-txn/Dockerfile.pg
@@ -1,6 +1,7 @@
 ARG PGVERSION=16
-FROM postgres:${PGVERSION}-bookworm
+FROM postgres:${PGVERSION}
 
+ARG PGVERSION=16
 RUN apt-get update \
     && apt-get install -y --no-install-recommends postgresql-${PGVERSION}-wal2json \
     && rm -rf /var/lib/apt/lists/*

--- a/tests/endpos-in-multi-wal-txn/Dockerfile.pg
+++ b/tests/endpos-in-multi-wal-txn/Dockerfile.pg
@@ -1,5 +1,5 @@
-FROM postgres:13-bullseye
+FROM postgres:17-bookworm
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends postgresql-13-wal2json \
+    && apt-get install -y --no-install-recommends postgresql-17-wal2json \
     && rm -rf /var/lib/apt/lists/*

--- a/tests/endpos-in-multi-wal-txn/Dockerfile.pg
+++ b/tests/endpos-in-multi-wal-txn/Dockerfile.pg
@@ -1,5 +1,6 @@
-FROM postgres:17-bookworm
+ARG PGVERSION=16
+FROM postgres:${PGVERSION}-bookworm
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends postgresql-17-wal2json \
+    && apt-get install -y --no-install-recommends postgresql-${PGVERSION}-wal2json \
     && rm -rf /var/lib/apt/lists/*

--- a/tests/endpos-in-multi-wal-txn/compose.yaml
+++ b/tests/endpos-in-multi-wal-txn/compose.yaml
@@ -15,7 +15,7 @@ services:
       -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
   target:
-    image: postgres:${PGVERSION:-16}-bookworm
+    image: postgres:${PGVERSION:-16}
     expose:
       - 5432
     environment:

--- a/tests/endpos-in-multi-wal-txn/compose.yaml
+++ b/tests/endpos-in-multi-wal-txn/compose.yaml
@@ -15,7 +15,7 @@ services:
       -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
   target:
-    image: postgres:17-bookworm
+    image: postgres:${PGVERSION:-16}-bookworm
     expose:
       - 5432
     environment:

--- a/tests/endpos-in-multi-wal-txn/compose.yaml
+++ b/tests/endpos-in-multi-wal-txn/compose.yaml
@@ -15,7 +15,7 @@ services:
       -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
   target:
-    image: postgres:13-bullseye
+    image: postgres:17-bookworm
     expose:
       - 5432
     environment:

--- a/tests/extensions/Dockerfile.pg
+++ b/tests/extensions/Dockerfile.pg
@@ -5,7 +5,7 @@ ARG PGVERSION=16
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
       postgresql-${PGVERSION}-wal2json \
-      postgresql-13-partman \
-      postgresql-13-postgis-3 \
+      postgresql-${PGVERSION}-partman \
+      postgresql-${PGVERSION}-postgis-3 \
       postgis \
     && rm -rf /var/lib/apt/lists/*

--- a/tests/extensions/Dockerfile.pg
+++ b/tests/extensions/Dockerfile.pg
@@ -1,8 +1,8 @@
-FROM postgres:13-bullseye
+FROM postgres:17-bookworm
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
-      postgresql-13-wal2json \
+      postgresql-17-wal2json \
       postgresql-13-partman \
       postgresql-13-postgis-3 \
       postgis \

--- a/tests/extensions/Dockerfile.pg
+++ b/tests/extensions/Dockerfile.pg
@@ -1,8 +1,9 @@
-FROM postgres:17-bookworm
+ARG PGVERSION=16
+FROM postgres:${PGVERSION}-bookworm
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
-      postgresql-17-wal2json \
+      postgresql-${PGVERSION}-wal2json \
       postgresql-13-partman \
       postgresql-13-postgis-3 \
       postgis \

--- a/tests/extensions/Dockerfile.pg
+++ b/tests/extensions/Dockerfile.pg
@@ -1,6 +1,7 @@
 ARG PGVERSION=16
-FROM postgres:${PGVERSION}-bookworm
+FROM postgres:${PGVERSION}
 
+ARG PGVERSION=16
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
       postgresql-${PGVERSION}-wal2json \

--- a/tests/extensions/compose.yaml
+++ b/tests/extensions/compose.yaml
@@ -3,6 +3,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.pg
+      args:
+        - PGVERSION=${PGVERSION:-16}
     expose:
       - 5432
     environment:
@@ -14,10 +16,17 @@ services:
       -c ssl=on
       -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
+    healthcheck:
+      test: 'pg_isready -U postgres'
+      interval: 5s
+      timeout: 5s
+      retries: 10
   target:
     build:
       context: .
       dockerfile: Dockerfile.pg
+      args:
+        - PGVERSION=${PGVERSION:-16}
     expose:
       - 5432
     environment:
@@ -28,6 +37,11 @@ services:
       -c ssl=on
       -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
+    healthcheck:
+      test: 'pg_isready -U postgres'
+      interval: 5s
+      timeout: 5s
+      retries: 10
   test:
     build: .
     environment:
@@ -41,5 +55,7 @@ services:
       PGCOPYDB_TABLE_JOBS: 4
       PGCOPYDB_INDEX_JOBS: 2
     depends_on:
-      - source
-      - target
+      source:
+        condition: service_healthy
+      target:
+        condition: service_healthy

--- a/tests/filtering/compose.yaml
+++ b/tests/filtering/compose.yaml
@@ -1,6 +1,6 @@
 services:
   source:
-    image: postgres:${PGVERSION:-16}-bookworm
+    image: postgres:${PGVERSION:-16}
     expose:
       - 5432
     environment:
@@ -12,7 +12,7 @@ services:
       -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
   target:
-    image: postgres:${PGVERSION:-16}-bookworm
+    image: postgres:${PGVERSION:-16}
     expose:
       - 5432
     environment:

--- a/tests/filtering/compose.yaml
+++ b/tests/filtering/compose.yaml
@@ -1,6 +1,6 @@
 services:
   source:
-    image: postgres:13-bullseye
+    image: postgres:17-bookworm
     expose:
       - 5432
     environment:
@@ -12,7 +12,7 @@ services:
       -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
   target:
-    image: postgres:13-bullseye
+    image: postgres:17-bookworm
     expose:
       - 5432
     environment:

--- a/tests/filtering/compose.yaml
+++ b/tests/filtering/compose.yaml
@@ -1,6 +1,6 @@
 services:
   source:
-    image: postgres:17-bookworm
+    image: postgres:${PGVERSION:-16}-bookworm
     expose:
       - 5432
     environment:
@@ -12,7 +12,7 @@ services:
       -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
   target:
-    image: postgres:17-bookworm
+    image: postgres:${PGVERSION:-16}-bookworm
     expose:
       - 5432
     environment:

--- a/tests/follow-9.6/compose.yaml
+++ b/tests/follow-9.6/compose.yaml
@@ -18,7 +18,7 @@ services:
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
 
   target:
-    image: postgres:17-bookworm
+    image: postgres:${PGVERSION:-16}-bookworm
     expose:
       - 5432
     env_file:

--- a/tests/follow-9.6/compose.yaml
+++ b/tests/follow-9.6/compose.yaml
@@ -18,7 +18,7 @@ services:
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
 
   target:
-    image: postgres:13-bullseye
+    image: postgres:17-bookworm
     expose:
       - 5432
     env_file:

--- a/tests/follow-9.6/compose.yaml
+++ b/tests/follow-9.6/compose.yaml
@@ -18,7 +18,7 @@ services:
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
 
   target:
-    image: postgres:${PGVERSION:-16}-bookworm
+    image: postgres:${PGVERSION:-16}
     expose:
       - 5432
     env_file:

--- a/tests/follow-9.6/compose.yaml
+++ b/tests/follow-9.6/compose.yaml
@@ -16,6 +16,11 @@ services:
       -c ssl=on
       -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
+    healthcheck:
+      test: 'pg_isready -U postgres --dbname=postgres'
+      interval: 5s
+      timeout: 5s
+      retries: 10
 
   target:
     image: postgres:${PGVERSION:-16}
@@ -27,6 +32,11 @@ services:
       -c ssl=on
       -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
+    healthcheck:
+      test: 'pg_isready -U postgres --dbname=postgres'
+      interval: 5s
+      timeout: 5s
+      retries: 10
 
   inject:
     image: follow-9.6-inject
@@ -41,6 +51,11 @@ services:
     # share TMPDIR between inject and test services
     volumes:
       - follow-9.6:/var/run/pgcopydb
+    depends_on:
+      source:
+        condition: service_healthy
+      target:
+        condition: service_healthy
 
   test:
     image: follow-9.6
@@ -57,9 +72,12 @@ services:
     volumes:
       - follow-9.6:/var/run/pgcopydb
     depends_on:
-      - source
-      - target
-      - inject
+      source:
+        condition: service_healthy
+      target:
+        condition: service_healthy
+      inject:
+        condition: service_started
 
 volumes:
   follow-9.6:

--- a/tests/follow-9.6/compose.yaml
+++ b/tests/follow-9.6/compose.yaml
@@ -4,7 +4,7 @@ services:
       context: .
       dockerfile: Dockerfile.pg
       args:
-        - PGVERSION
+        PGVERSION: "9.6"
     expose:
       - 5432
     env_file:
@@ -44,7 +44,7 @@ services:
       context: .
       dockerfile: Dockerfile.inject
     environment:
-      PGVERSION:
+      PGVERSION: "9.6"
     env_file:
       - ../uris.env
       - ../paths.env
@@ -61,7 +61,7 @@ services:
     image: follow-9.6
     build: .
     environment:
-      PGVERSION:
+      PGVERSION: "9.6"
       PGCOPYDB_TABLE_JOBS: 4
       PGCOPYDB_INDEX_JOBS: 2
       PGCOPYDB_SPLIT_TABLES_LARGER_THAN: 200kB

--- a/tests/follow-data-only/Dockerfile.pg
+++ b/tests/follow-data-only/Dockerfile.pg
@@ -1,6 +1,7 @@
 ARG PGVERSION=16
-FROM postgres:${PGVERSION}-bookworm
+FROM postgres:${PGVERSION}
 
+ARG PGVERSION=16
 RUN apt-get update \
     && apt-get install -y --no-install-recommends postgresql-${PGVERSION}-wal2json \
     && rm -rf /var/lib/apt/lists/*

--- a/tests/follow-data-only/Dockerfile.pg
+++ b/tests/follow-data-only/Dockerfile.pg
@@ -1,5 +1,5 @@
-FROM postgres:13-bullseye
+FROM postgres:17-bookworm
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends postgresql-13-wal2json \
+    && apt-get install -y --no-install-recommends postgresql-17-wal2json \
     && rm -rf /var/lib/apt/lists/*

--- a/tests/follow-data-only/Dockerfile.pg
+++ b/tests/follow-data-only/Dockerfile.pg
@@ -1,5 +1,6 @@
-FROM postgres:17-bookworm
+ARG PGVERSION=16
+FROM postgres:${PGVERSION}-bookworm
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends postgresql-17-wal2json \
+    && apt-get install -y --no-install-recommends postgresql-${PGVERSION}-wal2json \
     && rm -rf /var/lib/apt/lists/*

--- a/tests/follow-data-only/compose.yaml
+++ b/tests/follow-data-only/compose.yaml
@@ -14,7 +14,7 @@ services:
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
 
   target:
-    image: postgres:15-bullseye
+    image: postgres:17-bookworm
     expose:
       - 5432
     env_file:

--- a/tests/follow-data-only/compose.yaml
+++ b/tests/follow-data-only/compose.yaml
@@ -14,7 +14,7 @@ services:
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
 
   target:
-    image: postgres:17-bookworm
+    image: postgres:${PGVERSION:-16}-bookworm
     expose:
       - 5432
     env_file:

--- a/tests/follow-data-only/compose.yaml
+++ b/tests/follow-data-only/compose.yaml
@@ -14,7 +14,7 @@ services:
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
 
   target:
-    image: postgres:${PGVERSION:-16}-bookworm
+    image: postgres:${PGVERSION:-16}
     expose:
       - 5432
     env_file:

--- a/tests/follow-wal2json/Dockerfile.pg
+++ b/tests/follow-wal2json/Dockerfile.pg
@@ -1,6 +1,7 @@
 ARG PGVERSION=16
-FROM postgres:${PGVERSION}-bookworm
+FROM postgres:${PGVERSION}
 
+ARG PGVERSION=16
 RUN apt-get update \
     && apt-get install -y --no-install-recommends postgresql-${PGVERSION}-wal2json \
     && rm -rf /var/lib/apt/lists/*

--- a/tests/follow-wal2json/Dockerfile.pg
+++ b/tests/follow-wal2json/Dockerfile.pg
@@ -1,5 +1,5 @@
-FROM postgres:13-bullseye
+FROM postgres:17-bookworm
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends postgresql-13-wal2json \
+    && apt-get install -y --no-install-recommends postgresql-17-wal2json \
     && rm -rf /var/lib/apt/lists/*

--- a/tests/follow-wal2json/Dockerfile.pg
+++ b/tests/follow-wal2json/Dockerfile.pg
@@ -1,5 +1,6 @@
-FROM postgres:17-bookworm
+ARG PGVERSION=16
+FROM postgres:${PGVERSION}-bookworm
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends postgresql-17-wal2json \
+    && apt-get install -y --no-install-recommends postgresql-${PGVERSION}-wal2json \
     && rm -rf /var/lib/apt/lists/*

--- a/tests/follow-wal2json/compose.yaml
+++ b/tests/follow-wal2json/compose.yaml
@@ -15,7 +15,7 @@ services:
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
 
   target:
-    image: postgres:${PGVERSION:-16}-bookworm
+    image: postgres:${PGVERSION:-16}
     expose:
       - 5432
     env_file:

--- a/tests/follow-wal2json/compose.yaml
+++ b/tests/follow-wal2json/compose.yaml
@@ -15,7 +15,7 @@ services:
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
 
   target:
-    image: postgres:17-bookworm
+    image: postgres:${PGVERSION:-16}-bookworm
     expose:
       - 5432
     env_file:

--- a/tests/follow-wal2json/compose.yaml
+++ b/tests/follow-wal2json/compose.yaml
@@ -15,7 +15,7 @@ services:
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
 
   target:
-    image: postgres:16-bullseye
+    image: postgres:17-bookworm
     expose:
       - 5432
     env_file:

--- a/tests/pagila-multi-steps/compose.yaml
+++ b/tests/pagila-multi-steps/compose.yaml
@@ -1,6 +1,6 @@
 services:
   source:
-    image: postgres:13-bullseye
+    image: postgres:17-bookworm
     expose:
       - 5432
     environment:
@@ -8,7 +8,7 @@ services:
       POSTGRES_PASSWORD: h4ckm3
       POSTGRES_HOST_AUTH_METHOD: trust
   target:
-    image: postgres:13-bullseye
+    image: postgres:17-bookworm
     expose:
       - 5432
     environment:

--- a/tests/pagila-multi-steps/compose.yaml
+++ b/tests/pagila-multi-steps/compose.yaml
@@ -1,6 +1,6 @@
 services:
   source:
-    image: postgres:17-bookworm
+    image: postgres:${PGVERSION:-16}-bookworm
     expose:
       - 5432
     environment:
@@ -8,7 +8,7 @@ services:
       POSTGRES_PASSWORD: h4ckm3
       POSTGRES_HOST_AUTH_METHOD: trust
   target:
-    image: postgres:17-bookworm
+    image: postgres:${PGVERSION:-16}-bookworm
     expose:
       - 5432
     environment:

--- a/tests/pagila-multi-steps/compose.yaml
+++ b/tests/pagila-multi-steps/compose.yaml
@@ -1,6 +1,6 @@
 services:
   source:
-    image: postgres:${PGVERSION:-16}-bookworm
+    image: postgres:${PGVERSION:-16}
     expose:
       - 5432
     environment:
@@ -8,7 +8,7 @@ services:
       POSTGRES_PASSWORD: h4ckm3
       POSTGRES_HOST_AUTH_METHOD: trust
   target:
-    image: postgres:${PGVERSION:-16}-bookworm
+    image: postgres:${PGVERSION:-16}
     expose:
       - 5432
     environment:

--- a/tests/pagila-standby/compose.yaml
+++ b/tests/pagila-standby/compose.yaml
@@ -9,7 +9,7 @@ x-postgres-base-env-allow-replication: &x-postgres-base-env-allow-replication
   POSTGRES_HOST_AUTH_METHOD: "trust\nhost replication all 0.0.0.0/0 trust"
 
 x-postgres-base: &x-postgres-base
-    image: postgres:17-bookworm
+    image: postgres:${PGVERSION:-16}-bookworm
     user: postgres
     expose:
       - 5432

--- a/tests/pagila-standby/compose.yaml
+++ b/tests/pagila-standby/compose.yaml
@@ -9,7 +9,7 @@ x-postgres-base-env-allow-replication: &x-postgres-base-env-allow-replication
   POSTGRES_HOST_AUTH_METHOD: "trust\nhost replication all 0.0.0.0/0 trust"
 
 x-postgres-base: &x-postgres-base
-    image: postgres:13-bullseye
+    image: postgres:17-bookworm
     user: postgres
     expose:
       - 5432

--- a/tests/pagila-standby/compose.yaml
+++ b/tests/pagila-standby/compose.yaml
@@ -9,7 +9,7 @@ x-postgres-base-env-allow-replication: &x-postgres-base-env-allow-replication
   POSTGRES_HOST_AUTH_METHOD: "trust\nhost replication all 0.0.0.0/0 trust"
 
 x-postgres-base: &x-postgres-base
-    image: postgres:${PGVERSION:-16}-bookworm
+    image: postgres:${PGVERSION:-16}
     user: postgres
     expose:
       - 5432

--- a/tests/pagila-standby/compose.yaml
+++ b/tests/pagila-standby/compose.yaml
@@ -52,8 +52,15 @@ services:
       chmod 0700 /var/lib/postgresql/data
       postgres -c ssl=on -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
      "
+    healthcheck:
+      test: 'pg_isready -U postgres --dbname=pagila'
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 60s
     depends_on:
-      - source
+      source:
+        condition: service_healthy
 
   target:
     <<: *x-postgres-base
@@ -82,6 +89,9 @@ services:
       PGCOPYDB_SPLIT_TABLES_LARGER_THAN: 200kB
       PGCOPYDB_FAIL_FAST: "true"
     depends_on:
-      - source
-      - source-standby
-      - target
+      source:
+        condition: service_healthy
+      source-standby:
+        condition: service_healthy
+      target:
+        condition: service_healthy

--- a/tests/pagila-standby/compose.yaml
+++ b/tests/pagila-standby/compose.yaml
@@ -43,13 +43,14 @@ services:
         <<: *x-postgres-base-env
     command: |
      bash -c "
-      until pg_basebackup --pgdata=/var/lib/postgresql/data -R --slot=replication_slot -d postgres://postgres:h4ckm3@source/pagila
+      until pg_basebackup --pgdata=/var/lib/postgresql/data -R --checkpoint=fast --slot=replication_slot -d postgres://postgres:h4ckm3@source/pagila
       do
       echo 'Waiting for primary to connect...'
       sleep 1s
       done
       echo 'Backup done, starting replica...'
       chmod 0700 /var/lib/postgresql/data
+      rm -f /var/lib/postgresql/data/postmaster.pid
       postgres -c ssl=on -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
      "
     healthcheck:

--- a/tests/pagila-standby/compose.yaml
+++ b/tests/pagila-standby/compose.yaml
@@ -41,6 +41,11 @@ services:
     <<: *x-postgres-base
     environment:
         <<: *x-postgres-base-env
+        # PG18 changed PGDATA from /var/lib/postgresql/data to a versioned
+        # subdirectory (/var/lib/postgresql/18/docker). Pin it back to the
+        # traditional path so that pg_basebackup and the subsequent postgres
+        # invocation both use the same directory regardless of PG version.
+        PGDATA: /var/lib/postgresql/data
     command: |
      bash -c "
       until pg_basebackup --pgdata=/var/lib/postgresql/data -R --checkpoint=fast --slot=replication_slot -d postgres://postgres:h4ckm3@source/pagila

--- a/tests/pagila/compose.yaml
+++ b/tests/pagila/compose.yaml
@@ -1,6 +1,6 @@
 services:
   source:
-    image: postgres:${PGVERSION:-16}-bookworm
+    image: postgres:${PGVERSION:-16}
     expose:
       - 5432
     environment:
@@ -12,7 +12,7 @@ services:
       -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
   target:
-    image: postgres:${PGVERSION:-16}-bookworm
+    image: postgres:${PGVERSION:-16}
     expose:
       - 5432
     environment:

--- a/tests/pagila/compose.yaml
+++ b/tests/pagila/compose.yaml
@@ -1,6 +1,6 @@
 services:
   source:
-    image: postgres:13-bullseye
+    image: postgres:17-bookworm
     expose:
       - 5432
     environment:
@@ -12,7 +12,7 @@ services:
       -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
   target:
-    image: postgres:13-bullseye
+    image: postgres:17-bookworm
     expose:
       - 5432
     environment:

--- a/tests/pagila/compose.yaml
+++ b/tests/pagila/compose.yaml
@@ -1,6 +1,6 @@
 services:
   source:
-    image: postgres:17-bookworm
+    image: postgres:${PGVERSION:-16}-bookworm
     expose:
       - 5432
     environment:
@@ -12,7 +12,7 @@ services:
       -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
   target:
-    image: postgres:17-bookworm
+    image: postgres:${PGVERSION:-16}-bookworm
     expose:
       - 5432
     environment:

--- a/tests/timescaledb/compose.yml
+++ b/tests/timescaledb/compose.yml
@@ -1,6 +1,6 @@
 services:
   source:
-    image: timescale/timescaledb:latest-pg13
+    image: timescale/timescaledb:latest-pg${PGVERSION:-16}
     expose:
       - 5432
     environment:
@@ -8,7 +8,7 @@ services:
       POSTGRES_PASSWORD: h4ckm3
       POSTGRES_HOST_AUTH_METHOD: trust
   target:
-    image: timescale/timescaledb:latest-pg13
+    image: timescale/timescaledb:latest-pg${PGVERSION:-16}
     expose:
       - 5432
     environment:

--- a/tests/timescaledb/compose.yml
+++ b/tests/timescaledb/compose.yml
@@ -1,6 +1,6 @@
 services:
   source:
-    image: timescale/timescaledb:latest-pg${PGVERSION:-16}
+    image: timescale/timescaledb:latest-pg13
     expose:
       - 5432
     environment:
@@ -8,7 +8,7 @@ services:
       POSTGRES_PASSWORD: h4ckm3
       POSTGRES_HOST_AUTH_METHOD: trust
   target:
-    image: timescale/timescaledb:latest-pg${PGVERSION:-16}
+    image: timescale/timescaledb:latest-pg13
     expose:
       - 5432
     environment:

--- a/tests/unit/compose.yaml
+++ b/tests/unit/compose.yaml
@@ -1,6 +1,6 @@
 services:
   source:
-    image: postgres:13-bullseye
+    image: postgres:17-bookworm
     expose:
       - 5432
     environment:
@@ -8,7 +8,7 @@ services:
       POSTGRES_PASSWORD: h4ckm3
       POSTGRES_HOST_AUTH_METHOD: trust
   target:
-    image: postgres:13-bullseye
+    image: postgres:17-bookworm
     expose:
       - 5432
     environment:

--- a/tests/unit/compose.yaml
+++ b/tests/unit/compose.yaml
@@ -1,6 +1,6 @@
 services:
   source:
-    image: postgres:17-bookworm
+    image: postgres:${PGVERSION:-16}-bookworm
     expose:
       - 5432
     environment:
@@ -8,7 +8,7 @@ services:
       POSTGRES_PASSWORD: h4ckm3
       POSTGRES_HOST_AUTH_METHOD: trust
   target:
-    image: postgres:17-bookworm
+    image: postgres:${PGVERSION:-16}-bookworm
     expose:
       - 5432
     environment:

--- a/tests/unit/compose.yaml
+++ b/tests/unit/compose.yaml
@@ -1,6 +1,6 @@
 services:
   source:
-    image: postgres:${PGVERSION:-16}-bookworm
+    image: postgres:${PGVERSION:-16}
     expose:
       - 5432
     environment:
@@ -8,7 +8,7 @@ services:
       POSTGRES_PASSWORD: h4ckm3
       POSTGRES_HOST_AUTH_METHOD: trust
   target:
-    image: postgres:${PGVERSION:-16}-bookworm
+    image: postgres:${PGVERSION:-16}
     expose:
       - 5432
     environment:

--- a/tests/unit/compose.yaml
+++ b/tests/unit/compose.yaml
@@ -7,6 +7,11 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: h4ckm3
       POSTGRES_HOST_AUTH_METHOD: trust
+    healthcheck:
+      test: 'pg_isready -U postgres'
+      interval: 5s
+      timeout: 5s
+      retries: 10
   target:
     image: postgres:${PGVERSION:-16}
     expose:
@@ -15,6 +20,11 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: h4ckm3
       POSTGRES_HOST_AUTH_METHOD: trust
+    healthcheck:
+      test: 'pg_isready -U postgres'
+      interval: 5s
+      timeout: 5s
+      retries: 10
   test:
     build: .
     environment:
@@ -23,5 +33,7 @@ services:
       PGCOPYDB_TABLE_JOBS: 4
       PGCOPYDB_INDEX_JOBS: 2
     depends_on:
-      - source
-      - target
+      source:
+        condition: service_healthy
+      target:
+        condition: service_healthy


### PR DESCRIPTION
## Summary

Adds PostgreSQL 17 and 18 to the CI test matrix and updates the entire build
and test infrastructure to be version-agnostic via a `PGVERSION` variable.

## Changes

### Build infrastructure

- **`Dockerfile`**: upgrade base image from `debian:11-slim` (bullseye) to
  `debian:12-slim` (bookworm); switch apt source list to `bookworm-pgdg`;
  add `libnuma-dev` required for PG 18.
- **`Makefile`**: pass `--build-arg PGVERSION=$(PGVERSION)` to
  `docker build`, so the pgcopydb container gets the matching
  `pg_dump`/`pg_restore` client tools.

### CI workflow (`.github/workflows/run-tests.yml`)

- Add `17` and `18` to the `PGVERSION` matrix (alongside existing `16`).
- Export `PGVERSION` into `$GITHUB_ENV` so it reaches test sub-processes.
- Increase per-test timeout from 5 to 15 minutes (PG 17/18 container pulls
  and cold builds take longer).

### Test infrastructure (`tests/`)

- **`Dockerfile.pagila`**: upgrade base from `debian:bullseye-slim` to
  `debian:bookworm-slim`; parameterise `PGVERSION` (default 16) for
  the postgresql client install.
- **`Makefile`**: default `PGVERSION ?= 16` (safe for local dev; CI overrides
  via environment); add `export PGVERSION` so the value propagates into
  `docker compose` sub-processes and compose files can use
  `${PGVERSION:-16}` correctly.
- **All `tests/*/compose.yaml`**: replace hardcoded `postgres:13-bullseye`
  (and similar) with `postgres:${PGVERSION:-16}`, making the Postgres
  server version match the client tools.
- **All `tests/*/Dockerfile.pg`**: fix Docker `ARG` scoping (re-declare
  `ARG PGVERSION` after `FROM` so it is available in `RUN` commands);
  replace hardcoded package names like `postgresql-13-wal2json` with
  `postgresql-${PGVERSION}-wal2json`.
- **`tests/extensions/`**: pass `PGVERSION` build arg through
  `compose.yaml`; add healthchecks.
- **`tests/blobs/`, `tests/unit/`**: add healthchecks + `service_healthy`
  dependency conditions.
- **`tests/follow-9.6/`**, **`tests/pagila-standby/`**: add healthchecks
  and proper `service_healthy` ordering to prevent DNS-resolution races.
- **`tests/timescaledb/`**: use `timescale/timescaledb:latest-pg${PGVERSION:-16}`.
- **`tests/extensions/Dockerfile.pg`**: use `postgresql-${PGVERSION}-partman`
  and `postgresql-${PGVERSION}-postgis-3` instead of hardcoded `pg13`.

### Documentation / version string

- `cli_common.c`: "compatible with Postgres 11, 12, 13, 14, 15, 16, 17, and 18"
- `docs/ref/pgcopydb.rst`: same
- `CHANGELOG.md`: new unreleased section

## Testing

`make tests/unit` and `make tests/filtering` pass locally (PG 16).
PG 17 and 18 coverage is validated through the expanded CI matrix.

Extracted from PR #939 ("Postgres 17 + 18 Support + Bug fixes") by Chris
Munns and Jeff Mealo. The `snprintf.c` PG18 fix from that PR was already
merged separately as PR #938 and is not included here.