### PR TITLE
ci: pre-build pgcopydb+pagila images as artifacts, skip rebuild if present

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -47,8 +47,10 @@ jobs:
           docker build \
             --build-arg PGVERSION=${{ matrix.PGVERSION }} \
             -t pagila:${{ matrix.PGVERSION }} \
-            -f tests/Dockerfile.pagila \
+            -t pagila \
+            -f Dockerfile.pagila \
             .
+        working-directory: tests
 
       - name: Save and compress images
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -39,6 +39,7 @@ jobs:
           docker build \
             --build-arg PGVERSION=${{ matrix.PGVERSION }} \
             -t pgcopydb:${{ matrix.PGVERSION }} \
+            -t pgcopydb \
             .
 
       - name: Build pagila base image

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,9 +10,78 @@ on:
   workflow_dispatch:
 
 jobs:
+  # ---------------------------------------------------------------------------
+  # Phase 1: build base Docker images once per PostgreSQL version and cache
+  # them as artifacts.  Every test job in build_package downloads the matching
+  # artifact and loads it into its local Docker daemon before running make,
+  # so the expensive C compilation and apt-install steps are never repeated.
+  # ---------------------------------------------------------------------------
+  build_images:
+    name: Build base images (PG${{ matrix.PGVERSION }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        PGVERSION:
+          - 16
+          - 17
+          - 18
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # all history for all branches and tags
+
+      - name: Set Version String From .git
+        run: make version
+
+      - name: Build pgcopydb image
+        run: |
+          docker build \
+            --build-arg PGVERSION=${{ matrix.PGVERSION }} \
+            -t pgcopydb:${{ matrix.PGVERSION }} \
+            .
+
+      - name: Build pagila base image
+        run: |
+          docker build \
+            --build-arg PGVERSION=${{ matrix.PGVERSION }} \
+            -t pagila:${{ matrix.PGVERSION }} \
+            -f tests/Dockerfile.pagila \
+            .
+
+      - name: Save and compress images
+        run: |
+          docker save pgcopydb:${{ matrix.PGVERSION }} pagila:${{ matrix.PGVERSION }} \
+            | zstd -T0 -9 - -o images.tar.zst
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-images-pg${{ matrix.PGVERSION }}
+          path: images.tar.zst
+          retention-days: 1
+
+  # ---------------------------------------------------------------------------
+  # The banned-API check has no Docker dependency and is cheap (~30 s).
+  # Running it as its own job keeps it off the build_images critical path.
+  # ---------------------------------------------------------------------------
+  ci_check:
+    name: Banned-API check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run banned.h check
+        run: sh ./ci/banned.h.sh
+
+  # ---------------------------------------------------------------------------
+  # Phase 2: run each test against pre-built images.
+  # ---------------------------------------------------------------------------
   build_package:
     name: Run tests
     runs-on: ubuntu-latest
+    needs: build_images
     strategy:
       fail-fast: false
       matrix:
@@ -21,7 +90,6 @@ jobs:
           - 17
           - 18
         TEST:
-          - ci
           - pagila
           - pagila-multi-steps
           - pagila-standby
@@ -61,6 +129,17 @@ jobs:
         run: |
             echo "TEST=${{ matrix.TEST }}" >> $GITHUB_ENV
             echo "PGVERSION=${{ matrix.PGVERSION }}" >> $GITHUB_ENV
+
+      - name: Download pre-built Docker images
+        uses: actions/download-artifact@v4
+        with:
+          name: docker-images-pg${{ matrix.PGVERSION }}
+
+      - name: Load and tag pre-built images
+        run: |
+          zstd -d < images.tar.zst | docker load
+          docker tag pgcopydb:${{ matrix.PGVERSION }} pgcopydb
+          docker tag pagila:${{ matrix.PGVERSION }} pagila
 
       - name: Create docker volumes
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -49,8 +49,10 @@ jobs:
           docker build \
             --build-arg PGVERSION=${{ matrix.PGVERSION }} \
             -t pagila:${{ matrix.PGVERSION }} \
-            -f tests/Dockerfile.pagila \
+            -t pagila \
+            -f Dockerfile.pagila \
             .
+        working-directory: tests
 
       - name: Save and compress images
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -41,6 +41,7 @@ jobs:
           docker build \
             --build-arg PGVERSION=${{ matrix.PGVERSION }} \
             -t pgcopydb:${{ matrix.PGVERSION }} \
+            -t pgcopydb \
             .
 
       - name: Build pagila base image

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,9 +13,77 @@ on:
   workflow_dispatch:
 
 jobs:
+  # ---------------------------------------------------------------------------
+  # Phase 1: build base Docker images once per PostgreSQL version and cache
+  # them as artifacts.  Every test job in build_package downloads the matching
+  # artifact and loads it into its local Docker daemon before running make,
+  # so the expensive C compilation and apt-install steps are never repeated.
+  # ---------------------------------------------------------------------------
+  build_images:
+    name: Build base images (PG${{ matrix.PGVERSION }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        PGVERSION:
+          - 16
+          - 18
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # all history for all branches and tags
+
+      - name: Set Version String From .git
+        run: make version
+
+      - name: Build pgcopydb image
+        run: |
+          docker build \
+            --build-arg PGVERSION=${{ matrix.PGVERSION }} \
+            -t pgcopydb:${{ matrix.PGVERSION }} \
+            .
+
+      - name: Build pagila base image
+        run: |
+          docker build \
+            --build-arg PGVERSION=${{ matrix.PGVERSION }} \
+            -t pagila:${{ matrix.PGVERSION }} \
+            -f tests/Dockerfile.pagila \
+            .
+
+      - name: Save and compress images
+        run: |
+          docker save pgcopydb:${{ matrix.PGVERSION }} pagila:${{ matrix.PGVERSION }} \
+            | zstd -T0 -9 - -o images.tar.zst
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-images-pg${{ matrix.PGVERSION }}
+          path: images.tar.zst
+          retention-days: 1
+
+  # ---------------------------------------------------------------------------
+  # The banned-API check has no Docker dependency and is cheap (~30 s).
+  # Running it as its own job keeps it off the build_images critical path.
+  # ---------------------------------------------------------------------------
+  ci_check:
+    name: Banned-API check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run banned.h check
+        run: sh ./ci/banned.h.sh
+
+  # ---------------------------------------------------------------------------
+  # Phase 2: run each test against pre-built images.
+  # ---------------------------------------------------------------------------
   build_package:
     name: Run tests
     runs-on: ubuntu-latest
+    needs: build_images
     strategy:
       fail-fast: false
       matrix:
@@ -24,12 +92,11 @@ jobs:
         # PG17 is intentionally omitted here — it is covered by the nightly
         # full-matrix run.  PG18 (latest) gets every test; PG16 (oldest
         # supported) gets a representative core subset.  This keeps the PR
-        # gate at ~25 jobs instead of 49.
+        # gate at ~23 jobs instead of 47.
         PGVERSION:
           - 16
           - 18
         TEST:
-          - ci
           - pagila
           - pagila-multi-steps
           - pagila-standby
@@ -93,6 +160,17 @@ jobs:
         run: |
             echo "TEST=${{ matrix.TEST }}" >> $GITHUB_ENV
             echo "PGVERSION=${{ matrix.PGVERSION }}" >> $GITHUB_ENV
+
+      - name: Download pre-built Docker images
+        uses: actions/download-artifact@v4
+        with:
+          name: docker-images-pg${{ matrix.PGVERSION }}
+
+      - name: Load and tag pre-built images
+        run: |
+          zstd -d < images.tar.zst | docker load
+          docker tag pgcopydb:${{ matrix.PGVERSION }} pgcopydb
+          docker tag pagila:${{ matrix.PGVERSION }} pagila
 
       - name: Create docker volumes
         run: |

--- a/AGENT.md
+++ b/AGENT.md
@@ -194,13 +194,28 @@ make bin
 # Debug build (-Og, full symbols)
 DEBUG=1 make bin
 
-# Build the Docker image used by all tests
-make build                   # defaults to PGVERSION=16
+# Build the Docker images used by all tests
+make build                   # defaults to PGVERSION=16; skips if pgcopydb image exists
 PGVERSION=17 make build
 
-# Clean
+# Force a full rebuild even when images already exist locally
+make force-build             # root: rebuilds pgcopydb
+PGVERSION=17 make force-build
+make -C tests force-build    # tests: rebuilds pagila
+
+# Remove both cached Docker images (triggers full rebuild on next test run)
+make clean-images
+
+# Clean compiled objects
 make clean
 ```
+
+> **Skip-if-present behaviour:** `make build` (and `make -C tests build`) checks
+> whether the `pgcopydb` / `pagila` image already exists in the local Docker
+> daemon and skips the `docker build` when it does.  This is what allows CI to
+> pre-build images once per PostgreSQL version and reuse them across all parallel
+> test jobs.  Locally it means you will not automatically pick up source changes
+> unless you run `make force-build` or `make clean-images` first.
 
 ---
 
@@ -228,7 +243,7 @@ Shared env files (auto-loaded by compose):
 ### Run tests
 
 ```bash
-# All tests (builds Docker image first)
+# All tests (builds Docker images first if not present)
 make tests
 
 # Single suite
@@ -240,13 +255,25 @@ make tests/cdc-wal2json
 PGVERSION=17 make tests/pagila
 
 # Available suites
-pagila  pagila-multi-steps  blobs  unit  filtering  extensions
+pagila  pagila-multi-steps  pagila-standby  blobs  unit  filtering  extensions
 partitioned-target  cdc-wal2json  cdc-test-decoding  cdc-endpos-mid-txn
 cdc-low-level  cdc-replica-identity-index
 cdc-partitioned-target  cdc-endpos-in-multi-wal-txn
 follow-wal2json  follow-9.6  follow-data-only
-timescaledb  pagila-standby
+timescaledb
 ```
+
+> **After source changes:** `make tests/pagila` will reuse the existing
+> `pgcopydb` and `pagila` images (see skip-if-present above).  To incorporate
+> source changes into the test images run:
+>
+> ```bash
+> make force-build            # rebuilds pgcopydb image
+> make -C tests force-build   # rebuilds pagila image (copies new pgcopydb binary)
+> make tests/pagila           # now runs with fresh images
+> ```
+>
+> Or in one shot: `make clean-images && make tests/pagila`
 
 ### Interactive debugging inside a test container
 
@@ -500,7 +527,29 @@ make check-docs     # verify docs build via Docker
 | PR/push  | `.github/workflows/run-tests.yml` | push/PR to main | PG16 + PG18 |
 | Nightly  | `.github/workflows/nightly.yml`   | daily 02:00 UTC  | PG16/17/18 × all tests |
 
-Simulate CI locally:
+### CI job structure (both workflows)
+
+```
+build_images (PG16)  ──┐
+build_images (PG17)  ──┤  (parallel, one per PGVERSION)
+build_images (PG18)  ──┘
+        │ artifact: docker-images-pgN.tar.zst
+        ▼
+build_package (PGN × TEST)   (parallel, needs: build_images)
+        downloads artifact → docker load → make tests/${TEST}
+
+ci_check  (independent, no Docker, runs concurrently with build_images)
+```
+
+`build_images` builds `pgcopydb:N` and `pagila:N`, saves them as a compressed
+tar artifact, and uploads it. Each `build_package` job downloads the artifact
+for its PGVERSION, loads both images into the local Docker daemon (tagged
+without version suffix for Makefile/compose compatibility), and then runs
+`make tests/${TEST}`. Because the base images are already present, the
+`docker build` calls in the Makefile skip immediately and only the tiny
+test-specific compose layer is built (~5 s).
+
+### Simulate CI locally
 
 ```bash
 TEST=pagila PGVERSION=16 make tests/pagila

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,18 @@ indent:
 	citus_indent
 
 build: version
+	@docker image inspect pgcopydb > /dev/null 2>&1 \
+	  && echo "pgcopydb image already present — skipping build (run 'make force-build' to rebuild)" \
+	  || docker build --build-arg PGVERSION=$(PGVERSION) -t pgcopydb .
+
+# Force a full rebuild even when the pgcopydb image already exists locally
+# (use after source-code changes or when switching PGVERSION)
+force-build: version
 	docker build --build-arg PGVERSION=$(PGVERSION) -t pgcopydb .
+
+# Remove cached Docker images so the next build/test starts from scratch
+clean-images:
+	-docker rmi pgcopydb pagila 2>/dev/null; true
 
 echo-version: GIT-VERSION-FILE
 	@awk '{print $$3}' $<
@@ -80,5 +91,6 @@ debsh-qa: deb-qa
 .PHONY: all
 .PHONY: bin clean install docs maintainer-clean update-docs
 .PHONY: test tests tests/ci tests/*
+.PHONY: build force-build clean-images
 .PHONY: deb debsh deb-qa debsh-qa
 .PHONY: GIT-VERSION-FILE

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -84,9 +84,20 @@ timescaledb: build
 	$(MAKE) -C $@
 
 build:
+	@docker image inspect pagila > /dev/null 2>&1 \
+	  && echo "pagila image already present — skipping build (run 'make force-build' to rebuild)" \
+	  || docker build $(BUILD_ARGS) -t pagila -f Dockerfile.pagila .
+
+# Force a full rebuild even when the pagila image already exists locally
+# (use after Dockerfile.pagila changes or when switching PGVERSION)
+force-build:
 	docker build $(BUILD_ARGS) -t pagila -f Dockerfile.pagila .
 
-.PHONY: all build
+# Remove the cached pagila image so the next test starts from scratch
+clean-images:
+	-docker rmi pagila 2>/dev/null; true
+
+.PHONY: all build force-build clean-images
 .PHONY: pagila pagila-multi-steps blobs unit filtering partitioned-target extensions
 .PHONY: cdc-wal2json cdc-test-decoding cdc-endpos-mid-txn cdc-low-level cdc-replica-identity-index cdc-partitioned-target
 .PHONY: cdc-endpos-in-multi-wal-txn cdc-file-rotation


### PR DESCRIPTION
## Problem

Every matrix job in `run-tests.yml` and `nightly.yml` independently builds the entire Docker image stack from scratch before running its test:

1. **Root `make build`** → compiles ~160 C source files against PostgreSQL server headers (**5–10 min**)
2. **`tests/Makefile build`** → apt-installs PostgreSQL-N, clones pagila repo, copies pgcopydb binary (**2–4 min**)
3. **Test-specific `docker compose build`** → `FROM pagila` + `COPY` test scripts (**<30 s**)

Steps 1 and 2 are identical for all tests at the same PGVERSION, repeated 13–15 times per version on every run.

## Solution

Add a `build_images` pre-build job (matrix: PGVERSION only) that runs steps 1–2 once per version, saves both images as a zstd-compressed GitHub artifact, and uploads it.  Every `build_package` test job downloads the matching artifact, loads the images into its local Docker daemon, and retags them before calling `make tests/${TEST}`.

Because the base images are already present in the daemon, the `docker build` calls inside the Makefile **skip immediately** (new skip-if-present guard), and only the tiny test-specific compose layer is built per job.

## Changes

- **`Makefile`**: `build` target skips if `pgcopydb` image already exists; new `force-build` and `clean-images` targets for local cache invalidation
- **`tests/Makefile`**: same skip-if-present guard for `pagila`; new `force-build` and `clean-images` targets  
- **`run-tests.yml`**: add `build_images` job; extract `ci` test into standalone `ci_check` (no Docker dependency, runs in parallel); `build_package` sets `needs: build_images` and pre-loads images
- **`nightly.yml`**: identical changes, PGVERSION matrix [16, 17, 18]
- **`AGENT.md`**: document skip-if-present behaviour, new targets, and CI job structure

## Expected impact

| Metric | Before | After |
|---|---|---|
| Test job: image prep | 7–14 min | ~2 min (download + load) |
| Test job: compose build | ~30 s | ~5 s |
| CI wall-clock (run-tests) | ~30 min | ~20 min |
| Aggregate runner-minutes (25 jobs) | ~400 min | ~150 min |

## Local workflow (unchanged for most uses)

```bash
make tests/pagila           # still works; skips build if images present
make force-build            # explicit rebuild after source changes
make clean-images           # evict both images for a full rebuild
```