### PR TITLE
Set GUC values in pgsql_create_logical_replication_slot()

### DIFF
--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -32,6 +32,7 @@
 #include "pg_utils.h"
 #include "signals.h"
 #include "string_utils.h"
+#include "copydb.h"
 
 #if defined(LIBPQ_HAS_PIPELINING) && LIBPQ_HAS_PIPELINING
 #define pqPipelineModeEnabled(conn) (PQpipelineStatus(conn) == PQ_PIPELINE_ON)
@@ -3941,6 +3942,23 @@ pgsql_create_logical_replication_slot(LogicalStreamClient *client,
 	if (!pgsql_identify_system(pgsql, &(client->system), client->cdcPathDir))
 	{
 		/* errors have already been logged */
+		return false;
+	}
+
+	/* also set our GUC values for the source connection */
+	if (!pgsql_server_version(pgsql))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	GUC *settings =
+		pgsql->pgversion_num < 90600 ? srcSettings95 : srcSettings;
+
+	if (!pgsql_set_gucs(pgsql, settings))
+	{
+		log_fatal("Failed to set our GUC settings on the source connection, "
+				  "see above for details");
 		return false;
 	}
 

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -32,7 +32,6 @@
 #include "pg_utils.h"
 #include "signals.h"
 #include "string_utils.h"
-#include "copydb.h"
 
 #if defined(LIBPQ_HAS_PIPELINING) && LIBPQ_HAS_PIPELINING
 #define pqPipelineModeEnabled(conn) (PQpipelineStatus(conn) == PQ_PIPELINE_ON)
@@ -3920,7 +3919,8 @@ OutputPluginToString(StreamOutputPlugin plugin)
  */
 bool
 pgsql_create_logical_replication_slot(LogicalStreamClient *client,
-									  ReplicationSlot *slot)
+									  ReplicationSlot *slot,
+                                      GUC *settings)
 {
 	PGSQL *pgsql = &(client->pgsql);
 
@@ -3946,15 +3946,6 @@ pgsql_create_logical_replication_slot(LogicalStreamClient *client,
 	}
 
 	/* also set our GUC values for the source connection */
-	if (!pgsql_server_version(pgsql))
-	{
-		/* errors have already been logged */
-		return false;
-	}
-
-	GUC *settings =
-		pgsql->pgversion_num < 90600 ? srcSettings95 : srcSettings;
-
 	if (!pgsql_set_gucs(pgsql, settings))
 	{
 		log_fatal("Failed to set our GUC settings on the source connection, "

--- a/src/bin/pgcopydb/pgsql.h
+++ b/src/bin/pgcopydb/pgsql.h
@@ -516,7 +516,8 @@ typedef struct ReplicationSlot
 } ReplicationSlot;
 
 bool pgsql_create_logical_replication_slot(LogicalStreamClient *client,
-										   ReplicationSlot *slot);
+										   ReplicationSlot *slot,
+                                           GUC *settings);
 
 bool pgsql_timestamptz_to_string(TimestampTz ts, char *str, size_t size);
 

--- a/src/bin/pgcopydb/snapshot.c
+++ b/src/bin/pgcopydb/snapshot.c
@@ -454,7 +454,12 @@ copydb_create_logical_replication_slot(CopyDataSpec *copySpecs,
 	}
 
 	/* now create the replication slot, exporting the snapshot */
-	if (!pgsql_create_logical_replication_slot(stream, slot))
+	if (!pgsql_server_version(&stream->pgsql)) { return false; }
+
+	GUC *settings =
+    	stream->pgsql.pgversion_num < 90600 ? srcSettings95 : srcSettings;
+
+	if (!pgsql_create_logical_replication_slot(stream, slot, settings))
 	{
 		log_error("Failed to create a logical replication slot "
 				  "and export a snapshot, see above for details");


### PR DESCRIPTION
In the pgsql_create_logical_replication_slot() function, GUC values are not set for the connection, holding a snapshot.

Therefore, if idle_in_transaction_session_timeout is set on the source, the session may be terminated due timeout and the snapshot may be lost.