### PR TITLE
feat: filter-aware publication creation and wal2json filter-tables (#910)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -130,6 +130,7 @@ jobs:
           - follow-9.6
           - follow-data-only
           - follow-pgoutput
+          - follow-filtering
           - cdc-endpos-in-multi-wal-txn
         exclude:
           # timescaledb uses timescale/timescaledb:latest-pg13 for both source

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -132,6 +132,7 @@ jobs:
           - follow-wal2json
           - follow-9.6
           - follow-data-only
+          - follow-filtering
           - cdc-endpos-in-multi-wal-txn
         exclude:
           # timescaledb uses timescale/timescaledb:latest-pg13 for both source
@@ -162,6 +163,8 @@ jobs:
           - TEST: follow-9.6
             PGVERSION: 16
           - TEST: follow-data-only
+            PGVERSION: 16
+          - TEST: follow-filtering
             PGVERSION: 16
           - TEST: cdc-endpos-in-multi-wal-txn
             PGVERSION: 16

--- a/src/bin/pgcopydb/cli_clone_follow.c
+++ b/src/bin/pgcopydb/cli_clone_follow.c
@@ -28,47 +28,47 @@
 #include "summary.h"
 
 #define PGCOPYDB_CLONE_GETOPTS_HELP \
-	"  --source                      Postgres URI to the source database\n" \
-	"  --target                      Postgres URI to the target database\n" \
-	"  --dir                         Work directory to use\n" \
-	"  --table-jobs                  Number of concurrent COPY jobs to run\n" \
-	"  --index-jobs                  Number of concurrent CREATE INDEX jobs to run\n" \
-	"  --restore-jobs                Number of concurrent jobs for pg_restore\n" \
-	"  --large-objects-jobs          Number of concurrent Large Objects jobs to run\n" \
-	"  --split-tables-larger-than    Same-table concurrency size threshold\n" \
-	"  --split-max-parts             Maximum number of jobs for Same-table concurrency \n" \
-	"  --estimate-table-sizes        Allow using estimates for relation sizes\n" \
-	"  --drop-if-exists              On the target database, clean-up from a previous run first\n" \
-	"  --roles                       Also copy roles found on source to target\n" \
-	"  --no-role-passwords           Do not dump passwords for roles\n" \
-	"  --no-owner                    Do not set ownership of objects to match the original database\n" \
-	"  --no-acl                      Prevent restoration of access privileges (grant/revoke commands).\n" \
-	"  --no-comments                 Do not output commands to restore comments\n" \
-	"  --no-tablespaces              Do not output commands to select tablespaces\n" \
-	"  --skip-large-objects          Skip copying large objects (blobs)\n" \
-	"  --skip-extensions             Skip restoring extensions\n" \
-	"  --skip-ext-comments           Skip restoring COMMENT ON EXTENSION\n" \
-	"  --skip-collations             Skip restoring collations\n" \
-	"  --skip-vacuum                 Skip running VACUUM ANALYZE\n" \
-	"  --skip-analyze                Skip running vacuumdb --analyze-only\n" \
-	"  --skip-db-properties          Skip copying ALTER DATABASE SET properties\n" \
-	"  --skip-split-by-ctid          Skip spliting tables by ctid\n" \
-	"  --requirements <filename>     List extensions requirements\n" \
-	"  --filters <filename>          Use the filters defined in <filename>\n" \
-	"  --fail-fast                   Abort early in case of error\n" \
-	"  --restart                     Allow restarting when temp files exist already\n" \
-	"  --resume                      Allow resuming operations after a failure\n" \
-	"  --not-consistent              Allow taking a new snapshot on the source database\n" \
-	"  --snapshot                    Use snapshot obtained with pg_export_snapshot\n" \
-	"  --follow                      Implement logical decoding to replay changes\n" \
-	"  --plugin                      Output plugin to use (pgoutput, test_decoding, wal2json)\n" \
-	"  --wal2json-numeric-as-string  Print numeric data type as string when using wal2json output plugin\n" \
-	"  --slot-name                   Use this Postgres replication slot name\n" \
-	"  --create-slot                 Create the replication slot\n" \
-	"  --origin                      Use this Postgres replication origin node name\n" \
-	"  --endpos                      Stop replaying changes when reaching this LSN\n" \
-	"  --use-copy-binary             Use the COPY BINARY format for COPY operations\n" \
-	"  --all-databases               Clone all databases found on the source instance\n" \
+		"  --source                      Postgres URI to the source database\n" \
+		"  --target                      Postgres URI to the target database\n" \
+		"  --dir                         Work directory to use\n" \
+		"  --table-jobs                  Number of concurrent COPY jobs to run\n" \
+		"  --index-jobs                  Number of concurrent CREATE INDEX jobs to run\n" \
+		"  --restore-jobs                Number of concurrent jobs for pg_restore\n" \
+		"  --large-objects-jobs          Number of concurrent Large Objects jobs to run\n" \
+		"  --split-tables-larger-than    Same-table concurrency size threshold\n" \
+		"  --split-max-parts             Maximum number of jobs for Same-table concurrency \n" \
+		"  --estimate-table-sizes        Allow using estimates for relation sizes\n" \
+		"  --drop-if-exists              On the target database, clean-up from a previous run first\n" \
+		"  --roles                       Also copy roles found on source to target\n" \
+		"  --no-role-passwords           Do not dump passwords for roles\n" \
+		"  --no-owner                    Do not set ownership of objects to match the original database\n" \
+		"  --no-acl                      Prevent restoration of access privileges (grant/revoke commands).\n" \
+		"  --no-comments                 Do not output commands to restore comments\n" \
+		"  --no-tablespaces              Do not output commands to select tablespaces\n" \
+		"  --skip-large-objects          Skip copying large objects (blobs)\n" \
+		"  --skip-extensions             Skip restoring extensions\n" \
+		"  --skip-ext-comments           Skip restoring COMMENT ON EXTENSION\n" \
+		"  --skip-collations             Skip restoring collations\n" \
+		"  --skip-vacuum                 Skip running VACUUM ANALYZE\n" \
+		"  --skip-analyze                Skip running vacuumdb --analyze-only\n" \
+		"  --skip-db-properties          Skip copying ALTER DATABASE SET properties\n" \
+		"  --skip-split-by-ctid          Skip spliting tables by ctid\n" \
+		"  --requirements <filename>     List extensions requirements\n" \
+		"  --filters <filename>          Use the filters defined in <filename>\n" \
+		"  --fail-fast                   Abort early in case of error\n" \
+		"  --restart                     Allow restarting when temp files exist already\n" \
+		"  --resume                      Allow resuming operations after a failure\n" \
+		"  --not-consistent              Allow taking a new snapshot on the source database\n" \
+		"  --snapshot                    Use snapshot obtained with pg_export_snapshot\n" \
+		"  --follow                      Implement logical decoding to replay changes\n" \
+		"  --plugin                      Output plugin to use (pgoutput, test_decoding, wal2json)\n" \
+		"  --wal2json-numeric-as-string  Print numeric data type as string when using wal2json output plugin\n" \
+		"  --slot-name                   Use this Postgres replication slot name\n" \
+		"  --create-slot                 Create the replication slot\n" \
+		"  --origin                      Use this Postgres replication origin node name\n" \
+		"  --endpos                      Stop replaying changes when reaching this LSN\n" \
+		"  --use-copy-binary             Use the COPY BINARY format for COPY operations\n" \
+		"  --all-databases               Clone all databases found on the source instance\n" \
 
 CommandLine clone_command =
 	make_command(
@@ -612,7 +612,8 @@ clone_and_follow(CopyDataSpec *copySpecs)
 						   &(copySpecs->catalogs.replay),
 						   copyDBoptions.stdIn,
 						   copyDBoptions.stdOut,
-						   logSQL))
+						   logSQL,
+						   &(copySpecs->filters)))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);
@@ -814,7 +815,8 @@ cli_follow(int argc, char **argv)
 						   &(copySpecs.catalogs.replay),
 						   copyDBoptions.stdIn,
 						   copyDBoptions.stdOut,
