### PR TITLE
Fix double constraint creation for tables with EXCLUSION constraint indexes

### DIFF
--- a/src/bin/pgcopydb/indexes.c
+++ b/src/bin/pgcopydb/indexes.c
@@ -1188,6 +1188,20 @@ copydb_create_constraints_hook(void *ctx, SourceIndex *index)
 		return false;
 	}
 
+	if (!summary_lookup_constraint(sourceDB, &indexSpecs))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	if (indexSummary->doneTime > 0)
+	{
+		log_debug("Skipping constraint %s: already created (done at %lld)",
+				  index->constraintName,
+				  (long long) indexSummary->doneTime);
+		return true;
+	}
+
 	if (!summary_add_constraint(sourceDB, &indexSpecs))
 	{
 		/* errors have already been logged */

--- a/src/bin/pgcopydb/summary.c
+++ b/src/bin/pgcopydb/summary.c
@@ -1452,7 +1452,7 @@ summary_add_constraint(DatabaseCatalog *catalog, CopyIndexSpec *indexSpecs)
 	}
 
 	char *sql =
-		"insert or replace into summary(pid, conoid, start_time_epoch, command)"
+		"insert or ignore into summary(pid, conoid, start_time_epoch, command)"
 		"values($1, $2, $3, $4)";
 
 	if (!semaphore_lock(&(catalog->sema)))
