### PR TITLE
fix: close SQLite catalog connections before fork (#910)

### DIFF
--- a/src/bin/pgcopydb/cli_clone_follow.c
+++ b/src/bin/pgcopydb/cli_clone_follow.c
@@ -685,7 +685,20 @@ clone_and_follow(CopyDataSpec *copySpecs)
 	/*
 	 * Preparation and snapshot are now done, time to fork our two main worker
 	 * processes.
+	 *
+	 * SQLite database connections are not safe to use across fork(). Close
+	 * them here in the parent before forking so that each child process opens
+	 * its own fresh connection. The IPC semaphores (semId) are inherited by
+	 * the children and remain valid — only the sqlite3 handles are recycled.
+	 * The catalog data written above persists on disk; children will reopen
+	 * and reuse it without refetching.
 	 */
+	if (!catalog_close_from_specs(copySpecs))
+	{
+		log_error("Failed to close catalog connections before forking");
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+
 	pid_t clonePID = -1;
 	pid_t followPID = -1;
 


### PR DESCRIPTION
## Problem

When `pgcopydb clone --follow --filters` is used, the supervisor process opens source.db and filter.db (including ATTACHing source.db into filter.db's connection), fetches the full schema and filter OIDs, then **forks** the clone and follow subprocesses.

After `fork()`, each child inherits the parent's open `sqlite3 *` handles — including the ATTACH state. SQLite explicitly documents that connections must not be used in a child process after `fork()` unless `exec()` immediately follows. The child's inherited handle has source.db already recorded as "source" in `db->aDb`. If anything triggers `catalog_attach(filtersDB, sourceDB, "source")` in the child, SQLite refuses:

```
ERROR  Failed to attach '/tmp/pgcopydb/schema/source.db' as source
ERROR  database source is already in use
```

Commit e6212e3 (#953) added a `PRAGMA database_list` pre-check to `catalog_attach()` to detect the already-attached case. That addresses the symptom but not the root cause: fork-inherited handles share underlying file descriptors with the parent, violating SQLite's safety contract.

## Fix

Call `catalog_close_from_specs()` right before the two `fork()` calls in `cli_clone_follow_setup_and_run`. This closes all three `sqlite3` handles in the parent (sets `db=NULL`). Each child process then calls `catalog_init()` with `db==NULL` and opens a fresh, unencumbered connection to the on-disk files.

Because all catalog sections are already marked fetched on disk, the children see `allDone=true` and return "Re-using catalog caches" immediately — no `ATTACH` is attempted, no conflict arises.

The IPC semaphores (`semId`) survive the close and continue to coordinate concurrent access across the child processes.

## Testing

- `make tests/unit` and `make tests/filtering` pass locally (both PG16 and PG18 images).