-						   logSQL))
+						   logSQL,
+						   &(copySpecs.filters)))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);

--- a/src/bin/pgcopydb/cli_clone_follow.c
+++ b/src/bin/pgcopydb/cli_clone_follow.c
@@ -28,47 +28,47 @@
 #include "summary.h"
 
 #define PGCOPYDB_CLONE_GETOPTS_HELP \
-		"  --source                      Postgres URI to the source database\n" \
-		"  --target                      Postgres URI to the target database\n" \
-		"  --dir                         Work directory to use\n" \
-		"  --table-jobs                  Number of concurrent COPY jobs to run\n" \
-		"  --index-jobs                  Number of concurrent CREATE INDEX jobs to run\n" \
-		"  --restore-jobs                Number of concurrent jobs for pg_restore\n" \
-		"  --large-objects-jobs          Number of concurrent Large Objects jobs to run\n" \
-		"  --split-tables-larger-than    Same-table concurrency size threshold\n" \
-		"  --split-max-parts             Maximum number of jobs for Same-table concurrency \n" \
-		"  --estimate-table-sizes        Allow using estimates for relation sizes\n" \
-		"  --drop-if-exists              On the target database, clean-up from a previous run first\n" \
-		"  --roles                       Also copy roles found on source to target\n" \
-		"  --no-role-passwords           Do not dump passwords for roles\n" \
-		"  --no-owner                    Do not set ownership of objects to match the original database\n" \
-		"  --no-acl                      Prevent restoration of access privileges (grant/revoke commands).\n" \
-		"  --no-comments                 Do not output commands to restore comments\n" \
-		"  --no-tablespaces              Do not output commands to select tablespaces\n" \
-		"  --skip-large-objects          Skip copying large objects (blobs)\n" \
-		"  --skip-extensions             Skip restoring extensions\n" \
-		"  --skip-ext-comments           Skip restoring COMMENT ON EXTENSION\n" \
-		"  --skip-collations             Skip restoring collations\n" \
-		"  --skip-vacuum                 Skip running VACUUM ANALYZE\n" \
-		"  --skip-analyze                Skip running vacuumdb --analyze-only\n" \
-		"  --skip-db-properties          Skip copying ALTER DATABASE SET properties\n" \
-		"  --skip-split-by-ctid          Skip spliting tables by ctid\n" \
-		"  --requirements <filename>     List extensions requirements\n" \
-		"  --filters <filename>          Use the filters defined in <filename>\n" \
-		"  --fail-fast                   Abort early in case of error\n" \
-		"  --restart                     Allow restarting when temp files exist already\n" \
-		"  --resume                      Allow resuming operations after a failure\n" \
-		"  --not-consistent              Allow taking a new snapshot on the source database\n" \
-		"  --snapshot                    Use snapshot obtained with pg_export_snapshot\n" \
-		"  --follow                      Implement logical decoding to replay changes\n" \
-		"  --plugin                      Output plugin to use (pgoutput, test_decoding, wal2json)\n" \
-		"  --wal2json-numeric-as-string  Print numeric data type as string when using wal2json output plugin\n" \
-		"  --slot-name                   Use this Postgres replication slot name\n" \
-		"  --create-slot                 Create the replication slot\n" \
-		"  --origin                      Use this Postgres replication origin node name\n" \
-		"  --endpos                      Stop replaying changes when reaching this LSN\n" \
-		"  --use-copy-binary             Use the COPY BINARY format for COPY operations\n" \
-		"  --all-databases               Clone all databases found on the source instance\n" \
+	"  --source                      Postgres URI to the source database\n" \
+	"  --target                      Postgres URI to the target database\n" \
+	"  --dir                         Work directory to use\n" \
+	"  --table-jobs                  Number of concurrent COPY jobs to run\n" \
+	"  --index-jobs                  Number of concurrent CREATE INDEX jobs to run\n" \
+	"  --restore-jobs                Number of concurrent jobs for pg_restore\n" \
+	"  --large-objects-jobs          Number of concurrent Large Objects jobs to run\n" \
+	"  --split-tables-larger-than    Same-table concurrency size threshold\n" \
+	"  --split-max-parts             Maximum number of jobs for Same-table concurrency \n" \
+	"  --estimate-table-sizes        Allow using estimates for relation sizes\n" \
+	"  --drop-if-exists              On the target database, clean-up from a previous run first\n" \
+	"  --roles                       Also copy roles found on source to target\n" \
+	"  --no-role-passwords           Do not dump passwords for roles\n" \
+	"  --no-owner                    Do not set ownership of objects to match the original database\n" \
+	"  --no-acl                      Prevent restoration of access privileges (grant/revoke commands).\n" \
+	"  --no-comments                 Do not output commands to restore comments\n" \
+	"  --no-tablespaces              Do not output commands to select tablespaces\n" \
+	"  --skip-large-objects          Skip copying large objects (blobs)\n" \
+	"  --skip-extensions             Skip restoring extensions\n" \
+	"  --skip-ext-comments           Skip restoring COMMENT ON EXTENSION\n" \
+	"  --skip-collations             Skip restoring collations\n" \
+	"  --skip-vacuum                 Skip running VACUUM ANALYZE\n" \
+	"  --skip-analyze                Skip running vacuumdb --analyze-only\n" \
+	"  --skip-db-properties          Skip copying ALTER DATABASE SET properties\n" \
+	"  --skip-split-by-ctid          Skip spliting tables by ctid\n" \
+	"  --requirements <filename>     List extensions requirements\n" \
+	"  --filters <filename>          Use the filters defined in <filename>\n" \
+	"  --fail-fast                   Abort early in case of error\n" \
+	"  --restart                     Allow restarting when temp files exist already\n" \
+	"  --resume                      Allow resuming operations after a failure\n" \
+	"  --not-consistent              Allow taking a new snapshot on the source database\n" \
+	"  --snapshot                    Use snapshot obtained with pg_export_snapshot\n" \
+	"  --follow                      Implement logical decoding to replay changes\n" \
+	"  --plugin                      Output plugin to use (pgoutput, test_decoding, wal2json)\n" \
+	"  --wal2json-numeric-as-string  Print numeric data type as string when using wal2json output plugin\n" \
+	"  --slot-name                   Use this Postgres replication slot name\n" \
+	"  --create-slot                 Create the replication slot\n" \
+	"  --origin                      Use this Postgres replication origin node name\n" \
+	"  --endpos                      Stop replaying changes when reaching this LSN\n" \
+	"  --use-copy-binary             Use the COPY BINARY format for COPY operations\n" \
+	"  --all-databases               Clone all databases found on the source instance\n" \
 
 CommandLine clone_command =
 	make_command(

--- a/src/bin/pgcopydb/cli_snapshot.c
+++ b/src/bin/pgcopydb/cli_snapshot.c
@@ -327,7 +327,8 @@ cli_create_snapshot(int argc, char **argv)
 							   &(copySpecs.catalogs.replay),
 							   createSNoptions.stdIn,
 							   createSNoptions.stdOut,
-							   logSQL))
+							   logSQL,
+							   &(copySpecs.filters)))
 		{
 			/* errors have already been logged */
 			exit(EXIT_CODE_INTERNAL_ERROR);

--- a/src/bin/pgcopydb/cli_stream.c
+++ b/src/bin/pgcopydb/cli_stream.c
@@ -632,7 +632,8 @@ cli_stream_setup(int argc, char **argv)
 						   &(copySpecs.catalogs.replay),
 						   streamDBoptions.stdIn,
 						   streamDBoptions.stdOut,
-						   logSQL))
+						   logSQL,
+						   NULL))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);
@@ -785,7 +786,8 @@ cli_stream_catchup(int argc, char **argv)
 						   &(copySpecs.catalogs.replay),
 						   streamDBoptions.stdIn,
 						   streamDBoptions.stdOut,