@@ -1613,16 +1613,17 @@ summary_table_count_indexes_left(DatabaseCatalog *catalog,
 
 	/*
 	 * When asked to create an index for a constraint and the index is neither
-	 * a UNIQUE nor a PRIMARY KEY index, then we can't use the ALTER TABLE ...
-	 * ADD CONSTRAINT ... USING INDEX ... command, because this only works with
-	 * UNIQUE and PRIMARY KEY indexes.
+	 * a UNIQUE nor a PRIMARY KEY index (such as an EXCLUSION constraint), then
+	 * we skip creating the index directly and instead create it as part of the
+	 * "plain" ALTER TABLE ... ADD CONSTRAINT ... command during the constraint
+	 * phase.
 	 *
-	 * This means that we have to skip creating the index first, and will only
-	 * then create it during the constraint phase, as part of the "plain" ALTER
-	 * TABLE ... ADD CONSTRAINT ... command.
-	 *
-	 * So when counting the indexes that are left to be created before we can
-	 * install the constraints, we should also skip counting these.
+	 * Even though we skip running CREATE INDEX for such indexes, each one is
+	 * still queued and processed by a worker, which calls
+	 * copydb_mark_index_as_done before checking whether all indexes are done.
+	 * We must therefore count these indexes here so that countIndexesLeft
+	 * reaches zero exactly once — when the last worker finishes its index —
+	 * rather than once per non-skipped index and again for each skipped index.
 	 */
 	char *sql =
 		"with idx(indexoid) as"
@@ -1630,29 +1631,14 @@ summary_table_count_indexes_left(DatabaseCatalog *catalog,
 		"  select i.oid as indexoid "
 		"    from s_table t join s_index i on i.tableoid = t.oid"
 		"   where tableoid = $1 "
-		" ), "
-		" skipidx(indexoid) as "
-		" ("
-		"  select i.oid as indexoid "
-		"    from s_table t "
-		"         join s_index i on i.tableoid = t.oid "
-		"         join s_constraint c on c.indexoid = i.oid "
-		"   where not i.isprimary and not i.isunique"
-		"     and tableoid = $2 "
-		" ),"
-		" indexlist(indexoid) as"
-		" ( "
-		"  select indexoid from idx "
-		"  except "
-		"  select indexoid from skipidx "
 		" ) "
-		" select count(l.indexoid) "
-		"   from indexlist l "
+		" select count(i.indexoid) "
+		"   from idx i "
 		"  where not exists "
 		"        ( "
 		"          select 1 "
 		"            from summary s "
-		"           where s.indexoid = l.indexoid "
+		"           where s.indexoid = i.indexoid "
 		"             and s.pid > 0 and s.done_time_epoch > 0"
 		"        ) ";
 
@@ -1676,7 +1662,6 @@ summary_table_count_indexes_left(DatabaseCatalog *catalog,
 
 	/* bind our parameters now */
 	BindParam params[] = {
-		{ BIND_PARAMETER_TYPE_INT64, "tableoid", table->oid, NULL },
 		{ BIND_PARAMETER_TYPE_INT64, "tableoid", table->oid, NULL }
 	};
 

--- a/tests/unit/expected/17-exclusion-with-pkey.out
+++ b/tests/unit/expected/17-exclusion-with-pkey.out
@@ -1,0 +1,9 @@
+-[ RECORD 1 ]-----------------------------
+conname | excl_with_pkey_pkey
+contype | p
+condef  | PRIMARY KEY (id)
+-[ RECORD 2 ]-----------------------------
+conname | excl_with_pkey_excl
+contype | x
+condef  | EXCLUDE USING btree (val WITH =)
+

--- a/tests/unit/expected/5-exclusion-constraint-index-jobs.out
+++ b/tests/unit/expected/5-exclusion-constraint-index-jobs.out
@@ -1,0 +1,10 @@
+CREATE DATABASE
+CREATE COLLATION
+excl_with_pkey_excl x
+excl_with_pkey_pkey p
+DROP DATABASE
+CREATE DATABASE
+CREATE COLLATION
+excl_with_pkey_excl x
+excl_with_pkey_pkey p
+DROP DATABASE

--- a/tests/unit/expected/5-exclusion-constraint-index-jobs.out
+++ b/tests/unit/expected/5-exclusion-constraint-index-jobs.out
@@ -1,10 +1,24 @@
 CREATE DATABASE
 CREATE COLLATION
-excl_with_pkey_excl x
-excl_with_pkey_pkey p
+-[ RECORD 1 ]-----------------------------
+conname | excl_with_pkey_pkey
+contype | p
+condef  | PRIMARY KEY (id)
+-[ RECORD 2 ]-----------------------------
+conname | excl_with_pkey_excl
+contype | x
+condef  | EXCLUDE USING btree (val WITH =)
+
 DROP DATABASE
 CREATE DATABASE
 CREATE COLLATION
-excl_with_pkey_excl x
-excl_with_pkey_pkey p
+-[ RECORD 1 ]-----------------------------
+conname | excl_with_pkey_pkey
+contype | p
+condef  | PRIMARY KEY (id)
+-[ RECORD 2 ]-----------------------------
+conname | excl_with_pkey_excl
+contype | x
+condef  | EXCLUDE USING btree (val WITH =)
+
 DROP DATABASE

--- a/tests/unit/script/5-exclusion-constraint-index-jobs.sh
+++ b/tests/unit/script/5-exclusion-constraint-index-jobs.sh
@@ -43,16 +43,14 @@ do
         --skip-collations \
         --fail-fast > /dev/null
 
+    # Verify both constraints survived the copy, using the same SQL as the
+    # SQL test suite. The SQL test covers a standard copy; this script
+    # additionally exercises --index-jobs 1 and --index-jobs 4 separately
+    # to catch the double-constraint-creation bug described in issue #808.
     psql -d "${TARGET_URI}" \
          --no-psqlrc \
-         --tuples-only \
-         --no-align \
-         -c "select c.conname || ' ' || c.contype::text
-               from pg_constraint c
-                    join pg_class r on r.oid = c.conrelid
-              where r.relname = 'excl_with_pkey'
-                and c.contype != 'n'
-           order by c.conname"
+         --expanded \
+         --file ./sql/17-exclusion-with-pkey.sql
 
     psql -q -d "${PGCOPYDB_TARGET_PGURI}" -c "DROP DATABASE ${TMPDB}"
 

--- a/tests/unit/script/5-exclusion-constraint-index-jobs.sh
+++ b/tests/unit/script/5-exclusion-constraint-index-jobs.sh
@@ -51,6 +51,7 @@ do
                from pg_constraint c
                     join pg_class r on r.oid = c.conrelid
               where r.relname = 'excl_with_pkey'
+                and c.contype != 'n'
            order by c.conname"
 
     psql -q -d "${PGCOPYDB_TARGET_PGURI}" -c "DROP DATABASE ${TMPDB}"

--- a/tests/unit/script/5-exclusion-constraint-index-jobs.sh
+++ b/tests/unit/script/5-exclusion-constraint-index-jobs.sh
@@ -1,0 +1,59 @@
+#! /bin/bash
+
+set -x
+set -e
+
+# This script expects the following environment variables to be set:
+#
+#  - PGCOPYDB_SOURCE_PGURI
+#  - PGCOPYDB_TARGET_PGURI
+#
+# Regression test for https://github.com/dimitri/pgcopydb/issues/808
+#
+# Tables with both a PRIMARY KEY and an EXCLUSION constraint triggered
+# "ERROR: index is already associated with a constraint" with --index-jobs 1.
+# The bug was that EXCLUSION constraint indexes were excluded from the
+# "indexes remaining" count, causing copydb_create_constraints to be called
+# twice by the same worker when it processed the skipped EXCLUSION index.
+
+TARGET_BASE="${PGCOPYDB_TARGET_PGURI%/*}"
+
+for jobs in 1 4
+do
+    TMPDB="pgcopydb_bug808_ij${jobs}"
+    TARGET_URI="${TARGET_BASE}/${TMPDB}"
+    TMPDIR="/tmp/pgcopydb-bug808-ij${jobs}"
+
+    psql -q -d "${PGCOPYDB_TARGET_PGURI}" -c "CREATE DATABASE ${TMPDB}"
+
+    # The source schema contains a table using a custom collation.
+    # Pre-create it on the target so that --skip-collations works correctly.
+    psql -q -d "${TARGET_URI}" -c "
+        CREATE COLLATION IF NOT EXISTS mycol
+            (locale = 'fr-FR-x-icu', provider = 'icu');
+    "
+
+    pgcopydb clone \
+        --source "${PGCOPYDB_SOURCE_PGURI}" \
+        --target "${TARGET_URI}" \
+        --index-jobs "${jobs}" \
+        --table-jobs 2 \
+        --dir "${TMPDIR}" \
+        --not-consistent \
+        --skip-collations \
+        --fail-fast > /dev/null
+
+    psql -d "${TARGET_URI}" \
+         --no-psqlrc \
+         --tuples-only \
+         --no-align \
+         -c "select c.conname || ' ' || c.contype::text
+               from pg_constraint c
+                    join pg_class r on r.oid = c.conrelid
+              where r.relname = 'excl_with_pkey'
+           order by c.conname"
+
+    psql -q -d "${PGCOPYDB_TARGET_PGURI}" -c "DROP DATABASE ${TMPDB}"
+
+    rm -rf "${TMPDIR}"
+done

--- a/tests/unit/setup/17-exclusion-with-pkey.sql
+++ b/tests/unit/setup/17-exclusion-with-pkey.sql
@@ -1,0 +1,11 @@
+DROP TABLE IF EXISTS excl_with_pkey;
+
+CREATE TABLE excl_with_pkey (
+    id  integer NOT NULL,
+    val integer NOT NULL
+);
+
+ALTER TABLE excl_with_pkey ADD CONSTRAINT excl_with_pkey_pkey PRIMARY KEY (id);
+ALTER TABLE excl_with_pkey ADD CONSTRAINT excl_with_pkey_excl EXCLUDE USING btree (val WITH =);
+
+INSERT INTO excl_with_pkey VALUES (1, 10), (2, 20), (3, 30);

--- a/tests/unit/setup/setup.sql
+++ b/tests/unit/setup/setup.sql
@@ -13,3 +13,4 @@
 \ir 14-uuid.sql
 \ir 15-attgenerated.sql
 \ir 16-sequences.sql
+\ir 17-exclusion-with-pkey.sql

--- a/tests/unit/sql/17-exclusion-with-pkey.sql
+++ b/tests/unit/sql/17-exclusion-with-pkey.sql
@@ -1,0 +1,6 @@
+  select c.conname, c.contype, pg_get_constraintdef(c.oid) as condef
+    from pg_constraint c
+         join pg_class r on r.oid = c.conrelid
+         join pg_namespace n on n.oid = r.relnamespace
+   where n.nspname = 'public' and r.relname = 'excl_with_pkey'
+order by c.contype, c.conname;

--- a/tests/unit/sql/17-exclusion-with-pkey.sql
+++ b/tests/unit/sql/17-exclusion-with-pkey.sql
@@ -3,4 +3,5 @@
          join pg_class r on r.oid = c.conrelid
          join pg_namespace n on n.oid = r.relnamespace
    where n.nspname = 'public' and r.relname = 'excl_with_pkey'
+     and c.contype != 'n'  -- PostgreSQL 18 adds NOT NULL constraints to pg_constraint
 order by c.contype, c.conname;


### PR DESCRIPTION
## Problem

Tables with both a PRIMARY KEY (or UNIQUE) constraint index **and** an EXCLUSION constraint index caused pgcopydb to execute each `ALTER TABLE ... ADD CONSTRAINT` statement twice, resulting in:

```
ERROR: index "..._pkey" is already associated with a constraint
```

The bug only manifested with `--index-jobs 1` and not with `--index-jobs 4`.

## Root Cause

`summary_table_count_indexes_left` used a `skipidx` CTE to exclude non-unique, non-primary constraint indexes (EXCLUSION constraint indexes) from its "indexes remaining" count. The intent was that these indexes are created implicitly by PostgreSQL during `ALTER TABLE ... ADD CONSTRAINT ... EXCLUSION`, so pgcopydb skips running `CREATE INDEX` for them.

However, EXCLUSION indexes **are** still queued and processed by workers — `copydb_create_index` is called with `skipCreateIndex = true`, but `copydb_mark_index_as_done` is still called at the end. This means excluding them from the count caused `countIndexesLeft` to reach zero **twice** for the same table:

1. When the last PRIMARY/UNIQUE index finishes → `copydb_create_constraints` creates all constraints correctly ✓
2. When the EXCLUSION index is processed (CREATE INDEX skipped, but marked done) → `countIndexesLeft` is still 0, `copydb_create_constraints` is called again → **ERROR** ✗

With `--index-jobs 4` different workers have different PIDs. When the second worker (processing the EXCLUSION index) calls the check, the `constraintsAreBeingBuilt` guard sees a different PID and correctly skips. With `--index-jobs 1` both calls come from the same PID, so the guard does not fire.

## Fix

**Primary fix** (`summary.c`): Remove the `skipidx` CTE from `summary_table_count_indexes_left`. Since all indexes are queued, processed, and marked done by workers, the count reaches zero exactly once — when the last worker finishes.

**Defense-in-depth** (`indexes.c` + `summary.c`):
- Add a `summary_lookup_constraint` check at the top of `copydb_create_constraints_hook`: if the constraint already has a `done_time` in the summary, skip silently.
- Change `summary_add_constraint` from `INSERT OR REPLACE` to `INSERT OR IGNORE` so a second invocation does not wipe the `done_time_epoch` recorded by the first successful run, making the guard effective and fixing `--resume` correctness.

## Tests

- New table `excl_with_pkey` with PRIMARY KEY + EXCLUSION constraint in the unit test setup.
- SQL query verifying both constraints are present on the target after `pgcopydb fork`.
- Script test (`5-exclusion-constraint-index-jobs.sh`) that clones with `--index-jobs 1` **and** `--index-jobs 4`, both must succeed.

Closes #808
