### PR TITLE
ci: fix nightly test matrix — rename and add missing tests

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -112,18 +112,25 @@ jobs:
           - unit
           - blobs
           - filtering
+          - partitioned-target
           - extensions
           - timescaledb
           - all-databases
           - three-databases
           - cdc-low-level
           - cdc-test-decoding
-          - cdc-endpos-between-transaction
+          - cdc-endpos-mid-txn
           - cdc-wal2json
+          - cdc-partitioned-target
+          - cdc-replica-identity-index
+          - cdc-file-rotation
+          - cdc-pgoutput
+          - cdc-filtering-pgoutput
           - follow-wal2json
           - follow-9.6
           - follow-data-only
-          - endpos-in-multi-wal-txn
+          - follow-pgoutput
+          - cdc-endpos-in-multi-wal-txn
         exclude:
           # timescaledb uses timescale/timescaledb:latest-pg13 for both source
           # and target. pg_restore from PG17+ emits "SET transaction_timeout = 0"


### PR DESCRIPTION
## Problem

The nightly CI workflow was failing for two jobs because their test directories were renamed but `nightly.yml` was never updated. Additionally, several newer tests present on disk and in `tests/Makefile` were never added to the nightly matrix.

## Changes

### Stale names fixed

| `nightly.yml` (broken) | Actual directory | `run-tests.yml` (already correct) |
|---|---|---|
| `cdc-endpos-between-transaction` | `cdc-endpos-mid-txn` | `cdc-endpos-mid-txn` ✓ |
| `endpos-in-multi-wal-txn` | `cdc-endpos-in-multi-wal-txn` | `cdc-endpos-in-multi-wal-txn` ✓ |

`run-tests.yml` already had the correct names — the nightly workflow was just missed during the rename.

### Missing tests added

Tests that exist on disk and are declared in `tests/Makefile` but were absent from the nightly matrix:

- `partitioned-target`
- `cdc-partitioned-target`
- `cdc-replica-identity-index`
- `cdc-file-rotation`
- `cdc-pgoutput`
- `cdc-filtering-pgoutput`
- `follow-pgoutput`

The nightly `TEST` matrix now matches `tests/Makefile` exactly. No changes to `run-tests.yml` or the `exclude:` block were needed.