### PR TITLE
Fix KEEPALIVE crash when timestamp is empty

### DIFF
--- a/src/bin/pgcopydb/ld_apply.c
+++ b/src/bin/pgcopydb/ld_apply.c
@@ -925,11 +925,35 @@ stream_apply_sql(StreamApplyContext *context,
 					  LSN_FORMAT_ARGS(context->previousLSN),
 					  context->reachedStartPos ? "" : "[skipping]");
 
-			if (metadata->lsn == InvalidXLogRecPtr ||
-				IS_EMPTY_STRING_BUFFER(metadata->timestamp))
+			if (metadata->lsn == InvalidXLogRecPtr)
 			{
 				log_fatal("Failed to parse KEEPALIVE message: %s", sql);
 				return false;
+			}
+
+			/*
+			 * When the timestamp is empty (e.g. from a stale SQL file
+			 * written before the empty-timestamp fix), use the current
+			 * time as a fallback. The timestamp is only used for
+			 * replication origin tracking, so a local timestamp is safe.
+			 */
+			if (IS_EMPTY_STRING_BUFFER(metadata->timestamp))
+			{
+				TimestampTz now = feGetCurrentTimestamp();
+
+				if (!pgsql_timestamptz_to_string(now,
+												 metadata->timestamp,
+												 sizeof(metadata->timestamp)))
+				{
+					log_fatal("Failed to generate fallback timestamp "
+							  "for KEEPALIVE message: %s", sql);
+					return false;
+				}
+
+				log_warn("KEEPALIVE at LSN %X/%X has empty timestamp, "
+						 "using current time \"%s\" as fallback",
+						 LSN_FORMAT_ARGS(metadata->lsn),
+						 metadata->timestamp);
 			}
 
 			/*

--- a/src/bin/pgcopydb/ld_apply.c
+++ b/src/bin/pgcopydb/ld_apply.c
@@ -950,10 +950,10 @@ stream_apply_sql(StreamApplyContext *context,
 					return false;
 				}
 
-				log_warn("KEEPALIVE at LSN %X/%X has empty timestamp, "
-						 "using current time \"%s\" as fallback",
-						 LSN_FORMAT_ARGS(metadata->lsn),
-						 metadata->timestamp);
+				log_debug("KEEPALIVE at LSN %X/%X has empty timestamp, "
+						  "using current time \"%s\" as fallback",
+						  LSN_FORMAT_ARGS(metadata->lsn),
+						  metadata->timestamp);
 			}
 
 			/*

--- a/src/bin/pgcopydb/ld_stream.c
+++ b/src/bin/pgcopydb/ld_stream.c
@@ -1480,10 +1480,24 @@ streamKeepalive(LogicalStreamContext *context)
 	/* register progress made through receiving keepalive messages */
 	if (privateContext->jsonFile != NULL)
 	{
+		/*
+		 * Use context->sendTime when available (from a real server keepalive
+		 * packet). For synthetic keepalive messages (generated during flush or
+		 * empty transaction skipping), sendTime may be 0, so fall back to the
+		 * current local timestamp to ensure the KEEPALIVE always has a valid
+		 * timestamp for the apply process.
+		 */
+		TimestampTz keepaliveTime = context->sendTime;
+
+		if (keepaliveTime == 0)
+		{
+			keepaliveTime = feGetCurrentTimestamp();
+		}
+
 		InternalMessage keepalive = {
 			.action = STREAM_ACTION_KEEPALIVE,
 			.lsn = context->cur_record_lsn,
-			.time = context->sendTime
+			.time = keepaliveTime
 		};
 
 		if (!stream_write_internal_message(context, &keepalive))

--- a/src/bin/pgcopydb/ld_transform.c
+++ b/src/bin/pgcopydb/ld_transform.c
@@ -2027,6 +2027,29 @@ stream_write_switchwal(FILE *out, LogicalMessageSwitchWAL *switchwal)
 bool
 stream_write_keepalive(FILE *out, LogicalMessageKeepalive *keepalive)
 {
+	/*
+	 * When the timestamp is empty (e.g. from a synthetic keepalive where
+	 * sendTime was 0), generate a current timestamp so that the SQL file
+	 * always contains a valid KEEPALIVE that the apply process can use.
+	 */
+	if (IS_EMPTY_STRING_BUFFER(keepalive->timestamp))
+	{
+		TimestampTz now = feGetCurrentTimestamp();
+
+		if (!pgsql_timestamptz_to_string(now,
+										 keepalive->timestamp,
+										 sizeof(keepalive->timestamp)))
+		{
+			log_error("Failed to format current timestamp for KEEPALIVE");
+			return false;
+		}
+
+		log_debug("stream_write_keepalive: generated fallback timestamp "
+				  "\"%s\" for LSN %X/%X",
+				  keepalive->timestamp,
+				  LSN_FORMAT_ARGS(keepalive->lsn));
+	}
+
 	FFORMAT(out, "%s{\"lsn\":\"%X/%X\",\"timestamp\":\"%s\"}\n",
 			OUTPUT_KEEPALIVE,
 			LSN_FORMAT_ARGS(keepalive->lsn),


### PR DESCRIPTION
## Problem

Closes #943.

When pgcopydb generates a **synthetic** KEEPALIVE message — triggered by the flush timer or by empty-transaction skipping — it calls `streamKeepalive()` with `InternalMessage.time = context->sendTime`. Before the first real server keepalive packet arrives, `sendTime == 0`.

`stream_write_internal_message()` treats `time == 0` as "no timestamp" and writes a timestampless JSON entry:
```
{"action":"K","lsn":"0/1C772DA0"}
```

The transform step finds an empty timestamp and writes a broken SQL line:
```
KEEPALIVE {"lsn":"0/1C772DA0","timestamp":""}
```

The apply process parses that line, detects the empty timestamp, and calls `log_fatal()` — crashing the apply worker. Because the broken `.sql` file persists on disk, every subsequent restart replays the same line and crashes again. `replay_lsn` never advances to `endpos`, permanently blocking cutover.

## Fix — three-layer defence

**1. `ld_stream.c` (root cause):** When `sendTime == 0`, substitute `feGetCurrentTimestamp()` before building the `InternalMessage`. Every KEEPALIVE entry written to the JSON file will now always carry a valid timestamp.

**2. `ld_transform.c` (middle layer):** In `stream_write_keepalive()`, if the timestamp is still empty after JSON parsing (e.g. from a pre-fix `.json` file on disk), generate a fallback timestamp before writing the SQL file.

**3. `ld_apply.c` (last resort):** Separate the two conditions that were combined in a single `log_fatal`:
- `lsn == InvalidXLogRecPtr` — still fatal; nothing can be done without an LSN.
- Empty timestamp — use `feGetCurrentTimestamp()` as a fallback and `log_warn` instead of `log_fatal`, allowing recovery from SQL files written by an older pgcopydb.

The timestamp in a KEEPALIVE message is used solely for replication origin tracking on the target; a local wall-clock time is a safe approximation.

## Testing

- `make tests/unit` passes locally (PG17).
- Patch contributed by @PradeepKumar29 in issue #943; applied cleanly to current `main`, commit message updated, build and unit tests verified.