-						   logSQL))
+						   logSQL,
+						   NULL))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);
@@ -874,7 +876,8 @@ cli_stream_replay(int argc, char **argv)
 						   &(copySpecs.catalogs.replay),
 						   true,  /* stdin */
 						   true, /* stdout */
-						   logSQL))
+						   logSQL,
+						   NULL))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);
@@ -976,7 +979,8 @@ cli_stream_transform(int argc, char **argv)
 							   &(copySpecs.catalogs.replay),
 							   true,    /* stdIn */
 							   true,    /* stdOut */
-							   logSQL))
+							   logSQL,
+							   NULL))
 		{
 			exit(EXIT_CODE_INTERNAL_ERROR);
 		}
@@ -1047,7 +1051,8 @@ cli_stream_transform(int argc, char **argv)
 						   &(copySpecs.catalogs.replay),
 						   false, /* stdIn */
 						   false, /* stdOut */
-						   logSQL))
+						   logSQL,
+						   NULL))
 	{
 		exit(EXIT_CODE_INTERNAL_ERROR);
 	}
@@ -1170,7 +1175,8 @@ cli_stream_apply(int argc, char **argv)
 							   &(copySpecs.catalogs.replay),
 							   true,   /* stdIn */
 							   false,  /* stdOut */
-							   logSQL))
+							   logSQL,
+							   NULL))
 		{
 			exit(EXIT_CODE_INTERNAL_ERROR);
 		}
@@ -1262,7 +1268,8 @@ cli_stream_apply(int argc, char **argv)
 						   &(copySpecs.catalogs.replay),
 						   false, /* stdIn */
 						   stdoutMode, /* stdOut */
-						   logSQL))
+						   logSQL,
+						   NULL))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);
@@ -1415,7 +1422,8 @@ stream_start_in_mode(LogicalStreamMode mode)
 						   &(copySpecs.catalogs.replay),
 						   streamDBoptions.stdIn,
 						   streamDBoptions.stdOut,
-						   logSQL))
+						   logSQL,
+						   NULL))
 	{
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);

