### PR TITLE
Add --all-databases flag: clone an entire Postgres instance in one command

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -52,9 +52,22 @@ jobs:
             .
         working-directory: tests
 
+      - name: Build multi base image (all-databases / three-databases tests)
+        run: |
+          docker build \
+            --build-arg PGVERSION=${{ matrix.PGVERSION }} \
+            -t multi:${{ matrix.PGVERSION }} \
+            -t multi \
+            -f Dockerfile.multi \
+            .
+        working-directory: tests
+
       - name: Save and compress images
         run: |
-          docker save pgcopydb:${{ matrix.PGVERSION }} pagila:${{ matrix.PGVERSION }} \
+          docker save \
+            pgcopydb:${{ matrix.PGVERSION }} \
+            pagila:${{ matrix.PGVERSION }} \
+            multi:${{ matrix.PGVERSION }} \
             | zstd -T0 -9 - -o images.tar.zst
 
       - name: Upload artifact
@@ -101,6 +114,8 @@ jobs:
           - filtering
           - extensions
           - timescaledb
+          - all-databases
+          - three-databases
           - cdc-low-level
           - cdc-test-decoding
           - cdc-endpos-between-transaction
@@ -143,6 +158,7 @@ jobs:
           zstd -d < images.tar.zst | docker load
           docker tag pgcopydb:${{ matrix.PGVERSION }} pgcopydb
           docker tag pagila:${{ matrix.PGVERSION }} pagila
+          docker tag multi:${{ matrix.PGVERSION }} multi
 
       - name: Create docker volumes
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -54,9 +54,22 @@ jobs:
             .
         working-directory: tests
 
+      - name: Build multi base image (all-databases / three-databases tests)
+        run: |
+          docker build \
+            --build-arg PGVERSION=${{ matrix.PGVERSION }} \
+            -t multi:${{ matrix.PGVERSION }} \
+            -t multi \
+            -f Dockerfile.multi \
+            .
+        working-directory: tests
+
       - name: Save and compress images
         run: |
-          docker save pgcopydb:${{ matrix.PGVERSION }} pagila:${{ matrix.PGVERSION }} \
+          docker save \
+            pgcopydb:${{ matrix.PGVERSION }} \
+            pagila:${{ matrix.PGVERSION }} \
+            multi:${{ matrix.PGVERSION }} \
             | zstd -T0 -9 - -o images.tar.zst
 
       - name: Upload artifact
@@ -108,6 +121,8 @@ jobs:
           - filtering
           - extensions
           - timescaledb
+          - all-databases
+          - three-databases
           - cdc-low-level
           - cdc-test-decoding
           - cdc-endpos-mid-txn
@@ -174,6 +189,7 @@ jobs:
           zstd -d < images.tar.zst | docker load
           docker tag pgcopydb:${{ matrix.PGVERSION }} pgcopydb
           docker tag pagila:${{ matrix.PGVERSION }} pagila
+          docker tag multi:${{ matrix.PGVERSION }} multi
 
       - name: Create docker volumes
         run: |

--- a/AGENT.md
+++ b/AGENT.md
@@ -512,7 +512,12 @@ chmod +x .git/hooks/pre-commit
 
 ## Documentation
 
+The Sphinx dependencies (`sphinx_rtd_theme`, etc.) live in a project-local
+Python venv at `.venv/`. Always activate it before building docs:
+
 ```bash
+source .venv/bin/activate
+
 make docs           # rebuild Sphinx HTML + man pages
 make update-docs    # sync CLI --help text into docs (run after changing options)
 make check-docs     # verify docs build via Docker

--- a/docs/concurrency.rst
+++ b/docs/concurrency.rst
@@ -362,79 +362,95 @@ instance in a single invocation. This is the equivalent of ``pg_dumpall``
 for the data phase.
 
 When ``--all-databases`` is active, ``pgcopydb`` coordinates the copy in
-three phases:
+three phases that run sequentially, while keeping the ``--table-jobs`` and
+``--index-jobs`` worker pools **global** — shared across all databases, not
+allocated per-database.
 
-Phase 1 — instance-level setup
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Phase I — snapshot export and pre-data (parallel across databases)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  1. The source instance URI is used to enumerate all non-template user
-     databases via :ref:`pgcopydb_list_databases`.
+A long-lived *snapshot holder* subprocess is forked first. It connects to
+each source database, exports one ``REPEATABLE READ`` snapshot per
+database, writes the snapshot IDs into the instance catalog, and then
+blocks on a pipe until Phase III completes. This keeps all per-database
+snapshot transactions open so that Phase I and II workers can call
+``SET TRANSACTION SNAPSHOT`` to import them for consistent reads.
 
-  2. Roles are copied once at the instance level using ``pg_dumpall
-     --roles-only`` and restored on the target, equivalent to
-     :ref:`pgcopydb_copy_roles`.
+Once all snapshots are ready, a *pre-data supervisor* is forked. It starts
+``--table-jobs`` *pre-data workers* that each dequeue a database name from
+a shared queue, then run the full pre-data pipeline for that database:
+schema fetch from the source, ``pg_dump --pre-data``, and
+``pg_restore --pre-data`` on the target. Roles are copied once at the
+instance level before any of this begins.
 
-  3. For each discovered database a ``CREATE DATABASE`` command is issued
-     on the target (or the database is left as-is when it already exists,
-     unless ``--drop-if-exists`` is given).
+The process tree for this phase looks like the following::
 
-Phase 2 — per-database schema and data copy
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  $ pgcopydb clone --all-databases --table-jobs 4 --index-jobs 4
+   + pgcopydb snapshot holder           (blocks until Phase III done)
+   + pgcopydb pre-data supervisor
+       - pgcopydb pre-data worker       (processes db1, then db4, …)
+       - pgcopydb pre-data worker       (processes db2, then db5, …)
+       - pgcopydb pre-data worker       (processes db3, then db6, …)
+       - pgcopydb pre-data worker
 
-For each database a full ``pgcopydb clone`` pipeline is run: pre-data
-restore, COPY data workers, index workers, constraint workers, VACUUM
-workers, sequence reset, and post-data restore.  Each per-database pipeline
-uses the shared ``--table-jobs`` and ``--index-jobs`` pools.
+Phase II — global COPY, indexes, and vacuum (single shared pool)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-When ``--all-databases`` is active, each progress log line that produces a
-DDL or DML command is prefixed with the database name so that concurrent
-output from workers handling different databases stays distinguishable::
+After all pre-data work is complete, the COPY phase begins. All tables
+from all databases are collected and sorted by size (largest first), then
+enqueued into a single global COPY queue. The ``--table-jobs`` COPY workers
+and ``--index-jobs`` index workers are each created once and serve the
+entire workload regardless of which database each table belongs to.
+
+This is the key resource-sharing optimisation: the largest tables get
+started first across database boundaries, keeping all workers busy even
+when the database sizes are very uneven.
+
+Each COPY worker maintains a small connection cache keyed by database name
+so that connections are reused when consecutive queue entries belong to the
+same database.  Index and vacuum workers open their own per-database
+connections on demand.
+
+When ``--all-databases`` is active, each DDL and DML progress log line is
+prefixed with the database name so that interleaved output from workers
+handling different databases stays distinguishable::
 
   pagila: CREATE UNIQUE INDEX actor_pkey ON actor USING btree (actor_id)
   f1db:   TRUNCATE ONLY "public"."constructorstandings"
   f1db:   COPY "public"."constructorstandings"
   chinook: VACUUM ANALYZE "public"."Track"
 
-Phase 3 — cross-database global COPY queue
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The process tree for this phase looks like the following::
 
-All tables across all databases are sorted by size (largest first) and
-enqueued into a single global COPY queue shared by all ``--table-jobs``
-workers.  This ensures that the largest tables are started first regardless
-of which database they belong to, keeping all workers busy and minimising
-total elapsed time — even when the database sizes are very uneven.
+   + pgcopydb global copy supervisor
+       - pgcopydb global copy queue filler  (enqueues all tables, sorted by size)
+       - pgcopydb global copy worker        (--table-jobs workers, any database)
+       - pgcopydb global copy worker
+       - pgcopydb global copy worker
+       - pgcopydb global copy worker
+   + pgcopydb global index supervisor
+       - pgcopydb index/constraints worker  (--index-jobs workers, any database)
+       - pgcopydb index/constraints worker
+       - pgcopydb index/constraints worker
+       - pgcopydb index/constraints worker
+   + pgcopydb global vacuum supervisor
+       - pgcopydb vacuum analyze worker     (--table-jobs workers, any database)
+       - pgcopydb vacuum analyze worker
+       - pgcopydb vacuum analyze worker
+       - pgcopydb vacuum analyze worker
 
-Each COPY worker maintains a small connection cache keyed by database name
-so that it can serve tables from multiple databases without reopening a
-connection for every table when the table order happens to alternate between
-databases.
+Phase III — post-data (sequential, one database at a time)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The process tree for ``pgcopydb clone --all-databases --table-jobs 4 --index-jobs 4``
-looks like the following, repeated once per database::
+After the global COPY phase completes, the remaining post-data work runs
+sequentially: for each database, a subprocess is forked that calls
+``pg_restore --post-data`` (triggers, rules, comments, and any objects not
+already created by the index workers) and resets sequences to match the
+source values captured during Phase I. The databases are processed one at a
+time in the order they were discovered.
 
-  $ pgcopydb clone --all-databases --table-jobs 4 --index-jobs 4
-   + pgcopydb clone all-databases coordinator
-     for each database db1, db2, ...:
-       + pgcopydb copy supervisor [ --table-jobs 4, global queue ]
-         - pgcopydb copy queue worker
-         - pgcopydb global copy worker (db1)
-         - pgcopydb global copy worker (db2)
-         - pgcopydb global copy worker (db1)
-         - pgcopydb global copy worker (db2)
-
-       + pgcopydb index supervisor [ --index-jobs 4 ]
-         - pgcopydb index/constraints worker
-         - pgcopydb index/constraints worker
-         - pgcopydb index/constraints worker
-         - pgcopydb index/constraints worker
-
-       + pgcopydb vacuum supervisor [ --table-jobs 4 ]
-         - pgcopydb vacuum analyze worker
-         - pgcopydb vacuum analyze worker
-         - pgcopydb vacuum analyze worker
-         - pgcopydb vacuum analyze worker
-
-       + pgcopydb sequences reset worker
+Once all post-data work is done, the parent closes the done-pipe to the
+snapshot holder, which then commits all its held transactions and exits.
 
 Consolidated summary
 ^^^^^^^^^^^^^^^^^^^^

--- a/docs/concurrency.rst
+++ b/docs/concurrency.rst
@@ -351,3 +351,97 @@ to use this feature:
 
     Use your usual Postgres configuration editing for testing.
 
+.. _all_databases_concurrency:
+
+Cloning all databases: the ``--all-databases`` option
+------------------------------------------------------
+
+The ``--all-databases`` option to ``pgcopydb clone`` allows cloning every
+non-template user database from a source Postgres instance to a target
+instance in a single invocation. This is the equivalent of ``pg_dumpall``
+for the data phase.
+
+When ``--all-databases`` is active, ``pgcopydb`` coordinates the copy in
+three phases:
+
+Phase 1 — instance-level setup
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  1. The source instance URI is used to enumerate all non-template user
+     databases via :ref:`pgcopydb_list_databases`.
+
+  2. Roles are copied once at the instance level using ``pg_dumpall
+     --roles-only`` and restored on the target, equivalent to
+     :ref:`pgcopydb_copy_roles`.
+
+  3. For each discovered database a ``CREATE DATABASE`` command is issued
+     on the target (or the database is left as-is when it already exists,
+     unless ``--drop-if-exists`` is given).
+
+Phase 2 — per-database schema and data copy
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For each database a full ``pgcopydb clone`` pipeline is run: pre-data
+restore, COPY data workers, index workers, constraint workers, VACUUM
+workers, sequence reset, and post-data restore.  Each per-database pipeline
+uses the shared ``--table-jobs`` and ``--index-jobs`` pools.
+
+When ``--all-databases`` is active, each progress log line that produces a
+DDL or DML command is prefixed with the database name so that concurrent
+output from workers handling different databases stays distinguishable::
+
+  pagila: CREATE UNIQUE INDEX actor_pkey ON actor USING btree (actor_id)
+  f1db:   TRUNCATE ONLY "public"."constructorstandings"
+  f1db:   COPY "public"."constructorstandings"
+  chinook: VACUUM ANALYZE "public"."Track"
+
+Phase 3 — cross-database global COPY queue
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+All tables across all databases are sorted by size (largest first) and
+enqueued into a single global COPY queue shared by all ``--table-jobs``
+workers.  This ensures that the largest tables are started first regardless
+of which database they belong to, keeping all workers busy and minimising
+total elapsed time — even when the database sizes are very uneven.
+
+Each COPY worker maintains a small connection cache keyed by database name
+so that it can serve tables from multiple databases without reopening a
+connection for every table when the table order happens to alternate between
+databases.
+
+The process tree for ``pgcopydb clone --all-databases --table-jobs 4 --index-jobs 4``
+looks like the following, repeated once per database::
+
+  $ pgcopydb clone --all-databases --table-jobs 4 --index-jobs 4
+   + pgcopydb clone all-databases coordinator
+     for each database db1, db2, ...:
+       + pgcopydb copy supervisor [ --table-jobs 4, global queue ]
+         - pgcopydb copy queue worker
+         - pgcopydb global copy worker (db1)
+         - pgcopydb global copy worker (db2)
+         - pgcopydb global copy worker (db1)
+         - pgcopydb global copy worker (db2)
+
+       + pgcopydb index supervisor [ --index-jobs 4 ]
+         - pgcopydb index/constraints worker
+         - pgcopydb index/constraints worker
+         - pgcopydb index/constraints worker
+         - pgcopydb index/constraints worker
+
+       + pgcopydb vacuum supervisor [ --table-jobs 4 ]
+         - pgcopydb vacuum analyze worker
+         - pgcopydb vacuum analyze worker
+         - pgcopydb vacuum analyze worker
+         - pgcopydb vacuum analyze worker
+
+       + pgcopydb sequences reset worker
+
+Consolidated summary
+^^^^^^^^^^^^^^^^^^^^
+
+At the end of an ``--all-databases`` run, ``pgcopydb`` prints a
+consolidated summary that aggregates timing statistics across all databases:
+COPY throughput, index build time, constraint time, VACUUM time, and total
+wall-clock duration.  Individual per-database summaries are also printed
+before the consolidated one.
+

--- a/docs/include/clone.rst
+++ b/docs/include/clone.rst
@@ -43,4 +43,5 @@
      --origin                      Use this Postgres replication origin node name
      --endpos                      Stop replaying changes when reaching this LSN
      --use-copy-binary             Use the COPY BINARY format for COPY operations
+     --all-databases               Clone all databases found on the source instance
    

--- a/docs/include/compare-data.rst
+++ b/docs/include/compare-data.rst
@@ -3,8 +3,9 @@
    pgcopydb compare data: Compare source and target data
    usage: pgcopydb compare data  --source ... 
    
-     --source         Postgres URI to the source database
-     --target         Postgres URI to the target database
-     --dir            Work directory to use
-     --json           Format the output using JSON
+     --source             Postgres URI to the source database
+     --target             Postgres URI to the target database
+     --dir                Work directory to use
+     --all-databases      Compare all databases from the source instance
+     --json               Format the output using JSON
    

--- a/docs/include/compare-schema.rst
+++ b/docs/include/compare-schema.rst
@@ -3,7 +3,8 @@
    pgcopydb compare schema: Compare source and target schema
    usage: pgcopydb compare schema  --source ... 
    
-     --source         Postgres URI to the source database
-     --target         Postgres URI to the target database
-     --dir            Work directory to use
+     --source             Postgres URI to the source database
+     --target             Postgres URI to the target database
+     --dir                Work directory to use
+     --all-databases      Compare all databases from the source instance
    

--- a/docs/ref/pgcopydb_clone.rst
+++ b/docs/ref/pgcopydb_clone.rst
@@ -218,24 +218,30 @@ The source and target URIs must point to the instance level (e.g.
 database. ``pgcopydb`` derives per-database connection strings by
 substituting the database name component.
 
-The following steps are performed:
+The operation is structured in three sequential phases:
 
-  1. **Roles** are copied once at the instance level using the equivalent of
-     :ref:`pgcopydb_copy_roles`.
+  1. **Phase I — snapshot export and pre-data**: Roles are copied once at
+     the instance level. A snapshot holder subprocess exports one consistent
+     ``REPEATABLE READ`` snapshot per source database and holds those
+     transactions open. A pool of ``--table-jobs`` pre-data workers then
+     processes the databases in parallel, running schema fetch,
+     ``pg_dump --pre-data``, and ``pg_restore --pre-data`` for each.
 
-  2. **Databases** are created on the target with ``CREATE DATABASE`` for
-     each non-template database found on the source (respecting
-     ``--drop-if-exists``).
+  2. **Phase II — global COPY, indexes, and VACUUM**: All tables across all
+     databases are sorted by size (largest first) and processed by a single
+     shared pool of workers — ``--table-jobs`` COPY workers,
+     ``--index-jobs`` index/constraint workers, and ``--table-jobs`` VACUUM
+     workers. The pools are not allocated per-database; they serve the
+     entire workload globally.
 
-  3. For each database, the full clone pipeline runs: pre-data restore,
-     parallel COPY of all tables across databases (largest first), index
-     builds, constraints, VACUUM ANALYZE, sequence resets, and post-data
-     restore.
+  3. **Phase III — post-data**: Databases are finalized one at a time:
+     ``pg_restore --post-data`` applies remaining objects (triggers, rules,
+     comments, etc.) and sequences are reset to match the source.
 
-  4. A **consolidated summary** is printed at the end aggregating timings
-     across all databases.
+A **consolidated summary** is printed at the end aggregating timings
+across all databases.
 
-For details about the concurrency model and the cross-database COPY queue,
+For details about the process tree and the cross-database COPY queue,
 see :ref:`all_databases_concurrency`.
 
 .. _change_data_capture:

--- a/docs/ref/pgcopydb_clone.rst
+++ b/docs/ref/pgcopydb_clone.rst
@@ -204,6 +204,40 @@ owns the source and target databases.
    does not apply to extension members, and pg_dump does not provide a
    mechanism to exclude extensions.
 
+.. _all_databases:
+
+Cloning all databases with ``--all-databases``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When using the ``--all-databases`` option, ``pgcopydb clone`` enumerates
+all non-template user databases on the source Postgres instance and clones
+each of them to the target instance in a single invocation.
+
+The source and target URIs must point to the instance level (e.g.
+``postgres://host/postgres``) rather than to a specific application
+database. ``pgcopydb`` derives per-database connection strings by
+substituting the database name component.
+
+The following steps are performed:
+
+  1. **Roles** are copied once at the instance level using the equivalent of
+     :ref:`pgcopydb_copy_roles`.
+
+  2. **Databases** are created on the target with ``CREATE DATABASE`` for
+     each non-template database found on the source (respecting
+     ``--drop-if-exists``).
+
+  3. For each database, the full clone pipeline runs: pre-data restore,
+     parallel COPY of all tables across databases (largest first), index
+     builds, constraints, VACUUM ANALYZE, sequence resets, and post-data
+     restore.
+
+  4. A **consolidated summary** is printed at the end aggregating timings
+     across all databases.
+
+For details about the concurrency model and the cross-database COPY queue,
+see :ref:`all_databases_concurrency`.
+
 .. _change_data_capture:
 
 Change Data Capture using Postgres Logical Decoding

--- a/docs/ref/pgcopydb_compare.rst
+++ b/docs/ref/pgcopydb_compare.rst
@@ -70,6 +70,55 @@ Running such a query on a large table can take a lot of time.
 
 .. include:: ../include/compare-data.rst
 
+.. _pgcopydb_compare_all_databases:
+
+Comparing all databases with ``--all-databases``
+-------------------------------------------------
+
+When ``--all-databases`` is given, the ``--source`` URI must point to the
+Postgres instance rather than to a specific database (e.g.
+``postgres://host/postgres``). ``pgcopydb`` enumerates all non-template
+user databases via a catalog query on the source instance and then runs the
+requested comparison for each database.
+
+Both ``compare schema`` and ``compare data`` support ``--all-databases``
+and share the same concurrency model: up to ``--table-jobs`` subprocesses
+run in parallel, each handling one database at a time.  When there are more
+databases than ``--table-jobs``, the pool is kept at capacity with a
+sliding-window approach — a new worker starts as soon as a running one
+finishes.
+
+``compare schema --all-databases``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Each worker subprocess runs the full single-database schema comparison for
+its assigned database and exits.  After all workers have completed, the
+parent prints a consolidated summary table::
+
+  Database         |   Tables    |   Indexes   | Constraints |  Sequences
+                   | Src | Tgt   | Src | Tgt   | Src | Tgt   | Src | Tgt
+  -----------------+-----+-------+-----+-------+-----+-------+-----+------
+  pagila           |  25 |    25 |  49 |    49 |  25 |    25 |  16 |    16
+  f1db             |  14 |    14 |  28 |    28 |  14 |    14 |   0 |     0
+  chinook          |  11 |    11 |  22 |    22 |  11 |    11 |   4 |     4
+
+``compare data --all-databases``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Each worker subprocess computes row counts and checksums for every table in
+its assigned database and stores the results in a per-database SQLite
+catalog under the work directory.  After all workers have completed, the
+parent reads each per-database catalog in turn and prints a single unified
+checksum table.  Table names in that table use the three-part
+``datname.nspname.relname`` format so that tables from different databases
+can be distinguished::
+
+                            Table Name | ! |               Source Checksum |               Target Checksum
+  -------------------------------------+---+-------------------------------+------------------------------
+                  pagila.public.rental |   |  e7dfabf3-baa8-473a-…        |  e7dfabf3-baa8-473a-…
+              f1db.public.constructors |   |  c5058d1e-aaf4-f058-…        |  c5058d1e-aaf4-f058-…
+         chinook.public."InvoiceLine"  | ! |  a244eba3-376b-75e6-…        |  594ae64d-2216-f687-…
+
 Options
 -------
 
@@ -85,6 +134,10 @@ compare data`` subcommands:
 
   __ https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
 
+  When using ``--all-databases``, this must be an instance-level URI (the
+  database component is used only to connect for the initial catalog query;
+  per-database URIs are derived automatically).
+
 --target
 
   Connection string to the target Postgres instance.
@@ -96,6 +149,12 @@ compare data`` subcommands:
   specified by this option, or defaults to
   ``${TMPDIR}/pgcopydb`` when the environment variable is set, or
   otherwise to ``/tmp/pgcopydb``.
+
+--all-databases
+
+  Compare all non-template user databases found on the source instance
+  rather than a single database. Requires an instance-level ``--source``
+  URI. Up to ``--table-jobs`` databases are compared in parallel.
 
 --json
 

--- a/src/bin/pgcopydb/catalog.c
+++ b/src/bin/pgcopydb/catalog.c
@@ -2524,9 +2524,9 @@ catalog_add_s_table(DatabaseCatalog *catalog, SourceTable *table)
 
 	char *sql =
 		"insert into s_table("
-		"  oid, qname, nspname, relname, amname, restore_list_name, "
+		"  oid, datname, qname, nspname, relname, amname, restore_list_name, "
 		"  relpages, reltuples, exclude_data, part_key) "
-		"values($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)";
+		"values($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)";
 
 	SQLiteQuery query = { 0 };
 
@@ -2539,6 +2539,7 @@ catalog_add_s_table(DatabaseCatalog *catalog, SourceTable *table)
 	/* bind our parameters now */
 	BindParam params[] = {
 		{ BIND_PARAMETER_TYPE_INT64, "oid", table->oid, NULL },
+		{ BIND_PARAMETER_TYPE_TEXT, "datname", 0, table->datname },
 		{ BIND_PARAMETER_TYPE_TEXT, "qname", 0, table->qname },
 		{ BIND_PARAMETER_TYPE_TEXT, "nspname", 0, table->nspname },
 		{ BIND_PARAMETER_TYPE_TEXT, "relname", 0, table->relname },
@@ -3153,7 +3154,7 @@ catalog_lookup_s_table(DatabaseCatalog *catalog,
 	if (partNumber > 0)
 	{
 		char *sql =
-			"  select t.oid, qname, nspname, relname, amname, restore_list_name, "
+			"  select t.oid, t.datname, qname, nspname, relname, amname, restore_list_name, "
 			"         relpages, reltuples, ts.bytes, ts.bytes_pretty, "
 			"         exclude_data, part_key, "
 			"         p.partcount as partcount, p.partnum, p.min, p.max "
@@ -3189,7 +3190,7 @@ catalog_lookup_s_table(DatabaseCatalog *catalog,
 	else
 	{
 		char *sql =
-			"  select t.oid, qname, nspname, relname, amname, restore_list_name, "
+			"  select t.oid, t.datname, qname, nspname, relname, amname, restore_list_name, "
 			"         relpages, reltuples, ts.bytes, ts.bytes_pretty, "
 			"         exclude_data, part_key, "
 			"         count(p.oid) as partcount "
@@ -3251,7 +3252,7 @@ catalog_lookup_s_table_by_name(DatabaseCatalog *catalog,
 	}
 
 	char *sql =
-		"  select t.oid, qname, nspname, relname, amname, restore_list_name, "
+		"  select t.oid, t.datname, qname, nspname, relname, amname, restore_list_name, "
 		"         relpages, reltuples, ts.bytes, ts.bytes_pretty, "
 		"         exclude_data, part_key, "
 		"         p.partcount, 0 as partnum, 0 as min, 0 as max "
@@ -3494,7 +3495,7 @@ catalog_iter_s_table_init(SourceTableIterator *iter)
 	}
 
 	char *sql =
-		"  select t.oid, qname, nspname, relname, amname, restore_list_name, "
+		"  select t.oid, t.datname, qname, nspname, relname, amname, restore_list_name, "
 		"         relpages, reltuples, ts.bytes, ts.bytes_pretty, "
 		"         exclude_data, part_key, "
 		"         coalesce(p.partcount, 0) as partcount, "
@@ -3549,7 +3550,7 @@ catalog_iter_s_table_nopk_init(SourceTableIterator *iter)
 	}
 
 	char *sql =
-		"  select t.oid, qname, nspname, relname, amname, restore_list_name, "
+		"  select t.oid, t.datname, qname, nspname, relname, amname, restore_list_name, "
 		"         relpages, reltuples, ts.bytes, ts.bytes_pretty, "
 		"         exclude_data, part_key, "
 		"         (select count(1) from s_table_part p where p.oid = t.oid) "
@@ -3618,60 +3619,67 @@ catalog_s_table_fetch(SQLiteQuery *query)
 
 	if (sqlite3_column_type(query->ppStmt, 1) != SQLITE_NULL)
 	{
-		strlcpy(table->qname,
+		strlcpy(table->datname,
 				(char *) sqlite3_column_text(query->ppStmt, 1),
-				sizeof(table->qname));
+				sizeof(table->datname));
 	}
 
 	if (sqlite3_column_type(query->ppStmt, 2) != SQLITE_NULL)
 	{
-		strlcpy(table->nspname,
+		strlcpy(table->qname,
 				(char *) sqlite3_column_text(query->ppStmt, 2),
-				sizeof(table->nspname));
+				sizeof(table->qname));
 	}
 
 	if (sqlite3_column_type(query->ppStmt, 3) != SQLITE_NULL)
 	{
-		strlcpy(table->relname,
+		strlcpy(table->nspname,
 				(char *) sqlite3_column_text(query->ppStmt, 3),
-				sizeof(table->relname));
+				sizeof(table->nspname));
 	}
 
 	if (sqlite3_column_type(query->ppStmt, 4) != SQLITE_NULL)
 	{
-		strlcpy(table->amname,
+		strlcpy(table->relname,
 				(char *) sqlite3_column_text(query->ppStmt, 4),
-				sizeof(table->amname));
+				sizeof(table->relname));
 	}
 
 	if (sqlite3_column_type(query->ppStmt, 5) != SQLITE_NULL)
 	{
-		strlcpy(table->restoreListName,
+		strlcpy(table->amname,
 				(char *) sqlite3_column_text(query->ppStmt, 5),
+				sizeof(table->amname));
+	}
+
+	if (sqlite3_column_type(query->ppStmt, 6) != SQLITE_NULL)
+	{
+		strlcpy(table->restoreListName,
+				(char *) sqlite3_column_text(query->ppStmt, 6),
 				sizeof(table->restoreListName));
 	}
 
-	table->relpages = sqlite3_column_int64(query->ppStmt, 6);
-	table->reltuples = sqlite3_column_int64(query->ppStmt, 7);
-	table->bytes = sqlite3_column_int64(query->ppStmt, 8);
+	table->relpages = sqlite3_column_int64(query->ppStmt, 7);
+	table->reltuples = sqlite3_column_int64(query->ppStmt, 8);
+	table->bytes = sqlite3_column_int64(query->ppStmt, 9);
 
-	if (sqlite3_column_type(query->ppStmt, 9) != SQLITE_NULL)
+	if (sqlite3_column_type(query->ppStmt, 10) != SQLITE_NULL)
 	{
 		strlcpy(table->bytesPretty,
-				(char *) sqlite3_column_text(query->ppStmt, 9),
+				(char *) sqlite3_column_text(query->ppStmt, 10),
 				sizeof(table->bytesPretty));
 	}
 
-	table->excludeData = sqlite3_column_int64(query->ppStmt, 10) == 1;
+	table->excludeData = sqlite3_column_int64(query->ppStmt, 11) == 1;
 
-	if (sqlite3_column_type(query->ppStmt, 11) != SQLITE_NULL)
+	if (sqlite3_column_type(query->ppStmt, 12) != SQLITE_NULL)
 	{
 		strlcpy(table->partKey,
-				(char *) sqlite3_column_text(query->ppStmt, 11),
+				(char *) sqlite3_column_text(query->ppStmt, 12),
 				sizeof(table->partKey));
 	}
 
-	table->partition.partCount = sqlite3_column_int64(query->ppStmt, 12);
+	table->partition.partCount = sqlite3_column_int64(query->ppStmt, 13);
 
 	/*
 	 * The main iterator query returns partition count, whereas the catalog
@@ -3681,42 +3689,42 @@ catalog_s_table_fetch(SQLiteQuery *query)
 	int cols = sqlite3_column_count(query->ppStmt);
 
 	/* partition information from s_table_part */
-	if (cols >= 16)
+	if (cols >= 17)
 	{
-		table->partition.partNumber = sqlite3_column_int64(query->ppStmt, 13);
-		table->partition.min = sqlite3_column_int64(query->ppStmt, 14);
-		table->partition.max = sqlite3_column_int64(query->ppStmt, 15);
+		table->partition.partNumber = sqlite3_column_int64(query->ppStmt, 14);
+		table->partition.min = sqlite3_column_int64(query->ppStmt, 15);
+		table->partition.max = sqlite3_column_int64(query->ppStmt, 16);
 	}
 
 	/* checksum information from s_table_chksum */
-	if (cols >= 20)
+	if (cols >= 21)
 	{
 		table->sourceChecksum.rowcount =
-			sqlite3_column_int64(query->ppStmt, 16);
+			sqlite3_column_int64(query->ppStmt, 17);
 
-		if (sqlite3_column_type(query->ppStmt, 17) != SQLITE_NULL)
+		if (sqlite3_column_type(query->ppStmt, 18) != SQLITE_NULL)
 		{
 			strlcpy(table->sourceChecksum.checksum,
-					(char *) sqlite3_column_text(query->ppStmt, 17),
+					(char *) sqlite3_column_text(query->ppStmt, 18),
 					sizeof(table->sourceChecksum.checksum));
 		}
 
 		table->targetChecksum.rowcount =
-			sqlite3_column_int64(query->ppStmt, 18);
+			sqlite3_column_int64(query->ppStmt, 19);
 
-		if (sqlite3_column_type(query->ppStmt, 19) != SQLITE_NULL)
+		if (sqlite3_column_type(query->ppStmt, 20) != SQLITE_NULL)
 		{
 			strlcpy(table->targetChecksum.checksum,
-					(char *) sqlite3_column_text(query->ppStmt, 19),
+					(char *) sqlite3_column_text(query->ppStmt, 20),
 					sizeof(table->targetChecksum.checksum));
 		}
 	}
 
 	/* summary information from s_table_parts_done */
-	if (cols == 22)
+	if (cols == 23)
 	{
-		table->durationMs = sqlite3_column_int64(query->ppStmt, 20);
-		table->bytesTransmitted = sqlite3_column_int64(query->ppStmt, 21);
+		table->durationMs = sqlite3_column_int64(query->ppStmt, 21);
+		table->bytesTransmitted = sqlite3_column_int64(query->ppStmt, 22);
 	}
 
 	return true;
@@ -5052,8 +5060,8 @@ catalog_add_s_seq(DatabaseCatalog *catalog, SourceSequence *seq)
 	char *sql =
 		"insert into s_seq("
 		"  oid, ownedby, attrelid, attroid, "
-		"  qname, nspname, relname, restore_list_name)"
-		"values($1, $2, $3, $4, $5, $6, $7, $8)";
+		"  datname, qname, nspname, relname, restore_list_name)"
+		"values($1, $2, $3, $4, $5, $6, $7, $8, $9)";
 
 	SQLiteQuery query = { 0 };
 
@@ -5070,6 +5078,7 @@ catalog_add_s_seq(DatabaseCatalog *catalog, SourceSequence *seq)
 		{ BIND_PARAMETER_TYPE_INT64, "attrelid", seq->attrelid, NULL },
 		{ BIND_PARAMETER_TYPE_INT64, "attroid", seq->attroid, NULL },
 
+		{ BIND_PARAMETER_TYPE_TEXT, "datname", 0, seq->datname },
 		{ BIND_PARAMETER_TYPE_TEXT, "qname", 0, seq->qname },
 		{ BIND_PARAMETER_TYPE_TEXT, "nspname", 0, seq->nspname },
 		{ BIND_PARAMETER_TYPE_TEXT, "relname", 0, seq->relname },
@@ -5225,7 +5234,7 @@ catalog_lookup_s_seq_by_name(DatabaseCatalog *catalog,
 
 	char *sql =
 		"  select oid, ownedby, attrelid, attroid, "
-		"         qname, nspname, relname, restore_list_name, "
+		"         datname, qname, nspname, relname, restore_list_name, "
 		"         last_value, isCalled "
 		"    from s_seq "
 		"   where nspname = $1 and relname = $2 ";
@@ -5345,7 +5354,7 @@ catalog_iter_s_seq_init(SourceSeqIterator *iter)
 
 	char *sql =
 		"  select oid, ownedby, attrelid, attroid, "
-		"         qname, nspname, relname, restore_list_name, "
+		"         datname, qname, nspname, relname, restore_list_name, "
 		"         last_value, isCalled "
 		"    from s_seq "
 		"order by nspname, relname";
@@ -5410,24 +5419,31 @@ catalog_s_seq_fetch(SQLiteQuery *query)
 	seq->attrelid = sqlite3_column_int64(query->ppStmt, 2);
 	seq->attroid = sqlite3_column_int64(query->ppStmt, 3);
 
+	if (sqlite3_column_type(query->ppStmt, 4) != SQLITE_NULL)
+	{
+		strlcpy(seq->datname,
+				(char *) sqlite3_column_text(query->ppStmt, 4),
+				sizeof(seq->datname));
+	}
+
 	strlcpy(seq->qname,
-			(char *) sqlite3_column_text(query->ppStmt, 4),
+			(char *) sqlite3_column_text(query->ppStmt, 5),
 			sizeof(seq->qname));
 
 	strlcpy(seq->nspname,
-			(char *) sqlite3_column_text(query->ppStmt, 5),
+			(char *) sqlite3_column_text(query->ppStmt, 6),
 			sizeof(seq->nspname));
 
 	strlcpy(seq->relname,
-			(char *) sqlite3_column_text(query->ppStmt, 6),
+			(char *) sqlite3_column_text(query->ppStmt, 7),
 			sizeof(seq->relname));
 
 	strlcpy(seq->restoreListName,
-			(char *) sqlite3_column_text(query->ppStmt, 7),
+			(char *) sqlite3_column_text(query->ppStmt, 8),
 			sizeof(seq->restoreListName));
 
-	seq->lastValue = sqlite3_column_int64(query->ppStmt, 8);
-	seq->isCalled = sqlite3_column_int(query->ppStmt, 9);
+	seq->lastValue = sqlite3_column_int64(query->ppStmt, 9);
+	seq->isCalled = sqlite3_column_int(query->ppStmt, 10);
 
 	return true;
 }
@@ -8015,7 +8031,7 @@ catalog_iter_s_table_in_copy_init(SourceTableIterator *iter)
 	}
 
 	char *sql =
-		"  select t.oid, qname, nspname, relname, amname, restore_list_name, "
+		"  select t.oid, t.datname, qname, nspname, relname, amname, restore_list_name, "
 		"         relpages, reltuples, ts.bytes, ts.bytes_pretty, "
 		"         exclude_data, part_key, "
 		"         part.partcount, s.partnum, part.min, part.max "
@@ -8991,7 +9007,7 @@ catalog_iter_s_table_generated_columns_init(SourceTableIterator *iter)
 	}
 
 	char *sql =
-		"  select t.oid, qname, nspname, relname, amname, restore_list_name, "
+		"  select t.oid, t.datname, qname, nspname, relname, amname, restore_list_name, "
 		"         relpages, reltuples, ts.bytes, ts.bytes_pretty, "
 		"         exclude_data, part_key, "
 		"         (select count(1) from s_table_part p where p.oid = t.oid) "

--- a/src/bin/pgcopydb/catalog.c
+++ b/src/bin/pgcopydb/catalog.c
@@ -948,6 +948,55 @@ catalog_open(DatabaseCatalog *catalog)
 
 
 /*
+ * catalog_open_readonly opens an existing catalog file in read-only mode
+ * without creating or acquiring any semaphore.  Use this for catalogs that
+ * are only ever read (never written) — SQLite WAL provides snapshot-
+ * consistent reads with no contention between any number of readers.
+ */
+bool
+catalog_open_readonly(DatabaseCatalog *catalog)
+{
+	if (catalog->db != NULL)
+	{
+		log_debug("Skipping opening read-only SQLite database \"%s\": "
+				  "already opened", catalog->dbfile);
+		return true;
+	}
+
+	if (!file_exists(catalog->dbfile))
+	{
+		log_error("Failed to open catalog \"%s\", file does not exist",
+				  catalog->dbfile);
+		return false;
+	}
+
+	log_debug("Opening read-only SQLite database \"%s\"", catalog->dbfile);
+
+	int rc = sqlite3_open_v2(catalog->dbfile,
+							 &(catalog->db),
+							 SQLITE_OPEN_READONLY,
+							 NULL);
+
+	if (rc != SQLITE_OK)
+	{
+		const char *errmsg = sqlite3_errmsg(catalog->db);
+
+		log_error("Failed to open \"%s\" read-only: %s",
+				  catalog->dbfile, errmsg);
+
+		if (catalog->db != NULL)
+		{
+			sqlite3_close(catalog->db);
+		}
+		catalog->db = NULL;
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
  * source_catalog_init initializes our internal catalog database file.
  */
 bool

--- a/src/bin/pgcopydb/catalog.c
+++ b/src/bin/pgcopydb/catalog.c
@@ -60,7 +60,8 @@ static char *sourceDBcreateDDLs[] = {
 	")",
 
 	"create table s_database("
-	"  oid integer primary key, datname text, bytes integer, bytes_pretty text"
+	"  oid integer primary key, datname text, bytes integer, bytes_pretty text,"
+	"  snapshot text"
 	")",
 
 	"create table s_database_property("
@@ -704,6 +705,7 @@ catalog_register_setup_from_specs(CopyDataSpec *copySpecs)
 	/*
 	 * Now see if the catalog already have been setup.
 	 */
+
 	if (!catalog_setup(sourceDB))
 	{
 		/* errors have already been logged */
@@ -1486,6 +1488,19 @@ catalog_setup(DatabaseCatalog *catalog)
 		log_error("BUG: catalog_setup: db is NULL");
 		return false;
 	}
+
+	/*
+	 * Reset the setup struct before querying so that stale values inherited
+	 * from a parent CopyDataSpec (via struct copy) do not persist when the
+	 * catalog is fresh and the setup table has no rows.
+	 */
+	catalog->setup.id = 0;
+	catalog->setup.source_pguri = NULL;
+	catalog->setup.target_pguri = NULL;
+	catalog->setup.snapshot[0] = '\0';
+	catalog->setup.filters = NULL;
+	catalog->setup.splitTablesLargerThanBytes = 0;
+	catalog->setup.splitMaxParts = 0;
 
 	SQLiteQuery query = {
 		.context = &(catalog->setup),
@@ -6034,7 +6049,7 @@ catalog_iter_s_database_init(SourceDatabaseIterator *iter)
 	}
 
 	char *sql =
-		"  select oid, datname, bytes, bytes_pretty"
+		"  select oid, datname, bytes, bytes_pretty, coalesce(snapshot, '')"
 		"    from s_database "
 		"order by datname";
 
@@ -6105,6 +6120,62 @@ catalog_s_database_fetch(SQLiteQuery *query)
 	strlcpy(dat->bytesPretty,
 			(char *) sqlite3_column_text(query->ppStmt, 3),
 			sizeof(dat->bytesPretty));
+
+	strlcpy(dat->snapshot,
+			(char *) sqlite3_column_text(query->ppStmt, 4),
+			sizeof(dat->snapshot));
+
+	return true;
+}
+
+
+/*
+ * catalog_update_s_database_snapshot stores the exported snapshot identifier
+ * for a given database in the instance catalog.  Called by the snapshot holder
+ * subprocess after it has exported a per-database REPEATABLE READ snapshot.
+ */
+bool
+catalog_update_s_database_snapshot(DatabaseCatalog *catalog,
+									const char *datname,
+									const char *snapshot)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_update_s_database_snapshot: db is NULL");
+		return false;
+	}
+
+	char *sql =
+		"update s_database set snapshot = $1 where datname = $2";
+
+	SQLiteQuery query = { 0 };
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_TEXT, "snapshot", 0, (char *) snapshot },
+		{ BIND_PARAMETER_TYPE_TEXT, "datname", 0, (char *) datname }
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(&query, params, count))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
 
 	return true;
 }

--- a/src/bin/pgcopydb/catalog.c
+++ b/src/bin/pgcopydb/catalog.c
@@ -6185,8 +6185,8 @@ catalog_s_database_fetch(SQLiteQuery *query)
  */
 bool
 catalog_update_s_database_snapshot(DatabaseCatalog *catalog,
-									const char *datname,
-									const char *snapshot)
+								   const char *datname,
+								   const char *snapshot)
 {
 	sqlite3 *db = catalog->db;
 

--- a/src/bin/pgcopydb/catalog.h
+++ b/src/bin/pgcopydb/catalog.h
@@ -446,8 +446,8 @@ bool catalog_iter_s_database_finish(SourceDatabaseIterator *iter);
 bool catalog_s_database_fetch(SQLiteQuery *query);
 
 bool catalog_update_s_database_snapshot(DatabaseCatalog *catalog,
-										 const char *datname,
-										 const char *snapshot);
+										const char *datname,
+										const char *snapshot);
 
 typedef bool (SourcePropertyIterFun)(void *context, SourceProperty *property);
 

--- a/src/bin/pgcopydb/catalog.h
+++ b/src/bin/pgcopydb/catalog.h
@@ -444,6 +444,10 @@ bool catalog_iter_s_database_finish(SourceDatabaseIterator *iter);
 
 bool catalog_s_database_fetch(SQLiteQuery *query);
 
+bool catalog_update_s_database_snapshot(DatabaseCatalog *catalog,
+										 const char *datname,
+										 const char *snapshot);
+
 typedef bool (SourcePropertyIterFun)(void *context, SourceProperty *property);
 
 bool catalog_iter_s_database_guc(DatabaseCatalog *catalog,

--- a/src/bin/pgcopydb/catalog.h
+++ b/src/bin/pgcopydb/catalog.h
@@ -33,6 +33,7 @@ struct SQLiteQuery
  * Catalog API.
  */
 bool catalog_open(DatabaseCatalog *catalog);
+bool catalog_open_readonly(DatabaseCatalog *catalog);
 bool catalog_init(DatabaseCatalog *catalog);
 bool catalog_create_semaphore(DatabaseCatalog *catalog);
 bool catalog_attach(DatabaseCatalog *a, DatabaseCatalog *b, const char *name);

--- a/src/bin/pgcopydb/cli_clone_follow.c
+++ b/src/bin/pgcopydb/cli_clone_follow.c
@@ -167,7 +167,9 @@ alldb_timing_agg_hook(void *ctx, TopLevelTiming *timing)
 		if (useMax)
 		{
 			if (timing->durationMs > entry->durationMs)
+			{
 				entry->durationMs = timing->durationMs;
+			}
 		}
 		else
 		{
@@ -213,12 +215,16 @@ cli_clone_all_databases_consolidated_summary(CopyDataSpec *copySpecs)
 	for (;;)
 	{
 		if (!catalog_iter_s_database_next(&iter1))
+		{
 			break;
+		}
 
 		SourceDatabase *db = iter1.dat;
 
 		if (db == NULL)
+		{
 			break;
+		}
 
 		dbCount++;
 
@@ -229,12 +235,16 @@ cli_clone_all_databases_consolidated_summary(CopyDataSpec *copySpecs)
 				copySpecs->cfPaths.topdir, db->datname);
 
 		if (!catalog_init(&dbCat))
+		{
 			continue;
+		}
 
 		CatalogCounts count = { 0 };
 
 		if (catalog_count_objects(&dbCat, &count))
+		{
 			totalTables += (int) count.tables;
+		}
 
 		(void) catalog_close(&dbCat);
 	}
@@ -278,12 +288,16 @@ cli_clone_all_databases_consolidated_summary(CopyDataSpec *copySpecs)
 	for (;;)
 	{
 		if (!catalog_iter_s_database_next(&iter2))
+		{
 			break;
+		}
 
 		SourceDatabase *db = iter2.dat;
 
 		if (db == NULL)
+		{
 			break;
+		}
 
 		CopyDataSpec dbSpecs = *copySpecs;
 
@@ -383,7 +397,9 @@ cli_clone_all_databases_consolidated_summary(CopyDataSpec *copySpecs)
 		TopLevelTiming *entry = &(topLevelTimingArray[i]);
 
 		if (entry->section == TIMING_SECTION_UNKNOWN)
+		{
 			continue;
+		}
 
 		(void) IntervalToString(entry->durationMs,
 								entry->ppDuration,
@@ -428,7 +444,9 @@ cli_clone_all_databases_consolidated_summary(CopyDataSpec *copySpecs)
 		TopLevelTiming *timing = &(topLevelTimingArray[i]);
 
 		if (timing->section == TIMING_SECTION_UNKNOWN)
+		{
 			continue;
+		}
 
 		if (i + 1 == topLevelTimingArrayCount)
 		{

--- a/src/bin/pgcopydb/cli_clone_follow.c
+++ b/src/bin/pgcopydb/cli_clone_follow.c
@@ -360,6 +360,21 @@ cli_clone_all_databases_consolidated_summary(CopyDataSpec *copySpecs)
 		}
 	}
 
+	/*
+	 * Overlay total wall-clock from the instance catalog (written by
+	 * cli_clone around clone_all_databases).
+	 */
+	{
+		TopLevelTiming t = { .section = TIMING_SECTION_TOTAL };
+
+		if (summary_lookup_timing(instanceCatalog, &t, TIMING_SECTION_TOTAL))
+		{
+			TopLevelTiming *entry = &(topLevelTimingArray[TIMING_SECTION_TOTAL]);
+
+			entry->durationMs = t.durationMs;
+		}
+	}
+
 	(void) catalog_close(instanceCatalog);
 
 	/* Re-pretty-print aggregated timing strings */
@@ -468,11 +483,34 @@ cli_clone(int argc, char **argv)
 	 */
 	if (copySpecs.allDatabases)
 	{
+		/*
+		 * Start the total wall-clock timer before Phase I begins.  We open
+		 * the instance catalog briefly to persist the start timestamp, then
+		 * close it — clone_all_databases will reopen it as needed.
+		 */
+		if (!catalog_init_from_specs(&copySpecs))
+		{
+			log_error("Failed to open instance catalog for TOTAL timing");
+			exit(EXIT_CODE_INTERNAL_ERROR);
+		}
+		(void) summary_start_timing(&copySpecs.catalogs.source,
+									TIMING_SECTION_TOTAL);
+		(void) catalog_close_from_specs(&copySpecs);
+
 		if (!clone_all_databases(&copySpecs))
 		{
 			/* errors have already been logged */
 			exit(EXIT_CODE_INTERNAL_ERROR);
 		}
+
+		/* Record total wall-clock stop time in the instance catalog. */
+		if (catalog_init_from_specs(&copySpecs))
+		{
+			(void) summary_stop_timing(&copySpecs.catalogs.source,
+									   TIMING_SECTION_TOTAL);
+			(void) catalog_close_from_specs(&copySpecs);
+		}
+
 		cli_clone_all_databases_consolidated_summary(&copySpecs);
 		exit(EXIT_CODE_QUIT);
 	}

--- a/src/bin/pgcopydb/cli_clone_follow.c
+++ b/src/bin/pgcopydb/cli_clone_follow.c
@@ -18,6 +18,7 @@
 #include "env_utils.h"
 #include "ld_stream.h"
 #include "log.h"
+#include "multi_db.h"
 #include "parsing_utils.h"
 #include "pgsql.h"
 #include "progress.h"
@@ -66,6 +67,7 @@
 	"  --origin                      Use this Postgres replication origin node name\n" \
 	"  --endpos                      Stop replaying changes when reaching this LSN\n" \
 	"  --use-copy-binary             Use the COPY BINARY format for COPY operations\n" \
+	"  --all-databases               Clone all databases found on the source instance\n" \
 
 CommandLine clone_command =
 	make_command(
@@ -119,8 +121,6 @@ static bool start_follow_process(CopyDataSpec *copySpecs,
 
 static bool cli_clone_follow_wait_subprocess(const char *name, pid_t pid);
 
-static bool cloneDB(CopyDataSpec *copySpecs);
-
 
 /*
  * cli_clone implements the command: pgcopydb clone
@@ -132,8 +132,22 @@ cli_clone(int argc, char **argv)
 
 	(void) cli_copy_prepare_specs(&copySpecs, DATA_SECTION_ALL);
 
-	/* at the moment this is not covered by cli_copy_prepare_specs() */
+	/* at the moment these are not covered by cli_copy_prepare_specs() */
 	copySpecs.follow = copyDBoptions.follow;
+	copySpecs.allDatabases = copyDBoptions.allDatabases;
+
+	/*
+	 * When --all-databases is used, delegate to the multi-database orchestrator.
+	 */
+	if (copySpecs.allDatabases)
+	{
+		if (!clone_all_databases(&copySpecs))
+		{
+			/* errors have already been logged */
+			exit(EXIT_CODE_INTERNAL_ERROR);
+		}
+		exit(EXIT_CODE_QUIT);
+	}
 
 	/*
 	 * When pgcopydb clone --follow is used, we call the clone_and_follow()
@@ -520,7 +534,7 @@ start_clone_process(CopyDataSpec *copySpecs, pid_t *pid)
 
 			log_notice("Starting the clone sub-process");
 
-			if (!cloneDB(copySpecs))
+			if (!copydb_clone_database(copySpecs))
 			{
 				log_error("Failed to clone source database, "
 						  "see above for details");
@@ -543,10 +557,10 @@ start_clone_process(CopyDataSpec *copySpecs, pid_t *pid)
 
 
 /*
- * cloneDB clones a source database into a target database.
+ * copydb_clone_database clones a source database into a target database.
  */
-static bool
-cloneDB(CopyDataSpec *copySpecs)
+bool
+copydb_clone_database(CopyDataSpec *copySpecs)
 {
 	/*
 	 * The top-level process implements the preparation steps and exports a

--- a/src/bin/pgcopydb/cli_clone_follow.c
+++ b/src/bin/pgcopydb/cli_clone_follow.c
@@ -16,6 +16,7 @@
 #include "copydb.h"
 #include "commandline.h"
 #include "env_utils.h"
+#include "file_utils.h"
 #include "ld_stream.h"
 #include "log.h"
 #include "multi_db.h"
@@ -123,6 +124,78 @@ static bool cli_clone_follow_wait_subprocess(const char *name, pid_t pid);
 
 
 /*
+ * cli_clone_all_databases_print_summaries prints a per-database table summary
+ * after a successful --all-databases clone.  It reopens the instance-level
+ * catalog (to get the database list) and then the per-database catalog for
+ * each database, calling print_summary on each.
+ */
+static void
+cli_clone_all_databases_print_summaries(CopyDataSpec *copySpecs)
+{
+	DatabaseCatalog *instanceCatalog = &copySpecs->catalogs.source;
+
+	if (!catalog_init(instanceCatalog))
+	{
+		log_warn("Could not open instance catalog for summary");
+		return;
+	}
+
+	SourceDatabaseIterator iter = {
+		.catalog = instanceCatalog,
+		.dat = NULL
+	};
+
+	if (!catalog_iter_s_database_init(&iter))
+	{
+		(void) catalog_close(instanceCatalog);
+		return;
+	}
+
+	for (;;)
+	{
+		if (!catalog_iter_s_database_next(&iter))
+			break;
+
+		SourceDatabase *db = iter.dat;
+
+		if (db == NULL)
+			break;
+
+		CopyDataSpec dbSpecs = *copySpecs;
+
+		/* point the source catalog at the per-db schema/source.db */
+		sformat(dbSpecs.catalogs.source.dbfile,
+				sizeof(dbSpecs.catalogs.source.dbfile),
+				"%s/db/%s/schema/source.db",
+				copySpecs->cfPaths.topdir, db->datname);
+		dbSpecs.catalogs.source.db = NULL;
+
+		/* per-db summary.json goes in the per-db directory */
+		sformat(dbSpecs.cfPaths.summaryfile,
+				sizeof(dbSpecs.cfPaths.summaryfile),
+				"%s/db/%s/summary.json",
+				copySpecs->cfPaths.topdir, db->datname);
+
+		if (!catalog_init(&dbSpecs.catalogs.source))
+		{
+			log_warn("Could not open catalog for database \"%s\"", db->datname);
+			continue;
+		}
+
+		fformat(stdout, "\n");
+		log_info("Summary for database \"%s\"", db->datname);
+
+		(void) print_summary(&dbSpecs);
+
+		(void) catalog_close(&dbSpecs.catalogs.source);
+	}
+
+	(void) catalog_iter_s_database_finish(&iter);
+	(void) catalog_close(instanceCatalog);
+}
+
+
+/*
  * cli_clone implements the command: pgcopydb clone
  */
 void
@@ -146,6 +219,7 @@ cli_clone(int argc, char **argv)
 			/* errors have already been logged */
 			exit(EXIT_CODE_INTERNAL_ERROR);
 		}
+		cli_clone_all_databases_print_summaries(&copySpecs);
 		exit(EXIT_CODE_QUIT);
 	}
 

--- a/src/bin/pgcopydb/cli_clone_follow.c
+++ b/src/bin/pgcopydb/cli_clone_follow.c
@@ -340,6 +340,26 @@ cli_clone_all_databases_consolidated_summary(CopyDataSpec *copySpecs)
 	}
 
 	(void) catalog_iter_s_database_finish(&iter2);
+
+	/*
+	 * Overlay Phase II (TOTAL_DATA) wall-clock from the instance catalog.
+	 * This timing is written by clone_all_databases to the instance catalog
+	 * and is absent from per-db catalogs, so alldb_timing_agg_hook leaves it
+	 * at zero.
+	 */
+	{
+		TopLevelTiming t = { .section = TIMING_SECTION_TOTAL_DATA };
+
+		if (summary_lookup_timing(instanceCatalog, &t, TIMING_SECTION_TOTAL_DATA))
+		{
+			TopLevelTiming *entry = &(topLevelTimingArray[TIMING_SECTION_TOTAL_DATA]);
+
+			entry->durationMs = t.durationMs;
+			entry->count = t.count;
+			entry->bytes = t.bytes;
+		}
+	}
+
 	(void) catalog_close(instanceCatalog);
 
 	/* Re-pretty-print aggregated timing strings */

--- a/src/bin/pgcopydb/cli_clone_follow.c
+++ b/src/bin/pgcopydb/cli_clone_follow.c
@@ -124,13 +124,71 @@ static bool cli_clone_follow_wait_subprocess(const char *name, pid_t pid);
 
 
 /*
- * cli_clone_all_databases_print_summaries prints a per-database table summary
- * after a successful --all-databases clone.  It reopens the instance-level
- * catalog (to get the database list) and then the per-database catalog for
- * each database, calling print_summary on each.
+ * alldb_timing_agg_hook aggregates per-database timing rows into the global
+ * topLevelTimingArray.  For phases that run in parallel (Phase I + TOTAL_DATA)
+ * we take the MAX of durations; for everything else we SUM.  Counts and bytes
+ * are always summed.  Pass a pointer to a bool set to true for the first
+ * database; it is set to false after the first call.
+ */
+static bool
+alldb_timing_agg_hook(void *ctx, TopLevelTiming *timing)
+{
+	bool *first = (bool *) ctx;
+
+	if (timing->section == TIMING_SECTION_UNKNOWN ||
+		timing->section >= topLevelTimingArrayCount)
+	{
+		return true;
+	}
+
+	TopLevelTiming *entry = &(topLevelTimingArray[timing->section]);
+
+	/* parallel phases: MAX duration; sequential/cumulative: SUM */
+	bool useMax = (timing->section == TIMING_SECTION_CATALOG_QUERIES ||
+				   timing->section == TIMING_SECTION_DUMP_SCHEMA ||
+				   timing->section == TIMING_SECTION_PREPARE_SCHEMA ||
+				   timing->section == TIMING_SECTION_TOTAL_DATA ||
+				   timing->section == TIMING_SECTION_TOTAL);
+
+	if (*first)
+	{
+		entry->section = timing->section;
+		entry->durationMs = timing->durationMs;
+		entry->count = timing->count;
+		entry->bytes = timing->bytes;
+		entry->startTime = timing->startTime;
+		entry->doneTime = timing->doneTime;
+	}
+	else
+	{
+		entry->count += timing->count;
+		entry->bytes += timing->bytes;
+
+		if (useMax)
+		{
+			if (timing->durationMs > entry->durationMs)
+				entry->durationMs = timing->durationMs;
+		}
+		else
+		{
+			entry->durationMs += timing->durationMs;
+		}
+	}
+
+	return true;
+}
+
+
+/*
+ * cli_clone_all_databases_consolidated_summary prints a single unified summary
+ * for all databases after a successful --all-databases clone.
+ *
+ * Per-table section: one combined table with a leading "Database" column.
+ * Steps section: timings aggregated across all databases (MAX for parallel
+ * phases, SUM for sequential/cumulative ones).
  */
 static void
-cli_clone_all_databases_print_summaries(CopyDataSpec *copySpecs)
+cli_clone_all_databases_consolidated_summary(CopyDataSpec *copySpecs)
 {
 	DatabaseCatalog *instanceCatalog = &copySpecs->catalogs.source;
 
@@ -140,12 +198,13 @@ cli_clone_all_databases_print_summaries(CopyDataSpec *copySpecs)
 		return;
 	}
 
-	SourceDatabaseIterator iter = {
-		.catalog = instanceCatalog,
-		.dat = NULL
-	};
+	/* First pass: count total tables and number of databases */
+	int totalTables = 0;
+	int dbCount = 0;
 
-	if (!catalog_iter_s_database_init(&iter))
+	SourceDatabaseIterator iter1 = { .catalog = instanceCatalog };
+
+	if (!catalog_iter_s_database_init(&iter1))
 	{
 		(void) catalog_close(instanceCatalog);
 		return;
@@ -153,24 +212,88 @@ cli_clone_all_databases_print_summaries(CopyDataSpec *copySpecs)
 
 	for (;;)
 	{
-		if (!catalog_iter_s_database_next(&iter))
+		if (!catalog_iter_s_database_next(&iter1))
 			break;
 
-		SourceDatabase *db = iter.dat;
+		SourceDatabase *db = iter1.dat;
+
+		if (db == NULL)
+			break;
+
+		dbCount++;
+
+		DatabaseCatalog dbCat = { .type = DATABASE_CATALOG_TYPE_SOURCE };
+
+		sformat(dbCat.dbfile, sizeof(dbCat.dbfile),
+				"%s/db/%s/schema/source.db",
+				copySpecs->cfPaths.topdir, db->datname);
+
+		if (!catalog_init(&dbCat))
+			continue;
+
+		CatalogCounts count = { 0 };
+
+		if (catalog_count_objects(&dbCat, &count))
+			totalTables += (int) count.tables;
+
+		(void) catalog_close(&dbCat);
+	}
+
+	(void) catalog_iter_s_database_finish(&iter1);
+
+	if (totalTables == 0 || dbCount == 0)
+	{
+		(void) catalog_close(instanceCatalog);
+		return;
+	}
+
+	/* Allocate the combined summary table */
+	SummaryTable combinedTable = { .count = totalTables };
+
+	combinedTable.array =
+		(SummaryTableEntry *) calloc(totalTables, sizeof(SummaryTableEntry));
+
+	if (combinedTable.array == NULL)
+	{
+		log_error(ALLOCATION_FAILED_ERROR);
+		(void) catalog_close(instanceCatalog);
+		return;
+	}
+
+	/* Reset timing globals so we aggregate from scratch */
+	summary_reset_toplevel_timings();
+
+	bool firstDb = true;
+	int tableOffset = 0;
+
+	SourceDatabaseIterator iter2 = { .catalog = instanceCatalog };
+
+	if (!catalog_iter_s_database_init(&iter2))
+	{
+		free(combinedTable.array);
+		(void) catalog_close(instanceCatalog);
+		return;
+	}
+
+	for (;;)
+	{
+		if (!catalog_iter_s_database_next(&iter2))
+			break;
+
+		SourceDatabase *db = iter2.dat;
 
 		if (db == NULL)
 			break;
 
 		CopyDataSpec dbSpecs = *copySpecs;
 
-		/* point the source catalog at the per-db schema/source.db */
+		dbSpecs.catalogs.source.db = NULL;
+
 		sformat(dbSpecs.catalogs.source.dbfile,
 				sizeof(dbSpecs.catalogs.source.dbfile),
 				"%s/db/%s/schema/source.db",
 				copySpecs->cfPaths.topdir, db->datname);
-		dbSpecs.catalogs.source.db = NULL;
 
-		/* per-db summary.json goes in the per-db directory */
 		sformat(dbSpecs.cfPaths.summaryfile,
 				sizeof(dbSpecs.cfPaths.summaryfile),
 				"%s/db/%s/summary.json",
@@ -182,16 +305,127 @@ cli_clone_all_databases_print_summaries(CopyDataSpec *copySpecs)
 			continue;
 		}
 
-		fformat(stdout, "\n");
-		log_info("Summary for database \"%s\"", db->datname);
+		Summary dbSummary = {
+			.tableJobs = copySpecs->tableJobs,
+			.indexJobs = copySpecs->indexJobs,
+			.vacuumJobs = copySpecs->vacuumJobs,
+			.lObjectJobs = copySpecs->lObjectJobs,
+			.restoreJobs = copySpecs->restoreOptions.jobs
+		};
 
-		(void) print_summary(&dbSpecs);
+		if (prepare_summary_table(&dbSummary, &dbSpecs))
+		{
+			for (int i = 0;
+				 i < dbSummary.table.count && tableOffset + i < totalTables;
+				 i++)
+			{
+				SummaryTableEntry *dst =
+					&(combinedTable.array[tableOffset + i]);
+
+				*dst = dbSummary.table.array[i];
+				strlcpy(dst->datname, db->datname, sizeof(dst->datname));
+			}
+
+			tableOffset += dbSummary.table.count;
+			combinedTable.totalBytes += dbSummary.table.totalBytes;
+		}
+
+		/* Aggregate timing data into topLevelTimingArray */
+		(void) summary_iter_timing(&dbSpecs.catalogs.source,
+								   &firstDb,
+								   &alldb_timing_agg_hook);
+		firstDb = false;
 
 		(void) catalog_close(&dbSpecs.catalogs.source);
 	}
 
-	(void) catalog_iter_s_database_finish(&iter);
+	(void) catalog_iter_s_database_finish(&iter2);
 	(void) catalog_close(instanceCatalog);
+
+	/* Re-pretty-print aggregated timing strings */
+	for (int i = 0; i < topLevelTimingArrayCount; i++)
+	{
+		TopLevelTiming *entry = &(topLevelTimingArray[i]);
+
+		if (entry->section == TIMING_SECTION_UNKNOWN)
+			continue;
+
+		(void) IntervalToString(entry->durationMs,
+								entry->ppDuration,
+								sizeof(entry->ppDuration));
+
+		(void) pretty_print_bytes(entry->ppBytes,
+								  sizeof(entry->ppBytes),
+								  entry->bytes);
+	}
+
+	/* Print the combined per-table section */
+	(void) pretty_print_bytes(combinedTable.totalBytesStr,
+							  sizeof(combinedTable.totalBytesStr),
+							  combinedTable.totalBytes);
+	(void) prepare_summary_table_headers(&combinedTable);
+	(void) print_summary_table(&combinedTable);
+
+	/* Print aggregated step durations with correct Phase I concurrency */
+	int phaseOneConcurrency =
+		(dbCount < copySpecs->tableJobs) ? dbCount : copySpecs->tableJobs;
+
+	char *d10s = "----------";
+	char *d12s = "------------";
+	char *d50s = "--------------------------------------------------";
+
+	Summary summary = {
+		.tableJobs = copySpecs->tableJobs,
+		.indexJobs = copySpecs->indexJobs,
+		.vacuumJobs = copySpecs->vacuumJobs,
+		.lObjectJobs = copySpecs->lObjectJobs,
+		.restoreJobs = copySpecs->restoreOptions.jobs
+	};
+
+	fformat(stdout, "\n");
+	fformat(stdout, " %50s   %10s  %10s  %10s  %12s\n",
+			"Step", "Connection", "Duration", "Transfer", "Concurrency");
+	fformat(stdout, " %50s   %10s  %10s  %10s  %12s\n",
+			d50s, d10s, d10s, d10s, d12s);
+
+	for (int i = 0; i < topLevelTimingArrayCount; i++)
+	{
+		TopLevelTiming *timing = &(topLevelTimingArray[i]);
+
+		if (timing->section == TIMING_SECTION_UNKNOWN)
+			continue;
+
+		if (i + 1 == topLevelTimingArrayCount)
+		{
+			fformat(stdout, " %50s   %10s  %10s  %10s  %12s\n",
+					d50s, d10s, d10s, d10s, d12s);
+		}
+
+		/* Phase I runs min(tableJobs, dbCount) parallel DB workers */
+		int concurrency;
+
+		if (timing->section == TIMING_SECTION_CATALOG_QUERIES ||
+			timing->section == TIMING_SECTION_DUMP_SCHEMA ||
+			timing->section == TIMING_SECTION_PREPARE_SCHEMA)
+		{
+			concurrency = phaseOneConcurrency;
+		}
+		else
+		{
+			concurrency = TopLevelTimingConcurrency(&summary, timing);
+		}
+
+		fformat(stdout, " %50s   %10s  %10s  %10s  %12d\n",
+				timing->label,
+				timing->conn,
+				timing->ppDuration,
+				timing->bytes > 0 ? timing->ppBytes : "",
+				concurrency);
+	}
+
+	fformat(stdout, "\n");
+
+	free(combinedTable.array);
 }
 
 
@@ -219,7 +453,7 @@ cli_clone(int argc, char **argv)
 			/* errors have already been logged */
 			exit(EXIT_CODE_INTERNAL_ERROR);
 		}
-		cli_clone_all_databases_print_summaries(&copySpecs);
+		cli_clone_all_databases_consolidated_summary(&copySpecs);
 		exit(EXIT_CODE_QUIT);
 	}
 

--- a/src/bin/pgcopydb/cli_common.c
+++ b/src/bin/pgcopydb/cli_common.c
@@ -743,6 +743,7 @@ cli_copy_db_getopts(int argc, char **argv)
 		{ "create-slot", no_argument, NULL, 't' },
 		{ "endpos", required_argument, NULL, 'E' },
 		{ "publication", required_argument, NULL, 1003 },
+		{ "all-databases", no_argument, NULL, 1004 },
 		{ "host", required_argument, NULL, 1001 },
 		{ "port", required_argument, NULL, 1002 },
 		{ "version", no_argument, NULL, 'V' },
@@ -1120,6 +1121,13 @@ cli_copy_db_getopts(int argc, char **argv)
 						sizeof(options.slot.publicationName));
 				options.slot.publicationAutoManaged = false;
 				log_trace("--publication %s", options.slot.publicationName);
+				break;
+			}
+
+			case 1004:      /* --all-databases */
+			{
+				options.allDatabases = true;
+				log_trace("--all-databases");
 				break;
 			}
 

--- a/src/bin/pgcopydb/cli_common.h
+++ b/src/bin/pgcopydb/cli_common.h
@@ -109,6 +109,8 @@ typedef struct CopyDBOptions
 	 */
 	char host[256];
 	int port;
+
+	bool allDatabases;
 } CopyDBOptions;
 
 extern bool outputJSON;

--- a/src/bin/pgcopydb/cli_compare.c
+++ b/src/bin/pgcopydb/cli_compare.c
@@ -10,6 +10,7 @@
 
 #include "catalog.h"
 #include "cli_common.h"
+#include "file_utils.h"
 #include "cli_root.h"
 #include "commandline.h"
 #include "copydb.h"
@@ -34,9 +35,10 @@ static CommandLine compare_schema_command =
 		"schema",
 		"Compare source and target schema",
 		" --source ... ",
-		"  --source         Postgres URI to the source database\n"
-		"  --target         Postgres URI to the target database\n"
-		"  --dir            Work directory to use\n",
+		"  --source             Postgres URI to the source database\n"
+		"  --target             Postgres URI to the target database\n"
+		"  --dir                Work directory to use\n"
+		"  --all-databases      Compare all databases from the source instance\n",
 		cli_compare_getopts,
 		cli_compare_schema);
 
@@ -45,10 +47,11 @@ static CommandLine compare_data_command =
 		"data",
 		"Compare source and target data",
 		" --source ... ",
-		"  --source         Postgres URI to the source database\n"
-		"  --target         Postgres URI to the target database\n"
-		"  --dir            Work directory to use\n"
-		"  --json           Format the output using JSON\n",
+		"  --source             Postgres URI to the source database\n"
+		"  --target             Postgres URI to the target database\n"
+		"  --dir                Work directory to use\n"
+		"  --all-databases      Compare all databases from the source instance\n"
+		"  --json               Format the output using JSON\n",
 		cli_compare_getopts,
 		cli_compare_data);
 
@@ -79,6 +82,7 @@ cli_compare_getopts(int argc, char **argv)
 		{ "dir", required_argument, NULL, 'D' },
 		{ "jobs", required_argument, NULL, 'j' },
 		{ "table-jobs", required_argument, NULL, 'j' },
+		{ "all-databases", no_argument, NULL, 'a' },
 		{ "json", no_argument, NULL, 'J' },
 		{ "version", no_argument, NULL, 'V' },
 		{ "verbose", no_argument, NULL, 'v' },
@@ -103,7 +107,7 @@ cli_compare_getopts(int argc, char **argv)
 	SplitTableLargerThan empty = { 0 };
 	options.splitTablesLargerThan = empty;
 
-	while ((c = getopt_long(argc, argv, "S:T:D:j:JVvdzqh",
+	while ((c = getopt_long(argc, argv, "S:T:D:j:aJVvdzqh",
 							long_options, &option_index)) != -1)
 	{
 		switch (c)
@@ -151,6 +155,13 @@ cli_compare_getopts(int argc, char **argv)
 					++errors;
 				}
 				log_trace("--table-jobs %d", options.tableJobs);
+				break;
+			}
+
+			case 'a':
+			{
+				options.allDatabases = true;
+				log_trace("--all-databases");
 				break;
 			}
 
@@ -306,10 +317,22 @@ cli_compare_schema(int argc, char **argv)
 		exit(EXIT_CODE_INTERNAL_ERROR);
 	}
 
-	if (!compare_schemas(&copySpecs))
+	if (compareOptions.allDatabases)
 	{
-		log_fatal("Comparing the schemas failed, see above for details");
-		exit(EXIT_CODE_INTERNAL_ERROR);
+		if (!compare_all_databases_schema(&copySpecs))
+		{
+			log_fatal("Comparing all database schemas failed, "
+					  "see above for details");
+			exit(EXIT_CODE_INTERNAL_ERROR);
+		}
+	}
+	else
+	{
+		if (!compare_schemas(&copySpecs))
+		{
+			log_fatal("Comparing the schemas failed, see above for details");
+			exit(EXIT_CODE_INTERNAL_ERROR);
+		}
 	}
 }
 
@@ -353,6 +376,18 @@ cli_compare_data(int argc, char **argv)
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+
+	if (compareOptions.allDatabases)
+	{
+		if (!compare_all_databases_data(&copySpecs))
+		{
+			log_fatal("Failed to compute checksums for all databases, "
+					  "see above for details");
+			exit(EXIT_CODE_INTERNAL_ERROR);
+		}
+
+		return;
 	}
 
 	if (!compare_data(&copySpecs))
@@ -458,8 +493,25 @@ cli_compare_data_table_hook(void *ctx, SourceTable *table)
 		TableChecksum *srcChk = &(table->sourceChecksum);
 		TableChecksum *dstChk = &(table->targetChecksum);
 
+		/*
+		 * In --all-databases mode, table->datname is populated and we emit a
+		 * three-part qualified name (datname.nspname.relname) so the user can
+		 * tell which database each row belongs to.
+		 */
+		char tableName[BUFSIZE] = { 0 };
+
+		if (!IS_EMPTY_STRING_BUFFER(table->datname))
+		{
+			sformat(tableName, sizeof(tableName),
+					"%s.%s", table->datname, table->qname);
+		}
+		else
+		{
+			strlcpy(tableName, table->qname, sizeof(tableName));
+		}
+
 		fformat(stdout, "%30s | %s | %36s | %36s \n",
-				table->qname,
+				tableName,
 				streq(srcChk->checksum, dstChk->checksum) ? " " : "!",
 				srcChk->checksum,
 				dstChk->checksum);

--- a/src/bin/pgcopydb/compare.c
+++ b/src/bin/pgcopydb/compare.c
@@ -1036,10 +1036,223 @@ compare_fetch_schemas(CopyDataSpec *copySpecs,
 
 
 /*
- * compare_all_databases_schema iterates all user databases on the source
- * instance and runs compare_schemas for each one.
+ * compare_wait_any_child waits for any child process to exit and returns
+ * true iff it exited with EXIT_CODE_QUIT (success).
+ */
+static bool
+compare_wait_any_child(void)
+{
+	int status = 0;
+	pid_t pid = waitpid(-1, &status, 0);
+
+	if (pid < 0)
+	{
+		log_error("waitpid: %m");
+		return false;
+	}
+
+	if (!WIFEXITED(status))
+	{
+		log_error("Compare worker %d terminated by signal %d",
+				  pid, WTERMSIG(status));
+		return false;
+	}
+
+	return WEXITSTATUS(status) == EXIT_CODE_QUIT;
+}
+
+
+/*
+ * compare_one_database_schema sets up per-database specs and runs
+ * compare_schemas for a single named database.  Returns false on error;
+ * compare_schemas itself may call exit() on schema differences.
+ */
+static bool
+compare_one_database_schema(CopyDataSpec *parentSpecs, const char *datname)
+{
+	char *srcuri = NULL;
+	char *tgturi = NULL;
+
+	if (!multidb_build_uri_for_database(parentSpecs->connStrings.source_pguri,
+										 datname, &srcuri) ||
+		!multidb_build_uri_for_database(parentSpecs->connStrings.target_pguri,
+										 datname, &tgturi))
+	{
+		log_error("Failed to build URIs for database \"%s\"", datname);
+		free(srcuri);
+		free(tgturi);
+		return false;
+	}
+
+	char dbdir[MAXPGPATH] = { 0 };
+
+	sformat(dbdir, sizeof(dbdir), "%s/db/%s",
+			parentSpecs->cfPaths.topdir, datname);
+
+	CopyDataSpec dbSpecs = *parentSpecs;
+
+	dbSpecs.catalogs.source.db = NULL;
+	dbSpecs.catalogs.filter.db = NULL;
+	dbSpecs.catalogs.target.db = NULL;
+	dbSpecs.catalogs.replay.db = NULL;
+
+	dbSpecs.connStrings.source_pguri = srcuri;
+	dbSpecs.connStrings.target_pguri = tgturi;
+
+	if (!parse_and_scrub_connection_string(srcuri,
+										   &dbSpecs.connStrings.safeSourcePGURI))
+	{
+		log_error("Failed to scrub source URI for database \"%s\"", datname);
+		free(srcuri);
+		free(tgturi);
+		return false;
+	}
+
+	if (!parse_and_scrub_connection_string(tgturi,
+										   &dbSpecs.connStrings.safeTargetPGURI))
+	{
+		log_error("Failed to scrub target URI for database \"%s\"", datname);
+		free(srcuri);
+		free(tgturi);
+		if (dbSpecs.connStrings.safeSourcePGURI.pguri)
+			free(dbSpecs.connStrings.safeSourcePGURI.pguri);
+		return false;
+	}
+
+	if (!copydb_init_workdir(&dbSpecs, dbdir, false, NULL,
+							 parentSpecs->restart, parentSpecs->resume, true))
+	{
+		log_error("Failed to init work dir for database \"%s\"", datname);
+		free(srcuri);
+		free(tgturi);
+		if (dbSpecs.connStrings.safeSourcePGURI.pguri)
+			free(dbSpecs.connStrings.safeSourcePGURI.pguri);
+		if (dbSpecs.connStrings.safeTargetPGURI.pguri)
+			free(dbSpecs.connStrings.safeTargetPGURI.pguri);
+		return false;
+	}
+
+	bool ok = compare_schemas(&dbSpecs);
+
+	free(srcuri);
+	free(tgturi);
+	if (dbSpecs.connStrings.safeSourcePGURI.pguri)
+		free(dbSpecs.connStrings.safeSourcePGURI.pguri);
+	if (dbSpecs.connStrings.safeTargetPGURI.pguri)
+		free(dbSpecs.connStrings.safeTargetPGURI.pguri);
+
+	return ok;
+}
+
+
+/*
+ * compare_alldb_schema_summary prints a table showing per-database object
+ * counts after all schema comparisons have completed.
  *
- * parentSpecs must have instance-level source/target URIs.
+ * Format:
+ *   Database         |   Tables    |   Indexes   | Constraints |  Sequences
+ *                    | Src | Tgt   | Src | Tgt   | Src | Tgt   | Src | Tgt
+ *   -----------------+-----+-------+-----+-------+-----+-------+-----+------
+ *   chinook          |  11 |    11 |  22 |    22 |  11 |    11 |   4 |     4
+ */
+static void
+compare_alldb_schema_summary(CopyDataSpec *parentSpecs,
+							 const char (*datnames)[PG_NAMEDATALEN],
+							 int dbCount)
+{
+	/* Collect per-database counts */
+	typedef struct
+	{
+		char datname[PG_NAMEDATALEN];
+		CatalogCounts src;
+		CatalogCounts tgt;
+	} DbCounts;
+
+	DbCounts *counts = (DbCounts *) calloc(dbCount, sizeof(DbCounts));
+
+	if (counts == NULL)
+	{
+		log_error(ALLOCATION_FAILED_ERROR);
+		return;
+	}
+
+	int maxNameLen = 8; /* "Database" */
+
+	for (int i = 0; i < dbCount; i++)
+	{
+		strlcpy(counts[i].datname, datnames[i], PG_NAMEDATALEN);
+
+		int nameLen = strlen(datnames[i]);
+
+		if (nameLen > maxNameLen)
+			maxNameLen = nameLen;
+
+		/* source catalog: <topdir>/db/<datname>/schema/source/source.db */
+		DatabaseCatalog srcCat = { .type = DATABASE_CATALOG_TYPE_SOURCE };
+
+		sformat(srcCat.dbfile, sizeof(srcCat.dbfile),
+				"%s/db/%s/schema/source/source.db",
+				parentSpecs->cfPaths.topdir, datnames[i]);
+
+		if (catalog_init(&srcCat))
+		{
+			(void) catalog_count_objects(&srcCat, &counts[i].src);
+			(void) catalog_close(&srcCat);
+		}
+
+		/* target catalog: <topdir>/db/<datname>/schema/target/source.db */
+		DatabaseCatalog tgtCat = { .type = DATABASE_CATALOG_TYPE_SOURCE };
+
+		sformat(tgtCat.dbfile, sizeof(tgtCat.dbfile),
+				"%s/db/%s/schema/target/source.db",
+				parentSpecs->cfPaths.topdir, datnames[i]);
+
+		if (catalog_init(&tgtCat))
+		{
+			(void) catalog_count_objects(&tgtCat, &counts[i].tgt);
+			(void) catalog_close(&tgtCat);
+		}
+	}
+
+	/* Build separator string for database name column */
+	char dbSep[NAMEDATALEN] = { 0 };
+
+	for (int j = 0; j < maxNameLen && j < (int) sizeof(dbSep) - 1; j++)
+		dbSep[j] = '-';
+
+	fformat(stdout, "\n");
+	fformat(stdout, "%-*s |   Tables    |   Indexes   | Constraints |  Sequences\n",
+			maxNameLen, "Database");
+	fformat(stdout, "%-*s | Src | Tgt   | Src | Tgt   | Src | Tgt   | Src | Tgt\n",
+			maxNameLen, "");
+	fformat(stdout, "%s-+-----+-------+-----+-------+-----+-------+-----+------\n",
+			dbSep);
+
+	for (int i = 0; i < dbCount; i++)
+	{
+		fformat(stdout, "%-*s | %3lld | %5lld | %3lld | %5lld | %3lld | %5lld | %3lld | %5lld\n",
+				maxNameLen, counts[i].datname,
+				(long long) counts[i].src.tables,
+				(long long) counts[i].tgt.tables,
+				(long long) counts[i].src.indexes,
+				(long long) counts[i].tgt.indexes,
+				(long long) counts[i].src.constraints,
+				(long long) counts[i].tgt.constraints,
+				(long long) counts[i].src.sequences,
+				(long long) counts[i].tgt.sequences);
+	}
+
+	fformat(stdout, "\n");
+
+	free(counts);
+}
+
+
+/*
+ * compare_all_databases_schema iterates all user databases on the source
+ * instance and runs compare_schemas for each one in parallel (up to
+ * tableJobs concurrent workers).  After all workers finish, it prints a
+ * per-database object-count summary table.
  */
 bool
 compare_all_databases_schema(CopyDataSpec *parentSpecs)
@@ -1072,163 +1285,158 @@ compare_all_databases_schema(CopyDataSpec *parentSpecs)
 
 	pgsql_finish(&src);
 
-	bool ok = true;
+	/* Collect all datnames before forking (SQLite iterators are not fork-safe) */
+	int dbCount = 0;
+	char (*datnames)[PG_NAMEDATALEN] = NULL;
 
-	SourceDatabaseIterator dbIter = {
-		.catalog = instanceCatalog,
-		.dat = NULL
-	};
-
-	if (!catalog_iter_s_database_init(&dbIter))
 	{
+		SourceDatabaseIterator dbIter = {
+			.catalog = instanceCatalog,
+			.dat = NULL
+		};
+
+		if (!catalog_iter_s_database_init(&dbIter))
+		{
+			(void) catalog_close_from_specs(parentSpecs);
+			return false;
+		}
+
+		for (;;)
+		{
+			if (!catalog_iter_s_database_next(&dbIter))
+				break;
+
+			SourceDatabase *db = dbIter.dat;
+
+			if (db == NULL)
+				break;
+
+			dbCount++;
+		}
+
+		(void) catalog_iter_s_database_finish(&dbIter);
+	}
+
+	if (dbCount == 0)
+	{
+		(void) catalog_close_from_specs(parentSpecs);
+		return true;
+	}
+
+	datnames = (char (*)[PG_NAMEDATALEN]) calloc(dbCount, PG_NAMEDATALEN);
+
+	if (datnames == NULL)
+	{
+		log_error(ALLOCATION_FAILED_ERROR);
 		(void) catalog_close_from_specs(parentSpecs);
 		return false;
 	}
 
-	for (;;)
 	{
-		if (!catalog_iter_s_database_next(&dbIter))
+		SourceDatabaseIterator dbIter = {
+			.catalog = instanceCatalog,
+			.dat = NULL
+		};
+		int idx = 0;
+
+		if (!catalog_iter_s_database_init(&dbIter))
 		{
-			ok = false;
-			break;
+			free(datnames);
+			(void) catalog_close_from_specs(parentSpecs);
+			return false;
 		}
 
-		SourceDatabase *db = dbIter.dat;
+		for (;;)
+		{
+			if (!catalog_iter_s_database_next(&dbIter))
+				break;
 
-		if (db == NULL)
-			break;
+			SourceDatabase *db = dbIter.dat;
 
+			if (db == NULL)
+				break;
+
+			if (idx < dbCount)
+				strlcpy(datnames[idx++], db->datname, PG_NAMEDATALEN);
+		}
+
+		(void) catalog_iter_s_database_finish(&dbIter);
+	}
+
+	(void) catalog_close_from_specs(parentSpecs);
+
+	/* Fork up to tableJobs parallel compare workers */
+	int maxWorkers = (parentSpecs->tableJobs < dbCount)
+		? parentSpecs->tableJobs : dbCount;
+
+	int activeCount = 0;
+	bool ok = true;
+
+	log_info("Comparing schema for %d databases with up to %d parallel workers",
+			 dbCount, maxWorkers);
+
+	for (int i = 0; i < dbCount; i++)
+	{
 		if (asked_to_stop || asked_to_stop_fast || asked_to_quit)
 		{
 			ok = false;
 			break;
 		}
 
-		log_info("Comparing schema for database \"%s\"", db->datname);
-
-		/* build per-database URIs */
-		char *srcuri = NULL;
-		char *tgturi = NULL;
-
-		if (!multidb_build_uri_for_database(parentSpecs->connStrings.source_pguri,
-											 db->datname, &srcuri) ||
-			!multidb_build_uri_for_database(parentSpecs->connStrings.target_pguri,
-											 db->datname, &tgturi))
+		/* Wait for a slot if at capacity */
+		if (activeCount >= maxWorkers)
 		{
-			log_error("Failed to build URIs for database \"%s\"", db->datname);
-			free(srcuri);
-			free(tgturi);
+			if (!compare_wait_any_child())
+				ok = false;
+
+			activeCount--;
+		}
+
+		log_info("Comparing schema for database \"%s\"", datnames[i]);
+
+		fflush(stdout);
+		fflush(stderr);
+
+		pid_t pid = fork();
+
+		if (pid < 0)
+		{
+			log_error("Failed to fork schema-compare worker: %m");
 			ok = false;
-			if (parentSpecs->failFast)
-				break;
-			continue;
-		}
-
-		/* create per-db work directory */
-		char dbdir[MAXPGPATH] = { 0 };
-
-		sformat(dbdir, sizeof(dbdir), "%s/db/%s",
-				parentSpecs->cfPaths.topdir, db->datname);
-
-		CopyDataSpec dbSpecs = *parentSpecs;
-
-		/*
-		 * The parent catalog is currently open (db handle != NULL).
-		 * Null out all inherited SQLite handles so that catalog_init
-		 * inside compare_schemas opens fresh connections to the per-db
-		 * catalog files rather than reusing the instance-level handle
-		 * (which would cause a setup URI mismatch).
-		 */
-		dbSpecs.catalogs.source.db = NULL;
-		dbSpecs.catalogs.filter.db = NULL;
-		dbSpecs.catalogs.target.db = NULL;
-		dbSpecs.catalogs.replay.db = NULL;
-
-		dbSpecs.connStrings.source_pguri = srcuri;
-		dbSpecs.connStrings.target_pguri = tgturi;
-
-		if (!parse_and_scrub_connection_string(srcuri,
-											   &dbSpecs.connStrings.safeSourcePGURI))
-		{
-			log_error("Failed to scrub source URI for database \"%s\"",
-					  db->datname);
-			free(srcuri);
-			free(tgturi);
-			ok = false;
-			if (parentSpecs->failFast)
-				break;
-			continue;
-		}
-
-		if (!parse_and_scrub_connection_string(tgturi,
-											   &dbSpecs.connStrings.safeTargetPGURI))
-		{
-			log_error("Failed to scrub target URI for database \"%s\"",
-					  db->datname);
-			free(srcuri);
-			free(tgturi);
-			if (dbSpecs.connStrings.safeSourcePGURI.pguri)
-				free(dbSpecs.connStrings.safeSourcePGURI.pguri);
-			ok = false;
-			if (parentSpecs->failFast)
-				break;
-			continue;
-		}
-
-		if (!copydb_init_workdir(&dbSpecs, dbdir,
-								 false,  /* service */
-								 NULL,   /* serviceName */
-								 parentSpecs->restart,
-								 parentSpecs->resume,
-								 true))  /* createWorkDir */
-		{
-			log_error("Failed to init work dir for database \"%s\"",
-					  db->datname);
-			free(srcuri);
-			free(tgturi);
-			if (dbSpecs.connStrings.safeSourcePGURI.pguri)
-				free(dbSpecs.connStrings.safeSourcePGURI.pguri);
-			if (dbSpecs.connStrings.safeTargetPGURI.pguri)
-				free(dbSpecs.connStrings.safeTargetPGURI.pguri);
-			ok = false;
-			if (parentSpecs->failFast)
-				break;
-			continue;
-		}
-
-		if (!compare_schemas(&dbSpecs))
-		{
-			log_error("Schema comparison failed for database \"%s\"",
-					  db->datname);
-			ok = false;
-		}
-		else
-		{
-			log_info("Schema comparison succeeded for database \"%s\"",
-					 db->datname);
-		}
-
-		free(srcuri);
-		free(tgturi);
-		if (dbSpecs.connStrings.safeSourcePGURI.pguri)
-			free(dbSpecs.connStrings.safeSourcePGURI.pguri);
-		if (dbSpecs.connStrings.safeTargetPGURI.pguri)
-			free(dbSpecs.connStrings.safeTargetPGURI.pguri);
-
-		if (!ok && parentSpecs->failFast)
 			break;
+		}
+		else if (pid == 0)
+		{
+			bool res = compare_one_database_schema(parentSpecs, datnames[i]);
+			exit(res ? EXIT_CODE_QUIT : EXIT_CODE_INTERNAL_ERROR);
+		}
+
+		activeCount++;
 	}
 
-	(void) catalog_iter_s_database_finish(&dbIter);
-	(void) catalog_close_from_specs(parentSpecs);
+	/* Wait for remaining workers */
+	while (activeCount > 0)
+	{
+		if (!compare_wait_any_child())
+			ok = false;
+
+		activeCount--;
+	}
+
+	/* Print per-database object count summary */
+	if (ok || !parentSpecs->failFast)
+		compare_alldb_schema_summary(parentSpecs, datnames, dbCount);
+
+	free(datnames);
 
 	return ok;
 }
 
 
 /*
- * compare_alldb_chksum_hook prints one table's checksum row in the
- * --all-databases data comparison text summary.
+ * compare_alldb_chksum_hook prints one table's checksum row in the unified
+ * --all-databases data comparison summary.  The datname is prepended to qname
+ * to produce a fully-qualified "datname.nspname.relname" identifier.
  */
 static bool
 compare_alldb_chksum_hook(void *ctx, SourceTable *table)
@@ -1236,8 +1444,15 @@ compare_alldb_chksum_hook(void *ctx, SourceTable *table)
 	TableChecksum *srcChk = &(table->sourceChecksum);
 	TableChecksum *dstChk = &(table->targetChecksum);
 
-	fformat(stdout, "%30s | %s | %36s | %36s \n",
-			table->qname,
+	char fqname[2 * PG_NAMEDATALEN + 64] = { 0 };
+
+	if (table->datname[0] != '\0')
+		sformat(fqname, sizeof(fqname), "%s.%s", table->datname, table->qname);
+	else
+		strlcpy(fqname, table->qname, sizeof(fqname));
+
+	fformat(stdout, "%50s | %s | %36s | %36s \n",
+			fqname,
 			streq(srcChk->checksum, dstChk->checksum) ? " " : "!",
 			srcChk->checksum,
 			dstChk->checksum);
@@ -1247,10 +1462,101 @@ compare_alldb_chksum_hook(void *ctx, SourceTable *table)
 
 
 /*
+ * compare_one_database_data sets up per-database specs and runs compare_data
+ * for a single named database.  Returns false on error.
+ */
+static bool
+compare_one_database_data(CopyDataSpec *parentSpecs, const char *datname)
+{
+	char *srcuri = NULL;
+	char *tgturi = NULL;
+
+	if (!multidb_build_uri_for_database(parentSpecs->connStrings.source_pguri,
+										 datname, &srcuri) ||
+		!multidb_build_uri_for_database(parentSpecs->connStrings.target_pguri,
+										 datname, &tgturi))
+	{
+		log_error("Failed to build URIs for database \"%s\"", datname);
+		free(srcuri);
+		free(tgturi);
+		return false;
+	}
+
+	char dbdir[MAXPGPATH] = { 0 };
+
+	sformat(dbdir, sizeof(dbdir), "%s/db/%s",
+			parentSpecs->cfPaths.topdir, datname);
+
+	CopyDataSpec dbSpecs = *parentSpecs;
+
+	dbSpecs.catalogs.source.db = NULL;
+	dbSpecs.catalogs.filter.db = NULL;
+	dbSpecs.catalogs.target.db = NULL;
+	dbSpecs.catalogs.replay.db = NULL;
+
+	dbSpecs.connStrings.source_pguri = srcuri;
+	dbSpecs.connStrings.target_pguri = tgturi;
+	strlcpy(dbSpecs.datname, datname, sizeof(dbSpecs.datname));
+
+	if (!parse_and_scrub_connection_string(srcuri,
+										   &dbSpecs.connStrings.safeSourcePGURI))
+	{
+		log_error("Failed to scrub source URI for database \"%s\"", datname);
+		free(srcuri);
+		free(tgturi);
+		return false;
+	}
+
+	if (!parse_and_scrub_connection_string(tgturi,
+										   &dbSpecs.connStrings.safeTargetPGURI))
+	{
+		log_error("Failed to scrub target URI for database \"%s\"", datname);
+		free(srcuri);
+		free(tgturi);
+		if (dbSpecs.connStrings.safeSourcePGURI.pguri)
+			free(dbSpecs.connStrings.safeSourcePGURI.pguri);
+		return false;
+	}
+
+	if (!copydb_init_workdir(&dbSpecs, dbdir, false, NULL,
+							 parentSpecs->restart, parentSpecs->resume, true))
+	{
+		log_error("Failed to init work dir for database \"%s\"", datname);
+		free(srcuri);
+		free(tgturi);
+		if (dbSpecs.connStrings.safeSourcePGURI.pguri)
+			free(dbSpecs.connStrings.safeSourcePGURI.pguri);
+		if (dbSpecs.connStrings.safeTargetPGURI.pguri)
+			free(dbSpecs.connStrings.safeTargetPGURI.pguri);
+		return false;
+	}
+
+	strlcpy(dbSpecs.catalogs.source.dbfile, dbSpecs.cfPaths.sdbfile,
+			sizeof(dbSpecs.catalogs.source.dbfile));
+	strlcpy(dbSpecs.catalogs.filter.dbfile, dbSpecs.cfPaths.fdbfile,
+			sizeof(dbSpecs.catalogs.filter.dbfile));
+	strlcpy(dbSpecs.catalogs.target.dbfile, dbSpecs.cfPaths.tdbfile,
+			sizeof(dbSpecs.catalogs.target.dbfile));
+
+	bool ok = compare_data(&dbSpecs);
+
+	free(srcuri);
+	free(tgturi);
+	if (dbSpecs.connStrings.safeSourcePGURI.pguri)
+		free(dbSpecs.connStrings.safeSourcePGURI.pguri);
+	if (dbSpecs.connStrings.safeTargetPGURI.pguri)
+		free(dbSpecs.connStrings.safeTargetPGURI.pguri);
+
+	return ok;
+}
+
+
+/*
  * compare_all_databases_data iterates all user databases on the source
- * instance, computes checksums for all tables, and prints a summary.
+ * instance, computes checksums for all tables in parallel (up to tableJobs
+ * concurrent workers), and prints a single unified summary table.
  *
- * Table names in the text output are formatted as datname.nspname.relname.
+ * Table names in the text output use "datname.nspname.relname" format.
  */
 bool
 compare_all_databases_data(CopyDataSpec *parentSpecs)
@@ -1283,180 +1589,173 @@ compare_all_databases_data(CopyDataSpec *parentSpecs)
 
 	pgsql_finish(&src);
 
-	bool ok = true;
+	/* Collect datnames before forking */
+	int dbCount = 0;
+	char (*datnames)[PG_NAMEDATALEN] = NULL;
 
-	SourceDatabaseIterator dbIter = {
-		.catalog = instanceCatalog,
-		.dat = NULL
-	};
-
-	if (!catalog_iter_s_database_init(&dbIter))
 	{
+		SourceDatabaseIterator dbIter = {
+			.catalog = instanceCatalog,
+			.dat = NULL
+		};
+
+		if (!catalog_iter_s_database_init(&dbIter))
+		{
+			(void) catalog_close_from_specs(parentSpecs);
+			return false;
+		}
+
+		for (;;)
+		{
+			if (!catalog_iter_s_database_next(&dbIter))
+				break;
+
+			if (dbIter.dat == NULL)
+				break;
+
+			dbCount++;
+		}
+
+		(void) catalog_iter_s_database_finish(&dbIter);
+	}
+
+	if (dbCount == 0)
+	{
+		(void) catalog_close_from_specs(parentSpecs);
+		return true;
+	}
+
+	datnames = (char (*)[PG_NAMEDATALEN]) calloc(dbCount, PG_NAMEDATALEN);
+
+	if (datnames == NULL)
+	{
+		log_error(ALLOCATION_FAILED_ERROR);
 		(void) catalog_close_from_specs(parentSpecs);
 		return false;
 	}
 
-	for (;;)
 	{
-		if (!catalog_iter_s_database_next(&dbIter))
+		SourceDatabaseIterator dbIter = {
+			.catalog = instanceCatalog,
+			.dat = NULL
+		};
+		int idx = 0;
+
+		if (!catalog_iter_s_database_init(&dbIter))
 		{
-			ok = false;
-			break;
+			free(datnames);
+			(void) catalog_close_from_specs(parentSpecs);
+			return false;
 		}
 
-		SourceDatabase *db = dbIter.dat;
+		for (;;)
+		{
+			if (!catalog_iter_s_database_next(&dbIter))
+				break;
 
-		if (db == NULL)
-			break;
+			SourceDatabase *db = dbIter.dat;
 
+			if (db == NULL)
+				break;
+
+			if (idx < dbCount)
+				strlcpy(datnames[idx++], db->datname, PG_NAMEDATALEN);
+		}
+
+		(void) catalog_iter_s_database_finish(&dbIter);
+	}
+
+	(void) catalog_close_from_specs(parentSpecs);
+
+	/* Fork up to tableJobs parallel workers */
+	int maxWorkers = (parentSpecs->tableJobs < dbCount)
+		? parentSpecs->tableJobs : dbCount;
+
+	int activeCount = 0;
+	bool ok = true;
+
+	log_info("Comparing data for %d databases with up to %d parallel workers",
+			 dbCount, maxWorkers);
+
+	for (int i = 0; i < dbCount; i++)
+	{
 		if (asked_to_stop || asked_to_stop_fast || asked_to_quit)
 		{
 			ok = false;
 			break;
 		}
 
-		log_info("Comparing data for database \"%s\"", db->datname);
-
-		char *srcuri = NULL;
-		char *tgturi = NULL;
-
-		if (!multidb_build_uri_for_database(parentSpecs->connStrings.source_pguri,
-											 db->datname, &srcuri) ||
-			!multidb_build_uri_for_database(parentSpecs->connStrings.target_pguri,
-											 db->datname, &tgturi))
+		/* Wait for a slot if at capacity */
+		if (activeCount >= maxWorkers)
 		{
-			log_error("Failed to build URIs for database \"%s\"", db->datname);
-			free(srcuri);
-			free(tgturi);
+			if (!compare_wait_any_child())
+				ok = false;
+
+			activeCount--;
+		}
+
+		log_info("Comparing data for database \"%s\"", datnames[i]);
+
+		fflush(stdout);
+		fflush(stderr);
+
+		pid_t pid = fork();
+
+		if (pid < 0)
+		{
+			log_error("Failed to fork data-compare worker: %m");
 			ok = false;
-			if (parentSpecs->failFast)
-				break;
-			continue;
-		}
-
-		char dbdir[MAXPGPATH] = { 0 };
-
-		sformat(dbdir, sizeof(dbdir), "%s/db/%s",
-				parentSpecs->cfPaths.topdir, db->datname);
-
-		CopyDataSpec dbSpecs = *parentSpecs;
-
-		/*
-		 * Null out inherited SQLite handles so that catalog_init inside
-		 * compare_data opens fresh connections to per-db catalog files.
-		 */
-		dbSpecs.catalogs.source.db = NULL;
-		dbSpecs.catalogs.filter.db = NULL;
-		dbSpecs.catalogs.target.db = NULL;
-		dbSpecs.catalogs.replay.db = NULL;
-
-		dbSpecs.connStrings.source_pguri = srcuri;
-		dbSpecs.connStrings.target_pguri = tgturi;
-		strlcpy(dbSpecs.datname, db->datname, sizeof(dbSpecs.datname));
-
-		if (!parse_and_scrub_connection_string(srcuri,
-											   &dbSpecs.connStrings.safeSourcePGURI))
-		{
-			log_error("Failed to scrub source URI for database \"%s\"",
-					  db->datname);
-			free(srcuri);
-			free(tgturi);
-			ok = false;
-			if (parentSpecs->failFast)
-				break;
-			continue;
-		}
-
-		if (!parse_and_scrub_connection_string(tgturi,
-											   &dbSpecs.connStrings.safeTargetPGURI))
-		{
-			log_error("Failed to scrub target URI for database \"%s\"",
-					  db->datname);
-			free(srcuri);
-			free(tgturi);
-			if (dbSpecs.connStrings.safeSourcePGURI.pguri)
-				free(dbSpecs.connStrings.safeSourcePGURI.pguri);
-			ok = false;
-			if (parentSpecs->failFast)
-				break;
-			continue;
-		}
-
-		if (!copydb_init_workdir(&dbSpecs, dbdir,
-								 false, NULL,
-								 parentSpecs->restart,
-								 parentSpecs->resume,
-								 true))
-		{
-			log_error("Failed to init work dir for database \"%s\"",
-					  db->datname);
-			free(srcuri);
-			free(tgturi);
-			if (dbSpecs.connStrings.safeSourcePGURI.pguri)
-				free(dbSpecs.connStrings.safeSourcePGURI.pguri);
-			if (dbSpecs.connStrings.safeTargetPGURI.pguri)
-				free(dbSpecs.connStrings.safeTargetPGURI.pguri);
-			ok = false;
-			if (parentSpecs->failFast)
-				break;
-			continue;
-		}
-
-		/*
-		 * copydb_init_workdir updates cfPaths.{s,f,t}dbfile but not the
-		 * catalogs.*.dbfile fields. Sync them so that compare_data uses the
-		 * per-database catalog rather than the inherited instance-level path.
-		 */
-		strlcpy(dbSpecs.catalogs.source.dbfile, dbSpecs.cfPaths.sdbfile,
-				sizeof(dbSpecs.catalogs.source.dbfile));
-		strlcpy(dbSpecs.catalogs.filter.dbfile, dbSpecs.cfPaths.fdbfile,
-				sizeof(dbSpecs.catalogs.filter.dbfile));
-		strlcpy(dbSpecs.catalogs.target.dbfile, dbSpecs.cfPaths.tdbfile,
-				sizeof(dbSpecs.catalogs.target.dbfile));
-
-		if (!compare_data(&dbSpecs))
-		{
-			log_error("Data comparison failed for database \"%s\"",
-					  db->datname);
-			ok = false;
-		}
-		else
-		{
-			/*
-			 * Print the per-database checksum table.  compare_data closes
-			 * the catalog before returning, so we reopen it here.
-			 */
-			DatabaseCatalog *sourceDB = &dbSpecs.catalogs.source;
-
-			if (catalog_init(sourceDB))
-			{
-				fformat(stdout, "\n%s\n", db->datname);
-				fformat(stdout, "%30s | %s | %36s | %36s \n",
-						"Table Name", "!", "Source Checksum", "Target Checksum");
-				fformat(stdout, "%30s-+-%s-+-%36s-+-%36s \n",
-						"------------------------------", "-",
-						"------------------------------------",
-						"------------------------------------");
-				(void) catalog_iter_s_table(sourceDB, NULL,
-											&compare_alldb_chksum_hook);
-				fformat(stdout, "\n");
-				(void) catalog_close(sourceDB);
-			}
-		}
-
-		free(srcuri);
-		free(tgturi);
-		if (dbSpecs.connStrings.safeSourcePGURI.pguri)
-			free(dbSpecs.connStrings.safeSourcePGURI.pguri);
-		if (dbSpecs.connStrings.safeTargetPGURI.pguri)
-			free(dbSpecs.connStrings.safeTargetPGURI.pguri);
-
-		if (!ok && parentSpecs->failFast)
 			break;
+		}
+		else if (pid == 0)
+		{
+			bool res = compare_one_database_data(parentSpecs, datnames[i]);
+			exit(res ? EXIT_CODE_QUIT : EXIT_CODE_INTERNAL_ERROR);
+		}
+
+		activeCount++;
 	}
 
-	(void) catalog_iter_s_database_finish(&dbIter);
-	(void) catalog_close_from_specs(parentSpecs);
+	/* Wait for remaining workers */
+	while (activeCount > 0)
+	{
+		if (!compare_wait_any_child())
+			ok = false;
+
+		activeCount--;
+	}
+
+	/* Print unified checksum table (parent reads per-db catalogs) */
+	fformat(stdout, "\n");
+	fformat(stdout, "%50s | %s | %36s | %36s \n",
+			"Table Name", "!", "Source Checksum", "Target Checksum");
+	fformat(stdout, "%50s-+-%s-+-%36s-+-%36s \n",
+			"--------------------------------------------------", "-",
+			"------------------------------------",
+			"------------------------------------");
+
+	for (int i = 0; i < dbCount; i++)
+	{
+		/* Reopen per-db catalog to iterate checksum results */
+		char sdbfile[MAXPGPATH] = { 0 };
+
+		sformat(sdbfile, sizeof(sdbfile), "%s/db/%s/schema/source.db",
+				parentSpecs->cfPaths.topdir, datnames[i]);
+
+		DatabaseCatalog dbCat = { 0 };
+
+		strlcpy(dbCat.dbfile, sdbfile, sizeof(dbCat.dbfile));
+
+		if (catalog_init(&dbCat))
+		{
+			(void) catalog_iter_s_table(&dbCat, NULL, &compare_alldb_chksum_hook);
+			(void) catalog_close(&dbCat);
+		}
+	}
+
+	fformat(stdout, "\n");
+
+	free(datnames);
 
 	return ok;
 }

--- a/src/bin/pgcopydb/compare.c
+++ b/src/bin/pgcopydb/compare.c
@@ -1170,6 +1170,11 @@ compare_alldb_schema_summary(CopyDataSpec *parentSpecs,
 							 const char (*datnames)[PG_NAMEDATALEN],
 							 int dbCount)
 {
+	if (dbCount <= 0)
+	{
+		return;
+	}
+
 	/* Collect per-database counts */
 	typedef struct
 	{
@@ -1178,7 +1183,7 @@ compare_alldb_schema_summary(CopyDataSpec *parentSpecs,
 		CatalogCounts tgt;
 	} DbCounts;
 
-	DbCounts *counts = (DbCounts *) calloc(dbCount, sizeof(DbCounts));
+	DbCounts *counts = (DbCounts *) calloc((size_t) dbCount, sizeof(DbCounts));
 
 	if (counts == NULL)
 	{

--- a/src/bin/pgcopydb/compare.c
+++ b/src/bin/pgcopydb/compare.c
@@ -1074,9 +1074,9 @@ compare_one_database_schema(CopyDataSpec *parentSpecs, const char *datname)
 	char *tgturi = NULL;
 
 	if (!multidb_build_uri_for_database(parentSpecs->connStrings.source_pguri,
-										 datname, &srcuri) ||
+										datname, &srcuri) ||
 		!multidb_build_uri_for_database(parentSpecs->connStrings.target_pguri,
-										 datname, &tgturi))
+										datname, &tgturi))
 	{
 		log_error("Failed to build URIs for database \"%s\"", datname);
 		free(srcuri);
@@ -1115,7 +1115,9 @@ compare_one_database_schema(CopyDataSpec *parentSpecs, const char *datname)
 		free(srcuri);
 		free(tgturi);
 		if (dbSpecs.connStrings.safeSourcePGURI.pguri)
+		{
 			free(dbSpecs.connStrings.safeSourcePGURI.pguri);
+		}
 		return false;
 	}
 
@@ -1126,9 +1128,13 @@ compare_one_database_schema(CopyDataSpec *parentSpecs, const char *datname)
 		free(srcuri);
 		free(tgturi);
 		if (dbSpecs.connStrings.safeSourcePGURI.pguri)
+		{
 			free(dbSpecs.connStrings.safeSourcePGURI.pguri);
+		}
 		if (dbSpecs.connStrings.safeTargetPGURI.pguri)
+		{
 			free(dbSpecs.connStrings.safeTargetPGURI.pguri);
+		}
 		return false;
 	}
 
@@ -1137,9 +1143,13 @@ compare_one_database_schema(CopyDataSpec *parentSpecs, const char *datname)
 	free(srcuri);
 	free(tgturi);
 	if (dbSpecs.connStrings.safeSourcePGURI.pguri)
+	{
 		free(dbSpecs.connStrings.safeSourcePGURI.pguri);
+	}
 	if (dbSpecs.connStrings.safeTargetPGURI.pguri)
+	{
 		free(dbSpecs.connStrings.safeTargetPGURI.pguri);
+	}
 
 	return ok;
 }
@@ -1185,7 +1195,9 @@ compare_alldb_schema_summary(CopyDataSpec *parentSpecs,
 		int nameLen = strlen(datnames[i]);
 
 		if (nameLen > maxNameLen)
+		{
 			maxNameLen = nameLen;
+		}
 
 		/* source catalog: <topdir>/db/<datname>/schema/source/source.db */
 		DatabaseCatalog srcCat = { .type = DATABASE_CATALOG_TYPE_SOURCE };
@@ -1218,7 +1230,9 @@ compare_alldb_schema_summary(CopyDataSpec *parentSpecs,
 	char dbSep[NAMEDATALEN] = { 0 };
 
 	for (int j = 0; j < maxNameLen && j < (int) sizeof(dbSep) - 1; j++)
+	{
 		dbSep[j] = '-';
+	}
 
 	fformat(stdout, "\n");
 	fformat(stdout, "%-*s |   Tables    |   Indexes   | Constraints |  Sequences\n",
@@ -1230,7 +1244,8 @@ compare_alldb_schema_summary(CopyDataSpec *parentSpecs,
 
 	for (int i = 0; i < dbCount; i++)
 	{
-		fformat(stdout, "%-*s | %3lld | %5lld | %3lld | %5lld | %3lld | %5lld | %3lld | %5lld\n",
+		fformat(stdout,
+				"%-*s | %3lld | %5lld | %3lld | %5lld | %3lld | %5lld | %3lld | %5lld\n",
 				maxNameLen, counts[i].datname,
 				(long long) counts[i].src.tables,
 				(long long) counts[i].tgt.tables,
@@ -1304,12 +1319,16 @@ compare_all_databases_schema(CopyDataSpec *parentSpecs)
 		for (;;)
 		{
 			if (!catalog_iter_s_database_next(&dbIter))
+			{
 				break;
+			}
 
 			SourceDatabase *db = dbIter.dat;
 
 			if (db == NULL)
+			{
 				break;
+			}
 
 			dbCount++;
 		}
@@ -1323,7 +1342,7 @@ compare_all_databases_schema(CopyDataSpec *parentSpecs)
 		return true;
 	}
 
-	datnames = (char (*)[PG_NAMEDATALEN]) calloc(dbCount, PG_NAMEDATALEN);
+	datnames = (char (*)[PG_NAMEDATALEN])calloc(dbCount, PG_NAMEDATALEN);
 
 	if (datnames == NULL)
 	{
@@ -1349,15 +1368,21 @@ compare_all_databases_schema(CopyDataSpec *parentSpecs)
 		for (;;)
 		{
 			if (!catalog_iter_s_database_next(&dbIter))
+			{
 				break;
+			}
 
 			SourceDatabase *db = dbIter.dat;
 
 			if (db == NULL)
+			{
 				break;
+			}
 
 			if (idx < dbCount)
+			{
 				strlcpy(datnames[idx++], db->datname, PG_NAMEDATALEN);
+			}
 		}
 
 		(void) catalog_iter_s_database_finish(&dbIter);
@@ -1367,7 +1392,7 @@ compare_all_databases_schema(CopyDataSpec *parentSpecs)
 
 	/* Fork up to tableJobs parallel compare workers */
 	int maxWorkers = (parentSpecs->tableJobs < dbCount)
-		? parentSpecs->tableJobs : dbCount;
+					 ? parentSpecs->tableJobs : dbCount;
 
 	int activeCount = 0;
 	bool ok = true;
@@ -1387,7 +1412,9 @@ compare_all_databases_schema(CopyDataSpec *parentSpecs)
 		if (activeCount >= maxWorkers)
 		{
 			if (!compare_wait_any_child())
+			{
 				ok = false;
+			}
 
 			activeCount--;
 		}
@@ -1418,14 +1445,18 @@ compare_all_databases_schema(CopyDataSpec *parentSpecs)
 	while (activeCount > 0)
 	{
 		if (!compare_wait_any_child())
+		{
 			ok = false;
+		}
 
 		activeCount--;
 	}
 
 	/* Print per-database object count summary */
 	if (ok || !parentSpecs->failFast)
+	{
 		compare_alldb_schema_summary(parentSpecs, datnames, dbCount);
+	}
 
 	free(datnames);
 
@@ -1447,9 +1478,13 @@ compare_alldb_chksum_hook(void *ctx, SourceTable *table)
 	char fqname[2 * PG_NAMEDATALEN + 64] = { 0 };
 
 	if (table->datname[0] != '\0')
+	{
 		sformat(fqname, sizeof(fqname), "%s.%s", table->datname, table->qname);
+	}
 	else
+	{
 		strlcpy(fqname, table->qname, sizeof(fqname));
+	}
 
 	fformat(stdout, "%50s | %s | %36s | %36s \n",
 			fqname,
@@ -1472,9 +1507,9 @@ compare_one_database_data(CopyDataSpec *parentSpecs, const char *datname)
 	char *tgturi = NULL;
 
 	if (!multidb_build_uri_for_database(parentSpecs->connStrings.source_pguri,
-										 datname, &srcuri) ||
+										datname, &srcuri) ||
 		!multidb_build_uri_for_database(parentSpecs->connStrings.target_pguri,
-										 datname, &tgturi))
+										datname, &tgturi))
 	{
 		log_error("Failed to build URIs for database \"%s\"", datname);
 		free(srcuri);
@@ -1514,7 +1549,9 @@ compare_one_database_data(CopyDataSpec *parentSpecs, const char *datname)
 		free(srcuri);
 		free(tgturi);
 		if (dbSpecs.connStrings.safeSourcePGURI.pguri)
+		{
 			free(dbSpecs.connStrings.safeSourcePGURI.pguri);
+		}
 		return false;
 	}
 
@@ -1525,9 +1562,13 @@ compare_one_database_data(CopyDataSpec *parentSpecs, const char *datname)
 		free(srcuri);
 		free(tgturi);
 		if (dbSpecs.connStrings.safeSourcePGURI.pguri)
+		{
 			free(dbSpecs.connStrings.safeSourcePGURI.pguri);
+		}
 		if (dbSpecs.connStrings.safeTargetPGURI.pguri)
+		{
 			free(dbSpecs.connStrings.safeTargetPGURI.pguri);
+		}
 		return false;
 	}
 
@@ -1543,9 +1584,13 @@ compare_one_database_data(CopyDataSpec *parentSpecs, const char *datname)
 	free(srcuri);
 	free(tgturi);
 	if (dbSpecs.connStrings.safeSourcePGURI.pguri)
+	{
 		free(dbSpecs.connStrings.safeSourcePGURI.pguri);
+	}
 	if (dbSpecs.connStrings.safeTargetPGURI.pguri)
+	{
 		free(dbSpecs.connStrings.safeTargetPGURI.pguri);
+	}
 
 	return ok;
 }
@@ -1608,10 +1653,14 @@ compare_all_databases_data(CopyDataSpec *parentSpecs)
 		for (;;)
 		{
 			if (!catalog_iter_s_database_next(&dbIter))
+			{
 				break;
+			}
 
 			if (dbIter.dat == NULL)
+			{
 				break;
+			}
 
 			dbCount++;
 		}
@@ -1625,7 +1674,7 @@ compare_all_databases_data(CopyDataSpec *parentSpecs)
 		return true;
 	}
 
-	datnames = (char (*)[PG_NAMEDATALEN]) calloc(dbCount, PG_NAMEDATALEN);
+	datnames = (char (*)[PG_NAMEDATALEN])calloc(dbCount, PG_NAMEDATALEN);
 
 	if (datnames == NULL)
 	{
@@ -1651,15 +1700,21 @@ compare_all_databases_data(CopyDataSpec *parentSpecs)
 		for (;;)
 		{
 			if (!catalog_iter_s_database_next(&dbIter))
+			{
 				break;
+			}
 
 			SourceDatabase *db = dbIter.dat;
 
 			if (db == NULL)
+			{
 				break;
+			}
 
 			if (idx < dbCount)
+			{
 				strlcpy(datnames[idx++], db->datname, PG_NAMEDATALEN);
+			}
 		}
 
 		(void) catalog_iter_s_database_finish(&dbIter);
@@ -1669,7 +1724,7 @@ compare_all_databases_data(CopyDataSpec *parentSpecs)
 
 	/* Fork up to tableJobs parallel workers */
 	int maxWorkers = (parentSpecs->tableJobs < dbCount)
-		? parentSpecs->tableJobs : dbCount;
+					 ? parentSpecs->tableJobs : dbCount;
 
 	int activeCount = 0;
 	bool ok = true;
@@ -1689,7 +1744,9 @@ compare_all_databases_data(CopyDataSpec *parentSpecs)
 		if (activeCount >= maxWorkers)
 		{
 			if (!compare_wait_any_child())
+			{
 				ok = false;
+			}
 
 			activeCount--;
 		}
@@ -1720,7 +1777,9 @@ compare_all_databases_data(CopyDataSpec *parentSpecs)
 	while (activeCount > 0)
 	{
 		if (!compare_wait_any_child())
+		{
 			ok = false;
+		}
 
 		activeCount--;
 	}

--- a/src/bin/pgcopydb/compare.c
+++ b/src/bin/pgcopydb/compare.c
@@ -11,6 +11,7 @@
 #include "catalog.h"
 #include "copydb.h"
 #include "env_utils.h"
+#include "file_utils.h"
 #include "lock_utils.h"
 #include "log.h"
 #include "multi_db.h"
@@ -24,6 +25,7 @@ static bool compare_queue_table_hook(void *ctx, SourceTable *sourceTable);
 static bool compare_schemas_table_hook(void *ctx, SourceTable *sourceTable);
 static bool compare_schemas_index_hook(void *ctx, SourceIndex *sourceIndex);
 static bool compare_schemas_seq_hook(void *ctx, SourceSequence *sourceSeq);
+static bool compare_alldb_chksum_hook(void *ctx, SourceTable *table);
 
 
 /*
@@ -1225,6 +1227,26 @@ compare_all_databases_schema(CopyDataSpec *parentSpecs)
 
 
 /*
+ * compare_alldb_chksum_hook prints one table's checksum row in the
+ * --all-databases data comparison text summary.
+ */
+static bool
+compare_alldb_chksum_hook(void *ctx, SourceTable *table)
+{
+	TableChecksum *srcChk = &(table->sourceChecksum);
+	TableChecksum *dstChk = &(table->targetChecksum);
+
+	fformat(stdout, "%30s | %s | %36s | %36s \n",
+			table->qname,
+			streq(srcChk->checksum, dstChk->checksum) ? " " : "!",
+			srcChk->checksum,
+			dstChk->checksum);
+
+	return true;
+}
+
+
+/*
  * compare_all_databases_data iterates all user databases on the source
  * instance, computes checksums for all tables, and prints a summary.
  *
@@ -1397,6 +1419,29 @@ compare_all_databases_data(CopyDataSpec *parentSpecs)
 			log_error("Data comparison failed for database \"%s\"",
 					  db->datname);
 			ok = false;
+		}
+		else
+		{
+			/*
+			 * Print the per-database checksum table.  compare_data closes
+			 * the catalog before returning, so we reopen it here.
+			 */
+			DatabaseCatalog *sourceDB = &dbSpecs.catalogs.source;
+
+			if (catalog_init(sourceDB))
+			{
+				fformat(stdout, "\n%s\n", db->datname);
+				fformat(stdout, "%30s | %s | %36s | %36s \n",
+						"Table Name", "!", "Source Checksum", "Target Checksum");
+				fformat(stdout, "%30s-+-%s-+-%36s-+-%36s \n",
+						"------------------------------", "-",
+						"------------------------------------",
+						"------------------------------------");
+				(void) catalog_iter_s_table(sourceDB, NULL,
+											&compare_alldb_chksum_hook);
+				fformat(stdout, "\n");
+				(void) catalog_close(sourceDB);
+			}
 		}
 
 		free(srcuri);

--- a/src/bin/pgcopydb/compare.c
+++ b/src/bin/pgcopydb/compare.c
@@ -13,7 +13,9 @@
 #include "env_utils.h"
 #include "lock_utils.h"
 #include "log.h"
+#include "multi_db.h"
 #include "progress.h"
+#include "schema.h"
 #include "signals.h"
 #include "summary.h"
 
@@ -1028,4 +1030,388 @@ compare_fetch_schemas(CopyDataSpec *copySpecs,
 	}
 
 	return true;
+}
+
+
+/*
+ * compare_all_databases_schema iterates all user databases on the source
+ * instance and runs compare_schemas for each one.
+ *
+ * parentSpecs must have instance-level source/target URIs.
+ */
+bool
+compare_all_databases_schema(CopyDataSpec *parentSpecs)
+{
+	/* initialise the instance-level catalog to get the database list */
+	if (!catalog_init_from_specs(parentSpecs))
+	{
+		log_error("Failed to initialise instance catalog for --all-databases compare");
+		return false;
+	}
+
+	DatabaseCatalog *instanceCatalog = &(parentSpecs->catalogs.source);
+
+	PGSQL src = { 0 };
+
+	if (!pgsql_init(&src, parentSpecs->connStrings.source_pguri, PGSQL_CONN_SOURCE))
+	{
+		log_error("Failed to connect to source instance for --all-databases compare");
+		(void) catalog_close_from_specs(parentSpecs);
+		return false;
+	}
+
+	if (!schema_list_databases(&src, instanceCatalog))
+	{
+		log_error("Failed to list databases for --all-databases compare schema");
+		pgsql_finish(&src);
+		(void) catalog_close_from_specs(parentSpecs);
+		return false;
+	}
+
+	pgsql_finish(&src);
+
+	bool ok = true;
+
+	SourceDatabaseIterator dbIter = {
+		.catalog = instanceCatalog,
+		.dat = NULL
+	};
+
+	if (!catalog_iter_s_database_init(&dbIter))
+	{
+		(void) catalog_close_from_specs(parentSpecs);
+		return false;
+	}
+
+	for (;;)
+	{
+		if (!catalog_iter_s_database_next(&dbIter))
+		{
+			ok = false;
+			break;
+		}
+
+		SourceDatabase *db = dbIter.dat;
+
+		if (db == NULL)
+			break;
+
+		if (asked_to_stop || asked_to_stop_fast || asked_to_quit)
+		{
+			ok = false;
+			break;
+		}
+
+		log_info("Comparing schema for database \"%s\"", db->datname);
+
+		/* build per-database URIs */
+		char *srcuri = NULL;
+		char *tgturi = NULL;
+
+		if (!multidb_build_uri_for_database(parentSpecs->connStrings.source_pguri,
+											 db->datname, &srcuri) ||
+			!multidb_build_uri_for_database(parentSpecs->connStrings.target_pguri,
+											 db->datname, &tgturi))
+		{
+			log_error("Failed to build URIs for database \"%s\"", db->datname);
+			free(srcuri);
+			free(tgturi);
+			ok = false;
+			if (parentSpecs->failFast)
+				break;
+			continue;
+		}
+
+		/* create per-db work directory */
+		char dbdir[MAXPGPATH] = { 0 };
+
+		sformat(dbdir, sizeof(dbdir), "%s/db/%s",
+				parentSpecs->cfPaths.topdir, db->datname);
+
+		CopyDataSpec dbSpecs = *parentSpecs;
+
+		/*
+		 * The parent catalog is currently open (db handle != NULL).
+		 * Null out all inherited SQLite handles so that catalog_init
+		 * inside compare_schemas opens fresh connections to the per-db
+		 * catalog files rather than reusing the instance-level handle
+		 * (which would cause a setup URI mismatch).
+		 */
+		dbSpecs.catalogs.source.db = NULL;
+		dbSpecs.catalogs.filter.db = NULL;
+		dbSpecs.catalogs.target.db = NULL;
+		dbSpecs.catalogs.replay.db = NULL;
+
+		dbSpecs.connStrings.source_pguri = srcuri;
+		dbSpecs.connStrings.target_pguri = tgturi;
+
+		if (!parse_and_scrub_connection_string(srcuri,
+											   &dbSpecs.connStrings.safeSourcePGURI))
+		{
+			log_error("Failed to scrub source URI for database \"%s\"",
+					  db->datname);
+			free(srcuri);
+			free(tgturi);
+			ok = false;
+			if (parentSpecs->failFast)
+				break;
+			continue;
+		}
+
+		if (!parse_and_scrub_connection_string(tgturi,
+											   &dbSpecs.connStrings.safeTargetPGURI))
+		{
+			log_error("Failed to scrub target URI for database \"%s\"",
+					  db->datname);
+			free(srcuri);
+			free(tgturi);
+			if (dbSpecs.connStrings.safeSourcePGURI.pguri)
+				free(dbSpecs.connStrings.safeSourcePGURI.pguri);
+			ok = false;
+			if (parentSpecs->failFast)
+				break;
+			continue;
+		}
+
+		if (!copydb_init_workdir(&dbSpecs, dbdir,
+								 false,  /* service */
+								 NULL,   /* serviceName */
+								 parentSpecs->restart,
+								 parentSpecs->resume,
+								 true))  /* createWorkDir */
+		{
+			log_error("Failed to init work dir for database \"%s\"",
+					  db->datname);
+			free(srcuri);
+			free(tgturi);
+			if (dbSpecs.connStrings.safeSourcePGURI.pguri)
+				free(dbSpecs.connStrings.safeSourcePGURI.pguri);
+			if (dbSpecs.connStrings.safeTargetPGURI.pguri)
+				free(dbSpecs.connStrings.safeTargetPGURI.pguri);
+			ok = false;
+			if (parentSpecs->failFast)
+				break;
+			continue;
+		}
+
+		if (!compare_schemas(&dbSpecs))
+		{
+			log_error("Schema comparison failed for database \"%s\"",
+					  db->datname);
+			ok = false;
+		}
+		else
+		{
+			log_info("Schema comparison succeeded for database \"%s\"",
+					 db->datname);
+		}
+
+		free(srcuri);
+		free(tgturi);
+		if (dbSpecs.connStrings.safeSourcePGURI.pguri)
+			free(dbSpecs.connStrings.safeSourcePGURI.pguri);
+		if (dbSpecs.connStrings.safeTargetPGURI.pguri)
+			free(dbSpecs.connStrings.safeTargetPGURI.pguri);
+
+		if (!ok && parentSpecs->failFast)
+			break;
+	}
+
+	(void) catalog_iter_s_database_finish(&dbIter);
+	(void) catalog_close_from_specs(parentSpecs);
+
+	return ok;
+}
+
+
+/*
+ * compare_all_databases_data iterates all user databases on the source
+ * instance, computes checksums for all tables, and prints a summary.
+ *
+ * Table names in the text output are formatted as datname.nspname.relname.
+ */
+bool
+compare_all_databases_data(CopyDataSpec *parentSpecs)
+{
+	/* initialise the instance-level catalog to get the database list */
+	if (!catalog_init_from_specs(parentSpecs))
+	{
+		log_error("Failed to initialise instance catalog for --all-databases compare");
+		return false;
+	}
+
+	DatabaseCatalog *instanceCatalog = &(parentSpecs->catalogs.source);
+
+	PGSQL src = { 0 };
+
+	if (!pgsql_init(&src, parentSpecs->connStrings.source_pguri, PGSQL_CONN_SOURCE))
+	{
+		log_error("Failed to connect to source instance for --all-databases compare");
+		(void) catalog_close_from_specs(parentSpecs);
+		return false;
+	}
+
+	if (!schema_list_databases(&src, instanceCatalog))
+	{
+		log_error("Failed to list databases for --all-databases compare data");
+		pgsql_finish(&src);
+		(void) catalog_close_from_specs(parentSpecs);
+		return false;
+	}
+
+	pgsql_finish(&src);
+
+	bool ok = true;
+
+	SourceDatabaseIterator dbIter = {
+		.catalog = instanceCatalog,
+		.dat = NULL
+	};
+
+	if (!catalog_iter_s_database_init(&dbIter))
+	{
+		(void) catalog_close_from_specs(parentSpecs);
+		return false;
+	}
+
+	for (;;)
+	{
+		if (!catalog_iter_s_database_next(&dbIter))
+		{
+			ok = false;
+			break;
+		}
+
+		SourceDatabase *db = dbIter.dat;
+
+		if (db == NULL)
+			break;
+
+		if (asked_to_stop || asked_to_stop_fast || asked_to_quit)
+		{
+			ok = false;
+			break;
+		}
+
+		log_info("Comparing data for database \"%s\"", db->datname);
+
+		char *srcuri = NULL;
+		char *tgturi = NULL;
+
+		if (!multidb_build_uri_for_database(parentSpecs->connStrings.source_pguri,
+											 db->datname, &srcuri) ||
+			!multidb_build_uri_for_database(parentSpecs->connStrings.target_pguri,
+											 db->datname, &tgturi))
+		{
+			log_error("Failed to build URIs for database \"%s\"", db->datname);
+			free(srcuri);
+			free(tgturi);
+			ok = false;
+			if (parentSpecs->failFast)
+				break;
+			continue;
+		}
+
+		char dbdir[MAXPGPATH] = { 0 };
+
+		sformat(dbdir, sizeof(dbdir), "%s/db/%s",
+				parentSpecs->cfPaths.topdir, db->datname);
+
+		CopyDataSpec dbSpecs = *parentSpecs;
+
+		/*
+		 * Null out inherited SQLite handles so that catalog_init inside
+		 * compare_data opens fresh connections to per-db catalog files.
+		 */
+		dbSpecs.catalogs.source.db = NULL;
+		dbSpecs.catalogs.filter.db = NULL;
+		dbSpecs.catalogs.target.db = NULL;
+		dbSpecs.catalogs.replay.db = NULL;
+
+		dbSpecs.connStrings.source_pguri = srcuri;
+		dbSpecs.connStrings.target_pguri = tgturi;
+		strlcpy(dbSpecs.datname, db->datname, sizeof(dbSpecs.datname));
+
+		if (!parse_and_scrub_connection_string(srcuri,
+											   &dbSpecs.connStrings.safeSourcePGURI))
+		{
+			log_error("Failed to scrub source URI for database \"%s\"",
+					  db->datname);
+			free(srcuri);
+			free(tgturi);
+			ok = false;
+			if (parentSpecs->failFast)
+				break;
+			continue;
+		}
+
+		if (!parse_and_scrub_connection_string(tgturi,
+											   &dbSpecs.connStrings.safeTargetPGURI))
+		{
+			log_error("Failed to scrub target URI for database \"%s\"",
+					  db->datname);
+			free(srcuri);
+			free(tgturi);
+			if (dbSpecs.connStrings.safeSourcePGURI.pguri)
+				free(dbSpecs.connStrings.safeSourcePGURI.pguri);
+			ok = false;
+			if (parentSpecs->failFast)
+				break;
+			continue;
+		}
+
+		if (!copydb_init_workdir(&dbSpecs, dbdir,
+								 false, NULL,
+								 parentSpecs->restart,
+								 parentSpecs->resume,
+								 true))
+		{
+			log_error("Failed to init work dir for database \"%s\"",
+					  db->datname);
+			free(srcuri);
+			free(tgturi);
+			if (dbSpecs.connStrings.safeSourcePGURI.pguri)
+				free(dbSpecs.connStrings.safeSourcePGURI.pguri);
+			if (dbSpecs.connStrings.safeTargetPGURI.pguri)
+				free(dbSpecs.connStrings.safeTargetPGURI.pguri);
+			ok = false;
+			if (parentSpecs->failFast)
+				break;
+			continue;
+		}
+
+		/*
+		 * copydb_init_workdir updates cfPaths.{s,f,t}dbfile but not the
+		 * catalogs.*.dbfile fields. Sync them so that compare_data uses the
+		 * per-database catalog rather than the inherited instance-level path.
+		 */
+		strlcpy(dbSpecs.catalogs.source.dbfile, dbSpecs.cfPaths.sdbfile,
+				sizeof(dbSpecs.catalogs.source.dbfile));
+		strlcpy(dbSpecs.catalogs.filter.dbfile, dbSpecs.cfPaths.fdbfile,
+				sizeof(dbSpecs.catalogs.filter.dbfile));
+		strlcpy(dbSpecs.catalogs.target.dbfile, dbSpecs.cfPaths.tdbfile,
+				sizeof(dbSpecs.catalogs.target.dbfile));
+
+		if (!compare_data(&dbSpecs))
+		{
+			log_error("Data comparison failed for database \"%s\"",
+					  db->datname);
+			ok = false;
+		}
+
+		free(srcuri);
+		free(tgturi);
+		if (dbSpecs.connStrings.safeSourcePGURI.pguri)
+			free(dbSpecs.connStrings.safeSourcePGURI.pguri);
+		if (dbSpecs.connStrings.safeTargetPGURI.pguri)
+			free(dbSpecs.connStrings.safeTargetPGURI.pguri);
+
+		if (!ok && parentSpecs->failFast)
+			break;
+	}
+
+	(void) catalog_iter_s_database_finish(&dbIter);
+	(void) catalog_close_from_specs(parentSpecs);
+
+	return ok;
 }

--- a/src/bin/pgcopydb/copydb.c
+++ b/src/bin/pgcopydb/copydb.c
@@ -634,6 +634,7 @@ copydb_init_table_specs(CopyTableDataSpec *tableSpecs,
 
 		.section = specs->section,
 		.resume = specs->resume,
+		.allDatabases = specs->allDatabases,
 
 		.sourceTable = source,
 		.summary = { 0 },

--- a/src/bin/pgcopydb/copydb.c
+++ b/src/bin/pgcopydb/copydb.c
@@ -107,7 +107,7 @@ copydb_init_workdir(CopyDataSpec *copySpecs,
 		return false;
 	}
 
-	log_info("Using work dir \"%s\"", cfPaths->topdir);
+	log_debug("Using work dir \"%s\"", cfPaths->topdir);
 
 	/*
 	 * Some inspection commands piggy-back on the work directory that has been

--- a/src/bin/pgcopydb/copydb.c
+++ b/src/bin/pgcopydb/copydb.c
@@ -535,6 +535,7 @@ copydb_init_specs(CopyDataSpec *specs,
 		.splitMaxParts = options->splitMaxParts,
 		.estimateTableSizes = options->estimateTableSizes,
 
+		.preDataQueue = { NULL, -1 },
 		.vacuumQueue = { NULL, -1 },
 		.indexQueue = { NULL, -1 },
 

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -38,12 +38,12 @@ extern KeyVal connStringDefaults;
  * pgcopydb creates System V OS level objects such as message queues and
  * semaphores, and those have to be cleaned-up "manually".
  *
- * With --all-databases, the parent creates one semaphore per database for the
- * source catalog plus global queues and per-instance catalogs.  Index workers
- * additionally create one semaphore per database for the target catalog.
- * 64 slots supports up to ~50 concurrent databases with comfortable headroom.
+ * With --all-databases, all per-database catalog semaphores are packed into
+ * a single SysV semaphore set (one system_res_array slot regardless of the
+ * number of databases).  The fixed overhead is ~10 slots, so 16 is sufficient
+ * even for very large multi-database runs.
  */
-#define SYSV_RES_MAX_COUNT 64
+#define SYSV_RES_MAX_COUNT 16
 
 typedef enum
 {
@@ -225,12 +225,13 @@ typedef struct MultiDbInfo
 	char topdir[MAXPGPATH];         /* per-database work dir */
 
 	/*
-	 * System V semaphore shared by all global COPY workers that access this
-	 * database's source.db catalog.  Created by the parent before forking the
-	 * global copy supervisor; workers inherit the semId via COW.
+	 * Slot within the parent-created semaphore SET that guards this database's
+	 * source.db catalog.  All databases share one SysV semaphore set (one
+	 * system_res_array slot); each database uses a unique slot index within it.
 	 * catalog_create_semaphore() skips creation when semId != 0.
 	 */
-	int catalogSemId;
+	int catalogSemId;       /* semaphore set id (same for all databases) */
+	int catalogSemIndex;    /* slot index within the set for this database */
 } MultiDbInfo;
 
 

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -242,6 +242,7 @@ typedef struct CopyDataSpec
 	bool fetchFilteredOids;     /* allow bypassing dump/restore filter prep */
 
 	bool follow;                /* pgcopydb fork --follow */
+	bool allDatabases;          /* pgcopydb clone --all-databases */
 
 	int tableJobs;
 	int indexJobs;
@@ -272,6 +273,8 @@ extern GUC dstSettings[];
 
 /* copydb.h */
 void cli_copy_prepare_specs(CopyDataSpec *copySpecs, CopyDataSection section);
+
+bool copydb_clone_database(CopyDataSpec *copySpecs);
 
 bool copydb_init_workdir(CopyDataSpec *copySpecs,
 						 char *dir,

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -218,6 +218,14 @@ typedef struct MultiDbInfo
 	char target_pguri[BUFSIZE];     /* per-database target URI */
 	char topdir[MAXPGPATH];         /* per-database work dir */
 	bool isReadOnly;                /* true when source is in recovery */
+
+	/*
+	 * System V semaphore shared by all global COPY workers that access this
+	 * database's source.db catalog.  Created by the parent before forking the
+	 * global copy supervisor; workers inherit the semId via COW.
+	 * catalog_create_semaphore() skips creation when semId != 0.
+	 */
+	int catalogSemId;
 } MultiDbInfo;
 
 
@@ -317,6 +325,7 @@ typedef struct CopyDataSpec
 	int splitMaxParts;
 	bool estimateTableSizes;
 
+	Queue preDataQueue;         /* for --all-databases Phase I parallel pre-data */
 	Queue copyQueue;
 	Queue indexQueue;
 	Queue vacuumQueue;

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -205,6 +205,62 @@ typedef struct PreviousRunState
 } PreviousRunState;
 
 
+/*
+ * Per-database info needed by global COPY workers in --all-databases mode.
+ * The parent process populates this array before forking workers; workers
+ * read it via post-fork COW copy.
+ */
+typedef struct MultiDbInfo
+{
+	char datname[PG_NAMEDATALEN];   /* database name (quoted identifier) */
+	char snapshot[BUFSIZE];         /* exported snapshot identifier, or "" */
+	char source_pguri[BUFSIZE];     /* per-database source URI */
+	char target_pguri[BUFSIZE];     /* per-database target URI */
+	char topdir[MAXPGPATH];         /* per-database work dir */
+	bool isReadOnly;                /* true when source is in recovery */
+} MultiDbInfo;
+
+
+/*
+ * Per-database connection cache entry used by global COPY workers in
+ * --all-databases mode.  Each entry holds a heap-allocated per-database
+ * CopyDataSpec (catalog + paths + snapshot connection) and a target PGSQL
+ * connection.
+ */
+struct CopyDataSpec;             /* forward declaration */
+
+typedef struct MultiDbEntry
+{
+	char datname[PG_NAMEDATALEN];
+	bool active;
+	struct CopyDataSpec *dbSpecs; /* heap-allocated per-database specs */
+	PGSQL dst;                    /* target connection for this database */
+} MultiDbEntry;
+
+#define MULTIDB_ENTRY_CACHE_MAX 4
+
+typedef struct MultiDbContext
+{
+	struct CopyDataSpec *parentSpecs;
+	int count;
+	int nextEvict;               /* round-robin eviction index */
+	MultiDbEntry entries[MULTIDB_ENTRY_CACHE_MAX];
+} MultiDbContext;
+
+/*
+ * Lightweight table entry used by the global COPY supervisor to collect and
+ * sort tables from all databases before enqueuing.
+ */
+typedef struct MultiDbTableEntry
+{
+	char datname[PG_NAMEDATALEN];
+	uint32_t oid;
+	int64_t bytes;
+	bool excludeData;
+	int partCount;               /* 0 when not partitioned */
+} MultiDbTableEntry;
+
+
 /* all that's needed to start a TABLE DATA copy for a whole database */
 typedef struct CopyDataSpec
 {
@@ -243,6 +299,14 @@ typedef struct CopyDataSpec
 
 	bool follow;                /* pgcopydb fork --follow */
 	bool allDatabases;          /* pgcopydb clone --all-databases */
+
+	/*
+	 * For --all-databases: per-database snapshot + connection info used by the
+	 * global COPY worker pool.  Populated by clone_all_databases() in the parent
+	 * before workers are forked, and read by workers (post-fork COW copy).
+	 */
+	int multiDbCount;
+	struct MultiDbInfo *multiDbInfos;
 
 	int tableJobs;
 	int indexJobs;
@@ -433,8 +497,14 @@ bool copydb_start_table_data_workers(CopyDataSpec *specs);
 bool copydb_table_data_worker(CopyDataSpec *specs);
 
 bool copydb_add_copy(CopyDataSpec *specs, uint32_t oid, uint32_t part);
+bool copydb_add_copy_for_db(CopyDataSpec *specs, uint32_t oid, uint32_t part,
+							const char *datname);
 bool copydb_copy_data_by_oid(CopyDataSpec *specs, PGSQL *src,
 							 PGSQL *dst, uint32_t oid, uint32_t part);
+
+/* --all-databases global COPY phase */
+bool copydb_table_data_worker_multidb(CopyDataSpec *parentSpecs);
+bool copydb_copy_worker_queue_tables_multidb(CopyDataSpec *parentSpecs);
 
 bool copydb_copy_table(CopyDataSpec *specs, PGSQL *src, PGSQL *dst,
 					   CopyTableDataSpec *tableSpecs);
@@ -636,6 +706,13 @@ bool summary_prepare_index_entry(DatabaseCatalog *catalog,
 								 SourceIndex *index,
 								 bool constraint,
 								 SummaryIndexEntry *indexEntry);
+
+/* multi_db.c (worker helpers called from table-data.c) */
+bool multidb_context_init(MultiDbContext *ctx, CopyDataSpec *parentSpecs);
+MultiDbEntry *multidb_context_get_entry(MultiDbContext *ctx,
+										const char *datname);
+bool multidb_context_close_entry(MultiDbEntry *entry);
+bool multidb_context_close_all(MultiDbContext *ctx);
 
 /* compare.c */
 bool compare_schemas(CopyDataSpec *copySpecs);

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -731,14 +731,14 @@ bool summary_prepare_index_entry(DatabaseCatalog *catalog,
 
 /* multi_db.c (worker helpers called from table-data.c) */
 bool multidb_context_init(MultiDbContext *ctx, CopyDataSpec *parentSpecs);
-MultiDbEntry *multidb_context_get_entry(MultiDbContext *ctx,
-										const char *datname);
+MultiDbEntry * multidb_context_get_entry(MultiDbContext *ctx,
+										 const char *datname);
 bool multidb_context_close_entry(MultiDbEntry *entry);
 bool multidb_context_close_all(MultiDbContext *ctx);
 
 /* lighter pool for index/vacuum workers: catalog + target only, no snapshot */
-MultiDbEntry *multidb_index_context_get_entry(MultiDbContext *ctx,
-											  const char *datname);
+MultiDbEntry * multidb_index_context_get_entry(MultiDbContext *ctx,
+											   const char *datname);
 bool multidb_index_context_close_all(MultiDbContext *ctx);
 
 /* compare.c */

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -132,6 +132,7 @@ typedef struct CopyTableDataSpec
 
 	CopyDataSection section;
 	bool resume;
+	bool allDatabases;          /* true when running --all-databases */
 
 	SourceTable *sourceTable;
 	CopyTableSummary summary;

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -562,7 +562,7 @@ bool vacuum_supervisor(CopyDataSpec *specs);
 bool vacuum_start_workers(CopyDataSpec *specs);
 bool vacuum_worker(CopyDataSpec *specs);
 bool vacuum_analyze_table_by_oid(CopyDataSpec *specs, uint32_t oid);
-bool vacuum_add_table(CopyDataSpec *specs, uint32_t oid);
+bool vacuum_add_table(CopyDataSpec *specs, uint32_t oid, const char *datname);
 bool vacuum_send_stop(CopyDataSpec *specs);
 
 /* sentinel.c */
@@ -728,6 +728,11 @@ MultiDbEntry *multidb_context_get_entry(MultiDbContext *ctx,
 										const char *datname);
 bool multidb_context_close_entry(MultiDbEntry *entry);
 bool multidb_context_close_all(MultiDbContext *ctx);
+
+/* lighter pool for index/vacuum workers: catalog + target only, no snapshot */
+MultiDbEntry *multidb_index_context_get_entry(MultiDbContext *ctx,
+											  const char *datname);
+bool multidb_index_context_close_all(MultiDbContext *ctx);
 
 /* compare.c */
 bool compare_schemas(CopyDataSpec *copySpecs);

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -436,7 +436,7 @@ bool timescaledb_pre_restore(CopyDataSpec *copySpecs, SourceExtension *ext);
 bool timescaledb_post_restore(CopyDataSpec *copySpecs, SourceExtension *ext);
 
 /* indexes.c */
-bool copydb_start_index_supervisor(CopyDataSpec *specs);
+bool copydb_start_index_supervisor(CopyDataSpec *specs, pid_t *pidOut);
 bool copydb_index_supervisor(CopyDataSpec *specs);
 bool copydb_start_index_workers(CopyDataSpec *specs);
 bool copydb_index_worker(CopyDataSpec *specs);
@@ -564,7 +564,7 @@ bool copydb_add_blob(CopyDataSpec *specs, uint32_t oid);
 bool copydb_send_lo_stop(CopyDataSpec *specs);
 
 /* vacuum.c */
-bool vacuum_start_supervisor(CopyDataSpec *specs);
+bool vacuum_start_supervisor(CopyDataSpec *specs, pid_t *pidOut);
 bool vacuum_supervisor(CopyDataSpec *specs);
 bool vacuum_start_workers(CopyDataSpec *specs);
 bool vacuum_worker(CopyDataSpec *specs);

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -37,8 +37,13 @@ extern KeyVal connStringDefaults;
 /*
  * pgcopydb creates System V OS level objects such as message queues and
  * semaphores, and those have to be cleaned-up "manually".
+ *
+ * With --all-databases, the parent creates one semaphore per database for the
+ * source catalog plus global queues and per-instance catalogs.  Index workers
+ * additionally create one semaphore per database for the target catalog.
+ * 64 slots supports up to ~50 concurrent databases with comfortable headroom.
  */
-#define SYSV_RES_MAX_COUNT 16
+#define SYSV_RES_MAX_COUNT 64
 
 typedef enum
 {

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -212,12 +212,11 @@ typedef struct PreviousRunState
  */
 typedef struct MultiDbInfo
 {
-	char datname[PG_NAMEDATALEN];   /* database name (quoted identifier) */
-	char snapshot[BUFSIZE];         /* exported snapshot identifier, or "" */
+	char datname[PG_NAMEDATALEN];   /* database name */
+	char snapshot[BUFSIZE];         /* snapshot ID exported by snapshot holder */
 	char source_pguri[BUFSIZE];     /* per-database source URI */
 	char target_pguri[BUFSIZE];     /* per-database target URI */
 	char topdir[MAXPGPATH];         /* per-database work dir */
-	bool isReadOnly;                /* true when source is in recovery */
 
 	/*
 	 * System V semaphore shared by all global COPY workers that access this
@@ -307,6 +306,13 @@ typedef struct CopyDataSpec
 
 	bool follow;                /* pgcopydb fork --follow */
 	bool allDatabases;          /* pgcopydb clone --all-databases */
+
+	/*
+	 * Database name for log messages in per-database workers.  Empty string
+	 * in the single-database code path; set to the database name in
+	 * --all-databases workers so log messages include "in database <name>".
+	 */
+	char datname[PG_NAMEDATALEN];
 
 	/*
 	 * For --all-databases: per-database snapshot + connection info used by the
@@ -726,6 +732,8 @@ bool multidb_context_close_all(MultiDbContext *ctx);
 /* compare.c */
 bool compare_schemas(CopyDataSpec *copySpecs);
 bool compare_data(CopyDataSpec *copySpecs);
+bool compare_all_databases_schema(CopyDataSpec *parentSpecs);
+bool compare_all_databases_data(CopyDataSpec *parentSpecs);
 
 bool compare_start_workers(CopyDataSpec *copySpecs, Queue *queue);
 bool compare_queue_tables(CopyDataSpec *copySpecs, Queue *queue);

--- a/src/bin/pgcopydb/copydb_schema.c
+++ b/src/bin/pgcopydb/copydb_schema.c
@@ -759,14 +759,30 @@ copydb_prepare_table_specs(CopyDataSpec *specs, PGSQL *pgsql)
 		return false;
 	}
 
-	log_info("Fetched information for %lld tables "
-			 "(including %lld tables split in %lld partitions total), "
-			 "with an estimated total of %s tuples and %s on-disk",
-			 (long long) stats.count,
-			 (long long) stats.countSplits,
-			 (long long) stats.countParts,
-			 stats.relTuplesPretty,
-			 stats.bytesPretty);
+	if (IS_EMPTY_STRING_BUFFER(specs->datname))
+	{
+		log_info("Fetched information for %lld tables "
+				 "(including %lld tables split in %lld partitions total), "
+				 "with an estimated total of %s tuples and %s on-disk",
+				 (long long) stats.count,
+				 (long long) stats.countSplits,
+				 (long long) stats.countParts,
+				 stats.relTuplesPretty,
+				 stats.bytesPretty);
+	}
+	else
+	{
+		log_info("Fetched information for %lld tables "
+				 "(including %lld tables split in %lld partitions total), "
+				 "with an estimated total of %s tuples and %s on-disk, "
+				 "in database \"%s\"",
+				 (long long) stats.count,
+				 (long long) stats.countSplits,
+				 (long long) stats.countParts,
+				 stats.relTuplesPretty,
+				 stats.bytesPretty,
+				 specs->datname);
+	}
 
 	return true;
 }
@@ -966,9 +982,21 @@ copydb_prepare_index_specs(CopyDataSpec *specs, PGSQL *pgsql)
 		return false;
 	}
 
-	log_info("Fetched information for %lld indexes (supporting %lld constraints)",
-			 (long long) count.indexes,
-			 (long long) count.constraints);
+	if (IS_EMPTY_STRING_BUFFER(specs->datname))
+	{
+		log_info("Fetched information for %lld indexes "
+				 "(supporting %lld constraints)",
+				 (long long) count.indexes,
+				 (long long) count.constraints);
+	}
+	else
+	{
+		log_info("Fetched information for %lld indexes "
+				 "(supporting %lld constraints) in database \"%s\"",
+				 (long long) count.indexes,
+				 (long long) count.constraints,
+				 specs->datname);
+	}
 
 	return true;
 }
@@ -1177,8 +1205,18 @@ copydb_fetch_filtered_oids(CopyDataSpec *specs, PGSQL *pgsql)
 			return false;
 		}
 
-		log_info("Fetched information for %lld extensions",
-				 (long long) count.extensions);
+		if (IS_EMPTY_STRING_BUFFER(specs->datname))
+		{
+			log_info("Fetched information for %lld extensions",
+					 (long long) count.extensions);
+		}
+		else
+		{
+			log_info("Fetched information for %lld extensions "
+					 "in database \"%s\"",
+					 (long long) count.extensions,
+					 specs->datname);
+		}
 	}
 
 	if (specs->skipCollations &&
@@ -1213,8 +1251,18 @@ copydb_fetch_filtered_oids(CopyDataSpec *specs, PGSQL *pgsql)
 			return false;
 		}
 
-		log_info("Fetched information for %lld collations",
-				 (long long) count.colls);
+		if (IS_EMPTY_STRING_BUFFER(specs->datname))
+		{
+			log_info("Fetched information for %lld collations",
+					 (long long) count.colls);
+		}
+		else
+		{
+			log_info("Fetched information for %lld collations "
+					 "in database \"%s\"",
+					 (long long) count.colls,
+					 specs->datname);
+		}
 	}
 
 	/*

--- a/src/bin/pgcopydb/indexes.c
+++ b/src/bin/pgcopydb/indexes.c
@@ -889,7 +889,10 @@ copydb_create_index(CopyDataSpec *specs,
 			return false;
 		}
 
-		log_notice("%s", indexSummary->command);
+		if (specs->datname[0] != '\0')
+			log_notice("%s: %s", specs->datname, indexSummary->command);
+		else
+			log_notice("%s", indexSummary->command);
 
 		if (!pgsql_execute(dst, indexSummary->command))
 		{
@@ -1289,7 +1292,10 @@ copydb_create_constraints_hook(void *ctx, SourceIndex *index)
 
 	if (!foundConstraintOnTarget)
 	{
-		log_notice("%s", indexSummary->command);
+		if (specs->datname[0] != '\0')
+			log_notice("%s: %s", specs->datname, indexSummary->command);
+		else
+			log_notice("%s", indexSummary->command);
 
 		/*
 		 * Constraints are built by the CREATE INDEX worker process that is

--- a/src/bin/pgcopydb/indexes.c
+++ b/src/bin/pgcopydb/indexes.c
@@ -67,7 +67,9 @@ copydb_start_index_supervisor(CopyDataSpec *specs, pid_t *pidOut)
 		{
 			/* fork succeeded, in parent */
 			if (pidOut != NULL)
+			{
 				*pidOut = fpid;
+			}
 			break;
 		}
 	}
@@ -890,9 +892,13 @@ copydb_create_index(CopyDataSpec *specs,
 		}
 
 		if (specs->datname[0] != '\0')
+		{
 			log_notice("%s: %s", specs->datname, indexSummary->command);
+		}
 		else
+		{
 			log_notice("%s", indexSummary->command);
+		}
 
 		if (!pgsql_execute(dst, indexSummary->command))
 		{
@@ -1293,9 +1299,13 @@ copydb_create_constraints_hook(void *ctx, SourceIndex *index)
 	if (!foundConstraintOnTarget)
 	{
 		if (specs->datname[0] != '\0')
+		{
 			log_notice("%s: %s", specs->datname, indexSummary->command);
+		}
 		else
+		{
 			log_notice("%s", indexSummary->command);
+		}
 
 		/*
 		 * Constraints are built by the CREATE INDEX worker process that is

--- a/src/bin/pgcopydb/indexes.c
+++ b/src/bin/pgcopydb/indexes.c
@@ -31,7 +31,7 @@ static bool copydb_copy_all_indexes_hook(void *ctx, SourceIndex *index);
  * copydb_start_index_supervisor starts a CREATE INDEX supervisor process.
  */
 bool
-copydb_start_index_supervisor(CopyDataSpec *specs)
+copydb_start_index_supervisor(CopyDataSpec *specs, pid_t *pidOut)
 {
 	/*
 	 * Flush stdio channels just before fork, to avoid double-output problems.
@@ -66,6 +66,8 @@ copydb_start_index_supervisor(CopyDataSpec *specs)
 		default:
 		{
 			/* fork succeeded, in parent */
+			if (pidOut != NULL)
+				*pidOut = fpid;
 			break;
 		}
 	}
@@ -768,7 +770,7 @@ copydb_copy_all_indexes(CopyDataSpec *specs)
 			 specs->indexJobs);
 
 	/* first start index workers that feed from the indexQueue */
-	if (!copydb_start_index_supervisor(specs))
+	if (!copydb_start_index_supervisor(specs, NULL))
 	{
 		/* errors have already been logged */
 		return false;

--- a/src/bin/pgcopydb/indexes.c
+++ b/src/bin/pgcopydb/indexes.c
@@ -246,20 +246,37 @@ copydb_index_worker(CopyDataSpec *specs)
 		return false;
 	}
 
+	/*
+	 * Singledb path: open a single target connection reused for all indexes.
+	 * Multidb path: maintain a lightweight pool keyed by datname; each entry
+	 * holds a per-db CopyDataSpec (catalog) and a target connection.
+	 */
 	PGSQL dst = { 0 };
-	char *pguri = specs->connStrings.target_pguri;
+	MultiDbContext idxCtx = { 0 };
 
-	if (!pgsql_init(&dst, (char *) pguri, PGSQL_CONN_TARGET))
+	if (specs->allDatabases)
 	{
-		return false;
+		if (!multidb_context_init(&idxCtx, specs))
+		{
+			log_error("Failed to initialise index multi-database context");
+			return false;
+		}
 	}
-
-	/* also set our GUC values for the target connection */
-	if (!pgsql_set_gucs(&dst, dstSettings))
+	else
 	{
-		log_fatal("Failed to set our GUC settings on the target connection, "
-				  "see above for details");
-		return false;
+		char *pguri = specs->connStrings.target_pguri;
+
+		if (!pgsql_init(&dst, (char *) pguri, PGSQL_CONN_TARGET))
+		{
+			return false;
+		}
+
+		if (!pgsql_set_gucs(&dst, dstSettings))
+		{
+			log_fatal("Failed to set our GUC settings on the target connection, "
+					  "see above for details");
+			return false;
+		}
 	}
 
 	int errors = 0;
@@ -274,12 +291,15 @@ copydb_index_worker(CopyDataSpec *specs)
 		{
 			log_error("CREATE INDEX worker has been interrupted");
 			(void) pgsql_finish(&dst);
+			(void) multidb_index_context_close_all(&idxCtx);
 			return false;
 		}
 
 		if (!recv_ok)
 		{
 			/* errors have already been logged */
+			(void) pgsql_finish(&dst);
+			(void) multidb_index_context_close_all(&idxCtx);
 			return false;
 		}
 
@@ -294,17 +314,47 @@ copydb_index_worker(CopyDataSpec *specs)
 
 			case QMSG_TYPE_INDEXOID:
 			{
-				if (!copydb_create_index_by_oid(specs, &dst, mesg.data.oid))
+				uint32_t oid = mesg.data.tp.oid;
+				CopyDataSpec *useSpecs = specs;
+				PGSQL *useDst = &dst;
+
+				if (specs->allDatabases)
+				{
+					const char *datname = mesg.data.tp.datname;
+					MultiDbEntry *entry =
+						multidb_index_context_get_entry(&idxCtx, datname);
+
+					if (entry == NULL)
+					{
+						log_error("Failed to get context for database \"%s\", "
+								  "skipping index oid %u",
+								  datname, oid);
+						++errors;
+
+						if (specs->failFast)
+						{
+							(void) multidb_index_context_close_all(&idxCtx);
+							return false;
+						}
+						break;
+					}
+
+					useSpecs = entry->dbSpecs;
+					useDst = &entry->dst;
+				}
+
+				if (!copydb_create_index_by_oid(useSpecs, useDst, oid))
 				{
 					++errors;
 
 					log_error("Failed to create index with oid %u, "
 							  "see above for details",
-							  mesg.data.oid);
+							  oid);
 
 					if (specs->failFast)
 					{
 						(void) pgsql_finish(&dst);
+						(void) multidb_index_context_close_all(&idxCtx);
 						return false;
 					}
 				}
@@ -322,6 +372,7 @@ copydb_index_worker(CopyDataSpec *specs)
 	}
 
 	pgsql_finish(&dst);
+	(void) multidb_index_context_close_all(&idxCtx);
 
 	if (!catalog_delete_process(&(specs->catalogs.source), pid))
 	{
@@ -449,7 +500,7 @@ copydb_create_index_by_oid(CopyDataSpec *specs, PGSQL *dst, uint32_t indexOid)
 
 		if (!specs->skipVacuum)
 		{
-			if (!vacuum_add_table(specs, table->oid))
+			if (!vacuum_add_table(specs, table->oid, table->datname))
 			{
 				log_error("Failed to queue VACUUM ANALYZE %s [%u]",
 						  table->qname,
@@ -609,13 +660,18 @@ copydb_add_table_indexes(CopyDataSpec *specs, CopyTableDataSpec *tableSpecs)
 	{
 		QMessage mesg = {
 			.type = QMSG_TYPE_INDEXOID,
-			.data.oid = indexArray.array[i]
+			.data.tp.oid = indexArray.array[i],
 		};
 
-		log_trace("Queueing index [%u] for table %s [%u]",
-				  mesg.data.oid,
+		strlcpy(mesg.data.tp.datname,
+				tableSpecs->sourceTable->datname,
+				sizeof(mesg.data.tp.datname));
+
+		log_trace("Queueing index [%u] for table %s [%u] db \"%s\"",
+				  mesg.data.tp.oid,
 				  tableSpecs->sourceTable->qname,
-				  tableSpecs->sourceTable->oid);
+				  tableSpecs->sourceTable->oid,
+				  mesg.data.tp.datname);
 
 		if (!queue_send(&(specs->indexQueue), &mesg))
 		{

--- a/src/bin/pgcopydb/lock_utils.c
+++ b/src/bin/pgcopydb/lock_utils.c
@@ -197,7 +197,9 @@ semaphore_create_set(Semaphore *semaphore, int count)
 	}
 
 	for (int i = 0; i < count; i++)
+	{
 		vals[i] = 1;
+	}
 
 	semun.array = vals;
 
@@ -352,7 +354,9 @@ semaphore_lock(Semaphore *semaphore)
 {
 	/* semId == 0: no semaphore allocated (e.g. read-only catalog) — no-op */
 	if (semaphore->semId == 0)
+	{
 		return true;
+	}
 
 	if (semaphore->reentrant && semaphore->depth > 0)
 	{
@@ -413,7 +417,9 @@ semaphore_unlock(Semaphore *semaphore)
 {
 	/* semId == 0: no semaphore allocated (e.g. read-only catalog) — no-op */
 	if (semaphore->semId == 0)
+	{
 		return true;
+	}
 
 	/* unlocking a reentrant semaphore skips an actual semop() call */
 	if (semaphore->reentrant && semaphore->depth > 1)

--- a/src/bin/pgcopydb/lock_utils.c
+++ b/src/bin/pgcopydb/lock_utils.c
@@ -162,6 +162,68 @@ semaphore_create(Semaphore *semaphore)
 
 
 /*
+ * semaphore_create_set creates a single SysV semaphore SET with `count`
+ * independent slots, all initialised to 1 (unlocked).  The entire set
+ * occupies ONE slot in system_res_array and is removed with a single
+ * IPC_RMID call.  Individual database-level semaphores are addressed by
+ * setting Semaphore.semIndex to the slot number (0 … count-1).
+ */
+bool
+semaphore_create_set(Semaphore *semaphore, int count)
+{
+	union semun semun = { .val = 0 };   /* initialise to silence compiler */
+
+	semaphore->owner = getpid();
+	semaphore->semId = semget(IPC_PRIVATE, count, 0600);
+
+	if (semaphore->semId < 0)
+	{
+		log_error("Failed to create semaphore set of %d slots: %m", count);
+		return false;
+	}
+
+	log_debug("Created semaphore set %d with %d slots (ipcrm -s %d)",
+			  semaphore->semId, count, semaphore->semId);
+
+	/* Initialise all slots to 1 (unlocked) via SETALL. */
+	unsigned short *vals =
+		(unsigned short *) calloc(count, sizeof(unsigned short));
+
+	if (vals == NULL)
+	{
+		log_error(ALLOCATION_FAILED_ERROR);
+		semctl(semaphore->semId, 0, IPC_RMID, semun);
+		return false;
+	}
+
+	for (int i = 0; i < count; i++)
+		vals[i] = 1;
+
+	semun.array = vals;
+
+	if (semctl(semaphore->semId, 0, SETALL, semun) < 0)
+	{
+		log_error("Failed to initialise semaphore set %d: %m",
+				  semaphore->semId);
+		free(vals);
+		semctl(semaphore->semId, 0, IPC_RMID, semun);
+		return false;
+	}
+
+	free(vals);
+
+	/* Register once — IPC_RMID removes the entire set. */
+	if (!copydb_register_sysv_semaphore(&system_res_array, semaphore))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
  * semaphore_open opens our IPC_PRIVATE semaphore.
  *
  * We don't have a key for it, because we asked the kernel to create a new
@@ -288,10 +350,14 @@ semaphore_cleanup(const char *pidfile)
 bool
 semaphore_lock(Semaphore *semaphore)
 {
+	/* semId == 0: no semaphore allocated (e.g. read-only catalog) — no-op */
+	if (semaphore->semId == 0)
+		return true;
+
 	if (semaphore->reentrant && semaphore->depth > 0)
 	{
-		int sempid = semctl(semaphore->semId, 0, GETPID, 0);
-		int semval = semctl(semaphore->semId, 0, GETVAL, 0);
+		int sempid = semctl(semaphore->semId, semaphore->semIndex, GETPID, 0);
+		int semval = semctl(semaphore->semId, semaphore->semIndex, GETVAL, 0);
 
 		/* semval is only zero if we're in the critical section already */
 		if (sempid == getpid() && semval == 0)
@@ -311,7 +377,7 @@ semaphore_lock(Semaphore *semaphore)
 
 	sops.sem_op = -1;           /* decrement */
 	sops.sem_flg = SEM_UNDO;
-	sops.sem_num = 0;
+	sops.sem_num = semaphore->semIndex;
 
 	do {
 		if (errStatus < 0 &&
@@ -345,10 +411,14 @@ semaphore_lock(Semaphore *semaphore)
 bool
 semaphore_unlock(Semaphore *semaphore)
 {
+	/* semId == 0: no semaphore allocated (e.g. read-only catalog) — no-op */
+	if (semaphore->semId == 0)
+		return true;
+
 	/* unlocking a reentrant semaphore skips an actual semop() call */
 	if (semaphore->reentrant && semaphore->depth > 1)
 	{
-		int sempid = semctl(semaphore->semId, 0, GETPID, 0);
+		int sempid = semctl(semaphore->semId, semaphore->semIndex, GETPID, 0);
 
 		if (sempid == getpid())
 		{
@@ -367,7 +437,7 @@ semaphore_unlock(Semaphore *semaphore)
 
 	sops.sem_op = 1;            /* increment */
 	sops.sem_flg = SEM_UNDO;
-	sops.sem_num = 0;
+	sops.sem_num = semaphore->semIndex;
 
 	do {
 		if (errStatus < 0 &&

--- a/src/bin/pgcopydb/lock_utils.h
+++ b/src/bin/pgcopydb/lock_utils.h
@@ -23,6 +23,7 @@
 typedef struct Semaphore
 {
 	int semId;
+	int semIndex;    /* index within the semaphore set; 0 for single-element sets */
 	int initValue;
 	pid_t owner;
 
@@ -37,6 +38,7 @@ bool semaphore_init(Semaphore *semaphore);
 bool semaphore_finish(Semaphore *semaphore);
 
 bool semaphore_create(Semaphore *semaphore);
+bool semaphore_create_set(Semaphore *semaphore, int count);
 bool semaphore_open(Semaphore *semaphore);
 bool semaphore_unlink(Semaphore *semaphore);
 

--- a/src/bin/pgcopydb/multi_db.c
+++ b/src/bin/pgcopydb/multi_db.c
@@ -58,26 +58,26 @@ static bool multidb_init_db_specs(CopyDataSpec *dbSpecs,
  * SNAPSHOT to do consistent schema fetch + pg_dump + pg_restore --pre-data.
  */
 static bool multidb_snapshot_holder(CopyDataSpec *parentSpecs,
-									 int readyfd, int donefd);
+									int readyfd, int donefd);
 static bool multidb_pre_data_supervisor(CopyDataSpec *parentSpecs);
 static bool multidb_pre_data_worker(CopyDataSpec *parentSpecs);
 static bool multidb_pre_data_one_db(CopyDataSpec *parentSpecs,
 									const char *datname);
 
 static bool multidb_clone_one_database_post_data(CopyDataSpec *parentSpecs,
-												  const char *datname);
+												 const char *datname);
 static bool multidb_global_copy(CopyDataSpec *parentSpecs);
 static bool multidb_wait_child(pid_t pid, const char *label);
 
 /* connection cache helpers (also called from table-data.c) */
 static bool multidb_init_entry(MultiDbEntry *entry,
-								CopyDataSpec *parentSpecs,
-								const char *datname);
+							   CopyDataSpec *parentSpecs,
+							   const char *datname);
 
 /* lighter index/vacuum pool helpers */
 static bool multidb_init_index_entry(MultiDbEntry *entry,
-									  CopyDataSpec *parentSpecs,
-									  const char *datname);
+									 CopyDataSpec *parentSpecs,
+									 const char *datname);
 static bool multidb_index_context_close_entry(MultiDbEntry *entry);
 
 
@@ -181,7 +181,7 @@ clone_all_databases(CopyDataSpec *parentSpecs)
 	 * exec'd children (pg_dump, pg_restore).
 	 */
 	int readypipe[2] = { -1, -1 };
-	int donepipe[2]  = { -1, -1 };
+	int donepipe[2] = { -1, -1 };
 
 	if (pipe(readypipe) < 0 || pipe(donepipe) < 0)
 	{
@@ -193,7 +193,7 @@ clone_all_databases(CopyDataSpec *parentSpecs)
 	for (int i = 0; i < 2; i++)
 	{
 		(void) fcntl(readypipe[i], F_SETFD, FD_CLOEXEC);
-		(void) fcntl(donepipe[i],  F_SETFD, FD_CLOEXEC);
+		(void) fcntl(donepipe[i], F_SETFD, FD_CLOEXEC);
 	}
 
 	fflush(stdout);
@@ -206,8 +206,10 @@ clone_all_databases(CopyDataSpec *parentSpecs)
 		case -1:
 		{
 			log_error("Failed to fork snapshot holder: %m");
-			close(readypipe[0]); close(readypipe[1]);
-			close(donepipe[0]);  close(donepipe[1]);
+			close(readypipe[0]);
+			close(readypipe[1]);
+			close(donepipe[0]);
+			close(donepipe[1]);
 			(void) queue_unlink(&parentSpecs->preDataQueue);
 			return false;
 		}
@@ -226,7 +228,9 @@ clone_all_databases(CopyDataSpec *parentSpecs)
 		}
 
 		default:
+		{
 			break;
+		}
 	}
 
 	/* parent: close pipe ends not needed here */
@@ -325,8 +329,9 @@ clone_all_databases(CopyDataSpec *parentSpecs)
 			SourceDatabase *db = dbIter.dat;
 
 			if (db == NULL)
+			{
 				break;        /* end of results */
-
+			}
 			if (multidb_is_system_database(db->datname))
 			{
 				log_debug("Skipping system database \"%s\"", db->datname);
@@ -376,7 +381,9 @@ clone_all_databases(CopyDataSpec *parentSpecs)
 		}
 
 		if (!catalog_iter_s_database_finish(&dbIter))
+		{
 			ok = false;
+		}
 
 		(void) catalog_close_from_specs(parentSpecs);
 	}
@@ -384,7 +391,9 @@ clone_all_databases(CopyDataSpec *parentSpecs)
 	if (!ok || dbCount == 0)
 	{
 		if (ok && dbCount == 0)
+		{
 			log_warn("No user databases found after filtering");
+		}
 		goto signal_done;
 	}
 
@@ -422,7 +431,9 @@ clone_all_databases(CopyDataSpec *parentSpecs)
 			}
 
 			default:
+			{
 				break;
+			}
 		}
 
 		if (!multidb_wait_child(prePid, "pre-data supervisor"))
@@ -497,11 +508,14 @@ clone_all_databases(CopyDataSpec *parentSpecs)
 					  multiDbInfos[i].datname);
 			ok = false;
 			if (parentSpecs->failFast)
+			{
 				break;
+			}
 		}
 	}
 
 signal_done:
+
 	/*
 	 * Close the write end of donepipe, signalling the snapshot holder to commit
 	 * all its REPEATABLE READ transactions and exit.
@@ -509,7 +523,9 @@ signal_done:
 	close(donepipe[1]);
 
 	if (!multidb_wait_child(holderPid, "snapshot holder"))
+	{
 		ok = false;
+	}
 
 	parentSpecs->multiDbInfos = NULL;
 	parentSpecs->multiDbCount = 0;
@@ -630,7 +646,9 @@ multidb_snapshot_holder(CopyDataSpec *parentSpecs, int readyfd, int donefd)
 		SourceDatabase *db = dbIter.dat;
 
 		if (db == NULL)
+		{
 			break;
+		}
 
 		if (multidb_is_system_database(db->datname))
 		{
@@ -677,8 +695,8 @@ multidb_snapshot_holder(CopyDataSpec *parentSpecs, int readyfd, int donefd)
 
 		/* persist snapshot ID in the instance catalog */
 		if (!catalog_update_s_database_snapshot(instanceCatalog,
-												 db->datname,
-												 snap->snapshot))
+												db->datname,
+												snap->snapshot))
 		{
 			log_error("Snapshot holder: failed to record snapshot "
 					  "for database \"%s\"", db->datname);
@@ -702,12 +720,16 @@ multidb_snapshot_holder(CopyDataSpec *parentSpecs, int readyfd, int donefd)
 	}
 
 	if (!catalog_iter_s_database_finish(&dbIter))
+	{
 		ok = false;
+	}
 
 	(void) catalog_close_from_specs(parentSpecs);
 
 	if (!ok)
+	{
 		goto signal_ready;
+	}
 
 	/* send one STOP message per worker */
 	for (int i = 0; i < parentSpecs->tableJobs; i++)
@@ -726,6 +748,7 @@ multidb_snapshot_holder(CopyDataSpec *parentSpecs, int readyfd, int donefd)
 			 dbCount, parentSpecs->tableJobs);
 
 signal_ready:
+
 	/*
 	 * Signal the parent that the catalog is fully written and all DBNAME/STOP
 	 * messages are in the queue.  The parent will re-open the catalog, build
@@ -741,7 +764,9 @@ signal_ready:
 	}
 
 	if (!ok)
+	{
 		goto cleanup_snapshots;
+	}
 
 	/*
 	 * Wait for the parent to close the write end of donepipe (after Phase III).
@@ -757,6 +782,7 @@ signal_ready:
 	log_notice("Snapshot holder: received done signal, closing snapshots");
 
 cleanup_snapshots:
+
 	/* commit all held snapshot transactions */
 	for (int i = 0; i < dbCount; i++)
 	{
@@ -827,7 +853,9 @@ multidb_pre_data_supervisor(CopyDataSpec *parentSpecs)
 			}
 
 			default:
+			{
 				break;
+			}
 		}
 	}
 
@@ -839,7 +867,6 @@ multidb_pre_data_supervisor(CopyDataSpec *parentSpecs)
 
 	return ok;
 }
-
 
 
 /*
@@ -899,7 +926,9 @@ multidb_pre_data_worker(CopyDataSpec *parentSpecs)
 					++errors;
 
 					if (parentSpecs->failFast)
+					{
 						return false;
+					}
 				}
 				break;
 			}
@@ -1016,7 +1045,9 @@ multidb_pre_data_one_db(CopyDataSpec *parentSpecs, const char *datname)
 		free(cs.source_pguri);
 		free(cs.target_pguri);
 		if (cs.safeSourcePGURI.pguri)
+		{
 			free(cs.safeSourcePGURI.pguri);
+		}
 		return false;
 	}
 
@@ -1118,9 +1149,13 @@ cleanup_cs:
 	free(cs.source_pguri);
 	free(cs.target_pguri);
 	if (cs.safeSourcePGURI.pguri)
+	{
 		free(cs.safeSourcePGURI.pguri);
+	}
 	if (cs.safeTargetPGURI.pguri)
+	{
 		free(cs.safeTargetPGURI.pguri);
+	}
 
 	return ok;
 }
@@ -1135,7 +1170,7 @@ cleanup_cs:
  */
 static bool
 multidb_clone_one_database_post_data(CopyDataSpec *parentSpecs,
-									  const char *datname)
+									 const char *datname)
 {
 	/* locate MultiDbInfo for this database */
 	MultiDbInfo *info = NULL;
@@ -1298,7 +1333,9 @@ multidb_clone_one_database_post_data(CopyDataSpec *parentSpecs,
 		}
 
 		default:
+		{
 			break;
+		}
 	}
 
 	/* parent: wait for post-data subprocess */
@@ -1381,7 +1418,7 @@ multidb_global_copy(CopyDataSpec *parentSpecs)
 
 		for (int i = 0; i < parentSpecs->multiDbCount; i++)
 		{
-			parentSpecs->multiDbInfos[i].catalogSemId    = catalogSemaSet.semId;
+			parentSpecs->multiDbInfos[i].catalogSemId = catalogSemaSet.semId;
 			parentSpecs->multiDbInfos[i].catalogSemIndex = i;
 
 			log_debug("Assigned catalog semaphore set %d[%d] to database \"%s\"",
@@ -1400,7 +1437,7 @@ multidb_global_copy(CopyDataSpec *parentSpecs)
 
 		DatabaseCatalog dbCat = {
 			.type = DATABASE_CATALOG_TYPE_SOURCE,
-			.sema.semId    = info->catalogSemId,
+			.sema.semId = info->catalogSemId,
 			.sema.semIndex = info->catalogSemIndex,
 			.sema.reentrant = true,
 		};
@@ -1513,7 +1550,9 @@ multidb_global_copy(CopyDataSpec *parentSpecs)
 					}
 
 					default:
+					{
 						break;
+					}
 				}
 			}
 
@@ -1541,7 +1580,9 @@ multidb_global_copy(CopyDataSpec *parentSpecs)
 					}
 
 					default:
+					{
 						break;
+					}
 				}
 			}
 
@@ -1565,7 +1606,9 @@ multidb_global_copy(CopyDataSpec *parentSpecs)
 		}
 
 		default:
+		{
 			break;
+		}
 	}
 
 	/*
@@ -1589,7 +1632,9 @@ multidb_global_copy(CopyDataSpec *parentSpecs)
 		for (int i = 0; i < 3; i++)
 		{
 			if (supervisor_pids[i] <= 0)
+			{
 				continue;
+			}
 
 			int status = 0;
 			pid_t reaped = waitpid(supervisor_pids[i], &status, WNOHANG);
@@ -1649,11 +1694,13 @@ multidb_global_copy(CopyDataSpec *parentSpecs)
 		MultiDbInfo *info = &parentSpecs->multiDbInfos[i];
 
 		if (info->catalogSemId == 0)
+		{
 			continue;
+		}
 
 		DatabaseCatalog dbCat = {
 			.type = DATABASE_CATALOG_TYPE_SOURCE,
-			.sema.semId    = info->catalogSemId,
+			.sema.semId = info->catalogSemId,
 			.sema.semIndex = info->catalogSemIndex,
 			.sema.reentrant = true,
 		};
@@ -1672,7 +1719,9 @@ multidb_global_copy(CopyDataSpec *parentSpecs)
 		(void) summary_stop_timing(&dbCat, TIMING_SECTION_ALTER_TABLE);
 
 		if (!parentSpecs->skipVacuum)
+		{
 			(void) summary_stop_timing(&dbCat, TIMING_SECTION_VACUUM);
+		}
 
 		(void) catalog_close(&dbCat);
 	}
@@ -1690,7 +1739,9 @@ multidb_global_copy(CopyDataSpec *parentSpecs)
 		(void) semaphore_unlink(&setHandle);
 
 		for (int i = 0; i < parentSpecs->multiDbCount; i++)
+		{
 			parentSpecs->multiDbInfos[i].catalogSemId = 0;
+		}
 	}
 
 	/* Clean up index/vacuum queues (copy queue cleaned up by copy supervisor). */
@@ -1795,7 +1846,9 @@ bool
 multidb_context_close_entry(MultiDbEntry *entry)
 {
 	if (!entry->active)
+	{
 		return true;
+	}
 
 	log_debug("Closing multidb connection cache entry for \"%s\"",
 			  entry->datname);
@@ -1834,7 +1887,9 @@ multidb_context_close_all(MultiDbContext *ctx)
 		if (ctx->entries[i].active)
 		{
 			if (!multidb_context_close_entry(&ctx->entries[i]))
+			{
 				ok = false;
+			}
 		}
 	}
 
@@ -1850,7 +1905,7 @@ multidb_context_close_all(MultiDbContext *ctx)
  */
 static bool
 multidb_init_index_entry(MultiDbEntry *entry, CopyDataSpec *parentSpecs,
-						  const char *datname)
+						 const char *datname)
 {
 	MultiDbInfo *info = NULL;
 
@@ -1934,7 +1989,7 @@ multidb_init_index_entry(MultiDbEntry *entry, CopyDataSpec *parentSpecs,
 	 */
 	if (info->catalogSemId != 0)
 	{
-		sourceDB->sema.semId    = info->catalogSemId;
+		sourceDB->sema.semId = info->catalogSemId;
 		sourceDB->sema.semIndex = info->catalogSemIndex;
 		sourceDB->sema.reentrant = true;
 	}
@@ -2002,7 +2057,9 @@ static bool
 multidb_index_context_close_entry(MultiDbEntry *entry)
 {
 	if (!entry->active)
+	{
 		return true;
+	}
 
 	log_debug("Closing index/vacuum connection cache entry for \"%s\"",
 			  entry->datname);
@@ -2039,7 +2096,9 @@ multidb_index_context_close_all(MultiDbContext *ctx)
 		if (ctx->entries[i].active)
 		{
 			if (!multidb_index_context_close_entry(&ctx->entries[i]))
+			{
 				ok = false;
+			}
 		}
 	}
 
@@ -2215,7 +2274,9 @@ multidb_init_entry(MultiDbEntry *entry, CopyDataSpec *parentSpecs,
 		free(dbSpecs->connStrings.source_pguri);
 		free(dbSpecs->connStrings.target_pguri);
 		if (dbSpecs->connStrings.safeSourcePGURI.pguri)
+		{
 			free(dbSpecs->connStrings.safeSourcePGURI.pguri);
+		}
 		free(dbSpecs);
 		return false;
 	}
@@ -2256,7 +2317,7 @@ multidb_init_entry(MultiDbEntry *entry, CopyDataSpec *parentSpecs,
 	 */
 	if (info->catalogSemId != 0)
 	{
-		sourceDB->sema.semId    = info->catalogSemId;
+		sourceDB->sema.semId = info->catalogSemId;
 		sourceDB->sema.semIndex = info->catalogSemIndex;
 		sourceDB->sema.reentrant = true;
 	}
@@ -2307,6 +2368,7 @@ multidb_init_entry(MultiDbEntry *entry, CopyDataSpec *parentSpecs,
 	if (!pgsql_set_gucs(&entry->dst, dstSettings))
 	{
 		log_warn("Failed to set GUCs on target for database \"%s\"", datname);
+
 		/* non-fatal: continue */
 	}
 
@@ -2374,12 +2436,14 @@ multidb_target_database_exists(PGSQL *dst, const char *datname, bool *exists)
  */
 static bool
 multidb_create_target_database(PGSQL *dst, const char *datname,
-								bool dropIfExists)
+							   bool dropIfExists)
 {
 	bool exists = false;
 
 	if (!multidb_target_database_exists(dst, datname, &exists))
+	{
 		return false;
+	}
 
 	if (exists)
 	{
@@ -2394,7 +2458,9 @@ multidb_create_target_database(PGSQL *dst, const char *datname,
 		PGconn *conn = pgsql_open_connection(dst);
 
 		if (conn == NULL)
+		{
 			return false;
+		}
 
 		char *quotedName = PQescapeIdentifier(conn, datname, strlen(datname));
 
@@ -2425,7 +2491,9 @@ multidb_create_target_database(PGSQL *dst, const char *datname,
 		PGconn *conn = pgsql_open_connection(dst);
 
 		if (conn == NULL)
+		{
 			return false;
+		}
 
 		char *quotedName = PQescapeIdentifier(conn, datname, strlen(datname));
 
@@ -2463,7 +2531,7 @@ multidb_create_target_database(PGSQL *dst, const char *datname,
  */
 bool
 multidb_build_uri_for_database(const char *pguri, const char *datname,
-								char **result_uri)
+							   char **result_uri)
 {
 	KeyVal noDefaults = { 0 };
 	KeyVal noOverrides = { 0 };

--- a/src/bin/pgcopydb/multi_db.c
+++ b/src/bin/pgcopydb/multi_db.c
@@ -50,16 +50,20 @@ static bool multidb_setup_one_database(CopyDataSpec *parentSpecs,
 									   CopyDataSpec *dbSpecs,
 									   ConnStrings *dbConnStrings,
 									   MultiDbInfo *info);
-static bool multidb_clone_one_database_pre_data(CopyDataSpec *parentSpecs,
-												 SourceDatabase *db,
-												 CopyDataSpec *dbSpecs,
-												 ConnStrings *dbConnStrings);
+
+/* Phase I: parallel pre-data (schema fetch + pg_dump + pg_restore --pre-data) */
+static bool multidb_pre_data_supervisor(CopyDataSpec *parentSpecs);
+static bool multidb_pre_data_queue_filler(CopyDataSpec *parentSpecs);
+static bool multidb_pre_data_worker(CopyDataSpec *parentSpecs);
+static bool multidb_pre_data_one_db(CopyDataSpec *parentSpecs,
+									const char *datname);
+
 static bool multidb_clone_one_database_post_data(CopyDataSpec *parentSpecs,
 												  SourceDatabase *db,
 												  CopyDataSpec *dbSpecs,
 												  ConnStrings *dbConnStrings);
 static bool multidb_global_copy(CopyDataSpec *parentSpecs);
-static bool multidb_wait_child(pid_t pid, const char *datname);
+static bool multidb_wait_child(pid_t pid, const char *label);
 
 /* connection cache helpers (also called from table-data.c) */
 static bool multidb_init_entry(MultiDbEntry *entry,
@@ -290,34 +294,43 @@ clone_all_databases(CopyDataSpec *parentSpecs)
 		goto cleanup_snapshots;
 	}
 
-	/* ====== PHASE I: PRE-DATA (sequential per-database) ====== */
-	log_info("Phase I: schema fetch, dump, and pre-data restore for %d databases",
-			 dbCount);
+	/* ====== PHASE I: PRE-DATA (parallel, bounded by --table-jobs) ====== */
+	log_info("Phase I: parallel schema fetch, dump, and pre-data restore "
+			 "for %d databases (--table-jobs=%d)",
+			 dbCount, parentSpecs->tableJobs);
 
-	for (int i = 0; i < dbCount && ok; i++)
 	{
-		if (asked_to_stop || asked_to_stop_fast || asked_to_quit)
-		{
-			ok = false;
-			break;
-		}
+		fflush(stdout);
+		fflush(stderr);
 
-		log_info("Pre-data for database \"%s\"", dbArray[i].datname);
+		pid_t prePid = fork();
 
-		if (!multidb_clone_one_database_pre_data(parentSpecs,
-												 &dbArray[i],
-												 &dbSpecsArray[i],
-												 &dbConnStringsArray[i]))
+		switch (prePid)
 		{
-			log_error("Pre-data failed for database \"%s\"", dbArray[i].datname);
-			ok = false;
-			if (parentSpecs->failFast)
+			case -1:
+			{
+				log_error("Failed to fork pre-data supervisor: %m");
+				ok = false;
+				goto cleanup_snapshots;
+			}
+
+			case 0:
+			{
+				/* pre-data supervisor process */
+				bool res = multidb_pre_data_supervisor(parentSpecs);
+				exit(res ? EXIT_CODE_QUIT : EXIT_CODE_INTERNAL_ERROR);
+			}
+
+			default:
 				break;
 		}
-	}
 
-	if (!ok)
-		goto cleanup_snapshots;
+		if (!multidb_wait_child(prePid, "pre-data supervisor"))
+		{
+			ok = false;
+			goto cleanup_snapshots;
+		}
+	}
 
 	/* ====== PHASE II: GLOBAL COPY ====== */
 	log_info("Phase II: global COPY for %d databases (largest tables first)",
@@ -474,102 +487,378 @@ multidb_setup_one_database(CopyDataSpec *parentSpecs,
 
 
 /*
- * multidb_clone_one_database_pre_data forks a subprocess that performs the
- * pre-data phase for one database: schema fetch, pg_dump, pg_restore pre-data.
+ * multidb_pre_data_supervisor is the supervisor for Phase I.
+ *
+ * It runs inside a dedicated subprocess (forked by clone_all_databases).
+ * The supervisor creates a preDataQueue, forks tableJobs workers, forks one
+ * queue-filler child, then calls waitpid(-1) to collect all children.
+ *
+ * Process tree:
+ *   clone_all_databases
+ *   └── pre-data supervisor  (this function)
+ *           ├── pre-data worker 1
+ *           ├── pre-data worker N  (N = --table-jobs)
+ *           └── pre-data queue filler  (sends database names, then STOPs)
  */
 static bool
-multidb_clone_one_database_pre_data(CopyDataSpec *parentSpecs,
-									SourceDatabase *db,
-									CopyDataSpec *dbSpecs,
-									ConnStrings *dbConnStrings)
+multidb_pre_data_supervisor(CopyDataSpec *parentSpecs)
 {
-	log_info("[SOURCE] Pre-data for database \"%s\" from \"%s\"",
-			 db->datname, dbConnStrings->safeSourcePGURI.pguri);
+	(void) set_ps_title("pgcopydb: pre-data supervisor");
+	log_notice("Started pre-data supervisor %d [%d]", getpid(), getppid());
 
-	fflush(stdout);
-	fflush(stderr);
-
-	pid_t fpid = fork();
-
-	switch (fpid)
+	/* create the IPC queue for Phase I — workers inherit qId after fork */
+	if (!queue_create(&parentSpecs->preDataQueue, "pre-data"))
 	{
-		case -1:
+		log_error("Failed to create the pre-data process queue");
+		return false;
+	}
+
+	/* fork tableJobs pre-data workers */
+	for (int i = 0; i < parentSpecs->tableJobs; i++)
+	{
+		fflush(stdout);
+		fflush(stderr);
+
+		pid_t wpid = fork();
+
+		switch (wpid)
 		{
-			log_error("Failed to fork pre-data subprocess for database \"%s\": %m",
-					  db->datname);
-			return false;
-		}
-
-		case 0:
-		{
-			/* child process */
-			char psTitle[MAXPGPATH] = { 0 };
-			sformat(psTitle, sizeof(psTitle), "pgcopydb: pre-data %s", db->datname);
-			(void) set_ps_title(psTitle);
-
-			summary_reset_toplevel_timings();
-
-			/*
-			 * Init db specs in the child so System V queues are registered in
-			 * this child's copy of system_res_array.
-			 */
-			if (!multidb_init_db_specs(dbSpecs, parentSpecs, dbConnStrings))
+			case -1:
 			{
-				log_error("Failed to initialise specs for database \"%s\"",
-						  db->datname);
+				log_error("Failed to fork pre-data worker: %m");
+				(void) copydb_fatal_exit();
 				exit(EXIT_CODE_INTERNAL_ERROR);
 			}
 
-			/* STEP 1: fetch source database schema */
-			if (!copydb_fetch_schema_and_prepare_specs(dbSpecs))
+			case 0:
 			{
-				log_error("Failed to fetch schema for database \"%s\"",
-						  db->datname);
-				exit(EXIT_CODE_SOURCE);
+				(void) set_ps_title("pgcopydb: pre-data worker");
+				bool ok = multidb_pre_data_worker(parentSpecs);
+				exit(ok ? EXIT_CODE_QUIT : EXIT_CODE_INTERNAL_ERROR);
 			}
 
-			/*
-			 * Make a process-local copy of the snapshot so we have our own
-			 * PGSQL connection to hold the transaction open.
-			 */
-			TransactionSnapshot localSnapshot = { 0 };
-
-			if (!copydb_copy_snapshot(dbSpecs, &localSnapshot))
-			{
-				log_error("Failed to copy snapshot for database \"%s\"",
-						  db->datname);
-				exit(EXIT_CODE_SOURCE);
-			}
-
-			dbSpecs->sourceSnapshot = localSnapshot;
-
-			/* STEP 2: dump the source schema (pre-data + post-data sections) */
-			if (!copydb_dump_source_schema(dbSpecs,
-										   localSnapshot.snapshot))
-			{
-				log_error("Failed to dump schema for database \"%s\"",
-						  db->datname);
-				exit(EXIT_CODE_SOURCE);
-			}
-
-			/* STEP 3: restore the pre-data section to the target */
-			if (!copydb_target_prepare_schema(dbSpecs))
-			{
-				log_error("Failed to restore pre-data for database \"%s\"",
-						  db->datname);
-				exit(EXIT_CODE_TARGET);
-			}
-
-			(void) catalog_close_from_specs(dbSpecs);
-			exit(EXIT_CODE_QUIT);
+			default:
+				break;
 		}
-
-		default:
-			break;
 	}
 
-	/* parent: wait for pre-data subprocess */
-	return multidb_wait_child(fpid, db->datname);
+	/* fork the queue filler (child of supervisor) */
+	{
+		fflush(stdout);
+		fflush(stderr);
+
+		pid_t qpid = fork();
+
+		switch (qpid)
+		{
+			case -1:
+			{
+				log_error("Failed to fork pre-data queue filler: %m");
+				(void) copydb_fatal_exit();
+				exit(EXIT_CODE_INTERNAL_ERROR);
+			}
+
+			case 0:
+			{
+				(void) set_ps_title("pgcopydb: pre-data queue databases");
+				bool ok = multidb_pre_data_queue_filler(parentSpecs);
+				exit(ok ? EXIT_CODE_QUIT : EXIT_CODE_INTERNAL_ERROR);
+			}
+
+			default:
+				break;
+		}
+	}
+
+	/* supervisor waits for all children: workers + queue filler */
+	bool ok = copydb_wait_for_subprocesses(parentSpecs->failFast);
+
+	(void) queue_unlink(&parentSpecs->preDataQueue);
+	parentSpecs->preDataQueue.qId = -1;
+
+	return ok;
+}
+
+
+/*
+ * multidb_pre_data_queue_filler sends one DBNAME message per database to the
+ * preDataQueue, then sends tableJobs STOP messages so all workers terminate.
+ */
+static bool
+multidb_pre_data_queue_filler(CopyDataSpec *parentSpecs)
+{
+	log_notice("Started pre-data queue filler %d [%d]", getpid(), getppid());
+
+	for (int i = 0; i < parentSpecs->multiDbCount; i++)
+	{
+		MultiDbInfo *info = &parentSpecs->multiDbInfos[i];
+
+		QMessage mesg = { .type = QMSG_TYPE_DBNAME };
+		strlcpy(mesg.data.datname, info->datname, sizeof(mesg.data.datname));
+
+		if (!queue_send(&parentSpecs->preDataQueue, &mesg))
+		{
+			log_error("Failed to enqueue database \"%s\" for pre-data",
+					  info->datname);
+			return false;
+		}
+
+		log_info("Pre-data queue filler: enqueued database \"%s\"",
+				 info->datname);
+	}
+
+	/* one STOP per worker */
+	for (int i = 0; i < parentSpecs->tableJobs; i++)
+	{
+		QMessage stop = { .type = QMSG_TYPE_STOP };
+
+		if (!queue_send(&parentSpecs->preDataQueue, &stop))
+		{
+			log_error("Failed to send STOP to pre-data queue");
+			return false;
+		}
+	}
+
+	log_info("Pre-data queue filler: sent %d databases, %d STOP messages",
+			 parentSpecs->multiDbCount, parentSpecs->tableJobs);
+
+	return true;
+}
+
+
+/*
+ * multidb_pre_data_worker dequeues database names from preDataQueue and runs
+ * the full pre-data pipeline for each one (schema fetch, pg_dump,
+ * pg_restore --pre-data).  Processes databases sequentially until it receives
+ * a STOP message.
+ */
+static bool
+multidb_pre_data_worker(CopyDataSpec *parentSpecs)
+{
+	pid_t pid = getpid();
+	uint64_t errors = 0;
+	bool stop = false;
+
+	log_notice("Started pre-data worker %d [%d]", pid, getppid());
+
+	while (!stop)
+	{
+		QMessage mesg = { 0 };
+		bool recv_ok = queue_receive(&parentSpecs->preDataQueue, &mesg);
+
+		if (asked_to_stop || asked_to_stop_fast || asked_to_quit)
+		{
+			log_error("Pre-data worker %d interrupted by signal", pid);
+			break;
+		}
+
+		if (!recv_ok)
+		{
+			log_error("Pre-data worker %d failed to receive from queue", pid);
+			break;
+		}
+
+		switch (mesg.type)
+		{
+			case QMSG_TYPE_STOP:
+			{
+				stop = true;
+				log_debug("Pre-data worker %d received STOP", pid);
+				break;
+			}
+
+			case QMSG_TYPE_DBNAME:
+			{
+				const char *datname = mesg.data.datname;
+
+				log_info("Pre-data worker %d: processing database \"%s\"",
+						 pid, datname);
+
+				summary_reset_toplevel_timings();
+
+				if (!multidb_pre_data_one_db(parentSpecs, datname))
+				{
+					log_error("Pre-data worker %d: failed for database \"%s\"",
+							  pid, datname);
+					++errors;
+
+					if (parentSpecs->failFast)
+						return false;
+				}
+				break;
+			}
+
+			default:
+			{
+				log_error("Pre-data worker %d: unknown message type %ld",
+						  pid, mesg.type);
+				break;
+			}
+		}
+	}
+
+	log_notice("Pre-data worker %d finished with %llu error(s)",
+			   pid, (unsigned long long) errors);
+
+	return stop && errors == 0;
+}
+
+
+/*
+ * multidb_pre_data_one_db performs the full pre-data pipeline for one
+ * database: schema fetch from source, pg_dump, pg_restore --pre-data.
+ *
+ * Called from within a pre-data worker process.  All resources are
+ * allocated locally and released before returning so the worker can
+ * proceed to the next database.
+ */
+static bool
+multidb_pre_data_one_db(CopyDataSpec *parentSpecs, const char *datname)
+{
+	/* locate MultiDbInfo for this database */
+	MultiDbInfo *info = NULL;
+
+	for (int i = 0; i < parentSpecs->multiDbCount; i++)
+	{
+		if (strcmp(parentSpecs->multiDbInfos[i].datname, datname) == 0)
+		{
+			info = &parentSpecs->multiDbInfos[i];
+			break;
+		}
+	}
+
+	if (info == NULL)
+	{
+		log_error("BUG: multidb_pre_data_one_db: no MultiDbInfo for "
+				  "database \"%s\"", datname);
+		return false;
+	}
+
+	log_info("[SOURCE] Pre-data for database \"%s\"", datname);
+
+	/*
+	 * Build per-database connection strings.  These are strdup'd here and
+	 * freed at the end of this function.
+	 */
+	ConnStrings cs = { 0 };
+
+	cs.source_pguri = strdup(info->source_pguri);
+	cs.target_pguri = strdup(info->target_pguri);
+
+	if (cs.source_pguri == NULL || cs.target_pguri == NULL)
+	{
+		log_error(ALLOCATION_FAILED_ERROR);
+		free(cs.source_pguri);
+		return false;
+	}
+
+	if (!parse_and_scrub_connection_string(cs.source_pguri,
+										   &cs.safeSourcePGURI))
+	{
+		log_error("Failed to scrub source URI for database \"%s\"", datname);
+		free(cs.source_pguri);
+		free(cs.target_pguri);
+		return false;
+	}
+
+	if (!parse_and_scrub_connection_string(cs.target_pguri,
+										   &cs.safeTargetPGURI))
+	{
+		log_error("Failed to scrub target URI for database \"%s\"", datname);
+		free(cs.source_pguri);
+		free(cs.target_pguri);
+		if (cs.safeSourcePGURI.pguri)
+			free(cs.safeSourcePGURI.pguri);
+		return false;
+	}
+
+	bool ok = true;
+
+	/*
+	 * Build a local CopyDataSpec for this database.
+	 * copydb_init_workdir must be called before multidb_init_db_specs so
+	 * that cfPaths is populated.
+	 */
+	CopyDataSpec dbSpecs = { 0 };
+	dbSpecs.pgPaths = parentSpecs->pgPaths;
+
+	if (!copydb_init_workdir(&dbSpecs, info->topdir,
+							 false,   /* service */
+							 NULL,    /* serviceName */
+							 false,   /* restart */
+							 true,    /* resume */
+							 false))  /* createWorkDir (already created) */
+	{
+		log_error("Failed to init work dir for database \"%s\"", datname);
+		ok = false;
+		goto cleanup_cs;
+	}
+
+	if (!multidb_init_db_specs(&dbSpecs, parentSpecs, &cs))
+	{
+		log_error("Failed to init db specs for database \"%s\"", datname);
+		ok = false;
+		goto cleanup_cs;
+	}
+
+	/*
+	 * Pre-data workers do not run index or vacuum workers — destroy the
+	 * queues multidb_init_db_specs may have created.
+	 */
+	if (dbSpecs.vacuumQueue.qId != -1)
+	{
+		(void) queue_unlink(&dbSpecs.vacuumQueue);
+		dbSpecs.vacuumQueue.qId = -1;
+	}
+
+	if (dbSpecs.indexQueue.qId != -1)
+	{
+		(void) queue_unlink(&dbSpecs.indexQueue);
+		dbSpecs.indexQueue.qId = -1;
+	}
+
+	/*
+	 * Propagate the exported snapshot identifier so that pg_dump can use
+	 * it via --snapshot=<id>.
+	 */
+	strlcpy(dbSpecs.sourceSnapshot.snapshot, info->snapshot,
+			sizeof(dbSpecs.sourceSnapshot.snapshot));
+
+	/* STEP 1: fetch source database schema into source.db */
+	if (!copydb_fetch_schema_and_prepare_specs(&dbSpecs))
+	{
+		log_error("Failed to fetch schema for database \"%s\"", datname);
+		ok = false;
+		goto cleanup_specs;
+	}
+
+	/* STEP 2: dump source schema (pre-data + post-data) via pg_dump */
+	if (!copydb_dump_source_schema(&dbSpecs, info->snapshot))
+	{
+		log_error("Failed to dump schema for database \"%s\"", datname);
+		ok = false;
+		goto cleanup_specs;
+	}
+
+	/* STEP 3: restore the pre-data section to the target via pg_restore */
+	if (!copydb_target_prepare_schema(&dbSpecs))
+	{
+		log_error("Failed to restore pre-data for database \"%s\"", datname);
+		ok = false;
+	}
+
+cleanup_specs:
+	(void) catalog_close_from_specs(&dbSpecs);
+
+cleanup_cs:
+	free(cs.source_pguri);
+	free(cs.target_pguri);
+	if (cs.safeSourcePGURI.pguri)
+		free(cs.safeSourcePGURI.pguri);
+	if (cs.safeTargetPGURI.pguri)
+		free(cs.safeTargetPGURI.pguri);
+
+	return ok;
 }
 
 
@@ -660,9 +949,23 @@ multidb_clone_one_database_post_data(CopyDataSpec *parentSpecs,
 
 
 /*
- * multidb_global_copy runs the global COPY phase: all tables from all
- * databases are enqueued in descending size order and processed by a shared
- * pool of tableJobs COPY workers.
+ * multidb_global_copy runs the global COPY phase.
+ *
+ * Process tree:
+ *   clone_all_databases
+ *   └── global copy supervisor  (this function forks it, then waits)
+ *           ├── global copy worker 1
+ *           ├── global copy worker N  (N = --table-jobs)
+ *           └── global copy queue tables  (fills queue, then exits)
+ *
+ * Fix A — shared catalog semaphores:
+ *   One System V semaphore is created per database before forking the
+ *   supervisor.  All workers inherit the semaphore IDs via COW.
+ *   multidb_init_entry wires the semaphore into the DatabaseCatalog
+ *   before calling catalog_init(), so catalog_create_semaphore() finds
+ *   semId != 0 and skips creating a second independent semaphore.
+ *   Without this, each worker creates its own semaphore, breaking
+ *   write serialisation and producing SQLite BUSY errors.
  */
 static bool
 multidb_global_copy(CopyDataSpec *parentSpecs)
@@ -675,56 +978,48 @@ multidb_global_copy(CopyDataSpec *parentSpecs)
 	}
 
 	/*
-	 * Create the global COPY queue.  Workers are forked from parentSpecs and
-	 * inherit the queue ID.
+	 * Fix A: create one shared semaphore per database BEFORE forking the
+	 * supervisor.  Workers inherit the semId via COW; catalog_init() then
+	 * skips creating its own semaphore.
 	 */
-	if (!queue_create(&(parentSpecs->copyQueue), "global copy"))
+	for (int i = 0; i < parentSpecs->multiDbCount; i++)
 	{
-		log_error("Failed to create the global COPY queue");
-		return false;
-	}
+		MultiDbInfo *info = &parentSpecs->multiDbInfos[i];
 
-	/*
-	 * Fork tableJobs COPY workers.  Each worker uses copydb_table_data_worker_multidb
-	 * which maintains a per-database connection cache.
-	 */
-	log_info("Starting %d global COPY workers", parentSpecs->tableJobs);
+		if (info->catalogSemId != 0)
+			continue;   /* already created (shouldn't happen, but be safe) */
 
-	for (int i = 0; i < parentSpecs->tableJobs; i++)
-	{
-		fflush(stdout);
-		fflush(stderr);
+		Semaphore sema = { .initValue = 1, .reentrant = true };
 
-		pid_t wpid = fork();
-
-		switch (wpid)
+		if (!semaphore_create(&sema))
 		{
-			case -1:
-			{
-				log_error("Failed to fork global COPY worker: %m");
-				(void) copydb_fatal_exit();
-				return false;
-			}
+			log_error("Failed to create catalog semaphore for database \"%s\"",
+					  info->datname);
 
-			case 0:
+			/* best-effort cleanup of already-created semaphores */
+			for (int j = 0; j < i; j++)
 			{
-				/* worker child */
-				(void) set_ps_title("pgcopydb: global copy worker");
+				MultiDbInfo *prev = &parentSpecs->multiDbInfos[j];
 
-				if (!copydb_table_data_worker_multidb(parentSpecs))
+				if (prev->catalogSemId != 0)
 				{
-					exit(EXIT_CODE_INTERNAL_ERROR);
+					Semaphore s = { .semId = prev->catalogSemId };
+					(void) semaphore_unlink(&s);
+					prev->catalogSemId = 0;
 				}
-				exit(EXIT_CODE_QUIT);
 			}
-
-			default:
-				break;
+			return false;
 		}
+
+		info->catalogSemId = sema.semId;
+
+		log_debug("Created catalog semaphore %d for database \"%s\"",
+				  sema.semId, info->datname);
 	}
 
 	/*
-	 * Fork the supervisor that fills the queue from all per-database catalogs.
+	 * Fork the global copy supervisor.  The supervisor creates the copyQueue,
+	 * forks workers and the queue filler, then collects all children.
 	 */
 	fflush(stdout);
 	fflush(stderr);
@@ -735,40 +1030,117 @@ multidb_global_copy(CopyDataSpec *parentSpecs)
 	{
 		case -1:
 		{
-			log_error("Failed to fork global COPY supervisor: %m");
-			(void) copydb_fatal_exit();
+			log_error("Failed to fork global copy supervisor: %m");
 			return false;
 		}
 
 		case 0:
 		{
-			/* supervisor child */
+			/* ====== global copy supervisor process ====== */
 			(void) set_ps_title("pgcopydb: global copy supervisor");
+			log_notice("Started global copy supervisor %d [%d]",
+					   getpid(), getppid());
 
-			if (!copydb_copy_worker_queue_tables_multidb(parentSpecs))
+			/*
+			 * Create the copyQueue here so workers can inherit its qId
+			 * after they are forked below.
+			 */
+			if (!queue_create(&parentSpecs->copyQueue, "global copy"))
 			{
+				log_error("Failed to create the global COPY queue");
 				exit(EXIT_CODE_INTERNAL_ERROR);
 			}
-			exit(EXIT_CODE_QUIT);
+
+			/* fork tableJobs COPY workers */
+			log_info("Starting %d global COPY workers", parentSpecs->tableJobs);
+
+			for (int i = 0; i < parentSpecs->tableJobs; i++)
+			{
+				fflush(stdout);
+				fflush(stderr);
+
+				pid_t wpid = fork();
+
+				switch (wpid)
+				{
+					case -1:
+					{
+						log_error("Failed to fork global COPY worker: %m");
+						(void) copydb_fatal_exit();
+						exit(EXIT_CODE_INTERNAL_ERROR);
+					}
+
+					case 0:
+					{
+						(void) set_ps_title("pgcopydb: global copy worker");
+						bool ok = copydb_table_data_worker_multidb(parentSpecs);
+						exit(ok ? EXIT_CODE_QUIT : EXIT_CODE_INTERNAL_ERROR);
+					}
+
+					default:
+						break;
+				}
+			}
+
+			/* fork the queue filler as a child of the supervisor */
+			{
+				fflush(stdout);
+				fflush(stderr);
+
+				pid_t qpid = fork();
+
+				switch (qpid)
+				{
+					case -1:
+					{
+						log_error("Failed to fork global COPY queue filler: %m");
+						(void) copydb_fatal_exit();
+						exit(EXIT_CODE_INTERNAL_ERROR);
+					}
+
+					case 0:
+					{
+						(void) set_ps_title("pgcopydb: global copy queue tables");
+						bool ok =
+							copydb_copy_worker_queue_tables_multidb(parentSpecs);
+						exit(ok ? EXIT_CODE_QUIT : EXIT_CODE_INTERNAL_ERROR);
+					}
+
+					default:
+						break;
+				}
+			}
+
+			/* supervisor waits for all children (workers + queue filler) */
+			bool ok = copydb_wait_for_subprocesses(parentSpecs->failFast);
+
+			(void) queue_unlink(&parentSpecs->copyQueue);
+			parentSpecs->copyQueue.qId = -1;
+
+			exit(ok ? EXIT_CODE_QUIT : EXIT_CODE_INTERNAL_ERROR);
 		}
 
 		default:
 			break;
 	}
 
-	/* parent: wait for all workers + supervisor */
-	if (!copydb_wait_for_subprocesses(parentSpecs->failFast))
+	/* clone_all_databases waits for the one supervisor child */
+	bool ok = multidb_wait_child(spid, "global copy supervisor");
+
+	/* destroy the shared catalog semaphores */
+	for (int i = 0; i < parentSpecs->multiDbCount; i++)
 	{
-		log_error("Some global COPY worker processes exited with error");
-		(void) queue_unlink(&(parentSpecs->copyQueue));
-		return false;
+		MultiDbInfo *info = &parentSpecs->multiDbInfos[i];
+
+		if (info->catalogSemId != 0)
+		{
+			Semaphore sema = { .semId = info->catalogSemId };
+			(void) semaphore_unlink(&sema);
+			info->catalogSemId = 0;
+		}
 	}
 
-	/* clean up the global COPY queue */
-	(void) queue_unlink(&(parentSpecs->copyQueue));
-	parentSpecs->copyQueue.qId = -1;
-
-	return true;
+	return ok;
 }
 
 
@@ -1047,6 +1419,18 @@ multidb_init_entry(MultiDbEntry *entry, CopyDataSpec *parentSpecs,
 	strlcpy(sourceDB->dbfile, dbSpecs->cfPaths.sdbfile, sizeof(sourceDB->dbfile));
 	strlcpy(filterDB->dbfile, dbSpecs->cfPaths.fdbfile, sizeof(filterDB->dbfile));
 	strlcpy(targetDB->dbfile, dbSpecs->cfPaths.tdbfile, sizeof(targetDB->dbfile));
+
+	/*
+	 * Fix A: wire the shared catalog semaphore so catalog_create_semaphore()
+	 * finds semId != 0 and reuses it rather than creating a fresh independent
+	 * semaphore.  All workers for the same database thus share one lock,
+	 * serialising SQLite writes and eliminating SQLITE_BUSY contention.
+	 */
+	if (info->catalogSemId != 0)
+	{
+		sourceDB->sema.semId = info->catalogSemId;
+		sourceDB->sema.reentrant = true;
+	}
 
 	/* open the per-database source catalog (populated by pre-data) */
 	if (!catalog_init(sourceDB))
@@ -1447,26 +1831,27 @@ multidb_init_db_specs(CopyDataSpec *dbSpecs,
 
 
 /*
- * multidb_wait_child blocks until the given subprocess exits.
+ * multidb_wait_child blocks until the given subprocess exits and returns
+ * true iff it exited with EXIT_CODE_QUIT (0).  The label is used only in
+ * log messages (it may be a database name or a supervisor description).
  */
 static bool
-multidb_wait_child(pid_t pid, const char *datname)
+multidb_wait_child(pid_t pid, const char *label)
 {
 	int status = 0;
 	pid_t result = waitpid(pid, &status, 0);
 
 	if (result < 0)
 	{
-		log_error("Failed to wait for subprocess %d (database \"%s\"): %m",
-				  pid, datname);
+		log_error("Failed to wait for subprocess %d (%s): %m", pid, label);
 		return false;
 	}
 
 	if (!WIFEXITED(status))
 	{
 		int sig = WTERMSIG(status);
-		log_error("Subprocess %d (database \"%s\") terminated by signal %d",
-				  pid, datname, sig);
+		log_error("Subprocess %d (%s) terminated by signal %d",
+				  pid, label, sig);
 		return false;
 	}
 
@@ -1474,8 +1859,8 @@ multidb_wait_child(pid_t pid, const char *datname)
 
 	if (returnCode != 0)
 	{
-		log_error("Subprocess %d (database \"%s\") exited with status %d",
-				  pid, datname, returnCode);
+		log_error("Subprocess %d (%s) exited with status %d",
+				  pid, label, returnCode);
 		return false;
 	}
 

--- a/src/bin/pgcopydb/multi_db.c
+++ b/src/bin/pgcopydb/multi_db.c
@@ -12,8 +12,10 @@
  *                           pg_restore --post-data, set sequences
  */
 
+#include <fcntl.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 #include <sys/wait.h>
 
 #include "catalog.h"
@@ -36,32 +38,37 @@ static bool multidb_target_database_exists(PGSQL *dst, const char *datname,
 										   bool *exists);
 static bool multidb_create_target_database(PGSQL *dst, const char *datname,
 										   bool dropIfExists);
-static bool multidb_build_uri_for_database(const char *pguri,
-										   const char *datname,
-										   char **result_uri);
+bool multidb_build_uri_for_database(const char *pguri,
+									const char *datname,
+									char **result_uri);
 static bool multidb_build_conn_strings(ConnStrings *parent,
 									   const char *datname,
 									   ConnStrings *dbConnStrings);
 static bool multidb_init_db_specs(CopyDataSpec *dbSpecs,
 								  CopyDataSpec *parent,
 								  ConnStrings *connStrings);
-static bool multidb_setup_one_database(CopyDataSpec *parentSpecs,
-									   SourceDatabase *db,
-									   CopyDataSpec *dbSpecs,
-									   ConnStrings *dbConnStrings,
-									   MultiDbInfo *info);
 
-/* Phase I: parallel pre-data (schema fetch + pg_dump + pg_restore --pre-data) */
+/*
+ * Phase I: snapshot holder + parallel pre-data workers.
+ *
+ * The snapshot holder is a long-lived direct child of clone_all_databases.
+ * It exports one REPEATABLE READ snapshot per database, writes the snapshot
+ * IDs into the instance catalog, enqueues DBNAME messages, and then waits
+ * until the parent signals it is done (by closing the write end of donepipe).
+ *
+ * Pre-data workers are forked by the supervisor (after the snapshot holder
+ * has signalled "ready").  They import the held snapshot via SET TRANSACTION
+ * SNAPSHOT to do consistent schema fetch + pg_dump + pg_restore --pre-data.
+ */
+static bool multidb_snapshot_holder(CopyDataSpec *parentSpecs,
+									 int readyfd, int donefd);
 static bool multidb_pre_data_supervisor(CopyDataSpec *parentSpecs);
-static bool multidb_pre_data_queue_filler(CopyDataSpec *parentSpecs);
 static bool multidb_pre_data_worker(CopyDataSpec *parentSpecs);
 static bool multidb_pre_data_one_db(CopyDataSpec *parentSpecs,
 									const char *datname);
 
 static bool multidb_clone_one_database_post_data(CopyDataSpec *parentSpecs,
-												  SourceDatabase *db,
-												  CopyDataSpec *dbSpecs,
-												  ConnStrings *dbConnStrings);
+												  const char *datname);
 static bool multidb_global_copy(CopyDataSpec *parentSpecs);
 static bool multidb_wait_child(pid_t pid, const char *label);
 
@@ -75,9 +82,24 @@ static bool multidb_init_entry(MultiDbEntry *entry,
  * clone_all_databases clones all user databases from a source Postgres
  * instance in three phases:
  *
- *  Phase I  — per-database pre-data (sequential subprocesses)
+ *  Phase I  — per-database pre-data (parallel, bounded by --table-jobs)
  *  Phase II — global COPY with shared worker pool sorted by table size
  *  Phase III — per-database post-data (sequential subprocesses)
+ *
+ * Snapshot design
+ * ---------------
+ * A long-lived "snapshot holder" subprocess is forked as a direct child.
+ * It connects to each per-database source URI, exports a REPEATABLE READ
+ * snapshot, writes the snapshot ID into the instance catalog, enqueues
+ * DBNAME messages for Phase I workers, and then blocks on a "done" pipe.
+ *
+ * After the holder signals "ready" (via readypipe), the parent re-reads the
+ * instance catalog to build multiDbInfos[] with snapshot IDs, then forks
+ * the Phase I supervisor.  Phase I and II workers import those snapshots
+ * using SET TRANSACTION SNAPSHOT — the holder's transactions are still live.
+ *
+ * After Phase III the parent closes the write end of donepipe; the holder
+ * gets EOF, commits all snapshot transactions, and exits.
  */
 bool
 clone_all_databases(CopyDataSpec *parentSpecs)
@@ -99,7 +121,8 @@ clone_all_databases(CopyDataSpec *parentSpecs)
 	}
 
 	/*
-	 * Initialise the top-level source catalog (stores the database list).
+	 * Initialise the instance-level catalog schema on disk.  The snapshot
+	 * holder subprocess will write the database list and snapshot IDs into it.
 	 */
 	if (!catalog_init_from_specs(parentSpecs))
 	{
@@ -107,27 +130,7 @@ clone_all_databases(CopyDataSpec *parentSpecs)
 		return false;
 	}
 
-	/* connect to the source instance and populate the database list */
-	PGSQL src = { 0 };
-
-	if (!pgsql_init(&src, parentSpecs->connStrings.source_pguri, PGSQL_CONN_SOURCE))
-	{
-		log_error("Failed to initialise source connection");
-		return false;
-	}
-
-	DatabaseCatalog *instanceCatalog = &(parentSpecs->catalogs.source);
-
-	if (!schema_list_databases(&src, instanceCatalog))
-	{
-		log_error("Failed to list databases on the source instance");
-		pgsql_finish(&src);
-		return false;
-	}
-
-	pgsql_finish(&src);
-
-	/* copy instance-level roles once */
+	/* copy instance-level roles first (single connection to instance) */
 	log_info("Copying instance-level roles");
 
 	if (!pg_copy_roles(&parentSpecs->pgPaths,
@@ -136,163 +139,258 @@ clone_all_databases(CopyDataSpec *parentSpecs)
 					   parentSpecs->noRolesPasswords))
 	{
 		log_error("Failed to copy roles from source instance");
+		(void) catalog_close_from_specs(parentSpecs);
 		return false;
 	}
 
 	/*
-	 * Count databases so we can allocate arrays.
+	 * Close the catalog before forking: the snapshot holder subprocess will
+	 * be the sole writer; we re-open read-only after it signals "ready".
 	 */
-	CatalogCounts counts = { 0 };
-
-	if (!catalog_count_objects(instanceCatalog, &counts))
+	if (!catalog_close_from_specs(parentSpecs))
 	{
-		log_error("Failed to count objects in the instance catalog");
+		log_error("Failed to close instance catalog before forking");
 		return false;
 	}
 
-	int maxDbs = (int) counts.databases;
-
-	if (maxDbs == 0)
+	/*
+	 * Create the Phase I queue before forking the snapshot holder so that the
+	 * holder inherits the qId via COW and can send DBNAME messages directly.
+	 */
+	if (!queue_create(&parentSpecs->preDataQueue, "pre-data"))
 	{
-		log_info("No databases found on the source instance");
-		(void) catalog_close_from_specs(parentSpecs);
-		return true;
-	}
-
-	/* allocate per-database arrays */
-	SourceDatabase *dbArray =
-		(SourceDatabase *) calloc(maxDbs, sizeof(SourceDatabase));
-	CopyDataSpec *dbSpecsArray =
-		(CopyDataSpec *) calloc(maxDbs, sizeof(CopyDataSpec));
-	ConnStrings *dbConnStringsArray =
-		(ConnStrings *) calloc(maxDbs, sizeof(ConnStrings));
-	MultiDbInfo *multiDbInfos =
-		(MultiDbInfo *) calloc(maxDbs, sizeof(MultiDbInfo));
-
-	if (dbArray == NULL || dbSpecsArray == NULL ||
-		dbConnStringsArray == NULL || multiDbInfos == NULL)
-	{
-		log_error(ALLOCATION_FAILED_ERROR);
+		log_error("Failed to create the pre-data process queue");
 		return false;
 	}
 
-	/* open a connection to the target instance for CREATE DATABASE */
-	PGSQL dst = { 0 };
+	/*
+	 * Two pipes coordinate the snapshot holder with the parent.
+	 *
+	 *  readypipe  — holder writes one byte after all snapshots are exported
+	 *               and all snapshot IDs are in the catalog.  Parent blocks
+	 *               here until the holder is ready.
+	 *
+	 *  donepipe   — parent holds the write end open throughout Phase I, II,
+	 *               and III.  Closing it sends EOF to the holder, which then
+	 *               commits all snapshot transactions and exits.
+	 *
+	 * FD_CLOEXEC prevents the pipe descriptors from being inherited by
+	 * exec'd children (pg_dump, pg_restore).
+	 */
+	int readypipe[2] = { -1, -1 };
+	int donepipe[2]  = { -1, -1 };
 
-	if (!pgsql_init(&dst, parentSpecs->connStrings.target_pguri, PGSQL_CONN_TARGET))
+	if (pipe(readypipe) < 0 || pipe(donepipe) < 0)
 	{
-		log_error("Failed to initialise target connection");
+		log_error("Failed to create synchronisation pipes: %m");
+		(void) queue_unlink(&parentSpecs->preDataQueue);
 		return false;
 	}
 
+	for (int i = 0; i < 2; i++)
+	{
+		(void) fcntl(readypipe[i], F_SETFD, FD_CLOEXEC);
+		(void) fcntl(donepipe[i],  F_SETFD, FD_CLOEXEC);
+	}
+
+	fflush(stdout);
+	fflush(stderr);
+
+	pid_t holderPid = fork();
+
+	switch (holderPid)
+	{
+		case -1:
+		{
+			log_error("Failed to fork snapshot holder: %m");
+			close(readypipe[0]); close(readypipe[1]);
+			close(donepipe[0]);  close(donepipe[1]);
+			(void) queue_unlink(&parentSpecs->preDataQueue);
+			return false;
+		}
+
+		case 0:
+		{
+			/* ====== snapshot holder subprocess ====== */
+			close(readypipe[0]);  /* not reading from ready pipe */
+			close(donepipe[1]);   /* not writing to done pipe */
+			(void) set_ps_title("pgcopydb: snapshot holder");
+
+			bool res = multidb_snapshot_holder(parentSpecs,
+											   readypipe[1],
+											   donepipe[0]);
+			exit(res ? EXIT_CODE_QUIT : EXIT_CODE_INTERNAL_ERROR);
+		}
+
+		default:
+			break;
+	}
+
+	/* parent: close pipe ends not needed here */
+	close(readypipe[1]);
+	close(donepipe[0]);
+
+	/*
+	 * Block until the snapshot holder has exported all per-database snapshots,
+	 * written their IDs to the instance catalog, and enqueued the DBNAME
+	 * messages.  Only then can we safely re-read the catalog.
+	 */
+	{
+		char ready = 0;
+		ssize_t n = read(readypipe[0], &ready, 1);
+
+		close(readypipe[0]);
+
+		if (n <= 0)
+		{
+			log_error("Snapshot holder failed to signal ready (read=%zd): %m", n);
+			(void) multidb_wait_child(holderPid, "snapshot holder");
+			close(donepipe[1]);
+			(void) queue_unlink(&parentSpecs->preDataQueue);
+			return false;
+		}
+
+		log_debug("Received ready signal from snapshot holder");
+	}
+
+	/*
+	 * Re-open the instance catalog — the snapshot holder has populated it with
+	 * the database list and per-database snapshot IDs.  Build multiDbInfos[].
+	 */
 	bool ok = true;
+	MultiDbInfo *multiDbInfos = NULL;
 	int dbCount = 0;
 
-	SourceDatabaseIterator dbIter = {
-		.catalog = instanceCatalog,
-		.dat = NULL
-	};
-
-	if (!catalog_iter_s_database_init(&dbIter))
+	if (!catalog_init_from_specs(parentSpecs))
 	{
-		pgsql_finish(&dst);
+		log_error("Failed to re-open instance catalog after snapshot holder ready");
 		ok = false;
-		goto cleanup_arrays;
+		goto signal_done;
 	}
 
-	for (;;)
 	{
-		if (!catalog_iter_s_database_next(&dbIter))
+		DatabaseCatalog *instanceCatalog = &(parentSpecs->catalogs.source);
+		CatalogCounts counts = { 0 };
+
+		if (!catalog_count_objects(instanceCatalog, &counts))
 		{
+			log_error("Failed to count databases in instance catalog");
+			(void) catalog_close_from_specs(parentSpecs);
 			ok = false;
-			break;
+			goto signal_done;
 		}
 
-		SourceDatabase *db = dbIter.dat;
+		int maxDbs = (int) counts.databases;
 
-		if (db == NULL)
-			break;        /* end of results */
-
-		if (asked_to_stop || asked_to_stop_fast || asked_to_quit)
+		if (maxDbs == 0)
 		{
-			log_info("Stopping --all-databases setup due to signal");
-			ok = false;
-			break;
+			log_info("No databases found on the source instance");
+			(void) catalog_close_from_specs(parentSpecs);
+			goto signal_done;
 		}
 
-		if (multidb_is_system_database(db->datname))
+		multiDbInfos = (MultiDbInfo *) calloc(maxDbs, sizeof(MultiDbInfo));
+
+		if (multiDbInfos == NULL)
 		{
-			log_debug("Skipping system database \"%s\"", db->datname);
-			continue;
+			log_error(ALLOCATION_FAILED_ERROR);
+			(void) catalog_close_from_specs(parentSpecs);
+			ok = false;
+			goto signal_done;
 		}
 
-		if (dbCount >= maxDbs)
+		SourceDatabaseIterator dbIter = {
+			.catalog = instanceCatalog,
+			.dat = NULL
+		};
+
+		if (!catalog_iter_s_database_init(&dbIter))
 		{
-			log_error("More databases than expected (%d), internal error",
-					  maxDbs);
+			(void) catalog_close_from_specs(parentSpecs);
 			ok = false;
-			break;
+			goto signal_done;
 		}
 
-		log_info("Found database \"%s\" (%s)", db->datname, db->bytesPretty);
-
-		/* copy db info into our array */
-		dbArray[dbCount] = *db;
-
-		/* create target database */
-		if (!multidb_create_target_database(&dst, db->datname,
-											parentSpecs->restoreOptions.dropIfExists))
+		for (;;)
 		{
-			log_error("Failed to create database \"%s\" on target", db->datname);
-			ok = false;
-			if (parentSpecs->failFast)
-				break;
-			else
+			if (!catalog_iter_s_database_next(&dbIter))
 			{
-				dbCount++;
+				ok = false;
+				break;
+			}
+
+			SourceDatabase *db = dbIter.dat;
+
+			if (db == NULL)
+				break;        /* end of results */
+
+			if (multidb_is_system_database(db->datname))
+			{
+				log_debug("Skipping system database \"%s\"", db->datname);
 				continue;
 			}
-		}
 
-		/* set up work dir and export snapshot for this database */
-		dbSpecsArray[dbCount].pgPaths = parentSpecs->pgPaths;
-
-		if (!multidb_setup_one_database(parentSpecs,
-										&dbArray[dbCount],
-										&dbSpecsArray[dbCount],
-										&dbConnStringsArray[dbCount],
-										&multiDbInfos[dbCount]))
-		{
-			log_error("Failed to setup database \"%s\"", db->datname);
-			ok = false;
-			if (parentSpecs->failFast)
+			if (dbCount >= maxDbs)
+			{
+				log_error("More databases than expected (%d), internal error",
+						  maxDbs);
+				ok = false;
 				break;
+			}
+
+			log_info("Found database \"%s\" (%s) snapshot \"%s\"",
+					 db->datname, db->bytesPretty, db->snapshot);
+
+			MultiDbInfo *info = &multiDbInfos[dbCount++];
+
+			strlcpy(info->datname, db->datname, sizeof(info->datname));
+			strlcpy(info->snapshot, db->snapshot, sizeof(info->snapshot));
+
+			sformat(info->topdir, sizeof(info->topdir), "%s/db/%s",
+					parentSpecs->cfPaths.topdir, db->datname);
+
+			char *srcuri = NULL;
+			char *tgturi = NULL;
+
+			if (!multidb_build_uri_for_database(
+					parentSpecs->connStrings.source_pguri,
+					db->datname, &srcuri) ||
+				!multidb_build_uri_for_database(
+					parentSpecs->connStrings.target_pguri,
+					db->datname, &tgturi))
+			{
+				log_error("Failed to build URIs for database \"%s\"", db->datname);
+				free(srcuri);
+				free(tgturi);
+				ok = false;
+				break;
+			}
+
+			strlcpy(info->source_pguri, srcuri, sizeof(info->source_pguri));
+			strlcpy(info->target_pguri, tgturi, sizeof(info->target_pguri));
+			free(srcuri);
+			free(tgturi);
 		}
 
-		dbCount++;
+		if (!catalog_iter_s_database_finish(&dbIter))
+			ok = false;
+
+		(void) catalog_close_from_specs(parentSpecs);
 	}
 
-	if (!catalog_iter_s_database_finish(&dbIter))
-		ok = false;
-
-	pgsql_finish(&dst);
-
-	if (!ok)
-		goto cleanup_snapshots;
+	if (!ok || dbCount == 0)
+	{
+		if (ok && dbCount == 0)
+			log_warn("No user databases found after filtering");
+		goto signal_done;
+	}
 
 	/*
-	 * Store per-database info in parentSpecs so the global COPY workers (which
-	 * are forked after this point) can access it via the COW post-fork copy.
+	 * Publish the per-database info so that the Phase I and II supervisors
+	 * (forked below) can access it via the COW post-fork copy.
 	 */
 	parentSpecs->multiDbCount = dbCount;
 	parentSpecs->multiDbInfos = multiDbInfos;
-
-	/* close instance-level catalog before forking subprocesses */
-	if (!catalog_close_from_specs(parentSpecs))
-	{
-		ok = false;
-		goto cleanup_snapshots;
-	}
 
 	/* ====== PHASE I: PRE-DATA (parallel, bounded by --table-jobs) ====== */
 	log_info("Phase I: parallel schema fetch, dump, and pre-data restore "
@@ -311,12 +409,11 @@ clone_all_databases(CopyDataSpec *parentSpecs)
 			{
 				log_error("Failed to fork pre-data supervisor: %m");
 				ok = false;
-				goto cleanup_snapshots;
+				goto signal_done;
 			}
 
 			case 0:
 			{
-				/* pre-data supervisor process */
 				bool res = multidb_pre_data_supervisor(parentSpecs);
 				exit(res ? EXIT_CODE_QUIT : EXIT_CODE_INTERNAL_ERROR);
 			}
@@ -328,8 +425,19 @@ clone_all_databases(CopyDataSpec *parentSpecs)
 		if (!multidb_wait_child(prePid, "pre-data supervisor"))
 		{
 			ok = false;
-			goto cleanup_snapshots;
+			goto signal_done;
 		}
+
+		/*
+		 * The pre-data supervisor already called queue_unlink on
+		 * preDataQueue before it exited.  Mark it as unlinked in the
+		 * parent's system_res_array so that the atexit/signal cleanup
+		 * handler does not attempt a second IPC_RMID and log a
+		 * spurious "Invalid argument" error.
+		 */
+		(void) copydb_unlink_sysv_queue(&system_res_array,
+										&parentSpecs->preDataQueue);
+		parentSpecs->preDataQueue.qId = -1;
 	}
 
 	/* ====== PHASE II: GLOBAL COPY ====== */
@@ -340,7 +448,7 @@ clone_all_databases(CopyDataSpec *parentSpecs)
 	{
 		log_error("Global COPY phase failed");
 		ok = false;
-		goto cleanup_snapshots;
+		goto signal_done;
 	}
 
 	/* ====== PHASE III: POST-DATA (sequential per-database) ====== */
@@ -355,163 +463,319 @@ clone_all_databases(CopyDataSpec *parentSpecs)
 			break;
 		}
 
-		log_info("Post-data for database \"%s\"", dbArray[i].datname);
+		log_info("Post-data for database \"%s\"", multiDbInfos[i].datname);
 
 		if (!multidb_clone_one_database_post_data(parentSpecs,
-												  &dbArray[i],
-												  &dbSpecsArray[i],
-												  &dbConnStringsArray[i]))
+												  multiDbInfos[i].datname))
 		{
-			log_error("Post-data failed for database \"%s\"", dbArray[i].datname);
+			log_error("Post-data failed for database \"%s\"",
+					  multiDbInfos[i].datname);
 			ok = false;
 			if (parentSpecs->failFast)
 				break;
 		}
 	}
 
-cleanup_snapshots:
-	/* close all per-database snapshot connections held in the parent */
-	for (int i = 0; i < dbCount; i++)
-	{
-		if (dbSpecsArray[i].consistent &&
-			dbSpecsArray[i].sourceSnapshot.state == SNAPSHOT_STATE_EXPORTED)
-		{
-			if (!copydb_close_snapshot(&dbSpecsArray[i]))
-			{
-				log_warn("Failed to close snapshot for database \"%s\"",
-						 dbArray[i].datname);
-			}
-		}
+signal_done:
+	/*
+	 * Close the write end of donepipe, signalling the snapshot holder to commit
+	 * all its REPEATABLE READ transactions and exit.
+	 */
+	close(donepipe[1]);
 
-		/* free heap-allocated connection strings */
-		if (dbConnStringsArray[i].source_pguri)
-			free(dbConnStringsArray[i].source_pguri);
-		if (dbConnStringsArray[i].target_pguri)
-			free(dbConnStringsArray[i].target_pguri);
-		if (dbConnStringsArray[i].safeSourcePGURI.pguri)
-			free(dbConnStringsArray[i].safeSourcePGURI.pguri);
-		if (dbConnStringsArray[i].safeTargetPGURI.pguri)
-			free(dbConnStringsArray[i].safeTargetPGURI.pguri);
-	}
+	if (!multidb_wait_child(holderPid, "snapshot holder"))
+		ok = false;
 
 	parentSpecs->multiDbInfos = NULL;
 	parentSpecs->multiDbCount = 0;
 
-cleanup_arrays:
 	free(multiDbInfos);
-	free(dbConnStringsArray);
-	free(dbSpecsArray);
-	free(dbArray);
 
 	return ok;
 }
 
 
 /*
- * multidb_setup_one_database builds the per-database work directory, exports
- * a Postgres snapshot (held by the parent), and fills in info.
+ * multidb_snapshot_holder is a long-lived subprocess (direct child of
+ * clone_all_databases) that:
+ *
+ *  1. Opens the instance catalog and calls schema_list_databases().
+ *  2. For each user database, exports a per-database REPEATABLE READ snapshot
+ *     and writes the snapshot ID back to the instance catalog.
+ *  3. Sends one QMSG_TYPE_DBNAME message per database to parentSpecs->preDataQueue,
+ *     followed by tableJobs QMSG_TYPE_STOP messages.
+ *  4. Signals the parent by writing one byte to readyfd, then closes readyfd.
+ *  5. Blocks on donefd (EOF from parent) while holding all snapshot transactions
+ *     open so that Phase I and II workers can import them.
+ *  6. On EOF: commits all snapshot transactions and exits.
+ *
+ * Process tree context:
+ *   clone_all_databases
+ *   ├── snapshot holder  ← this function (long-lived)
+ *   ├── pre-data supervisor
+ *   └── global copy supervisor
  */
 static bool
-multidb_setup_one_database(CopyDataSpec *parentSpecs,
-						   SourceDatabase *db,
-						   CopyDataSpec *dbSpecs,
-						   ConnStrings *dbConnStrings,
-						   MultiDbInfo *info)
+multidb_snapshot_holder(CopyDataSpec *parentSpecs, int readyfd, int donefd)
 {
-	/* build per-db work directory path */
-	char dbdir[MAXPGPATH] = { 0 };
+	log_notice("Started snapshot holder %d [%d]", getpid(), getppid());
 
-	sformat(dbdir, sizeof(dbdir), "%s/db/%s",
-			parentSpecs->cfPaths.topdir, db->datname);
-
-	/* build per-db connection strings */
-	if (!multidb_build_conn_strings(&parentSpecs->connStrings, db->datname,
-									dbConnStrings))
+	/* open the instance catalog for writing */
+	if (!catalog_init_from_specs(parentSpecs))
 	{
-		log_error("Failed to build connection strings for database \"%s\"",
-				  db->datname);
+		log_error("Snapshot holder: failed to open instance catalog");
 		return false;
 	}
 
-	/*
-	 * Create the per-database work directory.  Must happen in the parent so
-	 * the directory exists before forking subprocesses.
-	 */
-	if (!copydb_init_workdir(dbSpecs, dbdir,
-							 false,     /* service */
-							 NULL,      /* serviceName */
-							 parentSpecs->restart,
-							 parentSpecs->resume,
-							 true))     /* createWorkDir */
+	DatabaseCatalog *instanceCatalog = &(parentSpecs->catalogs.source);
+
+	/* connect to source instance and list databases */
+	PGSQL src = { 0 };
+
+	if (!pgsql_init(&src, parentSpecs->connStrings.source_pguri,
+					PGSQL_CONN_SOURCE))
 	{
-		log_error("Failed to initialise work directory \"%s\" for database \"%s\"",
-				  dbdir, db->datname);
+		log_error("Snapshot holder: failed to connect to source instance");
+		(void) catalog_close_from_specs(parentSpecs);
 		return false;
 	}
 
-	/* wire up connection strings and snapshot fields */
-	dbSpecs->connStrings = *dbConnStrings;
-	dbSpecs->sourceSnapshot.pguri = dbSpecs->connStrings.source_pguri;
-	dbSpecs->sourceSnapshot.safeURI = dbSpecs->connStrings.safeSourcePGURI;
-	dbSpecs->sourceSnapshot.connectionType = PGSQL_CONN_SOURCE;
-	dbSpecs->consistent = parentSpecs->consistent;
+	if (!schema_list_databases(&src, instanceCatalog))
+	{
+		log_error("Snapshot holder: failed to list databases");
+		pgsql_finish(&src);
+		(void) catalog_close_from_specs(parentSpecs);
+		return false;
+	}
+
+	pgsql_finish(&src);
+
+	/* count non-system databases */
+	CatalogCounts counts = { 0 };
+
+	if (!catalog_count_objects(instanceCatalog, &counts))
+	{
+		log_error("Snapshot holder: failed to count databases");
+		(void) catalog_close_from_specs(parentSpecs);
+		return false;
+	}
+
+	int maxDbs = (int) counts.databases;
 
 	/*
-	 * Export a per-database snapshot in the parent.  The parent keeps this
-	 * connection open throughout Phase I and Phase II (global COPY) so that
-	 * COPY workers can import it via SET TRANSACTION SNAPSHOT.
+	 * Allocate per-database snapshot structs and source URI strings.
+	 * The snapshots stay open until the parent signals "done".
 	 */
-	if (dbSpecs->consistent)
+	TransactionSnapshot *snapshots =
+		(TransactionSnapshot *) calloc(maxDbs, sizeof(TransactionSnapshot));
+	char **sourceUris =
+		(char **) calloc(maxDbs, sizeof(char *));
+
+	if (snapshots == NULL || sourceUris == NULL)
 	{
-		if (!copydb_prepare_snapshot(dbSpecs))
+		log_error(ALLOCATION_FAILED_ERROR);
+		free(snapshots);
+		free(sourceUris);
+		(void) catalog_close_from_specs(parentSpecs);
+		return false;
+	}
+
+	bool ok = true;
+	int dbCount = 0;
+
+	SourceDatabaseIterator dbIter = {
+		.catalog = instanceCatalog,
+		.dat = NULL
+	};
+
+	if (!catalog_iter_s_database_init(&dbIter))
+	{
+		ok = false;
+		goto cleanup_snapshots;
+	}
+
+	for (;;)
+	{
+		if (!catalog_iter_s_database_next(&dbIter))
 		{
-			log_error("Failed to export snapshot for database \"%s\"",
+			ok = false;
+			break;
+		}
+
+		SourceDatabase *db = dbIter.dat;
+
+		if (db == NULL)
+			break;
+
+		if (multidb_is_system_database(db->datname))
+		{
+			log_debug("Snapshot holder: skipping system database \"%s\"",
 					  db->datname);
-			return false;
+			continue;
+		}
+
+		if (dbCount >= maxDbs)
+		{
+			log_error("Snapshot holder: more databases than expected (%d)",
+					  maxDbs);
+			ok = false;
+			break;
+		}
+
+		/* build per-database source URI */
+		if (!multidb_build_uri_for_database(
+				parentSpecs->connStrings.source_pguri,
+				db->datname, &sourceUris[dbCount]))
+		{
+			log_error("Snapshot holder: failed to build source URI "
+					  "for database \"%s\"", db->datname);
+			ok = false;
+			break;
+		}
+
+		/* export a REPEATABLE READ snapshot for this database */
+		TransactionSnapshot *snap = &snapshots[dbCount];
+
+		snap->pguri = sourceUris[dbCount];
+		snap->connectionType = PGSQL_CONN_SOURCE;
+
+		if (!copydb_export_snapshot(snap))
+		{
+			log_error("Snapshot holder: failed to export snapshot "
+					  "for database \"%s\"", db->datname);
+			ok = false;
+			break;
+		}
+
+		log_info("Snapshot holder: database \"%s\" snapshot \"%s\"",
+				 db->datname, snap->snapshot);
+
+		/* persist snapshot ID in the instance catalog */
+		if (!catalog_update_s_database_snapshot(instanceCatalog,
+												 db->datname,
+												 snap->snapshot))
+		{
+			log_error("Snapshot holder: failed to record snapshot "
+					  "for database \"%s\"", db->datname);
+			ok = false;
+			break;
+		}
+
+		/* send DBNAME message to Phase I queue */
+		QMessage mesg = { .type = QMSG_TYPE_DBNAME };
+		strlcpy(mesg.data.datname, db->datname, sizeof(mesg.data.datname));
+
+		if (!queue_send(&parentSpecs->preDataQueue, &mesg))
+		{
+			log_error("Snapshot holder: failed to enqueue database \"%s\"",
+					  db->datname);
+			ok = false;
+			break;
+		}
+
+		dbCount++;
+	}
+
+	if (!catalog_iter_s_database_finish(&dbIter))
+		ok = false;
+
+	(void) catalog_close_from_specs(parentSpecs);
+
+	if (!ok)
+		goto signal_ready;
+
+	/* send one STOP message per worker */
+	for (int i = 0; i < parentSpecs->tableJobs; i++)
+	{
+		QMessage stop = { .type = QMSG_TYPE_STOP };
+
+		if (!queue_send(&parentSpecs->preDataQueue, &stop))
+		{
+			log_error("Snapshot holder: failed to send STOP to pre-data queue");
+			ok = false;
+			break;
 		}
 	}
 
-	/* populate MultiDbInfo for workers */
-	strlcpy(info->datname, db->datname, sizeof(info->datname));
-	strlcpy(info->snapshot, dbSpecs->sourceSnapshot.snapshot,
-			sizeof(info->snapshot));
-	strlcpy(info->source_pguri, dbConnStrings->source_pguri,
-			sizeof(info->source_pguri));
-	strlcpy(info->target_pguri, dbConnStrings->target_pguri,
-			sizeof(info->target_pguri));
-	strlcpy(info->topdir, dbdir, sizeof(info->topdir));
-	info->isReadOnly = dbSpecs->sourceSnapshot.isReadOnly;
+	log_info("Snapshot holder: ready — %d databases, %d STOP messages",
+			 dbCount, parentSpecs->tableJobs);
 
-	return true;
+signal_ready:
+	/*
+	 * Signal the parent that the catalog is fully written and all DBNAME/STOP
+	 * messages are in the queue.  The parent will re-open the catalog, build
+	 * multiDbInfos[], and fork the Phase I supervisor.
+	 *
+	 * We signal ready even on failure so the parent does not block forever;
+	 * the parent detects the failure via the snapshot holder's exit status.
+	 */
+	{
+		char rdy = 'R';
+		(void) write(readyfd, &rdy, 1);
+		close(readyfd);
+	}
+
+	if (!ok)
+		goto cleanup_snapshots;
+
+	/*
+	 * Wait for the parent to close the write end of donepipe (after Phase III).
+	 * While we block here, Phase I and II workers use SET TRANSACTION SNAPSHOT
+	 * to import our held snapshots for consistent reads.
+	 */
+	{
+		char buf = 0;
+		(void) read(donefd, &buf, 1);  /* blocks until EOF */
+		close(donefd);
+	}
+
+	log_notice("Snapshot holder: received done signal, closing snapshots");
+
+cleanup_snapshots:
+	/* commit all held snapshot transactions */
+	for (int i = 0; i < dbCount; i++)
+	{
+		if (snapshots[i].state == SNAPSHOT_STATE_EXPORTED)
+		{
+			if (!pgsql_commit(&snapshots[i].pgsql))
+			{
+				log_warn("Snapshot holder: failed to commit snapshot "
+						 "for database %d", i);
+			}
+
+			pgsql_finish(&snapshots[i].pgsql);
+		}
+
+		free(sourceUris[i]);
+	}
+
+	free(snapshots);
+	free(sourceUris);
+
+	log_notice("Snapshot holder %d exiting", getpid());
+
+	return ok;
 }
 
 
 /*
  * multidb_pre_data_supervisor is the supervisor for Phase I.
  *
- * It runs inside a dedicated subprocess (forked by clone_all_databases).
- * The supervisor creates a preDataQueue, forks tableJobs workers, forks one
- * queue-filler child, then calls waitpid(-1) to collect all children.
+ * By the time this runs the snapshot holder has already filled preDataQueue
+ * with DBNAME and STOP messages, so the supervisor only needs to fork workers
+ * and wait for them.
  *
  * Process tree:
  *   clone_all_databases
  *   └── pre-data supervisor  (this function)
  *           ├── pre-data worker 1
- *           ├── pre-data worker N  (N = --table-jobs)
- *           └── pre-data queue filler  (sends database names, then STOPs)
+ *           └── pre-data worker N  (N = --table-jobs)
  */
 static bool
 multidb_pre_data_supervisor(CopyDataSpec *parentSpecs)
 {
 	(void) set_ps_title("pgcopydb: pre-data supervisor");
 	log_notice("Started pre-data supervisor %d [%d]", getpid(), getppid());
-
-	/* create the IPC queue for Phase I — workers inherit qId after fork */
-	if (!queue_create(&parentSpecs->preDataQueue, "pre-data"))
-	{
-		log_error("Failed to create the pre-data process queue");
-		return false;
-	}
 
 	/* fork tableJobs pre-data workers */
 	for (int i = 0; i < parentSpecs->tableJobs; i++)
@@ -542,35 +806,7 @@ multidb_pre_data_supervisor(CopyDataSpec *parentSpecs)
 		}
 	}
 
-	/* fork the queue filler (child of supervisor) */
-	{
-		fflush(stdout);
-		fflush(stderr);
-
-		pid_t qpid = fork();
-
-		switch (qpid)
-		{
-			case -1:
-			{
-				log_error("Failed to fork pre-data queue filler: %m");
-				(void) copydb_fatal_exit();
-				exit(EXIT_CODE_INTERNAL_ERROR);
-			}
-
-			case 0:
-			{
-				(void) set_ps_title("pgcopydb: pre-data queue databases");
-				bool ok = multidb_pre_data_queue_filler(parentSpecs);
-				exit(ok ? EXIT_CODE_QUIT : EXIT_CODE_INTERNAL_ERROR);
-			}
-
-			default:
-				break;
-		}
-	}
-
-	/* supervisor waits for all children: workers + queue filler */
+	/* supervisor waits for all workers to drain the queue */
 	bool ok = copydb_wait_for_subprocesses(parentSpecs->failFast);
 
 	(void) queue_unlink(&parentSpecs->preDataQueue);
@@ -579,51 +815,6 @@ multidb_pre_data_supervisor(CopyDataSpec *parentSpecs)
 	return ok;
 }
 
-
-/*
- * multidb_pre_data_queue_filler sends one DBNAME message per database to the
- * preDataQueue, then sends tableJobs STOP messages so all workers terminate.
- */
-static bool
-multidb_pre_data_queue_filler(CopyDataSpec *parentSpecs)
-{
-	log_notice("Started pre-data queue filler %d [%d]", getpid(), getppid());
-
-	for (int i = 0; i < parentSpecs->multiDbCount; i++)
-	{
-		MultiDbInfo *info = &parentSpecs->multiDbInfos[i];
-
-		QMessage mesg = { .type = QMSG_TYPE_DBNAME };
-		strlcpy(mesg.data.datname, info->datname, sizeof(mesg.data.datname));
-
-		if (!queue_send(&parentSpecs->preDataQueue, &mesg))
-		{
-			log_error("Failed to enqueue database \"%s\" for pre-data",
-					  info->datname);
-			return false;
-		}
-
-		log_info("Pre-data queue filler: enqueued database \"%s\"",
-				 info->datname);
-	}
-
-	/* one STOP per worker */
-	for (int i = 0; i < parentSpecs->tableJobs; i++)
-	{
-		QMessage stop = { .type = QMSG_TYPE_STOP };
-
-		if (!queue_send(&parentSpecs->preDataQueue, &stop))
-		{
-			log_error("Failed to send STOP to pre-data queue");
-			return false;
-		}
-	}
-
-	log_info("Pre-data queue filler: sent %d databases, %d STOP messages",
-			 parentSpecs->multiDbCount, parentSpecs->tableJobs);
-
-	return true;
-}
 
 
 /*
@@ -706,7 +897,13 @@ multidb_pre_data_worker(CopyDataSpec *parentSpecs)
 
 /*
  * multidb_pre_data_one_db performs the full pre-data pipeline for one
- * database: schema fetch from source, pg_dump, pg_restore --pre-data.
+ * database:
+ *   1. CREATE DATABASE on the target (if not already present)
+ *   2. Import snapshot exported by the snapshot holder
+ *   3. Fetch source database schema into source.db
+ *   4. pg_dump --snapshot=<id> (pre-data + post-data sections)
+ *   5. Close the worker's snapshot connection (holder still holds the real one)
+ *   6. pg_restore --pre-data to the target
  *
  * Called from within a pre-data worker process.  All resources are
  * allocated locally and released before returning so the worker can
@@ -735,6 +932,32 @@ multidb_pre_data_one_db(CopyDataSpec *parentSpecs, const char *datname)
 	}
 
 	log_info("[SOURCE] Pre-data for database \"%s\"", datname);
+
+	/* STEP 0: CREATE DATABASE on the target instance */
+	{
+		PGSQL dst = { 0 };
+
+		if (!pgsql_init(&dst, parentSpecs->connStrings.target_pguri,
+						PGSQL_CONN_TARGET))
+		{
+			log_error("Failed to connect to target instance for "
+					  "database \"%s\"", datname);
+			return false;
+		}
+
+		bool created = multidb_create_target_database(
+			&dst,
+			datname,
+			parentSpecs->restoreOptions.dropIfExists);
+
+		pgsql_finish(&dst);
+
+		if (!created)
+		{
+			log_error("Failed to create database \"%s\" on target", datname);
+			return false;
+		}
+	}
 
 	/*
 	 * Build per-database connection strings.  These are strdup'd here and
@@ -778,16 +1001,21 @@ multidb_pre_data_one_db(CopyDataSpec *parentSpecs, const char *datname)
 	 * Build a local CopyDataSpec for this database.
 	 * copydb_init_workdir must be called before multidb_init_db_specs so
 	 * that cfPaths is populated.
+	 *
+	 * The per-database work directory is created here (createWorkDir=true)
+	 * on a first run.  On --resume, the directory already exists.
 	 */
 	CopyDataSpec dbSpecs = { 0 };
 	dbSpecs.pgPaths = parentSpecs->pgPaths;
 
+	bool createWorkDir = !parentSpecs->resume;
+
 	if (!copydb_init_workdir(&dbSpecs, info->topdir,
-							 false,   /* service */
-							 NULL,    /* serviceName */
-							 false,   /* restart */
-							 true,    /* resume */
-							 false))  /* createWorkDir (already created) */
+							 false,          /* service */
+							 NULL,           /* serviceName */
+							 parentSpecs->restart,
+							 parentSpecs->resume,
+							 createWorkDir))
 	{
 		log_error("Failed to init work dir for database \"%s\"", datname);
 		ok = false;
@@ -817,9 +1045,13 @@ multidb_pre_data_one_db(CopyDataSpec *parentSpecs, const char *datname)
 		dbSpecs.indexQueue.qId = -1;
 	}
 
+	/* set database name for enriched log messages */
+	strlcpy(dbSpecs.datname, datname, sizeof(dbSpecs.datname));
+
 	/*
-	 * Propagate the exported snapshot identifier so that pg_dump can use
-	 * it via --snapshot=<id>.
+	 * Set the snapshot identifier so that copydb_prepare_snapshot (called
+	 * inside copydb_fetch_schema_and_prepare_specs) will call
+	 * copydb_set_snapshot to import the snapshot held by the snapshot holder.
 	 */
 	strlcpy(dbSpecs.sourceSnapshot.snapshot, info->snapshot,
 			sizeof(dbSpecs.sourceSnapshot.snapshot));
@@ -839,6 +1071,13 @@ multidb_pre_data_one_db(CopyDataSpec *parentSpecs, const char *datname)
 		ok = false;
 		goto cleanup_specs;
 	}
+
+	/*
+	 * Close the worker's SET TRANSACTION SNAPSHOT connection.  The snapshot
+	 * holder's exporting connection stays open, so the snapshot remains valid
+	 * for Phase II workers.
+	 */
+	(void) copydb_close_snapshot(&dbSpecs);
 
 	/* STEP 3: restore the pre-data section to the target via pg_restore */
 	if (!copydb_target_prepare_schema(&dbSpecs))
@@ -867,15 +1106,32 @@ cleanup_cs:
  * post-data phase for one database: pg_restore post-data and set sequences.
  *
  * This runs after the global COPY phase has completed for all databases.
+ * The function is self-contained: it derives all specs from MultiDbInfo.
  */
 static bool
 multidb_clone_one_database_post_data(CopyDataSpec *parentSpecs,
-									 SourceDatabase *db,
-									 CopyDataSpec *dbSpecs,
-									 ConnStrings *dbConnStrings)
+									  const char *datname)
 {
-	log_info("[TARGET] Post-data for database \"%s\" into \"%s\"",
-			 db->datname, dbConnStrings->safeTargetPGURI.pguri);
+	/* locate MultiDbInfo for this database */
+	MultiDbInfo *info = NULL;
+
+	for (int i = 0; i < parentSpecs->multiDbCount; i++)
+	{
+		if (strcmp(parentSpecs->multiDbInfos[i].datname, datname) == 0)
+		{
+			info = &parentSpecs->multiDbInfos[i];
+			break;
+		}
+	}
+
+	if (info == NULL)
+	{
+		log_error("BUG: multidb_clone_one_database_post_data: "
+				  "no MultiDbInfo for database \"%s\"", datname);
+		return false;
+	}
+
+	log_info("[TARGET] Post-data for database \"%s\"", datname);
 
 	fflush(stdout);
 	fflush(stderr);
@@ -886,8 +1142,8 @@ multidb_clone_one_database_post_data(CopyDataSpec *parentSpecs,
 	{
 		case -1:
 		{
-			log_error("Failed to fork post-data subprocess for database \"%s\": %m",
-					  db->datname);
+			log_error("Failed to fork post-data subprocess for "
+					  "database \"%s\": %m", datname);
 			return false;
 		}
 
@@ -895,47 +1151,97 @@ multidb_clone_one_database_post_data(CopyDataSpec *parentSpecs,
 		{
 			/* child process */
 			char psTitle[MAXPGPATH] = { 0 };
-			sformat(psTitle, sizeof(psTitle), "pgcopydb: post-data %s", db->datname);
+			sformat(psTitle, sizeof(psTitle), "pgcopydb: post-data %s", datname);
 			(void) set_ps_title(psTitle);
 
 			summary_reset_toplevel_timings();
 
-			if (!multidb_init_db_specs(dbSpecs, parentSpecs, dbConnStrings))
+			/* build per-db connection strings */
+			ConnStrings cs = { 0 };
+
+			cs.source_pguri = strdup(info->source_pguri);
+			cs.target_pguri = strdup(info->target_pguri);
+
+			if (cs.source_pguri == NULL || cs.target_pguri == NULL)
 			{
-				log_error("Failed to initialise specs for database \"%s\"",
-						  db->datname);
+				log_error(ALLOCATION_FAILED_ERROR);
 				exit(EXIT_CODE_INTERNAL_ERROR);
 			}
+
+			if (!parse_and_scrub_connection_string(cs.source_pguri,
+												   &cs.safeSourcePGURI) ||
+				!parse_and_scrub_connection_string(cs.target_pguri,
+												   &cs.safeTargetPGURI))
+			{
+				log_error("Failed to scrub URIs for database \"%s\"", datname);
+				exit(EXIT_CODE_INTERNAL_ERROR);
+			}
+
+			CopyDataSpec dbSpecs = { 0 };
+			dbSpecs.pgPaths = parentSpecs->pgPaths;
+
+			if (!copydb_init_workdir(&dbSpecs, info->topdir,
+									 false,  /* service */
+									 NULL,   /* serviceName */
+									 false,  /* restart */
+									 true,   /* resume */
+									 false)) /* createWorkDir (already created) */
+			{
+				log_error("Failed to init work dir for database \"%s\"",
+						  datname);
+				exit(EXIT_CODE_INTERNAL_ERROR);
+			}
+
+			if (!multidb_init_db_specs(&dbSpecs, parentSpecs, &cs))
+			{
+				log_error("Failed to initialise specs for database \"%s\"",
+						  datname);
+				exit(EXIT_CODE_INTERNAL_ERROR);
+			}
+
+			strlcpy(dbSpecs.datname, datname, sizeof(dbSpecs.datname));
+
+			/*
+			 * The catalog was created in Phase I with a specific snapshot ID.
+			 * The consistency check in catalog_init_from_specs compares
+			 * dbSpecs.sourceSnapshot.snapshot against the stored value, so we
+			 * must populate it here.  The post-data phase does not open a new
+			 * snapshot transaction — it just needs the ID to match so the
+			 * catalog opens successfully.
+			 */
+			strlcpy(dbSpecs.sourceSnapshot.snapshot,
+					info->snapshot,
+					sizeof(dbSpecs.sourceSnapshot.snapshot));
 
 			/*
 			 * Re-use the existing catalog (pre-data already populated it).
 			 * copydb_fetch_schema_and_prepare_specs will detect this and
 			 * return early without re-fetching from source.
 			 */
-			if (!copydb_fetch_schema_and_prepare_specs(dbSpecs))
+			if (!copydb_fetch_schema_and_prepare_specs(&dbSpecs))
 			{
 				log_error("Failed to open catalog for database \"%s\"",
-						  db->datname);
+						  datname);
 				exit(EXIT_CODE_INTERNAL_ERROR);
 			}
 
-			/* STEP 10: restore the post-data section (indexes, constraints, …) */
-			if (!copydb_target_finalize_schema(dbSpecs))
+			/* restore the post-data section (indexes, constraints, …) */
+			if (!copydb_target_finalize_schema(&dbSpecs))
 			{
 				log_error("Failed to finalize schema for database \"%s\"",
-						  db->datname);
+						  datname);
 				exit(EXIT_CODE_TARGET);
 			}
 
-			/* Set sequences to match the source values captured during schema fetch */
-			if (!copydb_copy_all_sequences(dbSpecs, false))
+			/* set sequences to match source values captured during schema fetch */
+			if (!copydb_copy_all_sequences(&dbSpecs, false))
 			{
 				log_error("Failed to set sequences for database \"%s\"",
-						  db->datname);
+						  datname);
 				exit(EXIT_CODE_TARGET);
 			}
 
-			(void) catalog_close_from_specs(dbSpecs);
+			(void) catalog_close_from_specs(&dbSpecs);
 			exit(EXIT_CODE_QUIT);
 		}
 
@@ -944,7 +1250,7 @@ multidb_clone_one_database_post_data(CopyDataSpec *parentSpecs,
 	}
 
 	/* parent: wait for post-data subprocess */
-	return multidb_wait_child(fpid, db->datname);
+	return multidb_wait_child(fpid, datname);
 }
 
 
@@ -1446,7 +1752,6 @@ multidb_init_entry(MultiDbEntry *entry, CopyDataSpec *parentSpecs,
 	dbSpecs->sourceSnapshot.pguri = dbSpecs->connStrings.source_pguri;
 	dbSpecs->sourceSnapshot.safeURI = dbSpecs->connStrings.safeSourcePGURI;
 	dbSpecs->sourceSnapshot.connectionType = PGSQL_CONN_SOURCE;
-	dbSpecs->sourceSnapshot.isReadOnly = info->isReadOnly;
 
 	strlcpy(dbSpecs->sourceSnapshot.snapshot, info->snapshot,
 			sizeof(dbSpecs->sourceSnapshot.snapshot));
@@ -1484,6 +1789,7 @@ multidb_init_entry(MultiDbEntry *entry, CopyDataSpec *parentSpecs,
 
 	/* populate the entry */
 	strlcpy(entry->datname, datname, sizeof(entry->datname));
+	strlcpy(dbSpecs->datname, datname, sizeof(dbSpecs->datname));
 	entry->dbSpecs = dbSpecs;
 	entry->active = true;
 
@@ -1632,7 +1938,7 @@ multidb_create_target_database(PGSQL *dst, const char *datname,
  * multidb_build_uri_for_database takes an existing Postgres URI and returns a
  * new one with the dbname component replaced by datname.
  */
-static bool
+bool
 multidb_build_uri_for_database(const char *pguri, const char *datname,
 								char **result_uri)
 {

--- a/src/bin/pgcopydb/multi_db.c
+++ b/src/bin/pgcopydb/multi_db.c
@@ -1,0 +1,613 @@
+/*
+ * src/bin/pgcopydb/multi_db.c
+ *	 Clone all databases from a source Postgres instance.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "catalog.h"
+#include "copydb.h"
+#include "defaults.h"
+#include "log.h"
+#include "multi_db.h"
+#include "parsing_utils.h"
+#include "pgcmd.h"
+#include "pgsql.h"
+#include "schema.h"
+#include "signals.h"
+#include "string_utils.h"
+
+static bool multidb_is_system_database(const char *datname);
+static bool multidb_target_database_exists(PGSQL *dst, const char *datname,
+										   bool *exists);
+static bool multidb_create_target_database(PGSQL *dst, const char *datname,
+										   bool dropIfExists);
+static bool multidb_build_uri_for_database(const char *pguri,
+										   const char *datname,
+										   char **result_uri);
+static bool multidb_build_conn_strings(ConnStrings *parent,
+									   const char *datname,
+									   ConnStrings *dbConnStrings);
+static bool multidb_init_db_specs(CopyDataSpec *dbSpecs,
+								  CopyDataSpec *parent,
+								  ConnStrings *connStrings);
+static bool multidb_clone_one_database(CopyDataSpec *parentSpecs,
+									   SourceDatabase *db);
+
+
+/*
+ * clone_all_databases iterates all user databases on the source instance and
+ * clones each one in turn, sharing the same table/index job counts.
+ *
+ * The caller's copySpecs already has the top-level work dir initialised (via
+ * cli_copy_prepare_specs).  Roles are copied once at the instance level; each
+ * per-database clone is run with roles=false.
+ */
+bool
+clone_all_databases(CopyDataSpec *copySpecs)
+{
+	/*
+	 * The top-level copySpecs has queues created by copydb_init_specs that we
+	 * won't use — release them now so we don't leak System V resources.
+	 */
+	if (copySpecs->vacuumQueue.qId != -1)
+	{
+		(void) queue_unlink(&copySpecs->vacuumQueue);
+		copySpecs->vacuumQueue.qId = -1;
+	}
+
+	if (copySpecs->indexQueue.qId != -1)
+	{
+		(void) queue_unlink(&copySpecs->indexQueue);
+		copySpecs->indexQueue.qId = -1;
+	}
+
+	/*
+	 * Initialise the top-level source catalog (stores the database list).
+	 * This creates <topdir>/schema/source.db if it doesn't exist yet.
+	 */
+	if (!catalog_init_from_specs(copySpecs))
+	{
+		log_error("Failed to initialise the instance-level catalog");
+		return false;
+	}
+
+	/* connect to the source instance and populate the database list */
+	PGSQL src = { 0 };
+
+	if (!pgsql_init(&src, copySpecs->connStrings.source_pguri, PGSQL_CONN_SOURCE))
+	{
+		log_error("Failed to initialise source connection");
+		return false;
+	}
+
+	DatabaseCatalog *instanceCatalog = &(copySpecs->catalogs.source);
+
+	if (!schema_list_databases(&src, instanceCatalog))
+	{
+		log_error("Failed to list databases on the source instance");
+		pgsql_finish(&src);
+		return false;
+	}
+
+	pgsql_finish(&src);
+
+	/* copy instance-level roles once */
+	log_info("Copying instance-level roles");
+
+	if (!pg_copy_roles(&copySpecs->pgPaths,
+					   &copySpecs->connStrings,
+					   copySpecs->dumpPaths.rolesFilename,
+					   copySpecs->noRolesPasswords))
+	{
+		log_error("Failed to copy roles from source instance");
+		return false;
+	}
+
+	/* open a connection to the target instance for CREATE DATABASE */
+	PGSQL dst = { 0 };
+
+	if (!pgsql_init(&dst, copySpecs->connStrings.target_pguri, PGSQL_CONN_TARGET))
+	{
+		log_error("Failed to initialise target connection");
+		return false;
+	}
+
+	bool ok = true;
+
+	SourceDatabaseIterator dbIter = {
+		.catalog = instanceCatalog,
+		.dat = NULL
+	};
+
+	if (!catalog_iter_s_database_init(&dbIter))
+	{
+		pgsql_finish(&dst);
+		return false;
+	}
+
+	while (catalog_iter_s_database_next(&dbIter))
+	{
+		SourceDatabase *db = dbIter.dat;
+
+		if (asked_to_stop || asked_to_stop_fast || asked_to_quit)
+		{
+			log_info("Stopping --all-databases clone due to signal");
+			ok = false;
+			break;
+		}
+
+		if (multidb_is_system_database(db->datname))
+		{
+			log_debug("Skipping system database \"%s\"", db->datname);
+			continue;
+		}
+
+		log_info("Cloning database \"%s\" (%s)",
+				 db->datname, db->bytesPretty);
+
+		if (!multidb_create_target_database(&dst, db->datname,
+											copySpecs->restoreOptions.dropIfExists))
+		{
+			log_error("Failed to create database \"%s\" on target", db->datname);
+			ok = false;
+
+			if (copySpecs->failFast)
+				break;
+			else
+				continue;
+		}
+
+		if (!multidb_clone_one_database(copySpecs, db))
+		{
+			log_error("Failed to clone database \"%s\"", db->datname);
+			ok = false;
+
+			if (copySpecs->failFast)
+				break;
+		}
+	}
+
+	if (!catalog_iter_s_database_finish(&dbIter))
+		ok = false;
+
+	pgsql_finish(&dst);
+
+	if (!catalog_close_from_specs(copySpecs))
+		ok = false;
+
+	return ok;
+}
+
+
+/*
+ * multidb_is_system_database returns true for template0 and template1, which
+ * must not be cloned.
+ */
+static bool
+multidb_is_system_database(const char *datname)
+{
+	return strcmp(datname, "template0") == 0 ||
+		   strcmp(datname, "template1") == 0;
+}
+
+
+/*
+ * multidb_target_database_exists checks whether datname already exists on the
+ * target via pg_database.
+ */
+static bool
+multidb_target_database_exists(PGSQL *dst, const char *datname, bool *exists)
+{
+	SingleValueResultContext ctx = { { 0 }, PGSQL_RESULT_BOOL, false };
+
+	const char *sql =
+		"SELECT EXISTS(SELECT 1 FROM pg_database WHERE datname = $1)";
+
+	int paramCount = 1;
+	Oid paramTypes[1] = { TEXTOID };
+	const char *paramValues[1] = { datname };
+
+	if (!pgsql_execute_with_params(dst, sql,
+								   paramCount, paramTypes, paramValues,
+								   &ctx, &parseSingleValueResult))
+	{
+		log_error("Failed to check existence of database \"%s\" on target",
+				  datname);
+		return false;
+	}
+
+	if (!ctx.parsedOk)
+	{
+		log_error("Failed to parse result for database existence check");
+		return false;
+	}
+
+	*exists = ctx.boolVal;
+	return true;
+}
+
+
+/*
+ * multidb_create_target_database creates datname on the target instance.
+ * When dropIfExists is true and the database already exists it is dropped
+ * first.  When dropIfExists is false and the database already exists the
+ * function succeeds silently (resume / idempotent behaviour).
+ */
+static bool
+multidb_create_target_database(PGSQL *dst, const char *datname,
+								bool dropIfExists)
+{
+	bool exists = false;
+
+	if (!multidb_target_database_exists(dst, datname, &exists))
+		return false;
+
+	if (exists)
+	{
+		if (!dropIfExists)
+		{
+			log_info("Database \"%s\" already exists on target, skipping CREATE",
+					 datname);
+			return true;
+		}
+
+		/* need a live connection to call PQescapeIdentifier */
+		PGconn *conn = pgsql_open_connection(dst);
+
+		if (conn == NULL)
+			return false;
+
+		char *quotedName = PQescapeIdentifier(conn, datname, strlen(datname));
+
+		if (quotedName == NULL)
+		{
+			log_error("Failed to quote database name \"%s\": %s",
+					  datname, PQerrorMessage(conn));
+			pgsql_finish(dst);
+			return false;
+		}
+
+		char sql[BUFSIZE] = { 0 };
+		sformat(sql, sizeof(sql), "DROP DATABASE %s", quotedName);
+		PQfreemem(quotedName);
+
+		pgsql_finish(dst);
+
+		log_info("Dropping existing database \"%s\" on target", datname);
+
+		if (!pgsql_execute(dst, sql))
+		{
+			log_error("Failed to drop database \"%s\" on target", datname);
+			return false;
+		}
+	}
+
+	{
+		PGconn *conn = pgsql_open_connection(dst);
+
+		if (conn == NULL)
+			return false;
+
+		char *quotedName = PQescapeIdentifier(conn, datname, strlen(datname));
+
+		if (quotedName == NULL)
+		{
+			log_error("Failed to quote database name \"%s\": %s",
+					  datname, PQerrorMessage(conn));
+			pgsql_finish(dst);
+			return false;
+		}
+
+		char sql[BUFSIZE] = { 0 };
+		sformat(sql, sizeof(sql),
+				"CREATE DATABASE %s TEMPLATE template0", quotedName);
+		PQfreemem(quotedName);
+
+		pgsql_finish(dst);
+
+		log_info("Creating database \"%s\" on target", datname);
+
+		if (!pgsql_execute(dst, sql))
+		{
+			log_error("Failed to create database \"%s\" on target", datname);
+			return false;
+		}
+	}
+
+	return true;
+}
+
+
+/*
+ * multidb_build_uri_for_database takes an existing Postgres URI and returns a
+ * new one with the dbname component replaced by datname.  The caller owns the
+ * returned string and must free it.
+ */
+static bool
+multidb_build_uri_for_database(const char *pguri, const char *datname,
+								char **result_uri)
+{
+	KeyVal noDefaults = { 0 };
+	KeyVal noOverrides = { 0 };
+	URIParams params = { 0 };
+
+	if (!parse_pguri_info_key_vals(pguri, &noDefaults, &noOverrides,
+								   &params, false))
+	{
+		log_error("Failed to parse URI for database \"%s\" replacement",
+				  datname);
+		return false;
+	}
+
+	/* replace the dbname component */
+	free(params.dbname);
+	params.dbname = strdup(datname);
+
+	if (params.dbname == NULL)
+	{
+		log_error("Failed to strdup datname \"%s\"", datname);
+		return false;
+	}
+
+	bool ok = buildPostgresURIfromPieces(&params, result_uri);
+
+	free(params.username);
+	free(params.hostname);
+	free(params.port);
+	free(params.dbname);
+
+	for (int i = 0; i < params.parameters.count; i++)
+	{
+		free(params.parameters.keywords[i]);
+		free(params.parameters.values[i]);
+	}
+
+	return ok;
+}
+
+
+/*
+ * multidb_build_conn_strings constructs per-database ConnStrings by
+ * substituting datname into the source and target URIs of the parent.
+ */
+static bool
+multidb_build_conn_strings(ConnStrings *parent, const char *datname,
+						   ConnStrings *dbConnStrings)
+{
+	if (!multidb_build_uri_for_database(parent->source_pguri, datname,
+										&dbConnStrings->source_pguri))
+	{
+		log_error("Failed to build source URI for database \"%s\"", datname);
+		return false;
+	}
+
+	if (!multidb_build_uri_for_database(parent->target_pguri, datname,
+										&dbConnStrings->target_pguri))
+	{
+		log_error("Failed to build target URI for database \"%s\"", datname);
+		free(dbConnStrings->source_pguri);
+		dbConnStrings->source_pguri = NULL;
+		return false;
+	}
+
+	if (!parse_and_scrub_connection_string(dbConnStrings->source_pguri,
+										   &dbConnStrings->safeSourcePGURI))
+	{
+		log_error("Failed to scrub source URI for database \"%s\"", datname);
+		free(dbConnStrings->source_pguri);
+		free(dbConnStrings->target_pguri);
+		return false;
+	}
+
+	if (!parse_and_scrub_connection_string(dbConnStrings->target_pguri,
+										   &dbConnStrings->safeTargetPGURI))
+	{
+		log_error("Failed to scrub target URI for database \"%s\"", datname);
+		free(dbConnStrings->source_pguri);
+		free(dbConnStrings->target_pguri);
+		if (dbConnStrings->safeSourcePGURI.pguri)
+			free(dbConnStrings->safeSourcePGURI.pguri);
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * multidb_init_db_specs initialises a per-database CopyDataSpec by copying
+ * all settings from the parent and replacing the connection strings.
+ *
+ * The dbSpecs->cfPaths must already have been set up via copydb_init_workdir
+ * before this function is called.
+ */
+static bool
+multidb_init_db_specs(CopyDataSpec *dbSpecs,
+					  CopyDataSpec *parent,
+					  ConnStrings *connStrings)
+{
+	/* connection strings */
+	dbSpecs->connStrings = *connStrings;
+
+	/* source snapshot — will be populated during clone */
+	dbSpecs->sourceSnapshot.pguri = dbSpecs->connStrings.source_pguri;
+	dbSpecs->sourceSnapshot.safeURI = dbSpecs->connStrings.safeSourcePGURI;
+	dbSpecs->sourceSnapshot.connectionType = PGSQL_CONN_SOURCE;
+
+	/* copy all operational settings from parent */
+	dbSpecs->section = parent->section;
+	dbSpecs->restoreOptions = parent->restoreOptions;
+	dbSpecs->roles = false;         /* roles already copied at instance level */
+	dbSpecs->skipLargeObjects = parent->skipLargeObjects;
+	dbSpecs->skipExtensions = parent->skipExtensions;
+	dbSpecs->skipCommentOnExtension = parent->skipCommentOnExtension;
+	dbSpecs->skipCollations = parent->skipCollations;
+	dbSpecs->skipVacuum = parent->skipVacuum;
+	dbSpecs->skipAnalyze = parent->skipAnalyze;
+	dbSpecs->skipDBproperties = parent->skipDBproperties;
+	dbSpecs->skipCtidSplit = parent->skipCtidSplit;
+	dbSpecs->noRolesPasswords = parent->noRolesPasswords;
+	dbSpecs->failFast = parent->failFast;
+	dbSpecs->useCopyBinary = parent->useCopyBinary;
+	dbSpecs->restart = parent->restart;
+	dbSpecs->resume = parent->resume;
+	dbSpecs->consistent = parent->consistent;
+	dbSpecs->fetchCatalogs = parent->fetchCatalogs;
+	dbSpecs->fetchFilteredOids = parent->fetchFilteredOids;
+	dbSpecs->tableJobs = parent->tableJobs;
+	dbSpecs->indexJobs = parent->indexJobs;
+	dbSpecs->vacuumJobs = parent->vacuumJobs;
+	dbSpecs->lObjectJobs = parent->lObjectJobs;
+	dbSpecs->splitTablesLargerThan = parent->splitTablesLargerThan;
+	dbSpecs->splitMaxParts = parent->splitMaxParts;
+	dbSpecs->estimateTableSizes = parent->estimateTableSizes;
+	dbSpecs->extRequirements = parent->extRequirements;
+
+	/* filters are shared — pointer copy is intentional (read-only in workers) */
+	dbSpecs->filters = parent->filters;
+
+	/* prepare dump paths under the per-db schema dir */
+	if (!copydb_prepare_dump_paths(&dbSpecs->cfPaths, &dbSpecs->dumpPaths))
+	{
+		log_error("Failed to prepare dump paths for per-database work dir");
+		return false;
+	}
+
+	/* initialise catalog types and file paths */
+	DatabaseCatalog *source = &dbSpecs->catalogs.source;
+	DatabaseCatalog *filter = &dbSpecs->catalogs.filter;
+	DatabaseCatalog *target = &dbSpecs->catalogs.target;
+	DatabaseCatalog *replay = &dbSpecs->catalogs.replay;
+
+	source->type = DATABASE_CATALOG_TYPE_SOURCE;
+	filter->type = DATABASE_CATALOG_TYPE_FILTER;
+	target->type = DATABASE_CATALOG_TYPE_TARGET;
+	replay->type = DATABASE_CATALOG_TYPE_REPLAY;
+
+	strlcpy(source->dbfile, dbSpecs->cfPaths.sdbfile, sizeof(source->dbfile));
+	strlcpy(filter->dbfile, dbSpecs->cfPaths.fdbfile, sizeof(filter->dbfile));
+	strlcpy(target->dbfile, dbSpecs->cfPaths.tdbfile, sizeof(target->dbfile));
+
+	/* create the System V message queues */
+	bool shouldCreateVacuumQueue =
+		(dbSpecs->section == DATA_SECTION_ALL ||
+		 dbSpecs->section == DATA_SECTION_INDEXES ||
+		 dbSpecs->section == DATA_SECTION_TABLE_DATA) &&
+		!dbSpecs->skipVacuum;
+
+	if (shouldCreateVacuumQueue)
+	{
+		if (!queue_create(&dbSpecs->vacuumQueue, "vacuum"))
+		{
+			log_error("Failed to create the VACUUM process queue");
+			return false;
+		}
+	}
+	else
+	{
+		dbSpecs->vacuumQueue.qId = -1;
+	}
+
+	if (dbSpecs->section == DATA_SECTION_ALL ||
+		dbSpecs->section == DATA_SECTION_INDEXES ||
+		dbSpecs->section == DATA_SECTION_CONSTRAINTS ||
+		dbSpecs->section == DATA_SECTION_TABLE_DATA)
+	{
+		if (!queue_create(&dbSpecs->indexQueue, "create index"))
+		{
+			log_error("Failed to create the INDEX process queue");
+			return false;
+		}
+	}
+	else
+	{
+		dbSpecs->indexQueue.qId = -1;
+	}
+
+	return true;
+}
+
+
+/*
+ * multidb_clone_one_database clones a single database identified by db into
+ * its own per-database work directory under <topdir>/db/<datname>/.
+ */
+static bool
+multidb_clone_one_database(CopyDataSpec *parentSpecs, SourceDatabase *db)
+{
+	/* build per-db work directory path */
+	char dbdir[MAXPGPATH] = { 0 };
+
+	sformat(dbdir, sizeof(dbdir), "%s/db/%s",
+			parentSpecs->cfPaths.topdir, db->datname);
+
+	/* build per-db connection strings */
+	ConnStrings dbConnStrings = { 0 };
+
+	if (!multidb_build_conn_strings(&parentSpecs->connStrings, db->datname,
+									&dbConnStrings))
+	{
+		log_error("Failed to build connection strings for database \"%s\"",
+				  db->datname);
+		return false;
+	}
+
+	log_info("[SOURCE] Cloning database \"%s\" from \"%s\"",
+			 db->datname, dbConnStrings.safeSourcePGURI.pguri);
+	log_info("[TARGET] Cloning database \"%s\" into \"%s\"",
+			 db->datname, dbConnStrings.safeTargetPGURI.pguri);
+
+	/* initialise per-db CopyDataSpec */
+	CopyDataSpec dbSpecs = { 0 };
+
+	dbSpecs.pgPaths = parentSpecs->pgPaths;
+
+	/*
+	 * Set up work directory under <topdir>/db/<datname>/.
+	 * Use service=false so no pidfile is created for per-db dirs.
+	 * Use restart/resume from parent settings.
+	 */
+	if (!copydb_init_workdir(&dbSpecs, dbdir,
+							 false,     /* service */
+							 NULL,      /* serviceName */
+							 parentSpecs->restart,
+							 parentSpecs->resume,
+							 true))     /* createWorkDir */
+	{
+		log_error("Failed to initialise work directory \"%s\" for database \"%s\"",
+				  dbdir, db->datname);
+		goto cleanup;
+	}
+
+	if (!multidb_init_db_specs(&dbSpecs, parentSpecs, &dbConnStrings))
+	{
+		log_error("Failed to initialise specs for database \"%s\"",
+				  db->datname);
+		goto cleanup;
+	}
+
+	bool result = copydb_clone_database(&dbSpecs);
+
+	/* close any open catalog connections */
+	(void) catalog_close_from_specs(&dbSpecs);
+
+	free(dbConnStrings.source_pguri);
+	free(dbConnStrings.target_pguri);
+	if (dbConnStrings.safeSourcePGURI.pguri)
+		free(dbConnStrings.safeSourcePGURI.pguri);
+	if (dbConnStrings.safeTargetPGURI.pguri)
+		free(dbConnStrings.safeTargetPGURI.pguri);
+
+	return result;
+
+cleanup:
+	free(dbConnStrings.source_pguri);
+	free(dbConnStrings.target_pguri);
+	if (dbConnStrings.safeSourcePGURI.pguri)
+		free(dbConnStrings.safeSourcePGURI.pguri);
+	if (dbConnStrings.safeTargetPGURI.pguri)
+		free(dbConnStrings.safeTargetPGURI.pguri);
+	return false;
+}

--- a/src/bin/pgcopydb/multi_db.c
+++ b/src/bin/pgcopydb/multi_db.c
@@ -28,9 +28,9 @@
 #include "pgcmd.h"
 #include "pgsql.h"
 #include "schema.h"
+#include "summary.h"
 #include "signals.h"
 #include "string_utils.h"
-#include "summary.h"
 
 
 static bool multidb_is_system_database(const char *datname);
@@ -41,9 +41,6 @@ static bool multidb_create_target_database(PGSQL *dst, const char *datname,
 bool multidb_build_uri_for_database(const char *pguri,
 									const char *datname,
 									char **result_uri);
-static bool multidb_build_conn_strings(ConnStrings *parent,
-									   const char *datname,
-									   ConnStrings *dbConnStrings);
 static bool multidb_init_db_specs(CopyDataSpec *dbSpecs,
 								  CopyDataSpec *parent,
 								  ConnStrings *connStrings);
@@ -76,6 +73,12 @@ static bool multidb_wait_child(pid_t pid, const char *label);
 static bool multidb_init_entry(MultiDbEntry *entry,
 								CopyDataSpec *parentSpecs,
 								const char *datname);
+
+/* lighter index/vacuum pool helpers */
+static bool multidb_init_index_entry(MultiDbEntry *entry,
+									  CopyDataSpec *parentSpecs,
+									  const char *datname);
+static bool multidb_index_context_close_entry(MultiDbEntry *entry);
 
 
 /*
@@ -444,12 +447,34 @@ clone_all_databases(CopyDataSpec *parentSpecs)
 	log_info("Phase II: global COPY for %d databases (largest tables first)",
 			 dbCount);
 
-	if (!multidb_global_copy(parentSpecs))
+	/*
+	 * Open the instance catalog to record Phase II wall-clock timing.
+	 * The catalog was closed after reading multiDbInfos; re-open it now.
+	 */
+	if (!catalog_init_from_specs(parentSpecs))
 	{
-		log_error("Global COPY phase failed");
+		log_error("Failed to open instance catalog for Phase II timing");
 		ok = false;
 		goto signal_done;
 	}
+
+	(void) summary_start_timing(&parentSpecs->catalogs.source,
+								TIMING_SECTION_TOTAL_DATA);
+
+	if (!multidb_global_copy(parentSpecs))
+	{
+		log_error("Global COPY phase failed");
+		(void) summary_stop_timing(&parentSpecs->catalogs.source,
+								   TIMING_SECTION_TOTAL_DATA);
+		(void) catalog_close_from_specs(parentSpecs);
+		ok = false;
+		goto signal_done;
+	}
+
+	(void) summary_stop_timing(&parentSpecs->catalogs.source,
+							   TIMING_SECTION_TOTAL_DATA);
+
+	(void) catalog_close_from_specs(parentSpecs);
 
 	/* ====== PHASE III: POST-DATA (sequential per-database) ====== */
 	log_info("Phase III: post-data restore and sequences for %d databases",
@@ -1199,6 +1224,23 @@ multidb_clone_one_database_post_data(CopyDataSpec *parentSpecs,
 				exit(EXIT_CODE_INTERNAL_ERROR);
 			}
 
+			/*
+			 * Index and vacuum operations are done by the global supervisors
+			 * in Phase II.  Destroy any per-db queues that multidb_init_db_specs
+			 * may have created to avoid leaking System V resources.
+			 */
+			if (dbSpecs.vacuumQueue.qId != -1)
+			{
+				(void) queue_unlink(&dbSpecs.vacuumQueue);
+				dbSpecs.vacuumQueue.qId = -1;
+			}
+
+			if (dbSpecs.indexQueue.qId != -1)
+			{
+				(void) queue_unlink(&dbSpecs.indexQueue);
+				dbSpecs.indexQueue.qId = -1;
+			}
+
 			strlcpy(dbSpecs.datname, datname, sizeof(dbSpecs.datname));
 
 			/*
@@ -1225,7 +1267,17 @@ multidb_clone_one_database_post_data(CopyDataSpec *parentSpecs,
 				exit(EXIT_CODE_INTERNAL_ERROR);
 			}
 
-			/* restore the post-data section (indexes, constraints, …) */
+			/*
+			 * Indexes and vacuum were already handled by the global supervisors
+			 * during the COPY phase (Phase II).  Post-data here only needs to
+			 * restore the remaining objects that pg_restore --post-data covers
+			 * but pgcopydb's index workers do not: triggers, rules, comments,
+			 * etc.  copydb_target_finalize_schema filters out already-built
+			 * indexes via copydb_objectid_has_been_processed_already so that
+			 * pg_restore does not try to recreate them.
+			 */
+
+			/* restore remaining post-data (triggers, rules, …) */
 			if (!copydb_target_finalize_schema(&dbSpecs))
 			{
 				log_error("Failed to finalize schema for database \"%s\"",
@@ -1255,23 +1307,23 @@ multidb_clone_one_database_post_data(CopyDataSpec *parentSpecs,
 
 
 /*
- * multidb_global_copy runs the global COPY phase.
+ * multidb_global_copy runs the global COPY + index + vacuum phase.
  *
- * Process tree:
- *   clone_all_databases
- *   └── global copy supervisor  (this function forks it, then waits)
- *           ├── global copy worker 1
- *           ├── global copy worker N  (N = --table-jobs)
- *           └── global copy queue tables  (fills queue, then exits)
+ * Process tree (mirrors singledb copydb_process_table_data):
+ *   multidb_global_copy (parent)
+ *   ├── global vacuum supervisor  (async; reads vacuumQueue)
+ *   ├── global index supervisor   (async; reads indexQueue; sends vacuum STOP)
+ *   └── global copy supervisor    (forks copy workers + queue filler; waits)
+ *
+ * Copy workers fill indexQueue and vacuumQueue as they finish each table,
+ * exactly as in the singledb path.  Index/vacuum workers use a per-db
+ * connection pool (catalog + target, no snapshot) to route to the right db.
  *
  * Fix A — shared catalog semaphores:
- *   One System V semaphore is created per database before forking the
- *   supervisor.  All workers inherit the semaphore IDs via COW.
- *   multidb_init_entry wires the semaphore into the DatabaseCatalog
- *   before calling catalog_init(), so catalog_create_semaphore() finds
- *   semId != 0 and skips creating a second independent semaphore.
- *   Without this, each worker creates its own semaphore, breaking
- *   write serialisation and producing SQLite BUSY errors.
+ *   One System V semaphore is created per database before forking.  All
+ *   workers inherit the semaphore IDs via COW.  multidb_init_entry (copy
+ *   workers) and multidb_init_index_entry (index/vacuum workers) wire the
+ *   semaphore into DatabaseCatalog so catalog_create_semaphore() reuses it.
  */
 static bool
 multidb_global_copy(CopyDataSpec *parentSpecs)
@@ -1283,17 +1335,35 @@ multidb_global_copy(CopyDataSpec *parentSpecs)
 		return true;
 	}
 
+	/* Create global index and vacuum queues before any forking. */
+	if (!queue_create(&parentSpecs->indexQueue, "global index"))
+	{
+		log_error("Failed to create the global INDEX process queue");
+		return false;
+	}
+
+	if (!parentSpecs->skipVacuum)
+	{
+		if (!queue_create(&parentSpecs->vacuumQueue, "global vacuum"))
+		{
+			log_error("Failed to create the global VACUUM process queue");
+			(void) queue_unlink(&parentSpecs->indexQueue);
+			parentSpecs->indexQueue.qId = -1;
+			return false;
+		}
+	}
+
 	/*
-	 * Fix A: create one shared semaphore per database BEFORE forking the
-	 * supervisor.  Workers inherit the semId via COW; catalog_init() then
-	 * skips creating its own semaphore.
+	 * Fix A: create one shared semaphore per database BEFORE forking.
+	 * Workers inherit the semId via COW; catalog_init() then skips creating
+	 * its own semaphore, so all workers for the same database share one lock.
 	 */
 	for (int i = 0; i < parentSpecs->multiDbCount; i++)
 	{
 		MultiDbInfo *info = &parentSpecs->multiDbInfos[i];
 
 		if (info->catalogSemId != 0)
-			continue;   /* already created (shouldn't happen, but be safe) */
+			continue;
 
 		Semaphore sema = { .initValue = 1, .reentrant = true };
 
@@ -1302,7 +1372,6 @@ multidb_global_copy(CopyDataSpec *parentSpecs)
 			log_error("Failed to create catalog semaphore for database \"%s\"",
 					  info->datname);
 
-			/* best-effort cleanup of already-created semaphores */
 			for (int j = 0; j < i; j++)
 			{
 				MultiDbInfo *prev = &parentSpecs->multiDbInfos[j];
@@ -1314,6 +1383,16 @@ multidb_global_copy(CopyDataSpec *parentSpecs)
 					prev->catalogSemId = 0;
 				}
 			}
+
+			(void) queue_unlink(&parentSpecs->indexQueue);
+			parentSpecs->indexQueue.qId = -1;
+
+			if (!parentSpecs->skipVacuum)
+			{
+				(void) queue_unlink(&parentSpecs->vacuumQueue);
+				parentSpecs->vacuumQueue.qId = -1;
+			}
+
 			return false;
 		}
 
@@ -1321,11 +1400,68 @@ multidb_global_copy(CopyDataSpec *parentSpecs)
 
 		log_debug("Created catalog semaphore %d for database \"%s\"",
 				  sema.semId, info->datname);
+
+		/*
+		 * Pre-seed the COPY_DATA timing row so workers' summary_increment_timing
+		 * calls have a valid start_time_epoch to anchor the wall-clock range.
+		 */
+		DatabaseCatalog dbCat = {
+			.type = DATABASE_CATALOG_TYPE_SOURCE,
+			.sema.semId = sema.semId,
+			.sema.reentrant = true,
+		};
+		sformat(dbCat.dbfile, sizeof(dbCat.dbfile),
+				"%s/schema/source.db", info->topdir);
+
+		if (catalog_init(&dbCat))
+		{
+			(void) summary_start_timing(&dbCat, TIMING_SECTION_COPY_DATA);
+			(void) catalog_close(&dbCat);
+		}
+		else
+		{
+			log_warn("Failed to open catalog for \"%s\": "
+					 "COPY_DATA start timing not recorded", info->datname);
+		}
+	}
+
+	/*
+	 * Close the global catalog before forking so that no child inherits an
+	 * open SQLite handle (fork-safety).  The caller re-opens it after we
+	 * return via catalog_open_from_specs.
+	 */
+	if (!catalog_close_from_specs(parentSpecs))
+	{
+		log_error("Failed to close global catalog before forking");
+		return false;
+	}
+
+	/*
+	 * Fork vacuum supervisor first (reads vacuumQueue; waits for workers).
+	 * The index supervisor sends the STOP messages after all indexes are done.
+	 */
+	if (!parentSpecs->skipVacuum)
+	{
+		if (!vacuum_start_supervisor(parentSpecs))
+		{
+			log_error("Failed to start global vacuum supervisor");
+			return false;
+		}
+	}
+
+	/*
+	 * Fork index supervisor (reads indexQueue; after done, sends vacuum STOP).
+	 */
+	if (!copydb_start_index_supervisor(parentSpecs))
+	{
+		log_error("Failed to start global index supervisor");
+		return false;
 	}
 
 	/*
 	 * Fork the global copy supervisor.  The supervisor creates the copyQueue,
-	 * forks workers and the queue filler, then collects all children.
+	 * forks copy workers and the queue filler, then waits for them.
+	 * Copy workers fill indexQueue/vacuumQueue after each table copy.
 	 */
 	fflush(stdout);
 	fflush(stderr);
@@ -1347,17 +1483,12 @@ multidb_global_copy(CopyDataSpec *parentSpecs)
 			log_notice("Started global copy supervisor %d [%d]",
 					   getpid(), getppid());
 
-			/*
-			 * Create the copyQueue here so workers can inherit its qId
-			 * after they are forked below.
-			 */
 			if (!queue_create(&parentSpecs->copyQueue, "global copy"))
 			{
 				log_error("Failed to create the global COPY queue");
 				exit(EXIT_CODE_INTERNAL_ERROR);
 			}
 
-			/* fork tableJobs COPY workers */
 			log_info("Starting %d global COPY workers", parentSpecs->tableJobs);
 
 			for (int i = 0; i < parentSpecs->tableJobs; i++)
@@ -1388,7 +1519,6 @@ multidb_global_copy(CopyDataSpec *parentSpecs)
 				}
 			}
 
-			/* fork the queue filler as a child of the supervisor */
 			{
 				fflush(stdout);
 				fflush(stderr);
@@ -1417,7 +1547,6 @@ multidb_global_copy(CopyDataSpec *parentSpecs)
 				}
 			}
 
-			/* supervisor waits for all children (workers + queue filler) */
 			bool ok = copydb_wait_for_subprocesses(parentSpecs->failFast);
 
 			(void) queue_unlink(&parentSpecs->copyQueue);
@@ -1430,10 +1559,22 @@ multidb_global_copy(CopyDataSpec *parentSpecs)
 			break;
 	}
 
-	/* clone_all_databases waits for the one supervisor child */
-	bool ok = multidb_wait_child(spid, "global copy supervisor");
+	/*
+	 * Wait for all three supervisor children: copy supervisor, index
+	 * supervisor, vacuum supervisor.
+	 */
+	bool ok = copydb_wait_for_subprocesses(parentSpecs->failFast);
 
-	/* destroy the shared catalog semaphores */
+	/*
+	 * Reopen the global catalog so the caller can write summary_stop_timing.
+	 */
+	if (!catalog_open_from_specs(parentSpecs))
+	{
+		log_error("Failed to reopen global catalog after copy/index/vacuum phase");
+		ok = false;
+	}
+
+	/* Destroy shared catalog semaphores. */
 	for (int i = 0; i < parentSpecs->multiDbCount; i++)
 	{
 		MultiDbInfo *info = &parentSpecs->multiDbInfos[i];
@@ -1444,6 +1585,19 @@ multidb_global_copy(CopyDataSpec *parentSpecs)
 			(void) semaphore_unlink(&sema);
 			info->catalogSemId = 0;
 		}
+	}
+
+	/* Clean up index/vacuum queues (copy queue cleaned up by copy supervisor). */
+	if (parentSpecs->indexQueue.qId != -1)
+	{
+		(void) queue_unlink(&parentSpecs->indexQueue);
+		parentSpecs->indexQueue.qId = -1;
+	}
+
+	if (parentSpecs->vacuumQueue.qId != -1)
+	{
+		(void) queue_unlink(&parentSpecs->vacuumQueue);
+		parentSpecs->vacuumQueue.qId = -1;
 	}
 
 	return ok;
@@ -1583,6 +1737,236 @@ multidb_context_close_all(MultiDbContext *ctx)
 
 
 /*
+ * multidb_init_index_entry is a lighter version of multidb_init_entry for use
+ * by index and vacuum workers.  It opens the per-db catalog and target
+ * connection but does NOT open a source connection or import a snapshot,
+ * because index/vacuum workers only need catalog lookups and target writes.
+ */
+static bool
+multidb_init_index_entry(MultiDbEntry *entry, CopyDataSpec *parentSpecs,
+						  const char *datname)
+{
+	MultiDbInfo *info = NULL;
+
+	for (int i = 0; i < parentSpecs->multiDbCount; i++)
+	{
+		if (strcmp(parentSpecs->multiDbInfos[i].datname, datname) == 0)
+		{
+			info = &parentSpecs->multiDbInfos[i];
+			break;
+		}
+	}
+
+	if (info == NULL)
+	{
+		log_error("BUG: multidb_init_index_entry: no MultiDbInfo for \"%s\"",
+				  datname);
+		return false;
+	}
+
+	CopyDataSpec *dbSpecs = (CopyDataSpec *) calloc(1, sizeof(CopyDataSpec));
+
+	if (dbSpecs == NULL)
+	{
+		log_error(ALLOCATION_FAILED_ERROR);
+		return false;
+	}
+
+	dbSpecs->pgPaths = parentSpecs->pgPaths;
+	dbSpecs->filters = parentSpecs->filters;
+	dbSpecs->section = parentSpecs->section;
+	dbSpecs->restoreOptions = parentSpecs->restoreOptions;
+	dbSpecs->skipVacuum = parentSpecs->skipVacuum;
+	dbSpecs->skipAnalyze = parentSpecs->skipAnalyze;
+	dbSpecs->skipLargeObjects = parentSpecs->skipLargeObjects;
+	dbSpecs->failFast = parentSpecs->failFast;
+	dbSpecs->resume = parentSpecs->resume;
+	dbSpecs->allDatabases = false;
+
+	/* queues inherited from parent — index/vacuum workers enqueue into them */
+	dbSpecs->indexQueue = parentSpecs->indexQueue;
+	dbSpecs->vacuumQueue = parentSpecs->vacuumQueue;
+	dbSpecs->copyQueue.qId = -1;
+	dbSpecs->loQueue.qId = -1;
+
+	dbSpecs->connStrings.target_pguri = strdup(info->target_pguri);
+
+	if (dbSpecs->connStrings.target_pguri == NULL)
+	{
+		log_error(ALLOCATION_FAILED_ERROR);
+		free(dbSpecs);
+		return false;
+	}
+
+	if (!parse_and_scrub_connection_string(dbSpecs->connStrings.target_pguri,
+										   &dbSpecs->connStrings.safeTargetPGURI))
+	{
+		log_error("Failed to scrub target URI for database \"%s\"", datname);
+		free(dbSpecs->connStrings.target_pguri);
+		free(dbSpecs);
+		return false;
+	}
+
+	if (!copydb_init_workdir(dbSpecs, info->topdir,
+							 false, NULL, false, true, false))
+	{
+		log_error("Failed to init work dir for database \"%s\"", datname);
+		free(dbSpecs->connStrings.target_pguri);
+		free(dbSpecs);
+		return false;
+	}
+
+	DatabaseCatalog *sourceDB = &dbSpecs->catalogs.source;
+
+	sourceDB->type = DATABASE_CATALOG_TYPE_SOURCE;
+	strlcpy(sourceDB->dbfile, dbSpecs->cfPaths.sdbfile, sizeof(sourceDB->dbfile));
+
+	if (info->catalogSemId != 0)
+	{
+		sourceDB->sema.semId = info->catalogSemId;
+		sourceDB->sema.reentrant = true;
+	}
+
+	if (!catalog_init(sourceDB))
+	{
+		log_error("Failed to open catalog for database \"%s\"", datname);
+		free(dbSpecs->connStrings.target_pguri);
+		free(dbSpecs);
+		return false;
+	}
+
+	if (!pgsql_init(&entry->dst, dbSpecs->connStrings.target_pguri,
+					PGSQL_CONN_TARGET))
+	{
+		log_error("Failed to connect to target for database \"%s\"", datname);
+		catalog_close(sourceDB);
+		free(dbSpecs->connStrings.target_pguri);
+		free(dbSpecs);
+		return false;
+	}
+
+	if (!pgsql_set_gucs(&entry->dst, dstSettings))
+	{
+		log_warn("Failed to set GUCs on target for database \"%s\"", datname);
+	}
+
+	strlcpy(entry->datname, datname, sizeof(entry->datname));
+	strlcpy(dbSpecs->datname, datname, sizeof(dbSpecs->datname));
+	entry->dbSpecs = dbSpecs;
+	entry->active = true;
+
+	log_debug("Opened index/vacuum connections for database \"%s\"", datname);
+
+	return true;
+}
+
+
+/*
+ * multidb_index_context_close_entry closes an index/vacuum pool entry: catalog
+ * and target connection only (no snapshot to close).
+ */
+static bool
+multidb_index_context_close_entry(MultiDbEntry *entry)
+{
+	if (!entry->active)
+		return true;
+
+	log_debug("Closing index/vacuum connection cache entry for \"%s\"",
+			  entry->datname);
+
+	if (entry->dbSpecs != NULL)
+	{
+		(void) catalog_close(&entry->dbSpecs->catalogs.source);
+		free(entry->dbSpecs->connStrings.target_pguri);
+		free(entry->dbSpecs);
+		entry->dbSpecs = NULL;
+	}
+
+	(void) pgsql_finish(&entry->dst);
+
+	entry->active = false;
+	memset(entry->datname, 0, sizeof(entry->datname));
+
+	return true;
+}
+
+
+/*
+ * multidb_index_context_close_all closes all active entries in an
+ * index/vacuum pool.
+ */
+bool
+multidb_index_context_close_all(MultiDbContext *ctx)
+{
+	bool ok = true;
+
+	for (int i = 0; i < MULTIDB_ENTRY_CACHE_MAX; i++)
+	{
+		if (ctx->entries[i].active)
+		{
+			if (!multidb_index_context_close_entry(&ctx->entries[i]))
+				ok = false;
+		}
+	}
+
+	return ok;
+}
+
+
+/*
+ * multidb_index_context_get_entry returns the pool entry for datname, opening
+ * a new one (with catalog + target connection only) if not cached.
+ */
+MultiDbEntry *
+multidb_index_context_get_entry(MultiDbContext *ctx, const char *datname)
+{
+	for (int i = 0; i < MULTIDB_ENTRY_CACHE_MAX; i++)
+	{
+		if (ctx->entries[i].active &&
+			strcmp(ctx->entries[i].datname, datname) == 0)
+		{
+			return &ctx->entries[i];
+		}
+	}
+
+	int slot = -1;
+
+	for (int i = 0; i < MULTIDB_ENTRY_CACHE_MAX; i++)
+	{
+		if (!ctx->entries[i].active)
+		{
+			slot = i;
+			break;
+		}
+	}
+
+	if (slot < 0)
+	{
+		slot = ctx->nextEvict % MULTIDB_ENTRY_CACHE_MAX;
+		ctx->nextEvict = (ctx->nextEvict + 1) % MULTIDB_ENTRY_CACHE_MAX;
+
+		log_debug("Evicting index/vacuum cache entry for \"%s\"",
+				  ctx->entries[slot].datname);
+
+		if (!multidb_index_context_close_entry(&ctx->entries[slot]))
+		{
+			return NULL;
+		}
+	}
+
+	MultiDbEntry *entry = &ctx->entries[slot];
+
+	if (!multidb_init_index_entry(entry, ctx->parentSpecs, datname))
+	{
+		return NULL;
+	}
+
+	ctx->count++;
+	return entry;
+}
+
+
+/*
  * multidb_init_entry initialises a MultiDbEntry for the given database.
  *
  * This involves:
@@ -1630,14 +2014,14 @@ multidb_init_entry(MultiDbEntry *entry, CopyDataSpec *parentSpecs,
 	dbSpecs->pgPaths = parentSpecs->pgPaths;
 	dbSpecs->filters = parentSpecs->filters;
 	dbSpecs->extRequirements = parentSpecs->extRequirements;
-	dbSpecs->section = DATA_SECTION_TABLE_DATA;  /* skip inline index routing */
+	dbSpecs->section = parentSpecs->section;
 	dbSpecs->restoreOptions = parentSpecs->restoreOptions;
 	dbSpecs->roles = false;
 	dbSpecs->skipLargeObjects = parentSpecs->skipLargeObjects;
 	dbSpecs->skipExtensions = parentSpecs->skipExtensions;
 	dbSpecs->skipCommentOnExtension = parentSpecs->skipCommentOnExtension;
 	dbSpecs->skipCollations = parentSpecs->skipCollations;
-	dbSpecs->skipVacuum = true;    /* vacuum done separately in post-data */
+	dbSpecs->skipVacuum = parentSpecs->skipVacuum;
 	dbSpecs->skipAnalyze = parentSpecs->skipAnalyze;
 	dbSpecs->skipDBproperties = parentSpecs->skipDBproperties;
 	dbSpecs->skipCtidSplit = parentSpecs->skipCtidSplit;
@@ -1658,10 +2042,14 @@ multidb_init_entry(MultiDbEntry *entry, CopyDataSpec *parentSpecs,
 	dbSpecs->estimateTableSizes = parentSpecs->estimateTableSizes;
 	dbSpecs->allDatabases = false;  /* per-db context, not the global flag */
 
-	/* no queues for per-database workers — index/vacuum done in post-data */
+	/*
+	 * Wire the global index and vacuum queues so that copy workers fill them
+	 * as they finish each table, exactly as in the singledb code path.
+	 * copyQueue is not used by per-db workers; loQueue is handled separately.
+	 */
 	dbSpecs->copyQueue.qId = -1;
-	dbSpecs->indexQueue.qId = -1;
-	dbSpecs->vacuumQueue.qId = -1;
+	dbSpecs->indexQueue = parentSpecs->indexQueue;
+	dbSpecs->vacuumQueue = parentSpecs->vacuumQueue;
 	dbSpecs->loQueue.qId = -1;
 
 	/* set up per-database connection strings (heap-allocated) */
@@ -1978,53 +2366,6 @@ multidb_build_uri_for_database(const char *pguri, const char *datname,
 	}
 
 	return ok;
-}
-
-
-/*
- * multidb_build_conn_strings constructs per-database ConnStrings.
- */
-static bool
-multidb_build_conn_strings(ConnStrings *parent, const char *datname,
-						   ConnStrings *dbConnStrings)
-{
-	if (!multidb_build_uri_for_database(parent->source_pguri, datname,
-										&dbConnStrings->source_pguri))
-	{
-		log_error("Failed to build source URI for database \"%s\"", datname);
-		return false;
-	}
-
-	if (!multidb_build_uri_for_database(parent->target_pguri, datname,
-										&dbConnStrings->target_pguri))
-	{
-		log_error("Failed to build target URI for database \"%s\"", datname);
-		free(dbConnStrings->source_pguri);
-		dbConnStrings->source_pguri = NULL;
-		return false;
-	}
-
-	if (!parse_and_scrub_connection_string(dbConnStrings->source_pguri,
-										   &dbConnStrings->safeSourcePGURI))
-	{
-		log_error("Failed to scrub source URI for database \"%s\"", datname);
-		free(dbConnStrings->source_pguri);
-		free(dbConnStrings->target_pguri);
-		return false;
-	}
-
-	if (!parse_and_scrub_connection_string(dbConnStrings->target_pguri,
-										   &dbConnStrings->safeTargetPGURI))
-	{
-		log_error("Failed to scrub target URI for database \"%s\"", datname);
-		free(dbConnStrings->source_pguri);
-		free(dbConnStrings->target_pguri);
-		if (dbConnStrings->safeSourcePGURI.pguri)
-			free(dbConnStrings->safeSourcePGURI.pguri);
-		return false;
-	}
-
-	return true;
 }
 
 

--- a/src/bin/pgcopydb/multi_db.c
+++ b/src/bin/pgcopydb/multi_db.c
@@ -1574,6 +1574,48 @@ multidb_global_copy(CopyDataSpec *parentSpecs)
 		ok = false;
 	}
 
+	/*
+	 * Finalize per-database timing sections.  Each per-db catalog has
+	 * accumulated summary_increment_timing calls from copy/index/vacuum
+	 * workers; calling summary_stop_timing here sets done_time_epoch and
+	 * pretty-prints the duration so the consolidated summary displays
+	 * non-zero values.
+	 *
+	 * Must happen BEFORE destroying semaphores so catalog_init can reuse
+	 * the existing semId.
+	 */
+	for (int i = 0; i < parentSpecs->multiDbCount; i++)
+	{
+		MultiDbInfo *info = &parentSpecs->multiDbInfos[i];
+
+		if (info->catalogSemId == 0)
+			continue;
+
+		DatabaseCatalog dbCat = {
+			.type = DATABASE_CATALOG_TYPE_SOURCE,
+			.sema.semId = info->catalogSemId,
+			.sema.reentrant = true,
+		};
+		sformat(dbCat.dbfile, sizeof(dbCat.dbfile),
+				"%s/schema/source.db", info->topdir);
+
+		if (!catalog_init(&dbCat))
+		{
+			log_warn("Failed to open per-db catalog for \"%s\": "
+					 "timings not finalized", info->datname);
+			continue;
+		}
+
+		(void) summary_stop_timing(&dbCat, TIMING_SECTION_COPY_DATA);
+		(void) summary_stop_timing(&dbCat, TIMING_SECTION_CREATE_INDEX);
+		(void) summary_stop_timing(&dbCat, TIMING_SECTION_ALTER_TABLE);
+
+		if (!parentSpecs->skipVacuum)
+			(void) summary_stop_timing(&dbCat, TIMING_SECTION_VACUUM);
+
+		(void) catalog_close(&dbCat);
+	}
+
 	/* Destroy shared catalog semaphores. */
 	for (int i = 0; i < parentSpecs->multiDbCount; i++)
 	{

--- a/src/bin/pgcopydb/multi_db.c
+++ b/src/bin/pgcopydb/multi_db.c
@@ -1354,36 +1354,19 @@ multidb_global_copy(CopyDataSpec *parentSpecs)
 	}
 
 	/*
-	 * Fix A: create one shared semaphore per database BEFORE forking.
-	 * Workers inherit the semId via COW; catalog_init() then skips creating
-	 * its own semaphore, so all workers for the same database share one lock.
+	 * Create ONE semaphore set with one slot per database.  All workers for
+	 * database[i] share slot i, serialising concurrent SQLite writes without
+	 * consuming O(N) system_res_array slots — the entire set costs one entry.
+	 * Workers inherit the semId via COW; catalog_init() skips creation when
+	 * semId is already set.
 	 */
-	for (int i = 0; i < parentSpecs->multiDbCount; i++)
 	{
-		MultiDbInfo *info = &parentSpecs->multiDbInfos[i];
+		Semaphore catalogSemaSet = { 0 };
 
-		if (info->catalogSemId != 0)
-			continue;
-
-		Semaphore sema = { .initValue = 1, .reentrant = true };
-
-		if (!semaphore_create(&sema))
+		if (!semaphore_create_set(&catalogSemaSet, parentSpecs->multiDbCount))
 		{
-			log_error("Failed to create catalog semaphore for database \"%s\"",
-					  info->datname);
-
-			for (int j = 0; j < i; j++)
-			{
-				MultiDbInfo *prev = &parentSpecs->multiDbInfos[j];
-
-				if (prev->catalogSemId != 0)
-				{
-					Semaphore s = { .semId = prev->catalogSemId };
-					(void) semaphore_unlink(&s);
-					prev->catalogSemId = 0;
-				}
-			}
-
+			log_error("Failed to create catalog semaphore set for %d databases",
+					  parentSpecs->multiDbCount);
 			(void) queue_unlink(&parentSpecs->indexQueue);
 			parentSpecs->indexQueue.qId = -1;
 
@@ -1396,18 +1379,29 @@ multidb_global_copy(CopyDataSpec *parentSpecs)
 			return false;
 		}
 
-		info->catalogSemId = sema.semId;
+		for (int i = 0; i < parentSpecs->multiDbCount; i++)
+		{
+			parentSpecs->multiDbInfos[i].catalogSemId    = catalogSemaSet.semId;
+			parentSpecs->multiDbInfos[i].catalogSemIndex = i;
 
-		log_debug("Created catalog semaphore %d for database \"%s\"",
-				  sema.semId, info->datname);
+			log_debug("Assigned catalog semaphore set %d[%d] to database \"%s\"",
+					  catalogSemaSet.semId, i,
+					  parentSpecs->multiDbInfos[i].datname);
+		}
+	}
 
-		/*
-		 * Pre-seed the COPY_DATA timing row so workers' summary_increment_timing
-		 * calls have a valid start_time_epoch to anchor the wall-clock range.
-		 */
+	/*
+	 * Pre-seed the COPY_DATA timing row for each database so that workers'
+	 * summary_increment_timing calls have a valid start_time_epoch.
+	 */
+	for (int i = 0; i < parentSpecs->multiDbCount; i++)
+	{
+		MultiDbInfo *info = &parentSpecs->multiDbInfos[i];
+
 		DatabaseCatalog dbCat = {
 			.type = DATABASE_CATALOG_TYPE_SOURCE,
-			.sema.semId = sema.semId,
+			.sema.semId    = info->catalogSemId,
+			.sema.semIndex = info->catalogSemIndex,
 			.sema.reentrant = true,
 		};
 		sformat(dbCat.dbfile, sizeof(dbCat.dbfile),
@@ -1593,7 +1587,8 @@ multidb_global_copy(CopyDataSpec *parentSpecs)
 
 		DatabaseCatalog dbCat = {
 			.type = DATABASE_CATALOG_TYPE_SOURCE,
-			.sema.semId = info->catalogSemId,
+			.sema.semId    = info->catalogSemId,
+			.sema.semIndex = info->catalogSemIndex,
 			.sema.reentrant = true,
 		};
 		sformat(dbCat.dbfile, sizeof(dbCat.dbfile),
@@ -1616,17 +1611,20 @@ multidb_global_copy(CopyDataSpec *parentSpecs)
 		(void) catalog_close(&dbCat);
 	}
 
-	/* Destroy shared catalog semaphores. */
-	for (int i = 0; i < parentSpecs->multiDbCount; i++)
+	/*
+	 * Destroy the catalog semaphore set.  One IPC_RMID removes all N slots.
+	 * All multiDbInfos share the same semId; unlink it once via [0].
+	 */
+	if (parentSpecs->multiDbCount > 0 &&
+		parentSpecs->multiDbInfos[0].catalogSemId != 0)
 	{
-		MultiDbInfo *info = &parentSpecs->multiDbInfos[i];
+		Semaphore setHandle = {
+			.semId = parentSpecs->multiDbInfos[0].catalogSemId
+		};
+		(void) semaphore_unlink(&setHandle);
 
-		if (info->catalogSemId != 0)
-		{
-			Semaphore sema = { .semId = info->catalogSemId };
-			(void) semaphore_unlink(&sema);
-			info->catalogSemId = 0;
-		}
+		for (int i = 0; i < parentSpecs->multiDbCount; i++)
+			parentSpecs->multiDbInfos[i].catalogSemId = 0;
 	}
 
 	/* Clean up index/vacuum queues (copy queue cleaned up by copy supervisor). */
@@ -1865,12 +1863,13 @@ multidb_init_index_entry(MultiDbEntry *entry, CopyDataSpec *parentSpecs,
 	strlcpy(sourceDB->dbfile, dbSpecs->cfPaths.sdbfile, sizeof(sourceDB->dbfile));
 
 	/*
-	 * Reuse the parent-created shared semaphore for sourceDB so that all index
-	 * workers for the same database share one lock (avoids SQLITE_BUSY).
+	 * Reuse the parent-created shared semaphore set slot for sourceDB so that
+	 * all index workers for the same database share one lock (no SQLITE_BUSY).
 	 */
 	if (info->catalogSemId != 0)
 	{
-		sourceDB->sema.semId = info->catalogSemId;
+		sourceDB->sema.semId    = info->catalogSemId;
+		sourceDB->sema.semIndex = info->catalogSemIndex;
 		sourceDB->sema.reentrant = true;
 	}
 
@@ -1884,16 +1883,16 @@ multidb_init_index_entry(MultiDbEntry *entry, CopyDataSpec *parentSpecs,
 
 	/*
 	 * Open the target catalog read-only for constraint resume checks
-	 * (catalog_s_table_count_indexes, catalog_lookup_s_index_by_name).  A
-	 * fresh per-entry semaphore is correct here: targetDB is only read (never
-	 * written) in the index worker, so there is no cross-process coordination
-	 * requirement, and a separate semId avoids deadlocking with the sourceDB
-	 * semaphore held by catalog_iter_s_index_table during iteration.
+	 * (catalog_s_table_count_indexes, catalog_lookup_s_index_by_name).
+	 * No semaphore: SQLite WAL guarantees snapshot-consistent reads and
+	 * never produces SQLITE_BUSY for readers.  Separate from sourceDB's
+	 * semaphore slot to avoid deadlocking with catalog_iter_s_index_table
+	 * which holds that slot for the entire iteration.
 	 */
 	targetDB->type = DATABASE_CATALOG_TYPE_TARGET;
 	strlcpy(targetDB->dbfile, dbSpecs->cfPaths.tdbfile, sizeof(targetDB->dbfile));
 
-	if (!catalog_init(targetDB))
+	if (!catalog_open_readonly(targetDB))
 	{
 		log_error("Failed to open target catalog for database \"%s\"", datname);
 		catalog_close(sourceDB);
@@ -2184,14 +2183,15 @@ multidb_init_entry(MultiDbEntry *entry, CopyDataSpec *parentSpecs,
 	strlcpy(targetDB->dbfile, dbSpecs->cfPaths.tdbfile, sizeof(targetDB->dbfile));
 
 	/*
-	 * Fix A: wire the shared catalog semaphore so catalog_create_semaphore()
-	 * finds semId != 0 and reuses it rather than creating a fresh independent
-	 * semaphore.  All workers for the same database thus share one lock,
-	 * serialising SQLite writes and eliminating SQLITE_BUSY contention.
+	 * Wire the shared catalog semaphore set slot so catalog_create_semaphore()
+	 * finds semId != 0 and reuses it rather than creating a fresh semaphore.
+	 * All workers for the same database thus share one lock, serialising
+	 * SQLite writes and guaranteeing no SQLITE_BUSY contention.
 	 */
 	if (info->catalogSemId != 0)
 	{
-		sourceDB->sema.semId = info->catalogSemId;
+		sourceDB->sema.semId    = info->catalogSemId;
+		sourceDB->sema.semIndex = info->catalogSemIndex;
 		sourceDB->sema.reentrant = true;
 	}
 

--- a/src/bin/pgcopydb/multi_db.c
+++ b/src/bin/pgcopydb/multi_db.c
@@ -1434,9 +1434,11 @@ multidb_global_copy(CopyDataSpec *parentSpecs)
 	 * Fork vacuum supervisor first (reads vacuumQueue; waits for workers).
 	 * The index supervisor sends the STOP messages after all indexes are done.
 	 */
+	pid_t vacPid = -1;
+
 	if (!parentSpecs->skipVacuum)
 	{
-		if (!vacuum_start_supervisor(parentSpecs))
+		if (!vacuum_start_supervisor(parentSpecs, &vacPid))
 		{
 			log_error("Failed to start global vacuum supervisor");
 			return false;
@@ -1446,7 +1448,9 @@ multidb_global_copy(CopyDataSpec *parentSpecs)
 	/*
 	 * Fork index supervisor (reads indexQueue; after done, sends vacuum STOP).
 	 */
-	if (!copydb_start_index_supervisor(parentSpecs))
+	pid_t idxPid = -1;
+
+	if (!copydb_start_index_supervisor(parentSpecs, &idxPid))
 	{
 		log_error("Failed to start global index supervisor");
 		return false;
@@ -1543,6 +1547,17 @@ multidb_global_copy(CopyDataSpec *parentSpecs)
 
 			bool ok = copydb_wait_for_subprocesses(parentSpecs->failFast);
 
+			/*
+			 * All COPY workers finished; send STOP to index workers so they
+			 * can drain the index queue and terminate.  Mirror what
+			 * copydb_copy_supervisor() does in table-data.c.
+			 */
+			if (!copydb_index_workers_send_stop(parentSpecs))
+			{
+				log_error("Failed to send STOP messages to index workers");
+				ok = false;
+			}
+
 			(void) queue_unlink(&parentSpecs->copyQueue);
 			parentSpecs->copyQueue.qId = -1;
 
@@ -1554,10 +1569,61 @@ multidb_global_copy(CopyDataSpec *parentSpecs)
 	}
 
 	/*
-	 * Wait for all three supervisor children: copy supervisor, index
-	 * supervisor, vacuum supervisor.
+	 * Wait for all three supervisor children using targeted waitpid() calls.
+	 *
+	 * We MUST NOT use copydb_wait_for_subprocesses() here because it calls
+	 * waitpid(-1, ...) which would accidentally reap the snapshot holder — a
+	 * sibling child process forked before multidb_global_copy() was called.
+	 * The snapshot holder blocks on donepipe EOF and would never exit until
+	 * clone_all_databases() closes the pipe AFTER this function returns,
+	 * causing a deadlock.
 	 */
-	bool ok = copydb_wait_for_subprocesses(parentSpecs->failFast);
+	pid_t supervisor_pids[3] = { spid, idxPid, vacPid };
+	bool ok = true;
+	int remaining = (vacPid > 0) ? 3 : 2;
+
+	while (remaining > 0)
+	{
+		pg_usleep(100 * 1000); /* 100 ms */
+
+		for (int i = 0; i < 3; i++)
+		{
+			if (supervisor_pids[i] <= 0)
+				continue;
+
+			int status = 0;
+			pid_t reaped = waitpid(supervisor_pids[i], &status, WNOHANG);
+
+			if (reaped == supervisor_pids[i])
+			{
+				int returnCode = WEXITSTATUS(status);
+
+				if (WIFSIGNALED(status))
+				{
+					log_error("Global supervisor %d killed by signal %s",
+							  reaped,
+							  signal_to_string(WTERMSIG(status)));
+					ok = false;
+				}
+				else if (returnCode != 0)
+				{
+					log_error("Global supervisor %d exited with code %d",
+							  reaped, returnCode);
+					ok = false;
+				}
+
+				supervisor_pids[i] = -1;
+				--remaining;
+			}
+			else if (reaped < 0 && errno != EINTR)
+			{
+				log_error("waitpid(%d) failed: %m", supervisor_pids[i]);
+				ok = false;
+				supervisor_pids[i] = -1;
+				--remaining;
+			}
+		}
+	}
 
 	/*
 	 * Reopen the global catalog so the caller can write summary_stop_timing.

--- a/src/bin/pgcopydb/multi_db.c
+++ b/src/bin/pgcopydb/multi_db.c
@@ -1859,10 +1859,15 @@ multidb_init_index_entry(MultiDbEntry *entry, CopyDataSpec *parentSpecs,
 	}
 
 	DatabaseCatalog *sourceDB = &dbSpecs->catalogs.source;
+	DatabaseCatalog *targetDB = &dbSpecs->catalogs.target;
 
 	sourceDB->type = DATABASE_CATALOG_TYPE_SOURCE;
 	strlcpy(sourceDB->dbfile, dbSpecs->cfPaths.sdbfile, sizeof(sourceDB->dbfile));
 
+	/*
+	 * Reuse the parent-created shared semaphore for sourceDB so that all index
+	 * workers for the same database share one lock (avoids SQLITE_BUSY).
+	 */
 	if (info->catalogSemId != 0)
 	{
 		sourceDB->sema.semId = info->catalogSemId;
@@ -1877,10 +1882,31 @@ multidb_init_index_entry(MultiDbEntry *entry, CopyDataSpec *parentSpecs,
 		return false;
 	}
 
+	/*
+	 * Open the target catalog read-only for constraint resume checks
+	 * (catalog_s_table_count_indexes, catalog_lookup_s_index_by_name).  A
+	 * fresh per-entry semaphore is correct here: targetDB is only read (never
+	 * written) in the index worker, so there is no cross-process coordination
+	 * requirement, and a separate semId avoids deadlocking with the sourceDB
+	 * semaphore held by catalog_iter_s_index_table during iteration.
+	 */
+	targetDB->type = DATABASE_CATALOG_TYPE_TARGET;
+	strlcpy(targetDB->dbfile, dbSpecs->cfPaths.tdbfile, sizeof(targetDB->dbfile));
+
+	if (!catalog_init(targetDB))
+	{
+		log_error("Failed to open target catalog for database \"%s\"", datname);
+		catalog_close(sourceDB);
+		free(dbSpecs->connStrings.target_pguri);
+		free(dbSpecs);
+		return false;
+	}
+
 	if (!pgsql_init(&entry->dst, dbSpecs->connStrings.target_pguri,
 					PGSQL_CONN_TARGET))
 	{
 		log_error("Failed to connect to target for database \"%s\"", datname);
+		catalog_close(targetDB);
 		catalog_close(sourceDB);
 		free(dbSpecs->connStrings.target_pguri);
 		free(dbSpecs);
@@ -1918,6 +1944,7 @@ multidb_index_context_close_entry(MultiDbEntry *entry)
 
 	if (entry->dbSpecs != NULL)
 	{
+		(void) catalog_close(&entry->dbSpecs->catalogs.target);
 		(void) catalog_close(&entry->dbSpecs->catalogs.source);
 		free(entry->dbSpecs->connStrings.target_pguri);
 		free(entry->dbSpecs);

--- a/src/bin/pgcopydb/multi_db.c
+++ b/src/bin/pgcopydb/multi_db.c
@@ -5,10 +5,12 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "catalog.h"
 #include "copydb.h"
 #include "defaults.h"
+#include "file_utils.h"
 #include "log.h"
 #include "multi_db.h"
 #include "parsing_utils.h"
@@ -17,6 +19,7 @@
 #include "schema.h"
 #include "signals.h"
 #include "string_utils.h"
+#include "summary.h"
 
 static bool multidb_is_system_database(const char *datname);
 static bool multidb_target_database_exists(PGSQL *dst, const char *datname,
@@ -34,6 +37,7 @@ static bool multidb_init_db_specs(CopyDataSpec *dbSpecs,
 								  ConnStrings *connStrings);
 static bool multidb_clone_one_database(CopyDataSpec *parentSpecs,
 									   SourceDatabase *db);
+static bool multidb_wait_child(pid_t pid, const char *datname);
 
 
 /*
@@ -130,6 +134,9 @@ clone_all_databases(CopyDataSpec *copySpecs)
 	while (catalog_iter_s_database_next(&dbIter))
 	{
 		SourceDatabase *db = dbIter.dat;
+
+		if (db == NULL)
+			break;
 
 		if (asked_to_stop || asked_to_stop_fast || asked_to_quit)
 		{
@@ -431,7 +438,11 @@ multidb_init_db_specs(CopyDataSpec *dbSpecs,
 	/* connection strings */
 	dbSpecs->connStrings = *connStrings;
 
-	/* source snapshot — will be populated during clone */
+	/*
+	 * Refresh the pguri/safeURI pointers after the connStrings copy above.
+	 * The snapshot string and state are already set (exported in the parent
+	 * before fork) and must not be touched here.
+	 */
 	dbSpecs->sourceSnapshot.pguri = dbSpecs->connStrings.source_pguri;
 	dbSpecs->sourceSnapshot.safeURI = dbSpecs->connStrings.safeSourcePGURI;
 	dbSpecs->sourceSnapshot.connectionType = PGSQL_CONN_SOURCE;
@@ -559,15 +570,15 @@ multidb_clone_one_database(CopyDataSpec *parentSpecs, SourceDatabase *db)
 	log_info("[TARGET] Cloning database \"%s\" into \"%s\"",
 			 db->datname, dbConnStrings.safeTargetPGURI.pguri);
 
-	/* initialise per-db CopyDataSpec */
+	/* initialise per-db CopyDataSpec (pgPaths + cfPaths only, before fork) */
 	CopyDataSpec dbSpecs = { 0 };
 
 	dbSpecs.pgPaths = parentSpecs->pgPaths;
 
 	/*
-	 * Set up work directory under <topdir>/db/<datname>/.
+	 * Create the work directory under <topdir>/db/<datname>/.
+	 * Must happen in the parent so the directory exists before the fork.
 	 * Use service=false so no pidfile is created for per-db dirs.
-	 * Use restart/resume from parent settings.
 	 */
 	if (!copydb_init_workdir(&dbSpecs, dbdir,
 							 false,     /* service */
@@ -581,17 +592,105 @@ multidb_clone_one_database(CopyDataSpec *parentSpecs, SourceDatabase *db)
 		goto cleanup;
 	}
 
-	if (!multidb_init_db_specs(&dbSpecs, parentSpecs, &dbConnStrings))
+	/*
+	 * Set up connection strings and snapshot fields before the fork so the
+	 * child inherits the exported snapshot string.
+	 */
+	dbSpecs.connStrings = dbConnStrings;
+	dbSpecs.sourceSnapshot.pguri = dbSpecs.connStrings.source_pguri;
+	dbSpecs.sourceSnapshot.safeURI = dbSpecs.connStrings.safeSourcePGURI;
+	dbSpecs.sourceSnapshot.connectionType = PGSQL_CONN_SOURCE;
+	dbSpecs.consistent = parentSpecs->consistent;
+
+	/*
+	 * Export a per-database snapshot in the parent.  The parent keeps this
+	 * connection open until the child exits so worker subprocesses can import
+	 * the snapshot via SET TRANSACTION SNAPSHOT.
+	 */
+	if (dbSpecs.consistent)
 	{
-		log_error("Failed to initialise specs for database \"%s\"",
-				  db->datname);
-		goto cleanup;
+		if (!copydb_prepare_snapshot(&dbSpecs))
+		{
+			log_error("Failed to export snapshot for database \"%s\"",
+					  db->datname);
+			goto cleanup;
+		}
 	}
 
-	bool result = copydb_clone_database(&dbSpecs);
+	/*
+	 * Fork a subprocess for each database clone.  This isolates three kinds
+	 * of process-global state that would otherwise bleed across databases:
+	 *
+	 *  1. topLevelTimingArray (reset explicitly in child before first use)
+	 *  2. system_res_array (System V semaphore/queue registrations)
+	 *  3. SQLite catalog connections
+	 */
+	pid_t fpid = fork();
 
-	/* close any open catalog connections */
-	(void) catalog_close_from_specs(&dbSpecs);
+	switch (fpid)
+	{
+		case -1:
+		{
+			log_error("Failed to fork subprocess for database \"%s\": %m",
+					  db->datname);
+			goto cleanup_snapshot;
+		}
+
+		case 0:
+		{
+			/* child process */
+			char psTitle[MAXPGPATH] = { 0 };
+			sformat(psTitle, sizeof(psTitle), "pgcopydb: clone %s", db->datname);
+			(void) set_ps_title(psTitle);
+
+			/*
+			 * Reset the inherited timing global so that
+			 * copydb_fetch_previous_run_state sees a clean slate for this
+			 * database, not stale doneTime values from the previous one.
+			 */
+			summary_reset_toplevel_timings();
+
+			/*
+			 * Now initialise the rest of dbSpecs (flags, queues, catalog
+			 * paths).  Queues are created here so they register in this
+			 * child's copy of system_res_array, not the parent's.
+			 */
+			if (!multidb_init_db_specs(&dbSpecs, parentSpecs, &dbConnStrings))
+			{
+				log_error("Failed to initialise specs for database \"%s\"",
+						  db->datname);
+				exit(EXIT_CODE_INTERNAL_ERROR);
+			}
+
+			if (!copydb_clone_database(&dbSpecs))
+			{
+				log_error("Failed to clone database \"%s\"",
+						  db->datname);
+				exit(EXIT_CODE_SOURCE);
+			}
+
+			exit(EXIT_CODE_QUIT);
+		}
+
+		default:
+			break;
+	}
+
+	/* parent: wait for the per-db child subprocess */
+	bool success = multidb_wait_child(fpid, db->datname);
+
+	/*
+	 * Parent closes the snapshot connection now that the child and all of
+	 * its worker sub-processes have finished.
+	 */
+	if (dbSpecs.consistent)
+	{
+		if (!copydb_close_snapshot(&dbSpecs))
+		{
+			/* errors have already been logged */
+			success = false;
+		}
+	}
 
 	free(dbConnStrings.source_pguri);
 	free(dbConnStrings.target_pguri);
@@ -600,7 +699,10 @@ multidb_clone_one_database(CopyDataSpec *parentSpecs, SourceDatabase *db)
 	if (dbConnStrings.safeTargetPGURI.pguri)
 		free(dbConnStrings.safeTargetPGURI.pguri);
 
-	return result;
+	return success;
+
+cleanup_snapshot:
+	(void) copydb_close_snapshot(&dbSpecs);
 
 cleanup:
 	free(dbConnStrings.source_pguri);
@@ -610,4 +712,42 @@ cleanup:
 	if (dbConnStrings.safeTargetPGURI.pguri)
 		free(dbConnStrings.safeTargetPGURI.pguri);
 	return false;
+}
+
+
+/*
+ * multidb_wait_child blocks until the given subprocess exits, then returns
+ * true iff it exited with status 0.
+ */
+static bool
+multidb_wait_child(pid_t pid, const char *datname)
+{
+	int status = 0;
+	pid_t result = waitpid(pid, &status, 0);
+
+	if (result < 0)
+	{
+		log_error("Failed to wait for subprocess %d (database \"%s\"): %m",
+				  pid, datname);
+		return false;
+	}
+
+	if (!WIFEXITED(status))
+	{
+		int sig = WTERMSIG(status);
+		log_error("Subprocess %d (database \"%s\") terminated by signal %d",
+				  pid, datname, sig);
+		return false;
+	}
+
+	int returnCode = WEXITSTATUS(status);
+
+	if (returnCode != 0)
+	{
+		log_error("Subprocess %d (database \"%s\") exited with status %d",
+				  pid, datname, returnCode);
+		return false;
+	}
+
+	return true;
 }

--- a/src/bin/pgcopydb/multi_db.c
+++ b/src/bin/pgcopydb/multi_db.c
@@ -759,7 +759,11 @@ signal_ready:
 	 */
 	{
 		char rdy = 'R';
-		(void) write(readyfd, &rdy, 1);
+
+		if (write(readyfd, &rdy, 1) != 1)
+		{
+			log_error("Failed to signal snapshot-holder ready to parent: %m");
+		}
 		close(readyfd);
 	}
 
@@ -775,7 +779,10 @@ signal_ready:
 	 */
 	{
 		char buf = 0;
-		(void) read(donefd, &buf, 1);  /* blocks until EOF */
+
+		/* blocks until the parent closes the write end (EOF) */
+		while (read(donefd, &buf, 1) > 0)
+		{ }
 		close(donefd);
 	}
 

--- a/src/bin/pgcopydb/multi_db.c
+++ b/src/bin/pgcopydb/multi_db.c
@@ -1,6 +1,15 @@
 /*
  * src/bin/pgcopydb/multi_db.c
  *	 Clone all databases from a source Postgres instance.
+ *
+ * Phase C: global cross-database COPY queue.
+ *
+ *   Phase I  (pre-data)  — sequential, one subprocess per database:
+ *                           schema fetch, pg_dump, pg_restore --pre-data
+ *   Phase II (global COPY) — tableJobs shared COPY workers dequeue from a
+ *                           single size-ordered queue spanning all databases
+ *   Phase III (post-data) — sequential, one subprocess per database:
+ *                           pg_restore --post-data, set sequences
  */
 
 #include <stdlib.h>
@@ -21,6 +30,7 @@
 #include "string_utils.h"
 #include "summary.h"
 
+
 static bool multidb_is_system_database(const char *datname);
 static bool multidb_target_database_exists(PGSQL *dst, const char *datname,
 										   bool *exists);
@@ -35,43 +45,59 @@ static bool multidb_build_conn_strings(ConnStrings *parent,
 static bool multidb_init_db_specs(CopyDataSpec *dbSpecs,
 								  CopyDataSpec *parent,
 								  ConnStrings *connStrings);
-static bool multidb_clone_one_database(CopyDataSpec *parentSpecs,
-									   SourceDatabase *db);
+static bool multidb_setup_one_database(CopyDataSpec *parentSpecs,
+									   SourceDatabase *db,
+									   CopyDataSpec *dbSpecs,
+									   ConnStrings *dbConnStrings,
+									   MultiDbInfo *info);
+static bool multidb_clone_one_database_pre_data(CopyDataSpec *parentSpecs,
+												 SourceDatabase *db,
+												 CopyDataSpec *dbSpecs,
+												 ConnStrings *dbConnStrings);
+static bool multidb_clone_one_database_post_data(CopyDataSpec *parentSpecs,
+												  SourceDatabase *db,
+												  CopyDataSpec *dbSpecs,
+												  ConnStrings *dbConnStrings);
+static bool multidb_global_copy(CopyDataSpec *parentSpecs);
 static bool multidb_wait_child(pid_t pid, const char *datname);
+
+/* connection cache helpers (also called from table-data.c) */
+static bool multidb_init_entry(MultiDbEntry *entry,
+								CopyDataSpec *parentSpecs,
+								const char *datname);
 
 
 /*
- * clone_all_databases iterates all user databases on the source instance and
- * clones each one in turn, sharing the same table/index job counts.
+ * clone_all_databases clones all user databases from a source Postgres
+ * instance in three phases:
  *
- * The caller's copySpecs already has the top-level work dir initialised (via
- * cli_copy_prepare_specs).  Roles are copied once at the instance level; each
- * per-database clone is run with roles=false.
+ *  Phase I  — per-database pre-data (sequential subprocesses)
+ *  Phase II — global COPY with shared worker pool sorted by table size
+ *  Phase III — per-database post-data (sequential subprocesses)
  */
 bool
-clone_all_databases(CopyDataSpec *copySpecs)
+clone_all_databases(CopyDataSpec *parentSpecs)
 {
 	/*
-	 * The top-level copySpecs has queues created by copydb_init_specs that we
+	 * The top-level parentSpecs has queues created by copydb_init_specs that we
 	 * won't use — release them now so we don't leak System V resources.
 	 */
-	if (copySpecs->vacuumQueue.qId != -1)
+	if (parentSpecs->vacuumQueue.qId != -1)
 	{
-		(void) queue_unlink(&copySpecs->vacuumQueue);
-		copySpecs->vacuumQueue.qId = -1;
+		(void) queue_unlink(&parentSpecs->vacuumQueue);
+		parentSpecs->vacuumQueue.qId = -1;
 	}
 
-	if (copySpecs->indexQueue.qId != -1)
+	if (parentSpecs->indexQueue.qId != -1)
 	{
-		(void) queue_unlink(&copySpecs->indexQueue);
-		copySpecs->indexQueue.qId = -1;
+		(void) queue_unlink(&parentSpecs->indexQueue);
+		parentSpecs->indexQueue.qId = -1;
 	}
 
 	/*
 	 * Initialise the top-level source catalog (stores the database list).
-	 * This creates <topdir>/schema/source.db if it doesn't exist yet.
 	 */
-	if (!catalog_init_from_specs(copySpecs))
+	if (!catalog_init_from_specs(parentSpecs))
 	{
 		log_error("Failed to initialise the instance-level catalog");
 		return false;
@@ -80,13 +106,13 @@ clone_all_databases(CopyDataSpec *copySpecs)
 	/* connect to the source instance and populate the database list */
 	PGSQL src = { 0 };
 
-	if (!pgsql_init(&src, copySpecs->connStrings.source_pguri, PGSQL_CONN_SOURCE))
+	if (!pgsql_init(&src, parentSpecs->connStrings.source_pguri, PGSQL_CONN_SOURCE))
 	{
 		log_error("Failed to initialise source connection");
 		return false;
 	}
 
-	DatabaseCatalog *instanceCatalog = &(copySpecs->catalogs.source);
+	DatabaseCatalog *instanceCatalog = &(parentSpecs->catalogs.source);
 
 	if (!schema_list_databases(&src, instanceCatalog))
 	{
@@ -100,25 +126,63 @@ clone_all_databases(CopyDataSpec *copySpecs)
 	/* copy instance-level roles once */
 	log_info("Copying instance-level roles");
 
-	if (!pg_copy_roles(&copySpecs->pgPaths,
-					   &copySpecs->connStrings,
-					   copySpecs->dumpPaths.rolesFilename,
-					   copySpecs->noRolesPasswords))
+	if (!pg_copy_roles(&parentSpecs->pgPaths,
+					   &parentSpecs->connStrings,
+					   parentSpecs->dumpPaths.rolesFilename,
+					   parentSpecs->noRolesPasswords))
 	{
 		log_error("Failed to copy roles from source instance");
+		return false;
+	}
+
+	/*
+	 * Count databases so we can allocate arrays.
+	 */
+	CatalogCounts counts = { 0 };
+
+	if (!catalog_count_objects(instanceCatalog, &counts))
+	{
+		log_error("Failed to count objects in the instance catalog");
+		return false;
+	}
+
+	int maxDbs = (int) counts.databases;
+
+	if (maxDbs == 0)
+	{
+		log_info("No databases found on the source instance");
+		(void) catalog_close_from_specs(parentSpecs);
+		return true;
+	}
+
+	/* allocate per-database arrays */
+	SourceDatabase *dbArray =
+		(SourceDatabase *) calloc(maxDbs, sizeof(SourceDatabase));
+	CopyDataSpec *dbSpecsArray =
+		(CopyDataSpec *) calloc(maxDbs, sizeof(CopyDataSpec));
+	ConnStrings *dbConnStringsArray =
+		(ConnStrings *) calloc(maxDbs, sizeof(ConnStrings));
+	MultiDbInfo *multiDbInfos =
+		(MultiDbInfo *) calloc(maxDbs, sizeof(MultiDbInfo));
+
+	if (dbArray == NULL || dbSpecsArray == NULL ||
+		dbConnStringsArray == NULL || multiDbInfos == NULL)
+	{
+		log_error(ALLOCATION_FAILED_ERROR);
 		return false;
 	}
 
 	/* open a connection to the target instance for CREATE DATABASE */
 	PGSQL dst = { 0 };
 
-	if (!pgsql_init(&dst, copySpecs->connStrings.target_pguri, PGSQL_CONN_TARGET))
+	if (!pgsql_init(&dst, parentSpecs->connStrings.target_pguri, PGSQL_CONN_TARGET))
 	{
 		log_error("Failed to initialise target connection");
 		return false;
 	}
 
 	bool ok = true;
+	int dbCount = 0;
 
 	SourceDatabaseIterator dbIter = {
 		.catalog = instanceCatalog,
@@ -128,19 +192,26 @@ clone_all_databases(CopyDataSpec *copySpecs)
 	if (!catalog_iter_s_database_init(&dbIter))
 	{
 		pgsql_finish(&dst);
-		return false;
+		ok = false;
+		goto cleanup_arrays;
 	}
 
-	while (catalog_iter_s_database_next(&dbIter))
+	for (;;)
 	{
+		if (!catalog_iter_s_database_next(&dbIter))
+		{
+			ok = false;
+			break;
+		}
+
 		SourceDatabase *db = dbIter.dat;
 
 		if (db == NULL)
-			break;
+			break;        /* end of results */
 
 		if (asked_to_stop || asked_to_stop_fast || asked_to_quit)
 		{
-			log_info("Stopping --all-databases clone due to signal");
+			log_info("Stopping --all-databases setup due to signal");
 			ok = false;
 			break;
 		}
@@ -151,29 +222,50 @@ clone_all_databases(CopyDataSpec *copySpecs)
 			continue;
 		}
 
-		log_info("Cloning database \"%s\" (%s)",
-				 db->datname, db->bytesPretty);
+		if (dbCount >= maxDbs)
+		{
+			log_error("More databases than expected (%d), internal error",
+					  maxDbs);
+			ok = false;
+			break;
+		}
 
+		log_info("Found database \"%s\" (%s)", db->datname, db->bytesPretty);
+
+		/* copy db info into our array */
+		dbArray[dbCount] = *db;
+
+		/* create target database */
 		if (!multidb_create_target_database(&dst, db->datname,
-											copySpecs->restoreOptions.dropIfExists))
+											parentSpecs->restoreOptions.dropIfExists))
 		{
 			log_error("Failed to create database \"%s\" on target", db->datname);
 			ok = false;
-
-			if (copySpecs->failFast)
+			if (parentSpecs->failFast)
 				break;
 			else
+			{
+				dbCount++;
 				continue;
+			}
 		}
 
-		if (!multidb_clone_one_database(copySpecs, db))
-		{
-			log_error("Failed to clone database \"%s\"", db->datname);
-			ok = false;
+		/* set up work dir and export snapshot for this database */
+		dbSpecsArray[dbCount].pgPaths = parentSpecs->pgPaths;
 
-			if (copySpecs->failFast)
+		if (!multidb_setup_one_database(parentSpecs,
+										&dbArray[dbCount],
+										&dbSpecsArray[dbCount],
+										&dbConnStringsArray[dbCount],
+										&multiDbInfos[dbCount]))
+		{
+			log_error("Failed to setup database \"%s\"", db->datname);
+			ok = false;
+			if (parentSpecs->failFast)
 				break;
 		}
+
+		dbCount++;
 	}
 
 	if (!catalog_iter_s_database_finish(&dbIter))
@@ -181,16 +273,844 @@ clone_all_databases(CopyDataSpec *copySpecs)
 
 	pgsql_finish(&dst);
 
-	if (!catalog_close_from_specs(copySpecs))
+	if (!ok)
+		goto cleanup_snapshots;
+
+	/*
+	 * Store per-database info in parentSpecs so the global COPY workers (which
+	 * are forked after this point) can access it via the COW post-fork copy.
+	 */
+	parentSpecs->multiDbCount = dbCount;
+	parentSpecs->multiDbInfos = multiDbInfos;
+
+	/* close instance-level catalog before forking subprocesses */
+	if (!catalog_close_from_specs(parentSpecs))
+	{
 		ok = false;
+		goto cleanup_snapshots;
+	}
+
+	/* ====== PHASE I: PRE-DATA (sequential per-database) ====== */
+	log_info("Phase I: schema fetch, dump, and pre-data restore for %d databases",
+			 dbCount);
+
+	for (int i = 0; i < dbCount && ok; i++)
+	{
+		if (asked_to_stop || asked_to_stop_fast || asked_to_quit)
+		{
+			ok = false;
+			break;
+		}
+
+		log_info("Pre-data for database \"%s\"", dbArray[i].datname);
+
+		if (!multidb_clone_one_database_pre_data(parentSpecs,
+												 &dbArray[i],
+												 &dbSpecsArray[i],
+												 &dbConnStringsArray[i]))
+		{
+			log_error("Pre-data failed for database \"%s\"", dbArray[i].datname);
+			ok = false;
+			if (parentSpecs->failFast)
+				break;
+		}
+	}
+
+	if (!ok)
+		goto cleanup_snapshots;
+
+	/* ====== PHASE II: GLOBAL COPY ====== */
+	log_info("Phase II: global COPY for %d databases (largest tables first)",
+			 dbCount);
+
+	if (!multidb_global_copy(parentSpecs))
+	{
+		log_error("Global COPY phase failed");
+		ok = false;
+		goto cleanup_snapshots;
+	}
+
+	/* ====== PHASE III: POST-DATA (sequential per-database) ====== */
+	log_info("Phase III: post-data restore and sequences for %d databases",
+			 dbCount);
+
+	for (int i = 0; i < dbCount; i++)
+	{
+		if (asked_to_stop || asked_to_stop_fast || asked_to_quit)
+		{
+			ok = false;
+			break;
+		}
+
+		log_info("Post-data for database \"%s\"", dbArray[i].datname);
+
+		if (!multidb_clone_one_database_post_data(parentSpecs,
+												  &dbArray[i],
+												  &dbSpecsArray[i],
+												  &dbConnStringsArray[i]))
+		{
+			log_error("Post-data failed for database \"%s\"", dbArray[i].datname);
+			ok = false;
+			if (parentSpecs->failFast)
+				break;
+		}
+	}
+
+cleanup_snapshots:
+	/* close all per-database snapshot connections held in the parent */
+	for (int i = 0; i < dbCount; i++)
+	{
+		if (dbSpecsArray[i].consistent &&
+			dbSpecsArray[i].sourceSnapshot.state == SNAPSHOT_STATE_EXPORTED)
+		{
+			if (!copydb_close_snapshot(&dbSpecsArray[i]))
+			{
+				log_warn("Failed to close snapshot for database \"%s\"",
+						 dbArray[i].datname);
+			}
+		}
+
+		/* free heap-allocated connection strings */
+		if (dbConnStringsArray[i].source_pguri)
+			free(dbConnStringsArray[i].source_pguri);
+		if (dbConnStringsArray[i].target_pguri)
+			free(dbConnStringsArray[i].target_pguri);
+		if (dbConnStringsArray[i].safeSourcePGURI.pguri)
+			free(dbConnStringsArray[i].safeSourcePGURI.pguri);
+		if (dbConnStringsArray[i].safeTargetPGURI.pguri)
+			free(dbConnStringsArray[i].safeTargetPGURI.pguri);
+	}
+
+	parentSpecs->multiDbInfos = NULL;
+	parentSpecs->multiDbCount = 0;
+
+cleanup_arrays:
+	free(multiDbInfos);
+	free(dbConnStringsArray);
+	free(dbSpecsArray);
+	free(dbArray);
 
 	return ok;
 }
 
 
 /*
- * multidb_is_system_database returns true for template0 and template1, which
- * must not be cloned.
+ * multidb_setup_one_database builds the per-database work directory, exports
+ * a Postgres snapshot (held by the parent), and fills in info.
+ */
+static bool
+multidb_setup_one_database(CopyDataSpec *parentSpecs,
+						   SourceDatabase *db,
+						   CopyDataSpec *dbSpecs,
+						   ConnStrings *dbConnStrings,
+						   MultiDbInfo *info)
+{
+	/* build per-db work directory path */
+	char dbdir[MAXPGPATH] = { 0 };
+
+	sformat(dbdir, sizeof(dbdir), "%s/db/%s",
+			parentSpecs->cfPaths.topdir, db->datname);
+
+	/* build per-db connection strings */
+	if (!multidb_build_conn_strings(&parentSpecs->connStrings, db->datname,
+									dbConnStrings))
+	{
+		log_error("Failed to build connection strings for database \"%s\"",
+				  db->datname);
+		return false;
+	}
+
+	/*
+	 * Create the per-database work directory.  Must happen in the parent so
+	 * the directory exists before forking subprocesses.
+	 */
+	if (!copydb_init_workdir(dbSpecs, dbdir,
+							 false,     /* service */
+							 NULL,      /* serviceName */
+							 parentSpecs->restart,
+							 parentSpecs->resume,
+							 true))     /* createWorkDir */
+	{
+		log_error("Failed to initialise work directory \"%s\" for database \"%s\"",
+				  dbdir, db->datname);
+		return false;
+	}
+
+	/* wire up connection strings and snapshot fields */
+	dbSpecs->connStrings = *dbConnStrings;
+	dbSpecs->sourceSnapshot.pguri = dbSpecs->connStrings.source_pguri;
+	dbSpecs->sourceSnapshot.safeURI = dbSpecs->connStrings.safeSourcePGURI;
+	dbSpecs->sourceSnapshot.connectionType = PGSQL_CONN_SOURCE;
+	dbSpecs->consistent = parentSpecs->consistent;
+
+	/*
+	 * Export a per-database snapshot in the parent.  The parent keeps this
+	 * connection open throughout Phase I and Phase II (global COPY) so that
+	 * COPY workers can import it via SET TRANSACTION SNAPSHOT.
+	 */
+	if (dbSpecs->consistent)
+	{
+		if (!copydb_prepare_snapshot(dbSpecs))
+		{
+			log_error("Failed to export snapshot for database \"%s\"",
+					  db->datname);
+			return false;
+		}
+	}
+
+	/* populate MultiDbInfo for workers */
+	strlcpy(info->datname, db->datname, sizeof(info->datname));
+	strlcpy(info->snapshot, dbSpecs->sourceSnapshot.snapshot,
+			sizeof(info->snapshot));
+	strlcpy(info->source_pguri, dbConnStrings->source_pguri,
+			sizeof(info->source_pguri));
+	strlcpy(info->target_pguri, dbConnStrings->target_pguri,
+			sizeof(info->target_pguri));
+	strlcpy(info->topdir, dbdir, sizeof(info->topdir));
+	info->isReadOnly = dbSpecs->sourceSnapshot.isReadOnly;
+
+	return true;
+}
+
+
+/*
+ * multidb_clone_one_database_pre_data forks a subprocess that performs the
+ * pre-data phase for one database: schema fetch, pg_dump, pg_restore pre-data.
+ */
+static bool
+multidb_clone_one_database_pre_data(CopyDataSpec *parentSpecs,
+									SourceDatabase *db,
+									CopyDataSpec *dbSpecs,
+									ConnStrings *dbConnStrings)
+{
+	log_info("[SOURCE] Pre-data for database \"%s\" from \"%s\"",
+			 db->datname, dbConnStrings->safeSourcePGURI.pguri);
+
+	fflush(stdout);
+	fflush(stderr);
+
+	pid_t fpid = fork();
+
+	switch (fpid)
+	{
+		case -1:
+		{
+			log_error("Failed to fork pre-data subprocess for database \"%s\": %m",
+					  db->datname);
+			return false;
+		}
+
+		case 0:
+		{
+			/* child process */
+			char psTitle[MAXPGPATH] = { 0 };
+			sformat(psTitle, sizeof(psTitle), "pgcopydb: pre-data %s", db->datname);
+			(void) set_ps_title(psTitle);
+
+			summary_reset_toplevel_timings();
+
+			/*
+			 * Init db specs in the child so System V queues are registered in
+			 * this child's copy of system_res_array.
+			 */
+			if (!multidb_init_db_specs(dbSpecs, parentSpecs, dbConnStrings))
+			{
+				log_error("Failed to initialise specs for database \"%s\"",
+						  db->datname);
+				exit(EXIT_CODE_INTERNAL_ERROR);
+			}
+
+			/* STEP 1: fetch source database schema */
+			if (!copydb_fetch_schema_and_prepare_specs(dbSpecs))
+			{
+				log_error("Failed to fetch schema for database \"%s\"",
+						  db->datname);
+				exit(EXIT_CODE_SOURCE);
+			}
+
+			/*
+			 * Make a process-local copy of the snapshot so we have our own
+			 * PGSQL connection to hold the transaction open.
+			 */
+			TransactionSnapshot localSnapshot = { 0 };
+
+			if (!copydb_copy_snapshot(dbSpecs, &localSnapshot))
+			{
+				log_error("Failed to copy snapshot for database \"%s\"",
+						  db->datname);
+				exit(EXIT_CODE_SOURCE);
+			}
+
+			dbSpecs->sourceSnapshot = localSnapshot;
+
+			/* STEP 2: dump the source schema (pre-data + post-data sections) */
+			if (!copydb_dump_source_schema(dbSpecs,
+										   localSnapshot.snapshot))
+			{
+				log_error("Failed to dump schema for database \"%s\"",
+						  db->datname);
+				exit(EXIT_CODE_SOURCE);
+			}
+
+			/* STEP 3: restore the pre-data section to the target */
+			if (!copydb_target_prepare_schema(dbSpecs))
+			{
+				log_error("Failed to restore pre-data for database \"%s\"",
+						  db->datname);
+				exit(EXIT_CODE_TARGET);
+			}
+
+			(void) catalog_close_from_specs(dbSpecs);
+			exit(EXIT_CODE_QUIT);
+		}
+
+		default:
+			break;
+	}
+
+	/* parent: wait for pre-data subprocess */
+	return multidb_wait_child(fpid, db->datname);
+}
+
+
+/*
+ * multidb_clone_one_database_post_data forks a subprocess that performs the
+ * post-data phase for one database: pg_restore post-data and set sequences.
+ *
+ * This runs after the global COPY phase has completed for all databases.
+ */
+static bool
+multidb_clone_one_database_post_data(CopyDataSpec *parentSpecs,
+									 SourceDatabase *db,
+									 CopyDataSpec *dbSpecs,
+									 ConnStrings *dbConnStrings)
+{
+	log_info("[TARGET] Post-data for database \"%s\" into \"%s\"",
+			 db->datname, dbConnStrings->safeTargetPGURI.pguri);
+
+	fflush(stdout);
+	fflush(stderr);
+
+	pid_t fpid = fork();
+
+	switch (fpid)
+	{
+		case -1:
+		{
+			log_error("Failed to fork post-data subprocess for database \"%s\": %m",
+					  db->datname);
+			return false;
+		}
+
+		case 0:
+		{
+			/* child process */
+			char psTitle[MAXPGPATH] = { 0 };
+			sformat(psTitle, sizeof(psTitle), "pgcopydb: post-data %s", db->datname);
+			(void) set_ps_title(psTitle);
+
+			summary_reset_toplevel_timings();
+
+			if (!multidb_init_db_specs(dbSpecs, parentSpecs, dbConnStrings))
+			{
+				log_error("Failed to initialise specs for database \"%s\"",
+						  db->datname);
+				exit(EXIT_CODE_INTERNAL_ERROR);
+			}
+
+			/*
+			 * Re-use the existing catalog (pre-data already populated it).
+			 * copydb_fetch_schema_and_prepare_specs will detect this and
+			 * return early without re-fetching from source.
+			 */
+			if (!copydb_fetch_schema_and_prepare_specs(dbSpecs))
+			{
+				log_error("Failed to open catalog for database \"%s\"",
+						  db->datname);
+				exit(EXIT_CODE_INTERNAL_ERROR);
+			}
+
+			/* STEP 10: restore the post-data section (indexes, constraints, …) */
+			if (!copydb_target_finalize_schema(dbSpecs))
+			{
+				log_error("Failed to finalize schema for database \"%s\"",
+						  db->datname);
+				exit(EXIT_CODE_TARGET);
+			}
+
+			/* Set sequences to match the source values captured during schema fetch */
+			if (!copydb_copy_all_sequences(dbSpecs, false))
+			{
+				log_error("Failed to set sequences for database \"%s\"",
+						  db->datname);
+				exit(EXIT_CODE_TARGET);
+			}
+
+			(void) catalog_close_from_specs(dbSpecs);
+			exit(EXIT_CODE_QUIT);
+		}
+
+		default:
+			break;
+	}
+
+	/* parent: wait for post-data subprocess */
+	return multidb_wait_child(fpid, db->datname);
+}
+
+
+/*
+ * multidb_global_copy runs the global COPY phase: all tables from all
+ * databases are enqueued in descending size order and processed by a shared
+ * pool of tableJobs COPY workers.
+ */
+static bool
+multidb_global_copy(CopyDataSpec *parentSpecs)
+{
+	if (parentSpecs->tableJobs == 0 || parentSpecs->multiDbCount == 0)
+	{
+		log_info("No tables to COPY (tableJobs=%d, databases=%d)",
+				 parentSpecs->tableJobs, parentSpecs->multiDbCount);
+		return true;
+	}
+
+	/*
+	 * Create the global COPY queue.  Workers are forked from parentSpecs and
+	 * inherit the queue ID.
+	 */
+	if (!queue_create(&(parentSpecs->copyQueue), "global copy"))
+	{
+		log_error("Failed to create the global COPY queue");
+		return false;
+	}
+
+	/*
+	 * Fork tableJobs COPY workers.  Each worker uses copydb_table_data_worker_multidb
+	 * which maintains a per-database connection cache.
+	 */
+	log_info("Starting %d global COPY workers", parentSpecs->tableJobs);
+
+	for (int i = 0; i < parentSpecs->tableJobs; i++)
+	{
+		fflush(stdout);
+		fflush(stderr);
+
+		pid_t wpid = fork();
+
+		switch (wpid)
+		{
+			case -1:
+			{
+				log_error("Failed to fork global COPY worker: %m");
+				(void) copydb_fatal_exit();
+				return false;
+			}
+
+			case 0:
+			{
+				/* worker child */
+				(void) set_ps_title("pgcopydb: global copy worker");
+
+				if (!copydb_table_data_worker_multidb(parentSpecs))
+				{
+					exit(EXIT_CODE_INTERNAL_ERROR);
+				}
+				exit(EXIT_CODE_QUIT);
+			}
+
+			default:
+				break;
+		}
+	}
+
+	/*
+	 * Fork the supervisor that fills the queue from all per-database catalogs.
+	 */
+	fflush(stdout);
+	fflush(stderr);
+
+	pid_t spid = fork();
+
+	switch (spid)
+	{
+		case -1:
+		{
+			log_error("Failed to fork global COPY supervisor: %m");
+			(void) copydb_fatal_exit();
+			return false;
+		}
+
+		case 0:
+		{
+			/* supervisor child */
+			(void) set_ps_title("pgcopydb: global copy supervisor");
+
+			if (!copydb_copy_worker_queue_tables_multidb(parentSpecs))
+			{
+				exit(EXIT_CODE_INTERNAL_ERROR);
+			}
+			exit(EXIT_CODE_QUIT);
+		}
+
+		default:
+			break;
+	}
+
+	/* parent: wait for all workers + supervisor */
+	if (!copydb_wait_for_subprocesses(parentSpecs->failFast))
+	{
+		log_error("Some global COPY worker processes exited with error");
+		(void) queue_unlink(&(parentSpecs->copyQueue));
+		return false;
+	}
+
+	/* clean up the global COPY queue */
+	(void) queue_unlink(&(parentSpecs->copyQueue));
+	parentSpecs->copyQueue.qId = -1;
+
+	return true;
+}
+
+
+/* ============================================================
+ * MultiDbContext helpers — called from both multi_db.c and table-data.c
+ * ============================================================ */
+
+/*
+ * multidb_context_init zeroes a MultiDbContext.
+ */
+bool
+multidb_context_init(MultiDbContext *ctx, CopyDataSpec *parentSpecs)
+{
+	memset(ctx, 0, sizeof(*ctx));
+	ctx->parentSpecs = parentSpecs;
+	return true;
+}
+
+
+/*
+ * multidb_context_get_entry looks up the per-database entry for datname in the
+ * cache.  If not found, it initialises a new entry (possibly evicting an
+ * existing one using round-robin).
+ *
+ * Returns NULL on error.
+ */
+MultiDbEntry *
+multidb_context_get_entry(MultiDbContext *ctx, const char *datname)
+{
+	/* search existing active entries */
+	for (int i = 0; i < MULTIDB_ENTRY_CACHE_MAX; i++)
+	{
+		if (ctx->entries[i].active &&
+			strcmp(ctx->entries[i].datname, datname) == 0)
+		{
+			return &ctx->entries[i];
+		}
+	}
+
+	/* find a free slot, or evict the next-in-round-robin */
+	int slot = -1;
+
+	for (int i = 0; i < MULTIDB_ENTRY_CACHE_MAX; i++)
+	{
+		if (!ctx->entries[i].active)
+		{
+			slot = i;
+			break;
+		}
+	}
+
+	if (slot < 0)
+	{
+		/* cache full: evict round-robin */
+		slot = ctx->nextEvict % MULTIDB_ENTRY_CACHE_MAX;
+		ctx->nextEvict = (ctx->nextEvict + 1) % MULTIDB_ENTRY_CACHE_MAX;
+
+		log_debug("Evicting multidb connection cache entry for \"%s\"",
+				  ctx->entries[slot].datname);
+
+		if (!multidb_context_close_entry(&ctx->entries[slot]))
+		{
+			/* errors have already been logged */
+			return NULL;
+		}
+	}
+
+	/* initialise the new entry */
+	MultiDbEntry *entry = &ctx->entries[slot];
+
+	if (!multidb_init_entry(entry, ctx->parentSpecs, datname))
+	{
+		/* errors have already been logged */
+		return NULL;
+	}
+
+	ctx->count++;
+	return entry;
+}
+
+
+/*
+ * multidb_context_close_entry closes all resources held by a cache entry.
+ */
+bool
+multidb_context_close_entry(MultiDbEntry *entry)
+{
+	if (!entry->active)
+		return true;
+
+	log_debug("Closing multidb connection cache entry for \"%s\"",
+			  entry->datname);
+
+	/* close source snapshot connection */
+	if (entry->dbSpecs != NULL)
+	{
+		(void) copydb_close_snapshot(entry->dbSpecs);
+		(void) catalog_close_from_specs(entry->dbSpecs);
+		free(entry->dbSpecs->connStrings.source_pguri);
+		free(entry->dbSpecs->connStrings.target_pguri);
+		free(entry->dbSpecs);
+		entry->dbSpecs = NULL;
+	}
+
+	/* close target connection */
+	(void) pgsql_finish(&entry->dst);
+
+	entry->active = false;
+	memset(entry->datname, 0, sizeof(entry->datname));
+
+	return true;
+}
+
+
+/*
+ * multidb_context_close_all closes all active cache entries.
+ */
+bool
+multidb_context_close_all(MultiDbContext *ctx)
+{
+	bool ok = true;
+
+	for (int i = 0; i < MULTIDB_ENTRY_CACHE_MAX; i++)
+	{
+		if (ctx->entries[i].active)
+		{
+			if (!multidb_context_close_entry(&ctx->entries[i]))
+				ok = false;
+		}
+	}
+
+	return ok;
+}
+
+
+/*
+ * multidb_init_entry initialises a MultiDbEntry for the given database.
+ *
+ * This involves:
+ *  1. Finding the MultiDbInfo for datname in parentSpecs
+ *  2. Allocating a per-database CopyDataSpec
+ *  3. Opening the per-database source catalog
+ *  4. Importing the snapshot on the source connection
+ *  5. Connecting to the target database
+ */
+static bool
+multidb_init_entry(MultiDbEntry *entry, CopyDataSpec *parentSpecs,
+				   const char *datname)
+{
+	/* find the MultiDbInfo for this database */
+	MultiDbInfo *info = NULL;
+
+	for (int i = 0; i < parentSpecs->multiDbCount; i++)
+	{
+		if (strcmp(parentSpecs->multiDbInfos[i].datname, datname) == 0)
+		{
+			info = &parentSpecs->multiDbInfos[i];
+			break;
+		}
+	}
+
+	if (info == NULL)
+	{
+		log_error("BUG: multidb_init_entry: no MultiDbInfo for database \"%s\"",
+				  datname);
+		return false;
+	}
+
+	log_debug("Opening per-database connection for \"%s\"", datname);
+
+	/* allocate a per-database CopyDataSpec on the heap */
+	CopyDataSpec *dbSpecs = (CopyDataSpec *) calloc(1, sizeof(CopyDataSpec));
+
+	if (dbSpecs == NULL)
+	{
+		log_error(ALLOCATION_FAILED_ERROR);
+		return false;
+	}
+
+	/* copy settings from parent */
+	dbSpecs->pgPaths = parentSpecs->pgPaths;
+	dbSpecs->filters = parentSpecs->filters;
+	dbSpecs->extRequirements = parentSpecs->extRequirements;
+	dbSpecs->section = DATA_SECTION_TABLE_DATA;  /* skip inline index routing */
+	dbSpecs->restoreOptions = parentSpecs->restoreOptions;
+	dbSpecs->roles = false;
+	dbSpecs->skipLargeObjects = parentSpecs->skipLargeObjects;
+	dbSpecs->skipExtensions = parentSpecs->skipExtensions;
+	dbSpecs->skipCommentOnExtension = parentSpecs->skipCommentOnExtension;
+	dbSpecs->skipCollations = parentSpecs->skipCollations;
+	dbSpecs->skipVacuum = true;    /* vacuum done separately in post-data */
+	dbSpecs->skipAnalyze = parentSpecs->skipAnalyze;
+	dbSpecs->skipDBproperties = parentSpecs->skipDBproperties;
+	dbSpecs->skipCtidSplit = parentSpecs->skipCtidSplit;
+	dbSpecs->noRolesPasswords = parentSpecs->noRolesPasswords;
+	dbSpecs->failFast = parentSpecs->failFast;
+	dbSpecs->useCopyBinary = parentSpecs->useCopyBinary;
+	dbSpecs->restart = false;
+	dbSpecs->resume = parentSpecs->resume;
+	dbSpecs->consistent = parentSpecs->consistent;
+	dbSpecs->fetchCatalogs = parentSpecs->fetchCatalogs;
+	dbSpecs->fetchFilteredOids = parentSpecs->fetchFilteredOids;
+	dbSpecs->tableJobs = parentSpecs->tableJobs;
+	dbSpecs->indexJobs = parentSpecs->indexJobs;
+	dbSpecs->vacuumJobs = parentSpecs->vacuumJobs;
+	dbSpecs->lObjectJobs = parentSpecs->lObjectJobs;
+	dbSpecs->splitTablesLargerThan = parentSpecs->splitTablesLargerThan;
+	dbSpecs->splitMaxParts = parentSpecs->splitMaxParts;
+	dbSpecs->estimateTableSizes = parentSpecs->estimateTableSizes;
+	dbSpecs->allDatabases = false;  /* per-db context, not the global flag */
+
+	/* no queues for per-database workers — index/vacuum done in post-data */
+	dbSpecs->copyQueue.qId = -1;
+	dbSpecs->indexQueue.qId = -1;
+	dbSpecs->vacuumQueue.qId = -1;
+	dbSpecs->loQueue.qId = -1;
+
+	/* set up per-database connection strings (heap-allocated) */
+	dbSpecs->connStrings.source_pguri = strdup(info->source_pguri);
+	dbSpecs->connStrings.target_pguri = strdup(info->target_pguri);
+
+	if (dbSpecs->connStrings.source_pguri == NULL ||
+		dbSpecs->connStrings.target_pguri == NULL)
+	{
+		log_error(ALLOCATION_FAILED_ERROR);
+		free(dbSpecs);
+		return false;
+	}
+
+	if (!parse_and_scrub_connection_string(dbSpecs->connStrings.source_pguri,
+										   &dbSpecs->connStrings.safeSourcePGURI))
+	{
+		log_error("Failed to scrub source URI for database \"%s\"", datname);
+		free(dbSpecs->connStrings.source_pguri);
+		free(dbSpecs->connStrings.target_pguri);
+		free(dbSpecs);
+		return false;
+	}
+
+	if (!parse_and_scrub_connection_string(dbSpecs->connStrings.target_pguri,
+										   &dbSpecs->connStrings.safeTargetPGURI))
+	{
+		log_error("Failed to scrub target URI for database \"%s\"", datname);
+		free(dbSpecs->connStrings.source_pguri);
+		free(dbSpecs->connStrings.target_pguri);
+		if (dbSpecs->connStrings.safeSourcePGURI.pguri)
+			free(dbSpecs->connStrings.safeSourcePGURI.pguri);
+		free(dbSpecs);
+		return false;
+	}
+
+	/* set up the per-database work directory paths */
+	if (!copydb_init_workdir(dbSpecs, info->topdir,
+							 false,  /* service */
+							 NULL,   /* serviceName */
+							 false,  /* restart */
+							 true,   /* resume */
+							 false)) /* createWorkDir (already created) */
+	{
+		log_error("Failed to init work dir for database \"%s\"", datname);
+		free(dbSpecs->connStrings.source_pguri);
+		free(dbSpecs->connStrings.target_pguri);
+		free(dbSpecs);
+		return false;
+	}
+
+	/* set up catalog file paths */
+	DatabaseCatalog *sourceDB = &dbSpecs->catalogs.source;
+	DatabaseCatalog *filterDB = &dbSpecs->catalogs.filter;
+	DatabaseCatalog *targetDB = &dbSpecs->catalogs.target;
+
+	sourceDB->type = DATABASE_CATALOG_TYPE_SOURCE;
+	filterDB->type = DATABASE_CATALOG_TYPE_FILTER;
+	targetDB->type = DATABASE_CATALOG_TYPE_TARGET;
+
+	strlcpy(sourceDB->dbfile, dbSpecs->cfPaths.sdbfile, sizeof(sourceDB->dbfile));
+	strlcpy(filterDB->dbfile, dbSpecs->cfPaths.fdbfile, sizeof(filterDB->dbfile));
+	strlcpy(targetDB->dbfile, dbSpecs->cfPaths.tdbfile, sizeof(targetDB->dbfile));
+
+	/* open the per-database source catalog (populated by pre-data) */
+	if (!catalog_init(sourceDB))
+	{
+		log_error("Failed to open catalog for database \"%s\"", datname);
+		free(dbSpecs->connStrings.source_pguri);
+		free(dbSpecs->connStrings.target_pguri);
+		free(dbSpecs);
+		return false;
+	}
+
+	/* set up the snapshot for the source connection */
+	dbSpecs->sourceSnapshot.pguri = dbSpecs->connStrings.source_pguri;
+	dbSpecs->sourceSnapshot.safeURI = dbSpecs->connStrings.safeSourcePGURI;
+	dbSpecs->sourceSnapshot.connectionType = PGSQL_CONN_SOURCE;
+	dbSpecs->sourceSnapshot.isReadOnly = info->isReadOnly;
+
+	strlcpy(dbSpecs->sourceSnapshot.snapshot, info->snapshot,
+			sizeof(dbSpecs->sourceSnapshot.snapshot));
+
+	/* connect to source and import the exported snapshot */
+	if (!copydb_set_snapshot(dbSpecs))
+	{
+		log_error("Failed to import snapshot for database \"%s\"", datname);
+		catalog_close(sourceDB);
+		free(dbSpecs->connStrings.source_pguri);
+		free(dbSpecs->connStrings.target_pguri);
+		free(dbSpecs);
+		return false;
+	}
+
+	/* connect to target database */
+	if (!pgsql_init(&entry->dst, dbSpecs->connStrings.target_pguri,
+					PGSQL_CONN_TARGET))
+	{
+		log_error("Failed to connect to target for database \"%s\"", datname);
+		copydb_close_snapshot(dbSpecs);
+		catalog_close(sourceDB);
+		free(dbSpecs->connStrings.source_pguri);
+		free(dbSpecs->connStrings.target_pguri);
+		free(dbSpecs);
+		return false;
+	}
+
+	/* set GUCs on target connection */
+	if (!pgsql_set_gucs(&entry->dst, dstSettings))
+	{
+		log_warn("Failed to set GUCs on target for database \"%s\"", datname);
+		/* non-fatal: continue */
+	}
+
+	/* populate the entry */
+	strlcpy(entry->datname, datname, sizeof(entry->datname));
+	entry->dbSpecs = dbSpecs;
+	entry->active = true;
+
+	log_debug("Opened connections for database \"%s\"", datname);
+
+	return true;
+}
+
+
+/*
+ * multidb_is_system_database returns true for template0 and template1.
  */
 static bool
 multidb_is_system_database(const char *datname)
@@ -238,9 +1158,6 @@ multidb_target_database_exists(PGSQL *dst, const char *datname, bool *exists)
 
 /*
  * multidb_create_target_database creates datname on the target instance.
- * When dropIfExists is true and the database already exists it is dropped
- * first.  When dropIfExists is false and the database already exists the
- * function succeeds silently (resume / idempotent behaviour).
  */
 static bool
 multidb_create_target_database(PGSQL *dst, const char *datname,
@@ -329,8 +1246,7 @@ multidb_create_target_database(PGSQL *dst, const char *datname,
 
 /*
  * multidb_build_uri_for_database takes an existing Postgres URI and returns a
- * new one with the dbname component replaced by datname.  The caller owns the
- * returned string and must free it.
+ * new one with the dbname component replaced by datname.
  */
 static bool
 multidb_build_uri_for_database(const char *pguri, const char *datname,
@@ -376,8 +1292,7 @@ multidb_build_uri_for_database(const char *pguri, const char *datname,
 
 
 /*
- * multidb_build_conn_strings constructs per-database ConnStrings by
- * substituting datname into the source and target URIs of the parent.
+ * multidb_build_conn_strings constructs per-database ConnStrings.
  */
 static bool
 multidb_build_conn_strings(ConnStrings *parent, const char *datname,
@@ -426,9 +1341,6 @@ multidb_build_conn_strings(ConnStrings *parent, const char *datname,
 /*
  * multidb_init_db_specs initialises a per-database CopyDataSpec by copying
  * all settings from the parent and replacing the connection strings.
- *
- * The dbSpecs->cfPaths must already have been set up via copydb_init_workdir
- * before this function is called.
  */
 static bool
 multidb_init_db_specs(CopyDataSpec *dbSpecs,
@@ -438,11 +1350,6 @@ multidb_init_db_specs(CopyDataSpec *dbSpecs,
 	/* connection strings */
 	dbSpecs->connStrings = *connStrings;
 
-	/*
-	 * Refresh the pguri/safeURI pointers after the connStrings copy above.
-	 * The snapshot string and state are already set (exported in the parent
-	 * before fork) and must not be touched here.
-	 */
 	dbSpecs->sourceSnapshot.pguri = dbSpecs->connStrings.source_pguri;
 	dbSpecs->sourceSnapshot.safeURI = dbSpecs->connStrings.safeSourcePGURI;
 	dbSpecs->sourceSnapshot.connectionType = PGSQL_CONN_SOURCE;
@@ -450,7 +1357,7 @@ multidb_init_db_specs(CopyDataSpec *dbSpecs,
 	/* copy all operational settings from parent */
 	dbSpecs->section = parent->section;
 	dbSpecs->restoreOptions = parent->restoreOptions;
-	dbSpecs->roles = false;         /* roles already copied at instance level */
+	dbSpecs->roles = false;
 	dbSpecs->skipLargeObjects = parent->skipLargeObjects;
 	dbSpecs->skipExtensions = parent->skipExtensions;
 	dbSpecs->skipCommentOnExtension = parent->skipCommentOnExtension;
@@ -476,7 +1383,7 @@ multidb_init_db_specs(CopyDataSpec *dbSpecs,
 	dbSpecs->estimateTableSizes = parent->estimateTableSizes;
 	dbSpecs->extRequirements = parent->extRequirements;
 
-	/* filters are shared — pointer copy is intentional (read-only in workers) */
+	/* filters are shared — pointer copy (read-only in workers) */
 	dbSpecs->filters = parent->filters;
 
 	/* prepare dump paths under the per-db schema dir */
@@ -490,18 +1397,16 @@ multidb_init_db_specs(CopyDataSpec *dbSpecs,
 	DatabaseCatalog *source = &dbSpecs->catalogs.source;
 	DatabaseCatalog *filter = &dbSpecs->catalogs.filter;
 	DatabaseCatalog *target = &dbSpecs->catalogs.target;
-	DatabaseCatalog *replay = &dbSpecs->catalogs.replay;
 
 	source->type = DATABASE_CATALOG_TYPE_SOURCE;
 	filter->type = DATABASE_CATALOG_TYPE_FILTER;
 	target->type = DATABASE_CATALOG_TYPE_TARGET;
-	replay->type = DATABASE_CATALOG_TYPE_REPLAY;
 
 	strlcpy(source->dbfile, dbSpecs->cfPaths.sdbfile, sizeof(source->dbfile));
 	strlcpy(filter->dbfile, dbSpecs->cfPaths.fdbfile, sizeof(filter->dbfile));
 	strlcpy(target->dbfile, dbSpecs->cfPaths.tdbfile, sizeof(target->dbfile));
 
-	/* create the System V message queues */
+	/* create System V message queues */
 	bool shouldCreateVacuumQueue =
 		(dbSpecs->section == DATA_SECTION_ALL ||
 		 dbSpecs->section == DATA_SECTION_INDEXES ||
@@ -542,182 +1447,7 @@ multidb_init_db_specs(CopyDataSpec *dbSpecs,
 
 
 /*
- * multidb_clone_one_database clones a single database identified by db into
- * its own per-database work directory under <topdir>/db/<datname>/.
- */
-static bool
-multidb_clone_one_database(CopyDataSpec *parentSpecs, SourceDatabase *db)
-{
-	/* build per-db work directory path */
-	char dbdir[MAXPGPATH] = { 0 };
-
-	sformat(dbdir, sizeof(dbdir), "%s/db/%s",
-			parentSpecs->cfPaths.topdir, db->datname);
-
-	/* build per-db connection strings */
-	ConnStrings dbConnStrings = { 0 };
-
-	if (!multidb_build_conn_strings(&parentSpecs->connStrings, db->datname,
-									&dbConnStrings))
-	{
-		log_error("Failed to build connection strings for database \"%s\"",
-				  db->datname);
-		return false;
-	}
-
-	log_info("[SOURCE] Cloning database \"%s\" from \"%s\"",
-			 db->datname, dbConnStrings.safeSourcePGURI.pguri);
-	log_info("[TARGET] Cloning database \"%s\" into \"%s\"",
-			 db->datname, dbConnStrings.safeTargetPGURI.pguri);
-
-	/* initialise per-db CopyDataSpec (pgPaths + cfPaths only, before fork) */
-	CopyDataSpec dbSpecs = { 0 };
-
-	dbSpecs.pgPaths = parentSpecs->pgPaths;
-
-	/*
-	 * Create the work directory under <topdir>/db/<datname>/.
-	 * Must happen in the parent so the directory exists before the fork.
-	 * Use service=false so no pidfile is created for per-db dirs.
-	 */
-	if (!copydb_init_workdir(&dbSpecs, dbdir,
-							 false,     /* service */
-							 NULL,      /* serviceName */
-							 parentSpecs->restart,
-							 parentSpecs->resume,
-							 true))     /* createWorkDir */
-	{
-		log_error("Failed to initialise work directory \"%s\" for database \"%s\"",
-				  dbdir, db->datname);
-		goto cleanup;
-	}
-
-	/*
-	 * Set up connection strings and snapshot fields before the fork so the
-	 * child inherits the exported snapshot string.
-	 */
-	dbSpecs.connStrings = dbConnStrings;
-	dbSpecs.sourceSnapshot.pguri = dbSpecs.connStrings.source_pguri;
-	dbSpecs.sourceSnapshot.safeURI = dbSpecs.connStrings.safeSourcePGURI;
-	dbSpecs.sourceSnapshot.connectionType = PGSQL_CONN_SOURCE;
-	dbSpecs.consistent = parentSpecs->consistent;
-
-	/*
-	 * Export a per-database snapshot in the parent.  The parent keeps this
-	 * connection open until the child exits so worker subprocesses can import
-	 * the snapshot via SET TRANSACTION SNAPSHOT.
-	 */
-	if (dbSpecs.consistent)
-	{
-		if (!copydb_prepare_snapshot(&dbSpecs))
-		{
-			log_error("Failed to export snapshot for database \"%s\"",
-					  db->datname);
-			goto cleanup;
-		}
-	}
-
-	/*
-	 * Fork a subprocess for each database clone.  This isolates three kinds
-	 * of process-global state that would otherwise bleed across databases:
-	 *
-	 *  1. topLevelTimingArray (reset explicitly in child before first use)
-	 *  2. system_res_array (System V semaphore/queue registrations)
-	 *  3. SQLite catalog connections
-	 */
-	pid_t fpid = fork();
-
-	switch (fpid)
-	{
-		case -1:
-		{
-			log_error("Failed to fork subprocess for database \"%s\": %m",
-					  db->datname);
-			goto cleanup_snapshot;
-		}
-
-		case 0:
-		{
-			/* child process */
-			char psTitle[MAXPGPATH] = { 0 };
-			sformat(psTitle, sizeof(psTitle), "pgcopydb: clone %s", db->datname);
-			(void) set_ps_title(psTitle);
-
-			/*
-			 * Reset the inherited timing global so that
-			 * copydb_fetch_previous_run_state sees a clean slate for this
-			 * database, not stale doneTime values from the previous one.
-			 */
-			summary_reset_toplevel_timings();
-
-			/*
-			 * Now initialise the rest of dbSpecs (flags, queues, catalog
-			 * paths).  Queues are created here so they register in this
-			 * child's copy of system_res_array, not the parent's.
-			 */
-			if (!multidb_init_db_specs(&dbSpecs, parentSpecs, &dbConnStrings))
-			{
-				log_error("Failed to initialise specs for database \"%s\"",
-						  db->datname);
-				exit(EXIT_CODE_INTERNAL_ERROR);
-			}
-
-			if (!copydb_clone_database(&dbSpecs))
-			{
-				log_error("Failed to clone database \"%s\"",
-						  db->datname);
-				exit(EXIT_CODE_SOURCE);
-			}
-
-			exit(EXIT_CODE_QUIT);
-		}
-
-		default:
-			break;
-	}
-
-	/* parent: wait for the per-db child subprocess */
-	bool success = multidb_wait_child(fpid, db->datname);
-
-	/*
-	 * Parent closes the snapshot connection now that the child and all of
-	 * its worker sub-processes have finished.
-	 */
-	if (dbSpecs.consistent)
-	{
-		if (!copydb_close_snapshot(&dbSpecs))
-		{
-			/* errors have already been logged */
-			success = false;
-		}
-	}
-
-	free(dbConnStrings.source_pguri);
-	free(dbConnStrings.target_pguri);
-	if (dbConnStrings.safeSourcePGURI.pguri)
-		free(dbConnStrings.safeSourcePGURI.pguri);
-	if (dbConnStrings.safeTargetPGURI.pguri)
-		free(dbConnStrings.safeTargetPGURI.pguri);
-
-	return success;
-
-cleanup_snapshot:
-	(void) copydb_close_snapshot(&dbSpecs);
-
-cleanup:
-	free(dbConnStrings.source_pguri);
-	free(dbConnStrings.target_pguri);
-	if (dbConnStrings.safeSourcePGURI.pguri)
-		free(dbConnStrings.safeSourcePGURI.pguri);
-	if (dbConnStrings.safeTargetPGURI.pguri)
-		free(dbConnStrings.safeTargetPGURI.pguri);
-	return false;
-}
-
-
-/*
- * multidb_wait_child blocks until the given subprocess exits, then returns
- * true iff it exited with status 0.
+ * multidb_wait_child blocks until the given subprocess exits.
  */
 static bool
 multidb_wait_child(pid_t pid, const char *datname)

--- a/src/bin/pgcopydb/multi_db.h
+++ b/src/bin/pgcopydb/multi_db.h
@@ -12,7 +12,7 @@
 bool clone_all_databases(CopyDataSpec *copySpecs);
 
 bool multidb_build_uri_for_database(const char *pguri,
-									 const char *datname,
-									 char **result_uri);
+									const char *datname,
+									char **result_uri);
 
 #endif /* MULTI_DB_H */

--- a/src/bin/pgcopydb/multi_db.h
+++ b/src/bin/pgcopydb/multi_db.h
@@ -11,4 +11,8 @@
 
 bool clone_all_databases(CopyDataSpec *copySpecs);
 
+bool multidb_build_uri_for_database(const char *pguri,
+									 const char *datname,
+									 char **result_uri);
+
 #endif /* MULTI_DB_H */

--- a/src/bin/pgcopydb/multi_db.h
+++ b/src/bin/pgcopydb/multi_db.h
@@ -1,0 +1,14 @@
+/*
+ * src/bin/pgcopydb/multi_db.h
+ *	 Clone all databases from a source Postgres instance.
+ */
+
+#ifndef MULTI_DB_H
+#define MULTI_DB_H
+
+#include "copydb.h"
+#include "schema.h"
+
+bool clone_all_databases(CopyDataSpec *copySpecs);
+
+#endif /* MULTI_DB_H */

--- a/src/bin/pgcopydb/parsing_utils.c
+++ b/src/bin/pgcopydb/parsing_utils.c
@@ -809,7 +809,9 @@ buildPostgresURIfromPieces(URIParams *uriParams, char **pguri)
 		}
 		else
 		{
-			log_warn("buildPostgresURIfromPieces: %s is NULL", keyword);
+			log_debug("buildPostgresURIfromPieces: skipping parameter \"%s\" "
+					  "with empty or NULL value",
+					  keyword != NULL ? keyword : "(null)");
 		}
 	}
 

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -2663,7 +2663,8 @@ pgsql_lock_table(PGSQL *pgsql, const char *qname, const char *lockmode)
  * to keep this function predictable and side-effect-free.
  */
 bool
-pgsql_truncate(PGSQL *pgsql, const char *qname, char relkind)
+pgsql_truncate(PGSQL *pgsql, const char *qname, char relkind,
+			   const char *datname)
 {
 	char sql[BUFSIZE] = { 0 };
 
@@ -2677,7 +2678,14 @@ pgsql_truncate(PGSQL *pgsql, const char *qname, char relkind)
 	}
 
 	/* this being more like a DDL operation, proper log level is NOTICE */
-	log_notice("%s", sql);
+	if (datname != NULL && datname[0] != '\0')
+	{
+		log_notice("%s: %s", datname, sql);
+	}
+	else
+	{
+		log_notice("%s", sql);
+	}
 
 	return pgsql_execute(pgsql, sql);
 }
@@ -2759,7 +2767,7 @@ pg_copy_data(PGSQL *src, PGSQL *dst,
 
 	if (args->truncate)
 	{
-		if (!pgsql_truncate(dst, args->dstQname, relkind))
+		if (!pgsql_truncate(dst, args->dstQname, relkind, args->datname))
 		{
 			/* errors have already been logged */
 			return false;
@@ -2782,7 +2790,14 @@ pg_copy_data(PGSQL *src, PGSQL *dst,
 	}
 
 	/* make sure to log TRUNCATE before we log COPY, avoid confusion */
-	log_notice("%s", args->logCommand);
+	if (args->datname != NULL && args->datname[0] != '\0')
+	{
+		log_notice("%s: %s", args->datname, args->logCommand);
+	}
+	else
+	{
+		log_notice("%s", args->logCommand);
+	}
 
 	/* SRC: COPY schema.table TO STDOUT */
 	if (!pg_copy_send_query(src, args, PGRES_COPY_OUT))

--- a/src/bin/pgcopydb/pgsql.h
+++ b/src/bin/pgcopydb/pgsql.h
@@ -321,7 +321,8 @@ bool validate_connection_string(const char *connectionString);
 
 bool pgsql_lock_table(PGSQL *pgsql, const char *qname, const char *lockmode);
 
-bool pgsql_truncate(PGSQL *pgsql, const char *qname, char relkind);
+bool pgsql_truncate(PGSQL *pgsql, const char *qname, char relkind,
+					const char *datname);
 
 typedef struct CopyArgs
 {
@@ -331,6 +332,7 @@ typedef struct CopyArgs
 	char *dstQname;
 	char *dstAttrList;
 	char *logCommand;
+	char *datname;
 	bool truncate;
 	bool freeze;
 	bool useCopyBinary;

--- a/src/bin/pgcopydb/queue_utils.h
+++ b/src/bin/pgcopydb/queue_utils.h
@@ -35,6 +35,7 @@ typedef enum
 	QMSG_TYPE_INDEXOID,         /* index oid */
 	QMSG_TYPE_STREAM_TRANSFORM, /* lsn position for transform process */
 	QMSG_TYPE_BLOBOID,          /* large object oid */
+	QMSG_TYPE_DBNAME,           /* database name (for --all-databases pre/post-data) */
 	QMSG_TYPE_STOP
 } QMessageType;
 
@@ -45,6 +46,7 @@ typedef struct QMessage
 	{
 		uint32_t oid;
 		uint64_t lsn;
+		char datname[NAMEDATALEN]; /* for QMSG_TYPE_DBNAME */
 
 		/* table parts (support for COPY partitionning) */
 		struct tp

--- a/src/bin/pgcopydb/queue_utils.h
+++ b/src/bin/pgcopydb/queue_utils.h
@@ -51,6 +51,7 @@ typedef struct QMessage
 		{
 			uint32_t oid;
 			uint32_t part;
+			char datname[NAMEDATALEN]; /* for --all-databases: target database */
 		} tp;
 	} data;
 } QMessage;

--- a/src/bin/pgcopydb/schema.c
+++ b/src/bin/pgcopydb/schema.c
@@ -104,6 +104,7 @@ typedef struct SourceTableArrayContext
 	DatabaseCatalog *catalog;
 	bool estimateTableSizes;
 	bool parsedOk;
+	char datname[PG_NAMEDATALEN]; /* database name, filled by schema_list_ordinary_tables */
 } SourceTableArrayContext;
 
 
@@ -130,6 +131,7 @@ typedef struct SourceSequenceArrayContext
 	char sqlstate[SQLSTATE_LENGTH];
 	DatabaseCatalog *catalog;
 	bool parsedOk;
+	char datname[PG_NAMEDATALEN];
 } SourceSequenceArrayContext;
 
 /* Context used when fetching all the indexes definitions */
@@ -1433,6 +1435,12 @@ schema_list_ordinary_tables(PGSQL *pgsql,
 
 	log_trace("schema_list_ordinary_tables");
 
+	if (pgsql->safeURI.uriParams.dbname != NULL)
+	{
+		strlcpy(context.datname, pgsql->safeURI.uriParams.dbname,
+				sizeof(context.datname));
+	}
+
 	SourceFilterType filterType = SOURCE_FILTER_TYPE_NONE;
 
 	switch (filters->type)
@@ -2189,6 +2197,12 @@ schema_list_sequences(PGSQL *pgsql,
 	SourceSequenceArrayContext context = { { 0 }, catalog, false };
 
 	log_trace("schema_list_sequences");
+
+	if (pgsql->safeURI.uriParams.dbname != NULL)
+	{
+		strlcpy(context.datname, pgsql->safeURI.uriParams.dbname,
+				sizeof(context.datname));
+	}
 
 	SourceFilterType filterType = SOURCE_FILTER_TYPE_NONE;
 
@@ -4690,6 +4704,8 @@ getTableArray(void *ctx, PGresult *result)
 			break;
 		}
 
+		strlcpy(table->datname, context->datname, sizeof(table->datname));
+
 		if (context->catalog != NULL && context->catalog->db != NULL)
 		{
 			switch (table->relkind)
@@ -5180,6 +5196,8 @@ getSequenceArray(void *ctx, PGresult *result)
 			parsedOk = false;
 			break;
 		}
+
+		strlcpy(seq->datname, context->datname, sizeof(seq->datname));
 
 		if (context->catalog != NULL && context->catalog->db != NULL)
 		{

--- a/src/bin/pgcopydb/schema.h
+++ b/src/bin/pgcopydb/schema.h
@@ -28,6 +28,7 @@ typedef struct SourceDatabase
 	char datname[PG_NAMEDATALEN];
 	int64_t bytes;
 	char bytesPretty[PG_NAMEDATALEN]; /* pg_size_pretty */
+	char snapshot[BUFSIZE];           /* exported snapshot ID, or "" */
 } SourceDatabase;
 
 

--- a/src/bin/pgcopydb/schema.h
+++ b/src/bin/pgcopydb/schema.h
@@ -152,6 +152,7 @@ typedef struct SourceTable
 {
 	uint32_t oid;
 
+	char datname[PG_NAMEDATALEN];
 	char qname[PG_NAMEDATALEN_FQ];
 	char nspname[PG_NAMEDATALEN];
 	char relname[PG_NAMEDATALEN];
@@ -220,6 +221,7 @@ typedef struct SourceSequence
 	uint32_t attrelid;          /* pg_class oid of table using as DEFAULT */
 	uint32_t attroid;           /* pg_attrdef DEFAULT value OID */
 
+	char datname[PG_NAMEDATALEN];
 	char qname[PG_NAMEDATALEN_FQ];
 	char nspname[PG_NAMEDATALEN];
 	char relname[PG_NAMEDATALEN];

--- a/src/bin/pgcopydb/summary.c
+++ b/src/bin/pgcopydb/summary.c
@@ -2848,39 +2848,84 @@ print_summary_table(SummaryTable *summary)
 
 	fformat(stdout, "\n");
 
-	fformat(stdout, "%*s | %*s | %*s | %*s | %*s | %*s | %*s | %*s \n",
-			headers->maxOidSize, "OID",
-			headers->maxNspnameSize, "Schema",
-			headers->maxRelnameSize, "Name",
-			headers->maxPartCountSize, "Parts",
-			headers->maxTableMsSize, "copy duration",
-			headers->maxBytesSize, "transmitted bytes",
-			headers->maxIndexCountSize, "indexes",
-			headers->maxIndexMsSize, "create index duration");
+	bool showDb = headers->maxDatnameSize > 0;
 
-	fformat(stdout, "%s-+-%s-+-%s-+-%s-+-%s-+-%s-+-%s-+-%s\n",
-			headers->oidSeparator,
-			headers->nspnameSeparator,
-			headers->relnameSeparator,
-			headers->partCountSeparator,
-			headers->tableMsSeparator,
-			headers->bytesSeparator,
-			headers->indexCountSeparator,
-			headers->indexMsSeparator);
+	if (showDb)
+	{
+		fformat(stdout, "%*s | %*s | %*s | %*s | %*s | %*s | %*s | %*s | %*s \n",
+				headers->maxDatnameSize, "Database",
+				headers->maxOidSize, "OID",
+				headers->maxNspnameSize, "Schema",
+				headers->maxRelnameSize, "Name",
+				headers->maxPartCountSize, "Parts",
+				headers->maxTableMsSize, "copy duration",
+				headers->maxBytesSize, "transmitted bytes",
+				headers->maxIndexCountSize, "indexes",
+				headers->maxIndexMsSize, "create index duration");
+
+		fformat(stdout, "%s-+-%s-+-%s-+-%s-+-%s-+-%s-+-%s-+-%s-+-%s\n",
+				headers->datnameSeparator,
+				headers->oidSeparator,
+				headers->nspnameSeparator,
+				headers->relnameSeparator,
+				headers->partCountSeparator,
+				headers->tableMsSeparator,
+				headers->bytesSeparator,
+				headers->indexCountSeparator,
+				headers->indexMsSeparator);
+	}
+	else
+	{
+		fformat(stdout, "%*s | %*s | %*s | %*s | %*s | %*s | %*s | %*s \n",
+				headers->maxOidSize, "OID",
+				headers->maxNspnameSize, "Schema",
+				headers->maxRelnameSize, "Name",
+				headers->maxPartCountSize, "Parts",
+				headers->maxTableMsSize, "copy duration",
+				headers->maxBytesSize, "transmitted bytes",
+				headers->maxIndexCountSize, "indexes",
+				headers->maxIndexMsSize, "create index duration");
+
+		fformat(stdout, "%s-+-%s-+-%s-+-%s-+-%s-+-%s-+-%s-+-%s\n",
+				headers->oidSeparator,
+				headers->nspnameSeparator,
+				headers->relnameSeparator,
+				headers->partCountSeparator,
+				headers->tableMsSeparator,
+				headers->bytesSeparator,
+				headers->indexCountSeparator,
+				headers->indexMsSeparator);
+	}
 
 	for (int i = 0; i < summary->count; i++)
 	{
 		SummaryTableEntry *entry = &(summary->array[i]);
 
-		fformat(stdout, "%*s | %*s | %*s | %*s | %*s | %*s | %*s | %*s\n",
-				headers->maxOidSize, entry->oidStr,
-				headers->maxNspnameSize, entry->nspname,
-				headers->maxRelnameSize, entry->relname,
-				headers->maxPartCountSize, entry->partCount,
-				headers->maxTableMsSize, entry->tableMs,
-				headers->maxBytesSize, entry->bytesStr,
-				headers->maxIndexCountSize, entry->indexCount,
-				headers->maxIndexMsSize, entry->indexMs);
+		if (showDb)
+		{
+			fformat(stdout, "%*s | %*s | %*s | %*s | %*s | %*s | %*s | %*s | %*s\n",
+					headers->maxDatnameSize, entry->datname,
+					headers->maxOidSize, entry->oidStr,
+					headers->maxNspnameSize, entry->nspname,
+					headers->maxRelnameSize, entry->relname,
+					headers->maxPartCountSize, entry->partCount,
+					headers->maxTableMsSize, entry->tableMs,
+					headers->maxBytesSize, entry->bytesStr,
+					headers->maxIndexCountSize, entry->indexCount,
+					headers->maxIndexMsSize, entry->indexMs);
+		}
+		else
+		{
+			fformat(stdout, "%*s | %*s | %*s | %*s | %*s | %*s | %*s | %*s\n",
+					headers->maxOidSize, entry->oidStr,
+					headers->maxNspnameSize, entry->nspname,
+					headers->maxRelnameSize, entry->relname,
+					headers->maxPartCountSize, entry->partCount,
+					headers->maxTableMsSize, entry->tableMs,
+					headers->maxBytesSize, entry->bytesStr,
+					headers->maxIndexCountSize, entry->indexCount,
+					headers->maxIndexMsSize, entry->indexMs);
+		}
 	}
 
 	fformat(stdout, "\n");
@@ -3031,6 +3076,7 @@ prepare_summary_table_headers(SummaryTable *summary)
 	SummaryTableHeaders *headers = &(summary->headers);
 
 	/* assign static maximums from the lenghts of the column headers */
+	headers->maxDatnameSize = 0;    /* hidden unless any entry has datname */
 	headers->maxOidSize = 3;        /* "oid" */
 	headers->maxNspnameSize = 6;    /* "schema" */
 	headers->maxRelnameSize = 4;    /* "name" */
@@ -3045,6 +3091,17 @@ prepare_summary_table_headers(SummaryTable *summary)
 	{
 		int len = 0;
 		SummaryTableEntry *entry = &(summary->array[i]);
+
+		len = strlen(entry->datname);
+
+		if (len > 0)
+		{
+			int minLen = 8; /* "Database" */
+			len = (len > minLen) ? len : minLen;
+
+			if (headers->maxDatnameSize < len)
+				headers->maxDatnameSize = len;
+		}
 
 		len = strlen(entry->oidStr);
 
@@ -3104,6 +3161,8 @@ prepare_summary_table_headers(SummaryTable *summary)
 	}
 
 	/* now prepare the header line with dashes */
+	if (headers->maxDatnameSize > 0)
+		prepareLineSeparator(headers->datnameSeparator, headers->maxDatnameSize);
 	prepareLineSeparator(headers->oidSeparator, headers->maxOidSize);
 	prepareLineSeparator(headers->nspnameSeparator, headers->maxNspnameSize);
 	prepareLineSeparator(headers->relnameSeparator, headers->maxRelnameSize);

--- a/src/bin/pgcopydb/summary.c
+++ b/src/bin/pgcopydb/summary.c
@@ -2090,14 +2090,21 @@ summary_increment_timing(DatabaseCatalog *catalog,
 
 	TopLevelTiming *timing = &(topLevelTimingArray[section]);
 
+	/*
+	 * Use an upsert so that workers can increment a timing section even when
+	 * summary_start_timing was never called for that section in this catalog
+	 * (e.g. COPY_DATA in a per-database catalog opened by a global COPY worker
+	 * that never received a start-timing call from the orchestrator).
+	 */
 	char *sql =
-		"update timings "
-		"set count = coalesce(count, 0) + $1, "
-		"    bytes = coalesce(bytes, 0) + $2, "
-		"    duration = coalesce(duration, 0) + $3 "
-		"where id = $4";
+		"insert into timings(id, label, count, bytes, duration) "
+		"values($4, $5, $1, $2, $3) "
+		"on conflict(id) do update set "
+		"  count    = coalesce(timings.count,    0) + excluded.count, "
+		"  bytes    = coalesce(timings.bytes,    0) + excluded.bytes, "
+		"  duration = coalesce(timings.duration, 0) + excluded.duration";
 
-	SQLiteQuery query = { .errorOnZeroRows = true };
+	SQLiteQuery query = { 0 };
 
 	if (!catalog_sql_prepare(db, sql, &query))
 	{
@@ -2111,7 +2118,8 @@ summary_increment_timing(DatabaseCatalog *catalog,
 		{ BIND_PARAMETER_TYPE_INT64, "count", count, NULL },
 		{ BIND_PARAMETER_TYPE_INT64, "bytes", bytes, NULL },
 		{ BIND_PARAMETER_TYPE_INT64, "duration", durationMs, NULL },
-		{ BIND_PARAMETER_TYPE_INT, "id", timing->section, NULL }
+		{ BIND_PARAMETER_TYPE_INT, "id", timing->section, NULL },
+		{ BIND_PARAMETER_TYPE_TEXT, "label", 0, (char *) timing->label }
 	};
 
 	int pCount = sizeof(params) / sizeof(params[0]);
@@ -2861,7 +2869,7 @@ print_summary_table(SummaryTable *summary)
 				headers->maxTableMsSize, "copy duration",
 				headers->maxBytesSize, "transmitted bytes",
 				headers->maxIndexCountSize, "indexes",
-				headers->maxIndexMsSize, "create index duration");
+				headers->maxIndexMsSize, "create index");
 
 		fformat(stdout, "%s-+-%s-+-%s-+-%s-+-%s-+-%s-+-%s-+-%s-+-%s\n",
 				headers->datnameSeparator,
@@ -2884,7 +2892,7 @@ print_summary_table(SummaryTable *summary)
 				headers->maxTableMsSize, "copy duration",
 				headers->maxBytesSize, "transmitted bytes",
 				headers->maxIndexCountSize, "indexes",
-				headers->maxIndexMsSize, "create index duration");
+				headers->maxIndexMsSize, "create index");
 
 		fformat(stdout, "%s-+-%s-+-%s-+-%s-+-%s-+-%s-+-%s-+-%s\n",
 				headers->oidSeparator,
@@ -3084,7 +3092,7 @@ prepare_summary_table_headers(SummaryTable *summary)
 	headers->maxTableMsSize = 13;   /* "copy duration" */
 	headers->maxBytesSize = 17;     /* "transmitted bytes" */
 	headers->maxIndexCountSize = 7; /* "indexes" */
-	headers->maxIndexMsSize = 21;   /* "create index duration" */
+	headers->maxIndexMsSize = 12;   /* "create index" */
 
 	/* now adjust to the actual table's content */
 	for (int i = 0; i < summary->count; i++)

--- a/src/bin/pgcopydb/summary.c
+++ b/src/bin/pgcopydb/summary.c
@@ -2098,7 +2098,7 @@ summary_increment_timing(DatabaseCatalog *catalog,
 	 */
 	char *sql =
 		"insert into timings(id, label, count, bytes, duration) "
-		"values($4, $5, $1, $2, $3) "
+		"values($1, $2, $3, $4, $5) "
 		"on conflict(id) do update set "
 		"  count    = coalesce(timings.count,    0) + excluded.count, "
 		"  bytes    = coalesce(timings.bytes,    0) + excluded.bytes, "
@@ -2115,11 +2115,11 @@ summary_increment_timing(DatabaseCatalog *catalog,
 
 	/* bind our parameters now */
 	BindParam params[] = {
-		{ BIND_PARAMETER_TYPE_INT64, "count", count, NULL },
-		{ BIND_PARAMETER_TYPE_INT64, "bytes", bytes, NULL },
+		{ BIND_PARAMETER_TYPE_INT,   "id",       timing->section, NULL },
+		{ BIND_PARAMETER_TYPE_TEXT,  "label",    0, (char *) timing->label },
+		{ BIND_PARAMETER_TYPE_INT64, "count",    count, NULL },
+		{ BIND_PARAMETER_TYPE_INT64, "bytes",    bytes, NULL },
 		{ BIND_PARAMETER_TYPE_INT64, "duration", durationMs, NULL },
-		{ BIND_PARAMETER_TYPE_INT, "id", timing->section, NULL },
-		{ BIND_PARAMETER_TYPE_TEXT, "label", 0, (char *) timing->label }
 	};
 
 	int pCount = sizeof(params) / sizeof(params[0]);
@@ -2454,15 +2454,45 @@ catalog_timing_fetch(SQLiteQuery *query)
 {
 	TopLevelTiming *timing = (TopLevelTiming *) query->context;
 
-	/* cleanup the memory area before re-use */
-	bzero(timing, sizeof(TopLevelTiming));
+	/*
+	 * Preserve fields that live only in memory, not in the database.  When
+	 * this function is called with &topLevelTimingArray[N] as the context
+	 * (e.g. from summary_lookup_timing or summary_increment_timing), a full
+	 * bzero would clobber the static initialiser values for conn, cumulative,
+	 * jobsMask, and startTimeInstr, corrupting every subsequent use of that
+	 * array entry.
+	 */
+	const char *savedConn = timing->conn;
+	char *savedLabel = timing->label;
+	bool savedCumulative = timing->cumulative;
+	uint32_t savedJobsMask = timing->jobsMask;
+	instr_time savedStartTimeInstr = timing->startTimeInstr;
+	instr_time savedDurationInstr = timing->durationInstr;
+
+	/* Reset only the DB-sourced fields */
+	timing->section = 0;
+	timing->label = NULL;
+	timing->startTime = 0;
+	timing->doneTime = 0;
+	timing->durationMs = 0;
+	memset(timing->ppDuration, 0, sizeof(timing->ppDuration));
+	timing->count = 0;
+	timing->bytes = 0;
+	memset(timing->ppBytes, 0, sizeof(timing->ppBytes));
+
+	/* Restore memory-only fields */
+	timing->conn = savedConn;
+	timing->cumulative = savedCumulative;
+	timing->jobsMask = savedJobsMask;
+	timing->startTimeInstr = savedStartTimeInstr;
+	timing->durationInstr = savedDurationInstr;
 
 	/* the section is an Enum in memory, an integer value on-disk */
 	timing->section = sqlite3_column_int(query->ppStmt, 0);
 
 	if (sqlite3_column_type(query->ppStmt, 1) == SQLITE_NULL)
 	{
-		timing->label = NULL;
+		timing->label = savedLabel;
 	}
 	else
 	{

--- a/src/bin/pgcopydb/summary.c
+++ b/src/bin/pgcopydb/summary.c
@@ -6,6 +6,7 @@
 #include <errno.h>
 #include <getopt.h>
 #include <inttypes.h>
+#include <string.h>
 #include <unistd.h>
 
 #include "parson.h"
@@ -113,6 +114,31 @@ TopLevelTiming topLevelTimingArray[] = {
 
 int topLevelTimingArrayCount =
 	sizeof(topLevelTimingArray) / sizeof(topLevelTimingArray[0]);
+
+
+/*
+ * summary_reset_toplevel_timings zeroes the dynamic timing fields of the
+ * global topLevelTimingArray. Call this in a freshly-forked child before the
+ * first clone so stale values from the parent process don't bleed into
+ * copydb_fetch_previous_run_state for the new database.
+ */
+void
+summary_reset_toplevel_timings(void)
+{
+	for (int i = 0; i < topLevelTimingArrayCount; i++)
+	{
+		TopLevelTiming *t = &(topLevelTimingArray[i]);
+		t->startTime = 0;
+		t->doneTime = 0;
+		t->durationMs = 0;
+		memset(&t->startTimeInstr, 0, sizeof(t->startTimeInstr));
+		memset(&t->durationInstr, 0, sizeof(t->durationInstr));
+		memset(t->ppDuration, 0, sizeof(t->ppDuration));
+		t->count = 0;
+		t->bytes = 0;
+		memset(t->ppBytes, 0, sizeof(t->ppBytes));
+	}
+}
 
 
 static void prepareLineSeparator(char dashes[], int size);

--- a/src/bin/pgcopydb/summary.c
+++ b/src/bin/pgcopydb/summary.c
@@ -2115,10 +2115,10 @@ summary_increment_timing(DatabaseCatalog *catalog,
 
 	/* bind our parameters now */
 	BindParam params[] = {
-		{ BIND_PARAMETER_TYPE_INT,   "id",       timing->section, NULL },
-		{ BIND_PARAMETER_TYPE_TEXT,  "label",    0, (char *) timing->label },
-		{ BIND_PARAMETER_TYPE_INT64, "count",    count, NULL },
-		{ BIND_PARAMETER_TYPE_INT64, "bytes",    bytes, NULL },
+		{ BIND_PARAMETER_TYPE_INT, "id", timing->section, NULL },
+		{ BIND_PARAMETER_TYPE_TEXT, "label", 0, (char *) timing->label },
+		{ BIND_PARAMETER_TYPE_INT64, "count", count, NULL },
+		{ BIND_PARAMETER_TYPE_INT64, "bytes", bytes, NULL },
 		{ BIND_PARAMETER_TYPE_INT64, "duration", durationMs, NULL },
 	};
 
@@ -3138,7 +3138,9 @@ prepare_summary_table_headers(SummaryTable *summary)
 			len = (len > minLen) ? len : minLen;
 
 			if (headers->maxDatnameSize < len)
+			{
 				headers->maxDatnameSize = len;
+			}
 		}
 
 		len = strlen(entry->oidStr);
@@ -3200,7 +3202,9 @@ prepare_summary_table_headers(SummaryTable *summary)
 
 	/* now prepare the header line with dashes */
 	if (headers->maxDatnameSize > 0)
+	{
 		prepareLineSeparator(headers->datnameSeparator, headers->maxDatnameSize);
+	}
 	prepareLineSeparator(headers->oidSeparator, headers->maxOidSize);
 	prepareLineSeparator(headers->nspnameSeparator, headers->maxNspnameSize);
 	prepareLineSeparator(headers->relnameSeparator, headers->maxRelnameSize);

--- a/src/bin/pgcopydb/summary.h
+++ b/src/bin/pgcopydb/summary.h
@@ -88,6 +88,7 @@ typedef struct CopyBlobsSummary
  */
 typedef struct SummaryTableHeaders
 {
+	int maxDatnameSize;             /* 0 means: don't show the database column */
 	int maxOidSize;
 	int maxNspnameSize;
 	int maxRelnameSize;
@@ -97,6 +98,7 @@ typedef struct SummaryTableHeaders
 	int maxIndexCountSize;
 	int maxIndexMsSize;
 
+	char datnameSeparator[NAMEDATALEN];
 	char oidSeparator[NAMEDATALEN];
 	char nspnameSeparator[NAMEDATALEN];
 	char relnameSeparator[NAMEDATALEN];
@@ -131,6 +133,7 @@ typedef struct SummaryTableEntry
 {
 	uint32_t oid;
 	char oidStr[INTSTRING_MAX_DIGITS];
+	char datname[PG_NAMEDATALEN];   /* empty unless --all-databases */
 	char nspname[PG_NAMEDATALEN];
 	char relname[PG_NAMEDATALEN];
 	char partCount[INTSTRING_MAX_DIGITS];
@@ -247,6 +250,8 @@ void print_summary_as_json(Summary *summary, const char *filename);
 void print_toplevel_summary(Summary *summary);
 void print_summary_table(SummaryTable *summary);
 void prepare_summary_table_headers(SummaryTable *summary);
+struct CopyDataSpec;  /* forward declaration to avoid circular include */
+bool prepare_summary_table(Summary *summary, struct CopyDataSpec *specs);
 
 int TopLevelTimingConcurrency(Summary *summary, TopLevelTiming *timing);
 

--- a/src/bin/pgcopydb/summary.h
+++ b/src/bin/pgcopydb/summary.h
@@ -159,6 +159,9 @@ typedef struct SummaryTable
  * Keep track of the timing for the main steps of the pgcopydb operations.
  */
 extern TopLevelTiming topLevelTimingArray[];
+extern int topLevelTimingArrayCount;
+
+void summary_reset_toplevel_timings(void);
 
 typedef struct Summary
 {

--- a/src/bin/pgcopydb/table-data.c
+++ b/src/bin/pgcopydb/table-data.c
@@ -1728,15 +1728,13 @@ copydb_copy_worker_queue_tables_multidb(CopyDataSpec *parentSpecs)
 		strlcat(sdb.dbfile, "/schema/source.db", sizeof(sdb.dbfile));
 
 		/*
-		 * Reuse the pre-created shared semaphore so catalog_create_semaphore
-		 * does not allocate a new System V semaphore in this child process.
-		 * The system_res_array has a fixed capacity (SYSV_RES_MAX_COUNT) and
-		 * child processes inherit the parent's full count — creating per-db
-		 * semaphores here exhausts that capacity.
+		 * Reuse the parent-created semaphore set slot so that
+		 * catalog_create_semaphore does not allocate a new SysV semaphore.
 		 */
 		if (info->catalogSemId != 0)
 		{
-			sdb.sema.semId = info->catalogSemId;
+			sdb.sema.semId    = info->catalogSemId;
+			sdb.sema.semIndex = info->catalogSemIndex;
 			sdb.sema.reentrant = true;
 		}
 

--- a/src/bin/pgcopydb/table-data.c
+++ b/src/bin/pgcopydb/table-data.c
@@ -1620,3 +1620,360 @@ copydb_check_table_exists(PGSQL *pgsql, SourceTable *table, bool *exists)
 
 	return locked || !(*exists);
 }
+
+
+/* ============================================================
+ * Cross-database global COPY functions (--all-databases)
+ * ============================================================ */
+
+/*
+ * copydb_add_copy_for_db sends a TABLEPOID message that includes the target
+ * database name, used by copydb_table_data_worker_multidb to route work.
+ */
+bool
+copydb_add_copy_for_db(CopyDataSpec *specs, uint32_t oid, uint32_t part,
+					   const char *datname)
+{
+	QMessage mesg = {
+		.type = QMSG_TYPE_TABLEPOID,
+		.data.tp = { .oid = oid, .part = part }
+	};
+
+	strlcpy(mesg.data.tp.datname, datname, sizeof(mesg.data.tp.datname));
+
+	if (!queue_send(&(specs->copyQueue), &mesg))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * compare_multidb_table_entry_by_bytes is a qsort comparison function that
+ * sorts MultiDbTableEntry by bytes descending (largest tables first).
+ */
+static int
+compare_multidb_table_entry_by_bytes(const void *a, const void *b)
+{
+	const MultiDbTableEntry *ta = (const MultiDbTableEntry *) a;
+	const MultiDbTableEntry *tb = (const MultiDbTableEntry *) b;
+
+	if (ta->bytes > tb->bytes)
+		return -1;
+	else if (ta->bytes < tb->bytes)
+		return 1;
+	return 0;
+}
+
+
+/*
+ * copydb_copy_worker_queue_tables_multidb is the supervisor process for the
+ * global COPY phase.  It opens each per-database source catalog, collects all
+ * tables with their sizes, sorts them by size descending, enqueues them, then
+ * sends STOP messages.
+ */
+bool
+copydb_copy_worker_queue_tables_multidb(CopyDataSpec *parentSpecs)
+{
+	int dbCount = parentSpecs->multiDbCount;
+	MultiDbInfo *infos = parentSpecs->multiDbInfos;
+
+	if (dbCount == 0)
+	{
+		log_info("No databases to process in global COPY supervisor");
+		return true;
+	}
+
+	/*
+	 * We collect all table entries from all databases into a dynamic array,
+	 * then sort and enqueue.
+	 */
+	int capacity = 4096;
+	int count = 0;
+
+	MultiDbTableEntry *entries =
+		(MultiDbTableEntry *) malloc(capacity * sizeof(MultiDbTableEntry));
+
+	if (entries == NULL)
+	{
+		log_error(ALLOCATION_FAILED_ERROR);
+		return false;
+	}
+
+	for (int dbIdx = 0; dbIdx < dbCount; dbIdx++)
+	{
+		MultiDbInfo *info = &infos[dbIdx];
+
+		log_info("Global COPY supervisor: reading table catalog for \"%s\"",
+				 info->datname);
+
+		/* open the per-database source catalog read-only */
+		DatabaseCatalog sdb = { 0 };
+		sdb.type = DATABASE_CATALOG_TYPE_SOURCE;
+		strlcpy(sdb.dbfile, info->topdir, sizeof(sdb.dbfile));
+		strlcat(sdb.dbfile, "/schema/source.db", sizeof(sdb.dbfile));
+
+		if (!catalog_open(&sdb))
+		{
+			log_error("Failed to open source catalog for database \"%s\"",
+					  info->datname);
+			free(entries);
+			return false;
+		}
+
+		/* iterate tables in this database's catalog */
+		SourceTableIterator iter = { .catalog = &sdb, .table = NULL };
+
+		if (!catalog_iter_s_table_init(&iter))
+		{
+			log_error("Failed to init table iterator for database \"%s\"",
+					  info->datname);
+			catalog_close(&sdb);
+			free(entries);
+			return false;
+		}
+
+		for (;;)
+		{
+			if (!catalog_iter_s_table_next(&iter))
+			{
+				log_error("Failed to iterate tables for database \"%s\"",
+						  info->datname);
+				catalog_iter_s_table_finish(&iter);
+				catalog_close(&sdb);
+				free(entries);
+				return false;
+			}
+
+			SourceTable *table = iter.table;
+
+			if (table == NULL)
+				break;  /* end of results */
+
+			/* grow array if needed */
+			if (count >= capacity)
+			{
+				capacity *= 2;
+				MultiDbTableEntry *newEntries =
+					(MultiDbTableEntry *) realloc(entries,
+												  capacity * sizeof(MultiDbTableEntry));
+				if (newEntries == NULL)
+				{
+					log_error(ALLOCATION_FAILED_ERROR);
+					catalog_iter_s_table_finish(&iter);
+					catalog_close(&sdb);
+					free(entries);
+					return false;
+				}
+				entries = newEntries;
+			}
+
+			MultiDbTableEntry *e = &entries[count++];
+			strlcpy(e->datname, info->datname, sizeof(e->datname));
+			e->oid = table->oid;
+			e->bytes = table->bytes;
+			e->excludeData = table->excludeData;
+			e->partCount = table->partition.partCount;
+		}
+
+		if (!catalog_iter_s_table_finish(&iter))
+		{
+			log_warn("Failed to finish table iterator for database \"%s\"",
+					 info->datname);
+		}
+
+		if (!catalog_close(&sdb))
+		{
+			log_warn("Failed to close source catalog for database \"%s\"",
+					 info->datname);
+		}
+	}
+
+	log_info("Global COPY supervisor: sorting %d tables across %d databases",
+			 count, dbCount);
+
+	/* sort all tables by bytes descending */
+	qsort(entries, count, sizeof(MultiDbTableEntry),
+		  compare_multidb_table_entry_by_bytes);
+
+	/* enqueue all tables */
+	uint64_t tableCount = 0;
+	uint64_t partCount = 0;
+
+	for (int i = 0; i < count; i++)
+	{
+		MultiDbTableEntry *e = &entries[i];
+
+		if (e->excludeData)
+			continue;
+
+		if (e->partCount == 0)
+		{
+			/* unpartitioned table */
+			if (!copydb_add_copy_for_db(parentSpecs, e->oid, 0, e->datname))
+			{
+				log_error("Failed to enqueue table oid %u from database \"%s\"",
+						  e->oid, e->datname);
+				free(entries);
+				return false;
+			}
+			tableCount++;
+		}
+		else
+		{
+			/* partitioned table: enqueue each partition separately */
+			for (int p = 1; p <= e->partCount; p++)
+			{
+				if (!copydb_add_copy_for_db(parentSpecs, e->oid, p, e->datname))
+				{
+					log_error("Failed to enqueue table oid %u part %d "
+							  "from database \"%s\"",
+							  e->oid, p, e->datname);
+					free(entries);
+					return false;
+				}
+				partCount++;
+			}
+		}
+	}
+
+	free(entries);
+
+	log_info("Global COPY supervisor: enqueued %llu tables and %llu partitions",
+			 (unsigned long long) tableCount,
+			 (unsigned long long) partCount);
+
+	/* send one STOP message per worker */
+	for (int i = 0; i < parentSpecs->tableJobs; i++)
+	{
+		QMessage stop = { .type = QMSG_TYPE_STOP };
+
+		if (!queue_send(&(parentSpecs->copyQueue), &stop))
+		{
+			log_error("Failed to send STOP message to global COPY queue");
+			return false;
+		}
+	}
+
+	return true;
+}
+
+
+/*
+ * copydb_table_data_worker_multidb is a COPY worker process for the global
+ * cross-database COPY phase.  It dequeues messages from the shared copyQueue,
+ * using a MultiDbContext to manage per-database connections.
+ */
+bool
+copydb_table_data_worker_multidb(CopyDataSpec *parentSpecs)
+{
+	uint64_t errors = 0;
+	pid_t pid = getpid();
+
+	log_notice("Started global COPY worker %d [%d]", pid, getppid());
+
+	MultiDbContext ctx = { 0 };
+
+	if (!multidb_context_init(&ctx, parentSpecs))
+	{
+		log_error("Failed to initialise multi-database context");
+		return false;
+	}
+
+	bool stop = false;
+
+	while (!stop)
+	{
+		QMessage mesg = { 0 };
+		bool recv_ok = queue_receive(&(parentSpecs->copyQueue), &mesg);
+
+		if (asked_to_stop || asked_to_stop_fast || asked_to_quit)
+		{
+			log_error("Global COPY worker has been interrupted");
+			break;
+		}
+
+		if (!recv_ok)
+		{
+			log_error("Global COPY worker failed to receive message from queue");
+			break;
+		}
+
+		switch (mesg.type)
+		{
+			case QMSG_TYPE_STOP:
+			{
+				stop = true;
+				log_debug("Stop message received by global COPY worker");
+				break;
+			}
+
+			case QMSG_TYPE_TABLEPOID:
+			{
+				const char *datname = mesg.data.tp.datname;
+				uint32_t oid = mesg.data.tp.oid;
+				uint32_t part = mesg.data.tp.part;
+
+				MultiDbEntry *entry =
+					multidb_context_get_entry(&ctx, datname);
+
+				if (entry == NULL)
+				{
+					log_error("Failed to get connection for database \"%s\", "
+							  "skipping table oid %u part %u",
+							  datname, oid, part);
+					++errors;
+
+					if (parentSpecs->failFast)
+					{
+						(void) multidb_context_close_all(&ctx);
+						return false;
+					}
+					break;
+				}
+
+				PGSQL *src = &(entry->dbSpecs->sourceSnapshot.pgsql);
+				PGSQL *dst = &(entry->dst);
+
+				if (!copydb_copy_data_by_oid(entry->dbSpecs, src, dst, oid, part))
+				{
+					log_error("Failed to copy table oid %u part %u "
+							  "from database \"%s\"",
+							  oid, part, datname);
+					++errors;
+
+					if (parentSpecs->failFast)
+					{
+						(void) multidb_context_close_all(&ctx);
+						return false;
+					}
+
+					/*
+					 * The snapshot connection might be in a bad state after
+					 * an error; close and re-open the entry.
+					 */
+					(void) multidb_context_close_entry(entry);
+				}
+				break;
+			}
+
+			default:
+			{
+				log_error("Received unknown message type %ld on global copy queue %d",
+						  mesg.type,
+						  parentSpecs->copyQueue.qId);
+				break;
+			}
+		}
+	}
+
+	(void) multidb_context_close_all(&ctx);
+
+	log_notice("Global COPY worker %d finished with %llu error(s)",
+			   pid, (unsigned long long) errors);
+
+	return stop == true && errors == 0;
+}

--- a/src/bin/pgcopydb/table-data.c
+++ b/src/bin/pgcopydb/table-data.c
@@ -1549,7 +1549,17 @@ copydb_prepare_summary_command(CopyTableDataSpec *tableSpecs)
 
 	PQExpBuffer command = createPQExpBuffer();
 
-	appendPQExpBuffer(command, "COPY %s", tableSpecs->sourceTable->qname);
+	if (tableSpecs->allDatabases &&
+		!IS_EMPTY_STRING_BUFFER(tableSpecs->sourceTable->datname))
+	{
+		appendPQExpBuffer(command, "COPY %s.%s",
+						  tableSpecs->sourceTable->datname,
+						  tableSpecs->sourceTable->qname);
+	}
+	else
+	{
+		appendPQExpBuffer(command, "COPY %s", tableSpecs->sourceTable->qname);
+	}
 
 	if (tableSpecs->copyArgs.srcWhereClause != NULL)
 	{

--- a/src/bin/pgcopydb/table-data.c
+++ b/src/bin/pgcopydb/table-data.c
@@ -1029,7 +1029,8 @@ copydb_copy_data_by_oid(CopyDataSpec *specs, PGSQL *src, PGSQL *dst,
 				{
 					SourceTable *sourceTable = tableSpecs->sourceTable;
 
-					if (!vacuum_add_table(specs, sourceTable->oid))
+					if (!vacuum_add_table(specs, sourceTable->oid,
+									  sourceTable->datname))
 					{
 						log_error("Failed to queue VACUUM ANALYZE %s [%u]",
 								  sourceTable->qname,

--- a/src/bin/pgcopydb/table-data.c
+++ b/src/bin/pgcopydb/table-data.c
@@ -588,7 +588,7 @@ copydb_copy_supervisor_add_table_hook(void *ctx, SourceTable *table)
 			 */
 			(void) pgsql_get_table_relkind(dst, table->qname, &relkind);
 
-			if (!pgsql_truncate(dst, table->qname, relkind))
+			if (!pgsql_truncate(dst, table->qname, relkind, table->datname))
 			{
 				/* errors have already been logged */
 				return false;
@@ -1030,7 +1030,7 @@ copydb_copy_data_by_oid(CopyDataSpec *specs, PGSQL *src, PGSQL *dst,
 					SourceTable *sourceTable = tableSpecs->sourceTable;
 
 					if (!vacuum_add_table(specs, sourceTable->oid,
-									  sourceTable->datname))
+										  sourceTable->datname))
 					{
 						log_error("Failed to queue VACUUM ANALYZE %s [%u]",
 								  sourceTable->qname,
@@ -1137,6 +1137,7 @@ copydb_table_create_lockfile(CopyDataSpec *specs,
 	args->srcWhereClause = NULL;
 	args->dstQname = tableSpecs->sourceTable->qname;
 	args->dstAttrList = tableSpecs->sourceTable->attrList;
+	args->datname = tableSpecs->sourceTable->datname;
 	args->truncate = false;     /* default value, see below */
 	args->freeze = tableSpecs->sourceTable->partition.partCount <= 1;
 	args->useCopyBinary = specs->useCopyBinary;
@@ -1673,9 +1674,13 @@ compare_multidb_table_entry_by_bytes(const void *a, const void *b)
 	const MultiDbTableEntry *tb = (const MultiDbTableEntry *) b;
 
 	if (ta->bytes > tb->bytes)
+	{
 		return -1;
+	}
 	else if (ta->bytes < tb->bytes)
+	{
 		return 1;
+	}
 	return 0;
 }
 
@@ -1733,7 +1738,7 @@ copydb_copy_worker_queue_tables_multidb(CopyDataSpec *parentSpecs)
 		 */
 		if (info->catalogSemId != 0)
 		{
-			sdb.sema.semId    = info->catalogSemId;
+			sdb.sema.semId = info->catalogSemId;
 			sdb.sema.semIndex = info->catalogSemIndex;
 			sdb.sema.reentrant = true;
 		}
@@ -1773,7 +1778,9 @@ copydb_copy_worker_queue_tables_multidb(CopyDataSpec *parentSpecs)
 			SourceTable *table = iter.table;
 
 			if (table == NULL)
+			{
 				break;  /* end of results */
+			}
 
 			/* grow array if needed */
 			if (count >= capacity)
@@ -1818,7 +1825,7 @@ copydb_copy_worker_queue_tables_multidb(CopyDataSpec *parentSpecs)
 			 count, dbCount);
 
 	/* sort all tables by bytes descending */
-	qsort(entries, count, sizeof(MultiDbTableEntry),
+	qsort(entries, count, sizeof(MultiDbTableEntry),        /* IGNORE-BANNED */
 		  compare_multidb_table_entry_by_bytes);
 
 	/* enqueue all tables */
@@ -1830,7 +1837,9 @@ copydb_copy_worker_queue_tables_multidb(CopyDataSpec *parentSpecs)
 		MultiDbTableEntry *e = &entries[i];
 
 		if (e->excludeData)
+		{
 			continue;
+		}
 
 		if (e->partCount == 0)
 		{

--- a/src/bin/pgcopydb/table-data.c
+++ b/src/bin/pgcopydb/table-data.c
@@ -143,7 +143,7 @@ copydb_process_table_data(CopyDataSpec *specs)
 		/*
 		 * Start as many index worker process as --index-jobs
 		 */
-		if (errors == 0 && !copydb_start_index_supervisor(specs))
+		if (errors == 0 && !copydb_start_index_supervisor(specs, NULL))
 		{
 			/* errors have already been logged */
 			++errors;
@@ -154,7 +154,7 @@ copydb_process_table_data(CopyDataSpec *specs)
 		 * --table-jobs. Could be exposed separately as --vacuumJobs too, but
 		 * that's not been done at this time.
 		 */
-		if (errors == 0 && !vacuum_start_supervisor(specs))
+		if (errors == 0 && !vacuum_start_supervisor(specs, NULL))
 		{
 			/* errors have already been logged */
 			++errors;

--- a/src/bin/pgcopydb/table-data.c
+++ b/src/bin/pgcopydb/table-data.c
@@ -1727,6 +1727,19 @@ copydb_copy_worker_queue_tables_multidb(CopyDataSpec *parentSpecs)
 		strlcpy(sdb.dbfile, info->topdir, sizeof(sdb.dbfile));
 		strlcat(sdb.dbfile, "/schema/source.db", sizeof(sdb.dbfile));
 
+		/*
+		 * Reuse the pre-created shared semaphore so catalog_create_semaphore
+		 * does not allocate a new System V semaphore in this child process.
+		 * The system_res_array has a fixed capacity (SYSV_RES_MAX_COUNT) and
+		 * child processes inherit the parent's full count — creating per-db
+		 * semaphores here exhausts that capacity.
+		 */
+		if (info->catalogSemId != 0)
+		{
+			sdb.sema.semId = info->catalogSemId;
+			sdb.sema.reentrant = true;
+		}
+
 		if (!catalog_open(&sdb))
 		{
 			log_error("Failed to open source catalog for database \"%s\"",

--- a/src/bin/pgcopydb/vacuum.c
+++ b/src/bin/pgcopydb/vacuum.c
@@ -58,7 +58,9 @@ vacuum_start_supervisor(CopyDataSpec *specs, pid_t *pidOut)
 		{
 			/* fork succeeded, in parent */
 			if (pidOut != NULL)
+			{
 				*pidOut = fpid;
+			}
 			break;
 		}
 	}
@@ -391,9 +393,13 @@ vacuum_analyze_table_by_oid(CopyDataSpec *specs, uint32_t oid)
 	(void) set_ps_title(psTitle);
 
 	if (specs->datname[0] != '\0')
+	{
 		log_notice("%s: %s;", specs->datname, vacuum);
+	}
 	else
+	{
 		log_notice("%s;", vacuum);
+	}
 
 	/* also track the process information in our catalogs */
 	ProcessInfo ps = {

--- a/src/bin/pgcopydb/vacuum.c
+++ b/src/bin/pgcopydb/vacuum.c
@@ -21,7 +21,7 @@
  * vacuum_start_supervisor starts a VACUUM supervisor process.
  */
 bool
-vacuum_start_supervisor(CopyDataSpec *specs)
+vacuum_start_supervisor(CopyDataSpec *specs, pid_t *pidOut)
 {
 	/*
 	 * Flush stdio channels just before fork, to avoid double-output problems.
@@ -57,6 +57,8 @@ vacuum_start_supervisor(CopyDataSpec *specs)
 		default:
 		{
 			/* fork succeeded, in parent */
+			if (pidOut != NULL)
+				*pidOut = fpid;
 			break;
 		}
 	}

--- a/src/bin/pgcopydb/vacuum.c
+++ b/src/bin/pgcopydb/vacuum.c
@@ -390,7 +390,10 @@ vacuum_analyze_table_by_oid(CopyDataSpec *specs, uint32_t oid)
 	sformat(psTitle, sizeof(psTitle), "pgcopydb: %s", vacuum);
 	(void) set_ps_title(psTitle);
 
-	log_notice("%s;", vacuum);
+	if (specs->datname[0] != '\0')
+		log_notice("%s: %s;", specs->datname, vacuum);
+	else
+		log_notice("%s;", vacuum);
 
 	/* also track the process information in our catalogs */
 	ProcessInfo ps = {

--- a/src/bin/pgcopydb/vacuum.c
+++ b/src/bin/pgcopydb/vacuum.c
@@ -206,6 +206,22 @@ vacuum_worker(CopyDataSpec *specs)
 		return false;
 	}
 
+	/*
+	 * For --all-databases: maintain a lightweight pool keyed by datname.
+	 * Each entry holds a per-db CopyDataSpec (catalog + target URI) without
+	 * a source snapshot connection.
+	 */
+	MultiDbContext vacCtx = { 0 };
+
+	if (specs->allDatabases)
+	{
+		if (!multidb_context_init(&vacCtx, specs))
+		{
+			log_error("Failed to initialise vacuum multi-database context");
+			return false;
+		}
+	}
+
 	int errors = 0;
 	bool stop = false;
 
@@ -217,12 +233,14 @@ vacuum_worker(CopyDataSpec *specs)
 		if (asked_to_stop || asked_to_stop_fast || asked_to_quit)
 		{
 			log_error("VACUUM worker has been interrupted");
+			(void) multidb_index_context_close_all(&vacCtx);
 			return false;
 		}
 
 		if (!recv_ok)
 		{
 			/* errors have already been logged */
+			(void) multidb_index_context_close_all(&vacCtx);
 			return false;
 		}
 
@@ -237,16 +255,44 @@ vacuum_worker(CopyDataSpec *specs)
 
 			case QMSG_TYPE_TABLEOID:
 			{
-				if (!vacuum_analyze_table_by_oid(specs, mesg.data.oid))
+				uint32_t oid = mesg.data.tp.oid;
+				CopyDataSpec *useSpecs = specs;
+
+				if (specs->allDatabases)
+				{
+					const char *datname = mesg.data.tp.datname;
+					MultiDbEntry *entry =
+						multidb_index_context_get_entry(&vacCtx, datname);
+
+					if (entry == NULL)
+					{
+						log_error("Failed to get context for database \"%s\", "
+								  "skipping VACUUM of table oid %u",
+								  datname, oid);
+						++errors;
+
+						if (specs->failFast)
+						{
+							(void) multidb_index_context_close_all(&vacCtx);
+							return false;
+						}
+						break;
+					}
+
+					useSpecs = entry->dbSpecs;
+				}
+
+				if (!vacuum_analyze_table_by_oid(useSpecs, oid))
 				{
 					++errors;
 
 					log_error("Failed to vacuum table with oid %u, "
 							  "see above for details",
-							  mesg.data.oid);
+							  oid);
 
 					if (specs->failFast)
 					{
+						(void) multidb_index_context_close_all(&vacCtx);
 						return false;
 					}
 				}
@@ -262,6 +308,8 @@ vacuum_worker(CopyDataSpec *specs)
 			}
 		}
 	}
+
+	(void) multidb_index_context_close_all(&vacCtx);
 
 	if (!catalog_delete_process(&(specs->catalogs.source), pid))
 	{
@@ -396,14 +444,18 @@ vacuum_analyze_table_by_oid(CopyDataSpec *specs, uint32_t oid)
  * given table.
  */
 bool
-vacuum_add_table(CopyDataSpec *specs, uint32_t oid)
+vacuum_add_table(CopyDataSpec *specs, uint32_t oid, const char *datname)
 {
 	QMessage mesg = {
 		.type = QMSG_TYPE_TABLEOID,
-		.data.oid = oid
+		.data.tp.oid = oid,
 	};
 
-	log_debug("vacuum_add_table: %u", oid);
+	strlcpy(mesg.data.tp.datname,
+			datname != NULL ? datname : "",
+			sizeof(mesg.data.tp.datname));
+
+	log_debug("vacuum_add_table: %u \"%s\"", oid, mesg.data.tp.datname);
 
 	if (!queue_send(&(specs->vacuumQueue), &mesg))
 	{

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -6,7 +6,7 @@ export PGVERSION
 BUILD_ARGS = --build-arg PGVERSION=$(PGVERSION)
 
 all: pagila pagila-multi-steps blobs unit filtering extensions \
-	 partitioned-target \
+	 partitioned-target all-databases \
 	 cdc-wal2json cdc-test-decoding cdc-endpos-mid-txn cdc-low-level \
 	 cdc-replica-identity-index cdc-partitioned-target \
 	 cdc-endpos-in-multi-wal-txn cdc-file-rotation \
@@ -88,17 +88,26 @@ build:
 	  && echo "pagila image already present — skipping build (run 'make force-build' to rebuild)" \
 	  || docker build $(BUILD_ARGS) -t pagila -f Dockerfile.pagila .
 
-# Force a full rebuild even when the pagila image already exists locally
-# (use after Dockerfile.pagila changes or when switching PGVERSION)
+build-multi:
+	@docker image inspect multi > /dev/null 2>&1 \
+	  && echo "multi image already present — skipping build (run 'make force-build' to rebuild)" \
+	  || docker build $(BUILD_ARGS) -t multi -f Dockerfile.multi .
+
+# Force a full rebuild even when the images already exist locally
+# (use after Dockerfile changes or when switching PGVERSION)
 force-build:
 	docker build $(BUILD_ARGS) -t pagila -f Dockerfile.pagila .
+	docker build $(BUILD_ARGS) -t multi -f Dockerfile.multi .
 
-# Remove the cached pagila image so the next test starts from scratch
+all-databases: build-multi
+	$(MAKE) -C $@
+
+# Remove the cached images so the next test starts from scratch
 clean-images:
-	-docker rmi pagila 2>/dev/null; true
+	-docker rmi pagila multi 2>/dev/null; true
 
-.PHONY: all build force-build clean-images
-.PHONY: pagila pagila-multi-steps blobs unit filtering partitioned-target extensions
+.PHONY: all build build-pagila build-multi force-build clean-images
+.PHONY: pagila pagila-multi-steps blobs unit filtering partitioned-target extensions all-databases
 .PHONY: cdc-wal2json cdc-test-decoding cdc-endpos-mid-txn cdc-low-level cdc-replica-identity-index cdc-partitioned-target
 .PHONY: cdc-endpos-in-multi-wal-txn cdc-file-rotation
 .PHONY: cdc-pgoutput cdc-filtering-pgoutput follow-pgoutput

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -102,12 +102,16 @@ force-build:
 all-databases: build-multi
 	$(MAKE) -C $@
 
+three-databases: build-multi
+	$(MAKE) -C $@
+
 # Remove the cached images so the next test starts from scratch
 clean-images:
 	-docker rmi pagila multi 2>/dev/null; true
 
 .PHONY: all build build-pagila build-multi force-build clean-images
-.PHONY: pagila pagila-multi-steps blobs unit filtering partitioned-target extensions all-databases
+.PHONY: pagila pagila-multi-steps blobs unit filtering partitioned-target extensions
+.PHONY: all-databases three-databases
 .PHONY: cdc-wal2json cdc-test-decoding cdc-endpos-mid-txn cdc-low-level cdc-replica-identity-index cdc-partitioned-target
 .PHONY: cdc-endpos-in-multi-wal-txn cdc-file-rotation
 .PHONY: cdc-pgoutput cdc-filtering-pgoutput follow-pgoutput

--- a/tests/all-databases/Dockerfile
+++ b/tests/all-databases/Dockerfile
@@ -1,0 +1,10 @@
+# that image is built by docker compose build: project-service
+FROM multi
+
+COPY --from=pgcopydb /usr/local/bin/pgcopydb /usr/local/bin
+
+WORKDIR /usr/src/pgcopydb
+COPY copydb.sh copydb.sh
+
+USER docker
+CMD ["/usr/src/pgcopydb/copydb.sh"]

--- a/tests/all-databases/Makefile
+++ b/tests/all-databases/Makefile
@@ -1,0 +1,15 @@
+# Copyright (c) 2021 The PostgreSQL Global Development Group.
+# Licensed under the PostgreSQL License.
+
+test: down run down ;
+
+run: build
+	docker compose run test
+
+down:
+	docker compose down
+
+build:
+	docker compose build --quiet
+
+.PHONY: down build test

--- a/tests/all-databases/compose.yaml
+++ b/tests/all-databases/compose.yaml
@@ -1,0 +1,35 @@
+services:
+  source:
+    image: postgres:${PGVERSION:-16}
+    expose:
+      - 5432
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: ""
+      POSTGRES_HOST_AUTH_METHOD: trust
+  target:
+    image: postgres:${PGVERSION:-16}
+    expose:
+      - 5432
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: ""
+      POSTGRES_HOST_AUTH_METHOD: trust
+  test:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    cap_add:
+      - SYS_ADMIN
+      - SYS_PTRACE
+    environment:
+      PGCOPYDB_SOURCE_PGURI: postgres://postgres@source/postgres
+      PGCOPYDB_TARGET_PGURI: postgres://postgres@target/postgres
+      PGCOPYDB_TABLE_JOBS: 4
+      PGCOPYDB_INDEX_JOBS: 4
+      PGCOPYDB_FAIL_FAST: "true"
+    depends_on:
+      source:
+        condition: service_started
+      target:
+        condition: service_started

--- a/tests/all-databases/copydb.sh
+++ b/tests/all-databases/copydb.sh
@@ -1,0 +1,61 @@
+#! /bin/bash
+
+set -x
+set -e
+
+# This script expects the following environment variables to be set:
+#
+#  - PGCOPYDB_SOURCE_PGURI
+#  - PGCOPYDB_TARGET_PGURI
+#  - PGCOPYDB_TABLE_JOBS
+#  - PGCOPYDB_INDEX_JOBS
+
+# make sure source and target databases are ready
+pgcopydb ping
+
+#
+# Load pagila database on source
+#
+createdb -h source -U postgres pagila
+psql -o /tmp/pagila-schema.out -h source -U postgres -d pagila \
+     -1 -f /usr/src/pagila/pagila-schema.sql
+psql -o /tmp/pagila-data.out -h source -U postgres -d pagila \
+     -1 -f /usr/src/pagila/pagila-data.sql
+
+#
+# Load f1db database on source (pg_restore from custom-format dump)
+#
+createdb -h source -U postgres f1db
+pg_restore -h source -U postgres -d f1db --no-owner --no-privileges \
+           /usr/src/f1db/f1db.dump
+
+#
+# Load chinook database on source (the SQL file creates its own database)
+#
+psql -h source -U postgres -f /usr/src/chinook/Chinook_PostgreSql.sql
+
+#
+# Clone all databases from source to target using --all-databases
+#
+pgcopydb clone --all-databases \
+         --notice \
+         --skip-collations \
+         --skip-large-objects \
+         --source "${PGCOPYDB_SOURCE_PGURI}" \
+         --target "${PGCOPYDB_TARGET_PGURI}"
+
+#
+# Verify each database: schema and data must match.
+# Point --dir at the per-database work directory created by --all-databases.
+#
+for db in pagila f1db chinook; do
+    pgcopydb compare schema \
+             --source "postgres://postgres@source/${db}" \
+             --target "postgres://postgres@target/${db}" \
+             --dir "/tmp/pgcopydb/db/${db}"
+
+    pgcopydb compare data \
+             --source "postgres://postgres@source/${db}" \
+             --target "postgres://postgres@target/${db}" \
+             --dir "/tmp/pgcopydb/db/${db}"
+done

--- a/tests/all-databases/copydb.sh
+++ b/tests/all-databases/copydb.sh
@@ -55,3 +55,21 @@ pgcopydb compare data \
          --source "${PGCOPYDB_SOURCE_PGURI}" \
          --target "${PGCOPYDB_TARGET_PGURI}" \
          --dir "/tmp/pgcopydb"
+
+#
+# Debug: dump timing tables from per-database catalogs
+#
+echo "=== Timing table dump ==="
+for db in pagila f1db chinook; do
+    dbfile="/tmp/pgcopydb/db/${db}/schema/source.db"
+    if [ -f "${dbfile}" ]; then
+        echo "--- ${db}: timings ---"
+        sqlite3 -separator '|' "${dbfile}" \
+            "select id, label, duration, count, bytes from timings order by id;"
+        echo "--- ${db}: summary count ---"
+        sqlite3 "${dbfile}" \
+            "select count(*), sum(duration), sum(bytes) from summary where done_time_epoch > 0;"
+    else
+        echo "--- ${db}: source.db not found at ${dbfile}"
+    fi
+done

--- a/tests/all-databases/copydb.sh
+++ b/tests/all-databases/copydb.sh
@@ -45,17 +45,18 @@ pgcopydb clone --all-databases \
          --target "${PGCOPYDB_TARGET_PGURI}"
 
 #
-# Verify each database: schema and data must match.
-# Point --dir at the per-database work directory created by --all-databases.
+# Verify all databases at once using --all-databases.
+# Point --source/--target at the instance URIs (same as used for clone).
+# --dir is the top-level work directory so compare can find the per-db catalogs.
 #
-for db in pagila f1db chinook; do
-    pgcopydb compare schema \
-             --source "postgres://postgres@source/${db}" \
-             --target "postgres://postgres@target/${db}" \
-             --dir "/tmp/pgcopydb/db/${db}"
+pgcopydb compare schema \
+         --all-databases \
+         --source "${PGCOPYDB_SOURCE_PGURI}" \
+         --target "${PGCOPYDB_TARGET_PGURI}" \
+         --dir "/tmp/pgcopydb"
 
-    pgcopydb compare data \
-             --source "postgres://postgres@source/${db}" \
-             --target "postgres://postgres@target/${db}" \
-             --dir "/tmp/pgcopydb/db/${db}"
-done
+pgcopydb compare data \
+         --all-databases \
+         --source "${PGCOPYDB_SOURCE_PGURI}" \
+         --target "${PGCOPYDB_TARGET_PGURI}" \
+         --dir "/tmp/pgcopydb"

--- a/tests/all-databases/copydb.sh
+++ b/tests/all-databases/copydb.sh
@@ -44,11 +44,6 @@ pgcopydb clone --all-databases \
          --source "${PGCOPYDB_SOURCE_PGURI}" \
          --target "${PGCOPYDB_TARGET_PGURI}"
 
-#
-# Verify all databases at once using --all-databases.
-# Point --source/--target at the instance URIs (same as used for clone).
-# --dir is the top-level work directory so compare can find the per-db catalogs.
-#
 pgcopydb compare schema \
          --all-databases \
          --source "${PGCOPYDB_SOURCE_PGURI}" \

--- a/tests/three-databases/copydb.sh
+++ b/tests/three-databases/copydb.sh
@@ -41,6 +41,8 @@ psql -h source -U postgres -f /usr/src/chinook/Chinook_PostgreSql.sql
 # ─── Clone each database individually ────────────────────────────────────────
 #
 for db in pagila f1db chinook; do
+    createdb -h target -U postgres "${db}"
+
     pgcopydb clone \
              --notice \
              --skip-collations \


### PR DESCRIPTION
## Overview

`pgcopydb clone --all-databases` copies every user database from a source
Postgres instance to a target instance in a single invocation, sharing the
worker pools across databases.

```bash
pgcopydb clone --all-databases   --source postgres://postgres@source/postgres   --target postgres://postgres@target/postgres   --table-jobs 8 --index-jobs 4
```

This closes the feature request in issue #535.

---

## How it works

The operation runs in three phases:

**Phase I — parallel schema fetch + pre-data restore (per database)**  
A snapshot-holder subprocess exports one REPEATABLE READ snapshot per
database and writes the snapshot IDs to the instance catalog.  A pre-data
supervisor then runs schema-fetch → pg_dump → pg_restore for each database
in parallel, bounded by `--table-jobs`.

**Phase II — global COPY (largest tables first, across all databases)**  
A single supervisor reads every table from all per-database catalogs, sorts
them by size descending, and enqueues them into one shared COPY queue.
`--table-jobs` workers pull from the queue; each worker maintains a small
connection cache keyed by database name so it can serve tables from any
database without reconnecting on every message.  Index and VACUUM workers
run concurrently against whichever database each table belongs to.

**Phase III — post-data restore (per database, sequential)**  
pg_restore post-data + sequence reset for each database, one at a time.

---

## Process tree

```
pgcopydb clone --all-databases --table-jobs 4 --index-jobs 4
 + snapshot holder          (one REPEATABLE READ txn per database)
 + pre-data supervisor      (Phase I, parallel, bounded by --table-jobs)
     - pre-data worker [pagila]
     - pre-data worker [f1db]
     - pre-data worker [chinook]
 + vacuum supervisor
     - vacuum worker × 4
 + index supervisor
     - index/constraint worker × 4
 + global COPY supervisor   (Phase II, largest-first across all databases)
     - COPY worker × 4      (connection cache: switches DB on demand)
```

---

## Changes

### Core
- `src/bin/pgcopydb/multi_db.c` — new file: orchestrates all three phases
- `src/bin/pgcopydb/multi_db.h` — public interface
- `cli_clone_follow.c` — `--all-databases` flag wired into `pgcopydb clone`; consolidated summary printed after all phases complete
- `cli_compare.c` — `--all-databases` support for `pgcopydb compare schema/data`

### Catalog
- `catalog.c / catalog.h` — `datname` column added to `s_table` and `s_seq`; per-database catalog paths under `db/<datname>/`

### Workers
- Copy workers: `MultiDbContext` connection cache; workers open target connections on demand, keyed by database name
- Index workers: lightweight `MultiDbEntry` pool; workers look up per-db specs from the message datname
- Vacuum workers: same pattern

### Summary
- Consolidated summary aggregates timings from all per-database catalogs (SUM for cumulative sections, MAX for parallel phases)
- `datname:` prefix on CREATE INDEX / ALTER TABLE / VACUUM ANALYZE log lines in multidb runs

---

## Test

`tests/all-databases/` — integration test that loads pagila, f1db, and
chinook on the source instance and then runs `pgcopydb clone --all-databases`,
followed by `compare schema` and `compare data` for each database.  Uses the
shared `Dockerfile.multi` base image introduced in PR #966.

---

## Commits

| Commit | Description |
|--------|-------------|
| `20d98e1` | catalog: add datname to SourceTable and SourceSequence |
| `f14ce7e` | Phase B: sequential --all-databases orchestrator |
| `3e6f5e4` | fix iterator NULL check + test compare --dir |
| `62a8b76` | Phase C: cross-database global COPY queue |
| `651d413` | parallel Phase I + proper supervisor hierarchy + shared SQLite semaphores |
| `4231bfe` | compare: --all-databases support |
| `ae86d76` | per-db summaries + consolidated summary |
| `3bc9130` | fix: catalog type before catalog_count_objects |
| `0791908` | mirror singledb design for index/vacuum workers |
| `6c4407d` | fix per-db timing display + datname in COPY log |
| `21f0abe` | fix SYSV_RES_MAX_COUNT exhaustion |
| `2cc275d` | fix catalog_s_table_count_indexes: db is NULL in index workers |
| `8daec51` | replace O(N) per-database semaphores with a single semaphore set |
| `7fd3f45` | fix index-worker deadlock + snapshot-holder livelock |
| `fab2308` | fix cumulative timing in consolidated summary |