### PR TITLE
fix: loss of double precision during CDC replay

### DIFF
--- a/src/bin/pgcopydb/ld_transform.c
+++ b/src/bin/pgcopydb/ld_transform.c
@@ -2386,7 +2386,15 @@ stream_add_value_in_json_array(LogicalMessageValue *value, JSON_Array *jsArray)
 			{
 				char string[BUFSIZE] = { 0 };
 
-				sformat(string, sizeof(string), "%.17f", value->val.float8);
+				if (fmod(value->val.float8, 1) == 0.0)
+				{
+					sformat(string, sizeof(string), "%lld",
+							(long long) value->val.float8);
+				}
+				else
+				{
+					sformat(string, sizeof(string), "%.17f", value->val.float8);
+				}
 
 				json_array_append_string(jsArray, string);
 				break;

--- a/src/bin/pgcopydb/ld_transform.c
+++ b/src/bin/pgcopydb/ld_transform.c
@@ -2386,15 +2386,7 @@ stream_add_value_in_json_array(LogicalMessageValue *value, JSON_Array *jsArray)
 			{
 				char string[BUFSIZE] = { 0 };
 
-				if (fmod(value->val.float8, 1) == 0.0)
-				{
-					sformat(string, sizeof(string), "%lld",
-							(long long) value->val.float8);
-				}
-				else
-				{
-					sformat(string, sizeof(string), "%f", value->val.float8);
-				}
+				sformat(string, sizeof(string), "%.17g", value->val.float8);
 
 				json_array_append_string(jsArray, string);
 				break;

--- a/src/bin/pgcopydb/ld_transform.c
+++ b/src/bin/pgcopydb/ld_transform.c
@@ -2394,6 +2394,17 @@ stream_add_value_in_json_array(LogicalMessageValue *value, JSON_Array *jsArray)
 				else
 				{
 					sformat(string, sizeof(string), "%.17f", value->val.float8);
+
+					// Trim trailing zeros
+					char *p = string + strlen(string) - 1;
+					while (p > string && *p == '0')
+					{
+						*p-- = '\0';
+					}
+					if (*p == '.')
+					{
+						*p = '\0';
+					}
 				}
 
 				json_array_append_string(jsArray, string);

--- a/src/bin/pgcopydb/ld_transform.c
+++ b/src/bin/pgcopydb/ld_transform.c
@@ -2386,7 +2386,7 @@ stream_add_value_in_json_array(LogicalMessageValue *value, JSON_Array *jsArray)
 			{
 				char string[BUFSIZE] = { 0 };
 
-				sformat(string, sizeof(string), "%.17g", value->val.float8);
+				sformat(string, sizeof(string), "%.17f", value->val.float8);
 
 				json_array_append_string(jsArray, string);
 				break;


### PR DESCRIPTION
The `%f` format string used during conversion of doubles from `json` to `sql` only provides 6 decimal places of precision. This results in loss of precision, and thus subtle data corruption, for `double precision` values during CDC replay.

For example, try with the floating point value: `-216237.00000035969`. The value appears in the `.json` CDC files correctly, but is emitted in the `.sql` CDC files as `-216237.000000` in the output. This is an actual, not just apparent, loss of fidelity.

[According to wikipedia](https://en.wikipedia.org/wiki/Double-precision_floating-point_format#cite_ref-whyieee_1-0:~:text=If%20an%20IEEE%20754%20double%2Dprecision%20number%20is%20converted%20to%20a%20decimal%20string%20with%20at%20least%2017%20significant%20digits%2C%20and%20then%20converted%20back%20to%20double%2Dprecision%20representation%2C%20the%20final%20result%20must%20match%20the%20original%20number.), 17 decimal places is required to unambiguously represent a floating point values. That is what I use here.

Notes: 

1. We do _not_ implement here the same algorithm as Postgres, the [Ryu algorithm](https://github.com/ulfjack/ryu) for shortest unambiguous decimal representation for a float. (`shortest_dec.h/d2s.c` in [pg source code](https://github.com/postgres/postgres/blob/master/src/common/d2s.c).) 

   For example, Postgres + wal2json will actually emit `-216237.0000003597` rather than `-216237.00000035969`. Similarly PG will emit `14.95` instead of `14.949999999999999`.  

   This means we are slightly encoding inefficient, and there may still be an apparent mismatch between .sql and .json. (Input `.json` will show 14.95, output `.sql` 14.9499…) However, the two should have the equivalent IEEE754 bit-values when parsed (scanf, etc).

2. Although `%g` output would trim trailing zeroes, I'm not sure if we're on `%f` for a reason. So I added a bit of zero trimming on the end. An alternate option is just switching to `%.17g` formatting if we're comfortable with the occasional scientific notation.

3. Lastly, while I think (haven't tested) that the use of the `--wal2json-numeric-as-string` flag prevents this issue, not everyone has access to a version of `wal2json` that supports this option.