### PR TITLE
Fix single-quote escaping

### DIFF
--- a/src/bin/pgcopydb/ld_test_decoding.c
+++ b/src/bin/pgcopydb/ld_test_decoding.c
@@ -876,11 +876,6 @@ parseNextColumn(TestDecodingColumns *cols,
 
 	sformat(typname, sizeof(typname), "%.*s", typLen, typStart);
 
-	if (streq(typname, "text"))
-	{
-		cols->oid = TEXTOID;
-	}
-
 	cols->colnameStart = ptr;
 	cols->colnameLen = typA - ptr;
 
@@ -900,6 +895,8 @@ parseNextColumn(TestDecodingColumns *cols,
 	{
 		cols->isQuoted = true;
 
+		/* this column has quoted string value */
+		cols->oid = TEXTOID;
 		/* skip the opening single-quote now */
 		char *cur = ptr + 1;
 
@@ -1099,7 +1096,7 @@ listToTuple(LogicalMessageTuple *tuple, TestDecodingColumns *cols, int count)
 				char *nxt = cur->valueStart + pidx + 1;
 
 				/* unescape the single-quotes */
-				if (*ptr == '\'' && *nxt == '\'')
+				if (*ptr == '\'' && *nxt == '\'' && pidx < cur->valueLen - 1)
 				{
 					continue;
 				}


### PR DESCRIPTION
There are two problems in single-quotes escaping in ld_test_decoding.c:

1. Single-quotes in string values were unescaped for TEXT type only. For other string types (VARCHAR, CHAR etc) single-quotes were doubled in the result string. For example, "It's a sample" -> "It''s a sample".
2. If the string ends with single-quote character, it was lost. For example, "test'" -> "test".