--- a/src/bin/pgcopydb/ld_stream.c
+++ b/src/bin/pgcopydb/ld_stream.c
@@ -55,7 +55,8 @@ stream_init_specs(StreamSpecs *specs,
 				  DatabaseCatalog *replayDB,
 				  bool stdin,
 				  bool stdout,
-				  bool logSQL)
+				  bool logSQL,
+				  SourceFilters *filters)
 {
 	/* just copy into StreamSpecs what's been initialized in copySpecs */
 	specs->mode = mode;
@@ -140,6 +141,82 @@ stream_init_specs(StreamSpecs *specs,
 			};
 
 			specs->pluginOptions = options;
+
+			/*
+			 * Build wal2json filter-tables value from user-specified filters.
+			 * pgcopydb.* is always excluded; user exclusions are appended.
+			 * For include-only filters we also add an add-tables option so
+			 * wal2json only emits changes for the specified tables/schemas.
+			 */
+			strlcpy(specs->wal2jsonFilterTables,
+					"pgcopydb.*",
+					sizeof(specs->wal2jsonFilterTables));
+
+			if (filters != NULL)
+			{
+				if (filters->type == SOURCE_FILTER_TYPE_EXCL ||
+					filters->type == SOURCE_FILTER_TYPE_LIST_EXCL ||
+					filters->type == SOURCE_FILTER_TYPE_LIST_NOT_INCL)
+				{
+					for (int i = 0; i < filters->excludeSchemaList.count; i++)
+					{
+						char entry[BUFSIZE] = { 0 };
+						sformat(entry, sizeof(entry), ",%s.*",
+								filters->excludeSchemaList.array[i].nspname);
+						strlcat(specs->wal2jsonFilterTables, entry,
+								sizeof(specs->wal2jsonFilterTables));
+					}
+
+					for (int i = 0; i < filters->excludeTableList.count; i++)
+					{
+						char entry[BUFSIZE] = { 0 };
+						sformat(entry, sizeof(entry), ",%s.%s",
+								filters->excludeTableList.array[i].nspname,
+								filters->excludeTableList.array[i].relname);
+						strlcat(specs->wal2jsonFilterTables, entry,
+								sizeof(specs->wal2jsonFilterTables));
+					}
+				}
+				else if (filters->type == SOURCE_FILTER_TYPE_INCL)
+				{
+					bool first = true;
+
+					for (int i = 0; i < filters->includeOnlySchemaList.count; i++)
+					{
+						char entry[BUFSIZE] = { 0 };
+						sformat(entry, sizeof(entry), "%s%s.*",
+								first ? "" : ",",
+								filters->includeOnlySchemaList.array[i].nspname);
+						strlcat(specs->wal2jsonAddTables, entry,
+								sizeof(specs->wal2jsonAddTables));
+						first = false;
+					}
+
+					for (int i = 0; i < filters->includeOnlyTableList.count; i++)
+					{
+						char entry[BUFSIZE] = { 0 };
+						sformat(entry, sizeof(entry), "%s%s.%s",
+								first ? "" : ",",
+								filters->includeOnlyTableList.array[i].nspname,
+								filters->includeOnlyTableList.array[i].relname);
+						strlcat(specs->wal2jsonAddTables, entry,
+								sizeof(specs->wal2jsonAddTables));
+						first = false;
+					}
+
+					if (!IS_EMPTY_STRING_BUFFER(specs->wal2jsonAddTables))
+					{
+						int idx = specs->pluginOptions.count;
+						specs->pluginOptions.keywords[idx] = "add-tables";
+						specs->pluginOptions.values[idx] = specs->wal2jsonAddTables;
+						specs->pluginOptions.count++;
+					}
+				}
+			}
+
+			/* Point filter-tables at our stable buffer (index 5) */
+			specs->pluginOptions.values[5] = specs->wal2jsonFilterTables;
+
 			break;
 		}
 
@@ -167,6 +244,11 @@ stream_init_specs(StreamSpecs *specs,
 					  OutputPluginToString(slot->plugin));
 			return false;
 		}
+	}
+
+	if (filters != NULL)
+	{
+		specs->filters = *filters;
 	}
 
 	strlcpy(specs->origin, origin, sizeof(specs->origin));

--- a/src/bin/pgcopydb/ld_stream.h
+++ b/src/bin/pgcopydb/ld_stream.h
@@ -649,6 +649,19 @@ struct StreamSpecs
 	 */
 	char coordHost[256];
 	int coordPort;
+
+	/*
+	 * User-specified source filters.  For pgoutput the publication is created
+	 * with a filter-aware FOR TABLE list; for wal2json the filter-tables (and
+	 * optionally add-tables) plugin option is extended accordingly.
+	 */
+	SourceFilters filters;
+
+	/* Stable buffer for the dynamically-built wal2json filter-tables value */
+	char wal2jsonFilterTables[4096];
+
+	/* Stable buffer for the dynamically-built wal2json add-tables value */
+	char wal2jsonAddTables[4096];
 };
 
 /* ld_stream.c */
@@ -664,7 +677,8 @@ bool stream_init_specs(StreamSpecs *specs,
 					   DatabaseCatalog *replayDB,
 					   bool stdIn,
 					   bool stdOut,
-					   bool logSQL);
+					   bool logSQL,
+					   SourceFilters *filters);
 
 bool stream_init_for_mode(StreamSpecs *specs, LogicalStreamMode mode);
 

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -22,6 +22,7 @@
 #include "catalog.h"
 #include "cli_root.h"
 #include "defaults.h"
+#include "filtering.h"
 #include "env_utils.h"
 #include "file_utils.h"
 #include "log.h"
@@ -5194,6 +5195,10 @@ pgsql_drop_replication_slot(PGSQL *pgsql, const char *slotName)
  * by querying pg_tables directly on the live source connection.  Excludes
  * system schemas and the pgcopydb internal schema.  Uses only CREATE
  * privilege on the database — no superuser needed.
+ *
+ * When filters is non-NULL, exclude-table and exclude-schema entries are
+ * applied so that the publication matches the user-specified filter, giving
+ * true server-side filtering for the pgoutput plugin.
  */
 
 typedef struct PublicationTableListContext
@@ -5225,20 +5230,123 @@ publication_table_list_parse(void *ctx, PGresult *result)
 }
 
 
-bool
-pgsql_create_publication(PGSQL *pgsql, const char *pubName)
+/*
+ * appendStringLiteralPub appends a SQL string literal (single-quoted,
+ * with internal single quotes doubled) to the buffer.
+ */
+static void
+appendStringLiteralPub(PQExpBuffer buf, const char *str)
 {
-	const char *query =
-		"SELECT schemaname, tablename"
-		" FROM pg_tables"
-		" WHERE schemaname NOT IN"
-		" ('pg_catalog', 'information_schema', 'pgcopydb')"
-		" ORDER BY schemaname, tablename";
+	appendPQExpBufferChar(buf, '\'');
+	for (const char *p = str; *p; p++)
+	{
+		if (*p == '\'')
+			appendPQExpBufferChar(buf, '\'');
+		appendPQExpBufferChar(buf, *p);
+	}
+	appendPQExpBufferChar(buf, '\'');
+}
+
+
+bool
+pgsql_create_publication(PGSQL *pgsql, const char *pubName,
+						 SourceFilters *filters)
+{
+	PQExpBuffer query = createPQExpBuffer();
+	if (query == NULL)
+	{
+		log_error(ALLOCATION_FAILED_ERROR);
+		return false;
+	}
+
+	appendPQExpBufferStr(query,
+						 "SELECT schemaname, tablename"
+						 " FROM pg_tables"
+						 " WHERE schemaname NOT IN"
+						 " ('pg_catalog', 'information_schema', 'pgcopydb')");
+
+	if (filters != NULL)
+	{
+		/*
+		 * For include-only filter: restrict to specified schemas and tables.
+		 * We build an AND ( ... ) clause that ORs together all allowed entries.
+		 */
+		if (filters->type == SOURCE_FILTER_TYPE_INCL)
+		{
+			bool firstCond = true;
+
+			appendPQExpBufferStr(query, " AND (");
+
+			for (int i = 0; i < filters->includeOnlySchemaList.count; i++)
+			{
+				if (!firstCond)
+					appendPQExpBufferStr(query, " OR ");
+
+				appendPQExpBufferStr(query, "schemaname = ");
+				appendStringLiteralPub(query,
+									   filters->includeOnlySchemaList.array[i].nspname);
+				firstCond = false;
+			}
+
+			for (int i = 0; i < filters->includeOnlyTableList.count; i++)
+			{
+				if (!firstCond)
+					appendPQExpBufferStr(query, " OR ");
+
+				appendPQExpBufferStr(query, "(schemaname = ");
+				appendStringLiteralPub(query,
+									   filters->includeOnlyTableList.array[i].nspname);
+				appendPQExpBufferStr(query, " AND tablename = ");
+				appendStringLiteralPub(query,
+									   filters->includeOnlyTableList.array[i].relname);
+				appendPQExpBufferChar(query, ')');
+				firstCond = false;
+			}
+
+			if (firstCond)
+			{
+				/* No include entries: include nothing → publication FOR ALL TABLES won't work */
+				appendPQExpBufferStr(query, "false");
+			}
+
+			appendPQExpBufferChar(query, ')');
+		}
+
+		/*
+		 * For exclude filter: strip out specified schemas and tables.
+		 */
+		if (filters->type == SOURCE_FILTER_TYPE_EXCL ||
+			filters->type == SOURCE_FILTER_TYPE_LIST_EXCL ||
+			filters->type == SOURCE_FILTER_TYPE_LIST_NOT_INCL)
+		{
+			for (int i = 0; i < filters->excludeSchemaList.count; i++)
+			{
+				appendPQExpBufferStr(query, " AND schemaname != ");
+				appendStringLiteralPub(query,
+									   filters->excludeSchemaList.array[i].nspname);
+			}
+
+			for (int i = 0; i < filters->excludeTableList.count; i++)
+			{
+				appendPQExpBufferStr(query,
+									 " AND NOT (schemaname = ");
+				appendStringLiteralPub(query,
+									   filters->excludeTableList.array[i].nspname);
+				appendPQExpBufferStr(query, " AND tablename = ");
+				appendStringLiteralPub(query,
+									   filters->excludeTableList.array[i].relname);
+				appendPQExpBufferChar(query, ')');
+			}
+		}
+	}
+
+	appendPQExpBufferStr(query, " ORDER BY schemaname, tablename");
 
 	PQExpBuffer tableList = createPQExpBuffer();
 	if (tableList == NULL)
 	{
 		log_error(ALLOCATION_FAILED_ERROR);
+		destroyPQExpBuffer(query);
 		return false;
 	}
 
@@ -5247,12 +5355,15 @@ pgsql_create_publication(PGSQL *pgsql, const char *pubName)
 		.hasTable = false
 	};
 
-	if (!pgsql_execute_with_params(pgsql, query, 0, NULL, NULL,
+	if (!pgsql_execute_with_params(pgsql, query->data, 0, NULL, NULL,
 								   &ctx, &publication_table_list_parse))
 	{
+		destroyPQExpBuffer(query);
 		destroyPQExpBuffer(tableList);
 		return false;
 	}
+
+	destroyPQExpBuffer(query);
 
 	PQExpBuffer sql = createPQExpBuffer();
 	if (sql == NULL)

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -5241,7 +5241,9 @@ appendStringLiteralPub(PQExpBuffer buf, const char *str)
 	for (const char *p = str; *p; p++)
 	{
 		if (*p == '\'')
+		{
 			appendPQExpBufferChar(buf, '\'');
+		}
 		appendPQExpBufferChar(buf, *p);
 	}
 	appendPQExpBufferChar(buf, '\'');
@@ -5280,7 +5282,9 @@ pgsql_create_publication(PGSQL *pgsql, const char *pubName,
 			for (int i = 0; i < filters->includeOnlySchemaList.count; i++)
 			{
 				if (!firstCond)
+				{
 					appendPQExpBufferStr(query, " OR ");
+				}
 
 				appendPQExpBufferStr(query, "schemaname = ");
 				appendStringLiteralPub(query,
@@ -5291,7 +5295,9 @@ pgsql_create_publication(PGSQL *pgsql, const char *pubName,
 			for (int i = 0; i < filters->includeOnlyTableList.count; i++)
 			{
 				if (!firstCond)
+				{
 					appendPQExpBufferStr(query, " OR ");
+				}
 
 				appendPQExpBufferStr(query, "(schemaname = ");
 				appendStringLiteralPub(query,

--- a/src/bin/pgcopydb/pgsql.h
+++ b/src/bin/pgcopydb/pgsql.h
@@ -551,7 +551,11 @@ bool pgsql_replication_slot_exists(PGSQL *pgsql,
 
 bool pgsql_drop_replication_slot(PGSQL *pgsql, const char *slotName);
 
-bool pgsql_create_publication(PGSQL *pgsql, const char *pubName);
+/* Forward declaration; full definition in filtering.h */
+struct SourceFilters;
+
+bool pgsql_create_publication(PGSQL *pgsql, const char *pubName,
+							  struct SourceFilters *filters);
 bool pgsql_drop_publication(PGSQL *pgsql, const char *pubName);
 
 bool pgsql_role_exists(PGSQL *pgsql, const char *roleName, bool *exists);

--- a/src/bin/pgcopydb/snapshot.c
+++ b/src/bin/pgcopydb/snapshot.c
@@ -442,7 +442,8 @@ copydb_create_logical_replication_slot(CopyDataSpec *copySpecs,
 			return false;
 		}
 
-		if (!pgsql_create_publication(&src, slot->publicationName))
+		if (!pgsql_create_publication(&src, slot->publicationName,
+									  &copySpecs->filters))
 		{
 			log_error("Failed to create publication \"%s\"",
 					  slot->publicationName);

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -12,7 +12,7 @@ all: pagila pagila-multi-steps blobs unit filtering extensions \
 	 cdc-endpos-in-multi-wal-txn cdc-file-rotation \
 	 cdc-pgoutput cdc-filtering-pgoutput \
 	 follow-wal2json follow-9.6 follow-data-only \
-	 follow-pgoutput;
+	 follow-pgoutput follow-filtering;
 
 pagila: build
 	$(MAKE) -C $@
@@ -80,6 +80,9 @@ cdc-filtering-pgoutput: build
 follow-pgoutput: build
 	$(MAKE) -C $@
 
+follow-filtering: build
+	$(MAKE) -C $@
+
 timescaledb: build
 	$(MAKE) -C $@
 
@@ -114,5 +117,5 @@ clean-images:
 .PHONY: all-databases three-databases
 .PHONY: cdc-wal2json cdc-test-decoding cdc-endpos-mid-txn cdc-low-level cdc-replica-identity-index cdc-partitioned-target
 .PHONY: cdc-endpos-in-multi-wal-txn cdc-file-rotation
-.PHONY: cdc-pgoutput cdc-filtering-pgoutput follow-pgoutput
+.PHONY: cdc-pgoutput cdc-filtering-pgoutput follow-pgoutput follow-filtering
 .PHONY: follow-wal2json follow-9.6

--- a/tests/follow-filtering/Dockerfile
+++ b/tests/follow-filtering/Dockerfile
@@ -1,0 +1,14 @@
+FROM pagila
+
+# TMPDIR / XDG_DATA_HOME live under /var/run/pgcopydb (see tests/paths.env).
+USER root
+RUN mkdir -p /var/run/pgcopydb && chown -R docker /var/run/pgcopydb
+
+WORKDIR /usr/src/pgcopydb
+COPY ./copydb.sh copydb.sh
+COPY ./dml.sql dml.sql
+COPY ./ddl.sql ddl.sql
+COPY ./filters.ini filters.ini
+
+USER docker
+CMD ["/usr/src/pgcopydb/copydb.sh"]

--- a/tests/follow-filtering/Dockerfile.inject
+++ b/tests/follow-filtering/Dockerfile.inject
@@ -1,0 +1,14 @@
+FROM pgcopydb
+
+USER root
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends jq \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/src/pgcopydb
+COPY ./inject.sh inject.sh
+COPY ./dml.sql dml.sql
+
+USER docker
+CMD ["/usr/src/pgcopydb/inject.sh"]

--- a/tests/follow-filtering/Dockerfile.pg
+++ b/tests/follow-filtering/Dockerfile.pg
@@ -1,0 +1,2 @@
+ARG PGVERSION=16
+FROM postgres:${PGVERSION}

--- a/tests/follow-filtering/Makefile
+++ b/tests/follow-filtering/Makefile
@@ -1,0 +1,35 @@
+# Copyright (c) 2021 The PostgreSQL Global Development Group.
+# Licensed under the PostgreSQL License.
+
+COMPOSE_EXIT = --exit-code-from=test --abort-on-container-exit
+
+test: down run down ;
+
+up: down build
+	docker compose up $(COMPOSE_EXIT)
+
+run: build
+	# --use-aliases gives the one-off `run` container its "test" network alias
+	# so the inject container can reach the follow coordinator at test:5442.
+	docker compose run --use-aliases test
+
+down:
+	docker compose down --volumes --remove-orphans
+
+build:
+	docker compose build --quiet
+
+VPATH   = /var/run/pgcopydb
+CNAME   = follow-filtering
+VNAME   = follow-filtering
+VOLUMES = -v $(VNAME):$(VPATH)
+OPTS    = --env-file=../paths.env $(VOLUMES)
+CLEANUP = make -f /var/lib/postgres/cleanup.mk
+
+fix-volumes:
+	docker run --rm $(OPTS) $(CNAME) $(CLEANUP)
+
+attach:
+	docker run --rm -it $(OPTS) $(CNAME) bash
+
+.PHONY: run down build test fix-volumes attach

--- a/tests/follow-filtering/compose.yaml
+++ b/tests/follow-filtering/compose.yaml
@@ -1,0 +1,56 @@
+services:
+  source:
+    image: postgres-follow-filtering:${PGVERSION:-16}
+    build:
+      context: .
+      dockerfile: Dockerfile.pg
+    expose:
+      - 5432
+    env_file:
+      - ../postgres.env
+    command: >
+      -c wal_level=logical
+      -c ssl=on
+      -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
+      -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
+
+  target:
+    image: postgres:${PGVERSION:-16}
+    expose:
+      - 5432
+    env_file:
+      - ../postgres.env
+    command: >
+      -c ssl=on
+      -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
+      -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
+
+  inject:
+    build:
+      context: .
+      dockerfile: Dockerfile.inject
+    env_file:
+      - ../uris.env
+      - ../paths.env
+    environment:
+      PGCOPYDB_HOST: test
+      PGCOPYDB_PORT: "5442"
+
+  test:
+    image: follow-filtering
+    build: .
+    cap_add:
+      - SYS_ADMIN
+      - SYS_PTRACE
+    environment:
+      PGCOPYDB_TABLE_JOBS: 4
+      PGCOPYDB_INDEX_JOBS: 2
+      PGCOPYDB_HOST: "0.0.0.0"
+      PGCOPYDB_PORT: "5442"
+    env_file:
+      - ../uris.env
+      - ../paths.env
+    depends_on:
+      - source
+      - target
+      - inject

--- a/tests/follow-filtering/copydb.sh
+++ b/tests/follow-filtering/copydb.sh
@@ -1,0 +1,77 @@
+#! /bin/bash
+
+set -x
+set -e
+
+# This script expects the following environment variables to be set:
+#
+#  - PGCOPYDB_SOURCE_PGURI
+#  - PGCOPYDB_TARGET_PGURI
+#  - PGCOPYDB_TABLE_JOBS
+#  - PGCOPYDB_INDEX_JOBS
+
+# Wait for source and target to be ready
+pgcopydb ping
+
+psql -o /tmp/s.out -d ${PGCOPYDB_SOURCE_PGURI} -1 -f /usr/src/pagila/pagila-schema.sql
+psql -o /tmp/d.out -d ${PGCOPYDB_SOURCE_PGURI} -1 -f /usr/src/pagila/pagila-data.sql
+
+# Set replica identity on partitioned payment tables
+psql -d ${PGCOPYDB_SOURCE_PGURI} -f /usr/src/pgcopydb/ddl.sql
+
+# Clone with pgoutput plugin and filtering (excludes public.staff).
+# The publication will be created FOR TABLE ... without staff (server-side).
+# The TCP coordinator is exposed so the inject container can set endpos.
+pgcopydb clone \
+    --follow \
+    --plugin pgoutput \
+    --filters /usr/src/pgcopydb/filters.ini \
+    --host 0.0.0.0 \
+    --port 5442 \
+    --notice
+
+#
+# Verify that the filter excluded 'staff' from the initial clone.
+#
+staff_on_target=$(psql -AtqX -d ${PGCOPYDB_TARGET_PGURI} \
+  -c "select count(*) from information_schema.tables
+      where table_schema='public' and table_name='staff'")
+echo "staff table present on target (should be 0): ${staff_on_target}"
+test "${staff_on_target}" -eq 0
+
+#
+# Verify that the publication was created WITHOUT the staff table.
+# This is the key assertion that proves server-side (publication) filtering.
+#
+pub_staff=$(psql -AtqX -d ${PGCOPYDB_SOURCE_PGURI} \
+  -c "select count(*) from pg_publication_tables
+      where pubname = 'pgcopydb' and tablename = 'staff'")
+echo "staff in publication (should be 0): ${pub_staff}"
+test "${pub_staff}" -eq 0
+
+pub_actor=$(psql -AtqX -d ${PGCOPYDB_SOURCE_PGURI} \
+  -c "select count(*) from pg_publication_tables
+      where pubname = 'pgcopydb' and tablename = 'actor'")
+echo "actor in publication (should be > 0): ${pub_actor}"
+test "${pub_actor}" -gt 0
+
+#
+# Row count sanity check for several included tables.
+#
+for tbl in actor film category address; do
+    src_count=$(psql -AtqX -d ${PGCOPYDB_SOURCE_PGURI} -c "select count(*) from ${tbl}")
+    tgt_count=$(psql -AtqX -d ${PGCOPYDB_TARGET_PGURI} -c "select count(*) from ${tbl}")
+    echo "source ${tbl}: ${src_count}, target ${tbl}: ${tgt_count}"
+    test "${src_count}" -eq "${tgt_count}"
+done
+
+#
+# Verify that the actor injected by dml.sql was replicated.
+#
+actor_on_target=$(psql -AtqX -d ${PGCOPYDB_TARGET_PGURI} \
+  -c "select count(*) from actor where actor_id = 999")
+echo "injected actor on target (should be 1): ${actor_on_target}"
+test "${actor_on_target}" -eq 1
+
+# Drop the publication created by pgcopydb
+pgcopydb stream cleanup

--- a/tests/follow-filtering/ddl.sql
+++ b/tests/follow-filtering/ddl.sql
@@ -1,0 +1,15 @@
+---
+--- follow-filtering/ddl.sql
+---
+--- Set REPLICA IDENTITY FULL on partitioned payment tables so that
+--- UPDATE/DELETE changes can be captured without a primary key.
+
+begin;
+alter table payment_p2022_01 replica identity full;
+alter table payment_p2022_02 replica identity full;
+alter table payment_p2022_03 replica identity full;
+alter table payment_p2022_04 replica identity full;
+alter table payment_p2022_05 replica identity full;
+alter table payment_p2022_06 replica identity full;
+alter table payment_p2022_07 replica identity full;
+commit;

--- a/tests/follow-filtering/dml.sql
+++ b/tests/follow-filtering/dml.sql
@@ -1,0 +1,51 @@
+---
+--- follow-filtering/dml.sql
+---
+--- DML changes injected while pgcopydb clone --follow is running.
+--- Only touches tables that are included by the filter (not staff).
+
+\set customerid1 291
+\set customerid2 292
+
+\set staffid1 1
+\set staffid2 2
+
+\set inventoryid1 371
+\set inventoryid2 1097
+
+begin;
+
+with r as
+ (
+   insert into rental(rental_date, inventory_id, customer_id, staff_id, last_update)
+        select '2022-06-01', :inventoryid1, :customerid1, :staffid1, '2022-06-01'
+     returning rental_id, customer_id, staff_id
+ )
+ insert into payment(customer_id, staff_id, rental_id, amount, payment_date)
+      select customer_id, staff_id, rental_id, 5.99, '2022-06-01'
+        from r;
+
+commit;
+
+update public.payment set amount = 11.95 where amount = 11.99;
+
+begin;
+
+delete from payment
+      using rental
+      where rental.rental_id = payment.rental_id
+        and rental.last_update = '2022-06-01';
+
+delete from rental where rental.last_update = '2022-06-01';
+
+commit;
+
+begin;
+update public.payment set amount = 11.99 where amount = 11.95;
+commit;
+
+-- Also insert a new actor to provide a simple inclusion check
+begin;
+insert into public.actor (actor_id, first_name, last_name, last_update)
+values (999, 'Follow', 'Filter', now());
+commit;

--- a/tests/follow-filtering/filters.ini
+++ b/tests/follow-filtering/filters.ini
@@ -1,0 +1,11 @@
+#
+# follow-filtering/filters.ini
+#
+# Exclude the 'staff' table.  The test verifies that:
+#   1. The publication is created WITHOUT staff (server-side filtering).
+#   2. The initial clone does not copy staff to the target.
+#   3. CDC changes to other tables ARE replicated correctly.
+#
+
+[exclude-table]
+public.staff

--- a/tests/follow-filtering/inject.sh
+++ b/tests/follow-filtering/inject.sh
@@ -1,0 +1,51 @@
+#! /bin/bash
+
+set -x
+set -e
+
+# This script expects the following environment variables to be set:
+#
+#  - PGCOPYDB_SOURCE_PGURI
+#  - PGCOPYDB_TARGET_PGURI
+#  - PGCOPYDB_HOST / PGCOPYDB_PORT  (follow coordinator TCP endpoint)
+
+pgcopydb ping
+
+HP="--host ${PGCOPYDB_HOST} --port ${PGCOPYDB_PORT}"
+
+# Wait until clone --follow is streaming (coordinator is up)
+until pgcopydb stream sentinel get ${HP} >/dev/null 2>&1
+do
+    sleep 1
+done
+
+# Inject DML changes (does NOT touch staff — it is excluded)
+psql -d ${PGCOPYDB_SOURCE_PGURI} -f /usr/src/pgcopydb/dml.sql
+psql -d ${PGCOPYDB_SOURCE_PGURI} -c 'select pg_switch_wal()'
+
+psql -d ${PGCOPYDB_SOURCE_PGURI} -f /usr/src/pgcopydb/dml.sql
+psql -d ${PGCOPYDB_SOURCE_PGURI} -c 'select pg_switch_wal()'
+
+# Signal follow to stop at current WAL position
+echo "Setting endpos..."
+pgcopydb stream sentinel set endpos --current --debug ${HP} || { echo "Failed to set endpos"; exit 1; }
+echo "Final sentinel state:"
+pgcopydb stream sentinel get ${HP}
+
+endpos=$(pgcopydb stream sentinel get --endpos ${HP} 2>/dev/null)
+
+if [ -z "${endpos}" ] || [ "${endpos}" = "0/0" ]; then
+    echo "ERROR: endpos not set correctly (got: ${endpos})"
+    exit 1
+fi
+echo "Successfully set endpos to ${endpos}"
+
+# Wait until flush_lsn reaches endpos before exiting
+flushlsn="0/0"
+while [ "${flushlsn}" \< "${endpos}" ]
+do
+    flushlsn=$(pgcopydb stream sentinel get --flush-lsn ${HP} 2>/dev/null)
+    sleep 1
+done
+
+sleep 5


### PR DESCRIPTION
## Summary

Closes part of #910 (the publication-side filtering gap and wal2json filter-tables extension).

## What changed

### `pgsql_create_publication()` — server-side publication filtering

The function now accepts `SourceFilters *filters` and builds a filter-aware `WHERE` clause when querying `pg_tables` for the publication's table list:

- **Exclude filter** (`[exclude-table]` / `[exclude-schema]`): adds `AND NOT (schemaname = '...' AND tablename = '...')` / `AND schemaname != '...'` clauses so excluded tables/schemas never appear in the `FOR TABLE` list.
- **Include-only filter** (`[include-only-table]` / `[include-only-schema]`): adds `AND (schemaname = '...' OR ...)` so only the specified tables/schemas are in the publication.
- **No filter**: existing behaviour (all non-system tables).

This gives **true server-side filtering** via pgoutput: the server never streams WAL for tables absent from the publication.

### `stream_init_specs()` — wal2json filter-tables extension

A new `SourceFilters *filters` parameter is added:

- For **exclude** filters: appends `schema.*` or `schema.table` entries to the `filter-tables` plugin option (comma-separated, after the always-present `pgcopydb.*`).
- For **include-only** filters: adds an `add-tables` plugin option listing the permitted tables/schemas.
- Standalone stream CLI commands (`stream prefetch`, `stream catchup`, etc.) pass `NULL` — no change in behaviour.

The built strings are stored in stable `StreamSpecs` buffers (`wal2jsonFilterTables`, `wal2jsonAddTables`) so pointer validity is guaranteed.

## New test: `tests/follow-filtering`

Uses `pgcopydb clone --follow --plugin pgoutput --filters filters.ini` (excludes `public.staff`).

Key assertions:
1. `pg_publication_tables` does NOT include `staff` → server-side filtering works
2. `staff` table absent from target after clone → clone filter respected
3. Actor inserted by inject service (`actor_id = 999`) IS on target → included tables replicated correctly

## CI

- `tests/Makefile`: added `follow-filtering` target
- `run-tests.yml`: added `follow-filtering` to PR gate matrix (PG18 only, like other follow tests)
- `nightly.yml`: added `follow-filtering` to the nightly full-matrix run