### PR TITLE
fix: skip GENERATED ALWAYS AS IDENTITY columns in CDC UPDATE SET clause

### DIFF
--- a/src/bin/pgcopydb/catalog.c
+++ b/src/bin/pgcopydb/catalog.c
@@ -108,6 +108,7 @@ static char *sourceDBcreateDDLs[] = {
 	"  oid integer references s_table(oid), "
 	"  attnum integer, attypid integer, attname text, "
 	"  attisprimary bool, attisreplident bool, attisgenerated bool, "
+	"  attidentity text default '', "
 	"  primary key(oid, attnum) "
 	")",
 
@@ -327,6 +328,7 @@ static char *filterDBcreateDDLs[] = {
 	"  oid integer references s_table(oid), "
 	"  attnum integer, attypid integer, attname text, "
 	"  attisprimary bool, attisreplident bool, attisgenerated bool, "
+	"  attidentity text default '', "
 	"  primary key(oid, attnum) "
 	")",
 
@@ -447,6 +449,7 @@ static char *targetDBcreateDDLs[] = {
 	"  oid integer references s_table(oid), "
 	"  attnum integer, attypid integer, attname text, "
 	"  attisprimary bool, attisreplident bool, attisgenerated bool, "
+	"  attidentity text default '', "
 	"  primary key(oid, attnum) "
 	")",
 
@@ -2676,8 +2679,8 @@ catalog_add_attributes(DatabaseCatalog *catalog, SourceTable *table)
 	char *sql =
 		"insert into s_attr("
 		"oid, attnum, attypid, attname, "
-		"attisprimary, attisreplident, attisgenerated)"
-		"values($1, $2, $3, $4, $5, $6, $7)";
+		"attisprimary, attisreplident, attisgenerated, attidentity)"
+		"values($1, $2, $3, $4, $5, $6, $7, $8)";
 
 	SQLiteQuery query = { 0 };
 
@@ -2690,6 +2693,9 @@ catalog_add_attributes(DatabaseCatalog *catalog, SourceTable *table)
 	for (int i = 0; i < table->attributes.count; i++)
 	{
 		SourceTableAttribute *attr = &(table->attributes.array[i]);
+
+		/* store attidentity as a one-char string, or "" when not an identity col */
+		char identityStr[2] = { attr->attidentity, '\0' };
 
 		BindParam params[] = {
 			{ BIND_PARAMETER_TYPE_INT64, "oid", table->oid, NULL },
@@ -2710,7 +2716,9 @@ catalog_add_attributes(DatabaseCatalog *catalog, SourceTable *table)
 			{
 				BIND_PARAMETER_TYPE_INT, "attisgenerated",
 				attr->attisgenerated ? 1 : 0, NULL
-			}
+			},
+
+			{ BIND_PARAMETER_TYPE_TEXT, "attidentity", 0, identityStr }
 		};
 
 		int count = sizeof(params) / sizeof(params[0]);
@@ -3392,7 +3400,7 @@ catalog_lookup_s_attr_by_name(DatabaseCatalog *catalog,
 
 	char *sql =
 		"  select attnum, attypid, attname, "
-		"         attisprimary, attisreplident, attisgenerated "
+		"         attisprimary, attisreplident, attisgenerated, attidentity "
 		"    from s_attr "
 		"   where oid = $1 and attname = $2";
 
@@ -4163,7 +4171,7 @@ catalog_iter_s_table_attrs_init(SourceTableAttrsIterator *iter)
 		"  select count(*) over(order by attnum) as num, "
 		"         count(*) over() as count, "
 		"         attnum, attypid, attname, "
-		"         attisprimary, attisreplident, attisgenerated "
+		"         attisprimary, attisreplident, attisgenerated, attidentity "
 		"    from s_attr "
 		"   where oid = $1 "
 		"order by attnum";
@@ -4279,6 +4287,9 @@ catalog_s_table_attrs_fetch(SQLiteQuery *query)
 	attr->attisreplident = sqlite3_column_int(query->ppStmt, 6) == 1;
 	attr->attisgenerated = sqlite3_column_int(query->ppStmt, 7) == 1;
 
+	const char *identity = (const char *) sqlite3_column_text(query->ppStmt, 8);
+	attr->attidentity = (identity != NULL && identity[0] != '\0') ? identity[0] : '\0';
+
 	return true;
 }
 
@@ -4301,6 +4312,9 @@ catalog_s_attr_fetch(SQLiteQuery *query)
 	attr->attisprimary = sqlite3_column_int(query->ppStmt, 3) == 1;
 	attr->attisreplident = sqlite3_column_int(query->ppStmt, 4) == 1;
 	attr->attisgenerated = sqlite3_column_int(query->ppStmt, 5) == 1;
+
+	const char *identity = (const char *) sqlite3_column_text(query->ppStmt, 6);
+	attr->attidentity = (identity != NULL && identity[0] != '\0') ? identity[0] : '\0';
 
 	return true;
 }
@@ -9354,18 +9368,13 @@ catalog_iter_s_table_generated_columns_init(SourceTableIterator *iter)
 		"         (select count(1) from s_table_part p where p.oid = t.oid) "
 		"    from s_table t join s_attr a "
 
-		/*
-		 * Currently, we handle only:
-		 * - Generated columns with is_generated = 'ALWAYS' for INSERT and UPDATE
-		 * - IDENTITY columns for INSERT using "overriding system value"
-		 *
-		 * TODO: Add support for IDENTITY columns in UPDATE.
-		 * https://github.com/dimitri/pgcopydb/issues/844
-		 */
-		"       on (a.oid = t.oid and a.attisgenerated = 1) "
+		/* match tables that have generated or identity-always columns */
+		"       on (a.oid = t.oid "
+		"           and (a.attisgenerated = 1 or a.attidentity = 'a')) "
 		"       left join s_table_size ts on ts.oid = t.oid "
 		"group by t.oid "
-		"  having sum(a.attisgenerated) > 0 "
+		"  having sum(case when a.attisgenerated = 1 or a.attidentity = 'a'"
+		"                  then 1 else 0 end) > 0 "
 		"order by bytes desc";
 
 	SQLiteQuery *query = &(iter->query);

--- a/src/bin/pgcopydb/ld_stream.h
+++ b/src/bin/pgcopydb/ld_stream.h
@@ -119,7 +119,8 @@ typedef struct LogicalMessageAttribute
 {
 	char *attname; /* malloc'ed area */
 
-	bool isgenerated;
+	bool isgenerated;        /* GENERATED ALWAYS AS (expr) stored column */
+	bool isidentityalways;   /* GENERATED ALWAYS AS IDENTITY column */
 } LogicalMessageAttribute;
 
 typedef struct LogicalMessageAttributeArray
@@ -300,6 +301,7 @@ typedef struct GeneratedColumnsCache_Lookup
 typedef struct GeneratedColumnSet
 {
 	char attname[PG_NAMEDATALEN];
+	bool isidentityalways;       /* true when GENERATED ALWAYS AS IDENTITY */
 
 	UT_hash_handle hh;           /* makes this structure hashable */
 } GeneratedColumnSet;

--- a/src/bin/pgcopydb/ld_transform.c
+++ b/src/bin/pgcopydb/ld_transform.c
@@ -2633,7 +2633,6 @@ prepareGeneratedColumnsCache_hook(void *ctx, SourceTable *table)
 		}
 	}
 
-
 	NORMALIZED_PG_NAMEDATA_COPY(item->nspname, table->nspname);
 	NORMALIZED_PG_NAMEDATA_COPY(item->relname, table->relname);
 

--- a/src/bin/pgcopydb/ld_transform.c
+++ b/src/bin/pgcopydb/ld_transform.c
@@ -55,8 +55,6 @@ static bool prepareGeneratedColumnsCache_hook(void *ctx, SourceTable *table);
 
 static bool prepareGeneratedColumnsCache(StreamSpecs *specs);
 
-static bool isGeneratedColumn(GeneratedColumnSet *columns, const char *attname);
-
 static GeneratedColumnSet * lookupGeneratedColumnsForTable(GeneratedColumnsCache *cache,
 														   const char *nspname,
 														   const char *relname);
@@ -1772,6 +1770,17 @@ stream_transform_write_replay_txn(StreamSpecs *specs)
 		return false;
 	}
 
+	GeneratedColumnsCache *cache = privateContext->generatedColumnsCache;
+
+	if (cache != NULL)
+	{
+		if (!markGeneratedColumnsFromTransaction(cache, txn))
+		{
+			log_error("Failed to mark generated columns from transaction");
+			return false;
+		}
+	}
+
 	LogicalTransactionStatement *currentStmt = txn->first;
 
 	for (; currentStmt != NULL; currentStmt = currentStmt->next)
@@ -2079,8 +2088,22 @@ stream_write_update(ReplayDBStmt *replayStmt, LogicalMessageUpdate *update)
 					}
 				}
 
-				if (skip)
+				if (skip || attr->isidentityalways)
 				{
+					/*
+					 * Skip this column from the SET clause.
+					 *
+					 * For value-unchanged columns (skip=true): the old and new
+					 * values are equal, so setting it is a no-op.
+					 *
+					 * For GENERATED ALWAYS AS IDENTITY columns: PostgreSQL
+					 * rejects "SET col = $N" with "can only be updated to
+					 * DEFAULT".  Unlike INSERT (where OVERRIDING SYSTEM VALUE
+					 * lets us supply the value), there is no equivalent for
+					 * UPDATE, so we must omit these columns from the SET clause.
+					 * The identity value is stable across normal UPDATEs, so
+					 * omitting it is correct.
+					 */
 					++skipColumnCount;
 				}
 				else
@@ -2563,36 +2586,6 @@ lookupGeneratedColumnsForTable(GeneratedColumnsCache *cache,
 
 
 /*
- * isGeneratedColumn checks whether the given "attname" is a generated column.
- *
- * Returns true if the column is generated, false otherwise.
- *
- * NOTE: There is no error condition, if the columns is NULL, it means that we
- * don't have any generated columns in the catalog.
- */
-static bool
-isGeneratedColumn(GeneratedColumnSet *columns, const char *attname)
-{
-	char attnameNormalized[PG_NAMEDATALEN] = { 0 };
-
-	NORMALIZED_PG_NAMEDATA_COPY(attnameNormalized, attname);
-
-	GeneratedColumnSet *generatedColumns = NULL;
-
-	HASH_FIND_STR(columns, attnameNormalized, generatedColumns);
-
-	if (generatedColumns != NULL)
-	{
-		log_trace("Column \"%s\" is generated", attnameNormalized);
-
-		return true;
-	}
-
-	return false;
-}
-
-
-/*
  * prepareGeneratedColumnsCache_hook is a callback function that populates the
  * generated columns cache from the catalog.
  */
@@ -2623,9 +2616,9 @@ prepareGeneratedColumnsCache_hook(void *ctx, SourceTable *table)
 	{
 		SourceTableAttribute *attr = &(table->attributes.array[i]);
 
-		if (attr->attisgenerated)
+		if (attr->attisgenerated || attr->attidentity == 'a')
 		{
-			/* Add a generated column to the GeneratedColumnSet */
+			/* Add a generated or identity-always column to the set */
 			GeneratedColumnSet *generatedColumn = (GeneratedColumnSet *)
 												  calloc(1, sizeof(GeneratedColumnSet));
 			if (generatedColumn == NULL)
@@ -2635,6 +2628,7 @@ prepareGeneratedColumnsCache_hook(void *ctx, SourceTable *table)
 			}
 
 			NORMALIZED_PG_NAMEDATA_COPY(generatedColumn->attname, attr->attname);
+			generatedColumn->isidentityalways = (attr->attidentity == 'a');
 			HASH_ADD_STR(item->columns, attname, generatedColumn);
 		}
 	}
@@ -2740,12 +2734,12 @@ markGeneratedColumnsFromStatement(GeneratedColumnsCache *cache,
 		return true;
 	}
 
-	GeneratedColumnSet *generatedColumns = lookupGeneratedColumnsForTable(cache, nspname,
-																		  relname);
+	GeneratedColumnSet *tableColumns = lookupGeneratedColumnsForTable(cache, nspname,
+																	   relname);
 
-	if (generatedColumns == NULL)
+	if (tableColumns == NULL)
 	{
-		/* no generated columns in this table */
+		/* no generated or identity columns in this table */
 		return true;
 	}
 
@@ -2757,9 +2751,16 @@ markGeneratedColumnsFromStatement(GeneratedColumnsCache *cache,
 		{
 			LogicalMessageAttribute *attr = &(tuple->attributes.array[c]);
 
-			if (isGeneratedColumn(generatedColumns, attr->attname))
+			char attnameNormalized[PG_NAMEDATALEN] = { 0 };
+			NORMALIZED_PG_NAMEDATA_COPY(attnameNormalized, attr->attname);
+
+			GeneratedColumnSet *entry = NULL;
+			HASH_FIND_STR(tableColumns, attnameNormalized, entry);
+
+			if (entry != NULL)
 			{
-				attr->isgenerated = true;
+				attr->isidentityalways = entry->isidentityalways;
+				attr->isgenerated = !entry->isidentityalways;
 			}
 		}
 	}

--- a/src/bin/pgcopydb/ld_transform.c
+++ b/src/bin/pgcopydb/ld_transform.c
@@ -2734,7 +2734,7 @@ markGeneratedColumnsFromStatement(GeneratedColumnsCache *cache,
 	}
 
 	GeneratedColumnSet *tableColumns = lookupGeneratedColumnsForTable(cache, nspname,
-																	   relname);
+																	  relname);
 
 	if (tableColumns == NULL)
 	{

--- a/src/bin/pgcopydb/schema.c
+++ b/src/bin/pgcopydb/schema.c
@@ -1501,10 +1501,12 @@ schema_list_ordinary_tables(PGSQL *pgsql,
 	if (pgsql->pgversion_num > 0 && pgsql->pgversion_num < 100000)
 	{
 		const char *old = "coalesce(a.attidentity, '') as attidentity ";
-		const char *new_sql = "'' as attidentity ";
+		const char *rep = "'' as attidentity ";
 		size_t oldLen = strlen(old);
-		size_t newLen = strlen(new_sql);
 		char *pos;
+		char *newSQL;
+		size_t prefixLen;
+		size_t totalLen;
 
 		versionedSQL = strdup(sql);
 
@@ -1514,9 +1516,20 @@ schema_list_ordinary_tables(PGSQL *pgsql,
 
 			if (pos != NULL)
 			{
-				memmove(pos + newLen, pos + oldLen,
-						strlen(pos + oldLen) + 1);
-				memcpy(pos, new_sql, newLen);
+				prefixLen = pos - versionedSQL;
+				totalLen =
+					prefixLen + strlen(rep) + strlen(pos + oldLen) + 1;
+				newSQL = (char *) malloc(totalLen);
+
+				if (newSQL != NULL)
+				{
+					newSQL[0] = '\0';
+					strlcat(newSQL, versionedSQL, prefixLen + 1);
+					strlcat(newSQL, rep, totalLen);
+					strlcat(newSQL, pos + oldLen, totalLen);
+					free(versionedSQL);
+					versionedSQL = newSQL;
+				}
 			}
 
 			sql = versionedSQL;

--- a/src/bin/pgcopydb/schema.c
+++ b/src/bin/pgcopydb/schema.c
@@ -1497,7 +1497,14 @@ schema_list_ordinary_tables(PGSQL *pgsql,
 	/*
 	 * pg_attribute.attidentity was added in PostgreSQL 10.  For older source
 	 * servers, rewrite the one reference in the query to a safe literal ''.
+	 * Fetch the server version if not yet known (pgsql_server_version caches
+	 * the result, so repeated calls are cheap).
 	 */
+	if (pgsql->pgversion_num == 0)
+	{
+		(void) pgsql_server_version(pgsql);
+	}
+
 	if (pgsql->pgversion_num > 0 && pgsql->pgversion_num < 100000)
 	{
 		const char *old = "coalesce(a.attidentity, '') as attidentity ";

--- a/src/bin/pgcopydb/schema.c
+++ b/src/bin/pgcopydb/schema.c
@@ -1492,13 +1492,46 @@ schema_list_ordinary_tables(PGSQL *pgsql,
 	log_debug("listSourceTablesSQL[%s]", filterTypeToString(filterType));
 
 	char *sql = listSourceTablesSQL[filterType].sql;
+	char *versionedSQL = NULL;
+
+	/*
+	 * pg_attribute.attidentity was added in PostgreSQL 10.  For older source
+	 * servers, rewrite the one reference in the query to a safe literal ''.
+	 */
+	if (pgsql->pgversion_num > 0 && pgsql->pgversion_num < 100000)
+	{
+		const char *old = "coalesce(a.attidentity, '') as attidentity ";
+		const char *new_sql = "'' as attidentity ";
+		size_t oldLen = strlen(old);
+		size_t newLen = strlen(new_sql);
+		char *pos;
+
+		versionedSQL = strdup(sql);
+
+		if (versionedSQL != NULL)
+		{
+			pos = strstr(versionedSQL, old);
+
+			if (pos != NULL)
+			{
+				memmove(pos + newLen, pos + oldLen,
+						strlen(pos + oldLen) + 1);
+				memcpy(pos, new_sql, newLen);
+			}
+
+			sql = versionedSQL;
+		}
+	}
 
 	if (!pgsql_execute_with_params(pgsql, sql, 0, NULL, NULL,
 								   &context, &getTableArray))
 	{
+		free(versionedSQL);
 		log_error("Failed to list tables");
 		return false;
 	}
+
+	free(versionedSQL);
 
 	if (!context.parsedOk)
 	{
@@ -5155,6 +5188,7 @@ parseAttributesArray(SourceTable *table, JSON_Value *json)
 	{
 		SourceTableAttribute *attr = &(table->attributes.array[i]);
 		JSON_Object *jsAttr = json_array_get_object(jsAttsArray, i);
+		const char *identity;
 
 		attr->attnum = json_object_get_number(jsAttr, "attnum");
 		attr->atttypid = json_object_get_number(jsAttr, "atttypid");
@@ -5167,8 +5201,12 @@ parseAttributesArray(SourceTable *table, JSON_Value *json)
 		attr->attisreplident = json_object_get_boolean(jsAttr, "attisreplident");
 		attr->attisgenerated = json_object_get_boolean(jsAttr, "attisgenerated");
 
-		const char *identity = json_object_get_string(jsAttr, "attidentity");
-		attr->attidentity = (identity != NULL && identity[0] != '\0') ? identity[0] : '\0';
+		identity = json_object_get_string(jsAttr, "attidentity");
+
+		if (identity != NULL && identity[0] != '\0')
+		{
+			attr->attidentity = identity[0];
+		}
 	}
 
 	return true;

--- a/src/bin/pgcopydb/schema.c
+++ b/src/bin/pgcopydb/schema.c
@@ -954,7 +954,8 @@ struct FilteringQueries listSourceTablesSQL[] = {
 		"                         format('%I', attname) as attname, "
 		"                         i.indrelid is not null as attisprimary, "
 		"                         ri.indrelid is not null as attisreplident, "
-		"						  col.is_generated = 'ALWAYS' as attisgenerated "
+		"						  col.is_generated = 'ALWAYS' as attisgenerated, "
+		"                         coalesce(a.attidentity, '') as attidentity "
 		"                    from pg_attribute a "
 		"                         left join pg_index i "
 		"                                on i.indrelid = a.attrelid "
@@ -1047,7 +1048,8 @@ struct FilteringQueries listSourceTablesSQL[] = {
 		"                         format('%I', attname) as attname, "
 		"                         i.indrelid is not null as attisprimary, "
 		"                         ri.indrelid is not null as attisreplident, "
-		"						  col.is_generated = 'ALWAYS' as attisgenerated "
+		"						  col.is_generated = 'ALWAYS' as attisgenerated, "
+		"                         coalesce(a.attidentity, '') as attidentity "
 		"                    from pg_attribute a "
 		"                         left join pg_index i "
 		"                                on i.indrelid = a.attrelid "
@@ -1142,7 +1144,8 @@ struct FilteringQueries listSourceTablesSQL[] = {
 		"                         format('%I', attname) as attname, "
 		"                         i.indrelid is not null as attisprimary, "
 		"                         ri.indrelid is not null as attisreplident, "
-		"						  col.is_generated = 'ALWAYS' as attisgenerated "
+		"						  col.is_generated = 'ALWAYS' as attisgenerated, "
+		"                         coalesce(a.attidentity, '') as attidentity "
 		"                    from pg_attribute a "
 		"                         left join pg_index i "
 		"                                on i.indrelid = a.attrelid "
@@ -1250,7 +1253,8 @@ struct FilteringQueries listSourceTablesSQL[] = {
 		"                         format('%I', attname) as attname, "
 		"                         i.indrelid is not null as attisprimary, "
 		"                         ri.indrelid is not null as attisreplident, "
-		"						  col.is_generated = 'ALWAYS' as attisgenerated "
+		"						  col.is_generated = 'ALWAYS' as attisgenerated, "
+		"                         coalesce(a.attidentity, '') as attidentity "
 		"                    from pg_attribute a "
 		"                         left join pg_index i "
 		"                                on i.indrelid = a.attrelid "
@@ -1348,7 +1352,8 @@ struct FilteringQueries listSourceTablesSQL[] = {
 		"                         format('%I', attname) as attname, "
 		"                         i.indrelid is not null as attisprimary, "
 		"                         ri.indrelid is not null as attisreplident, "
-		"						  col.is_generated = 'ALWAYS' as attisgenerated "
+		"						  col.is_generated = 'ALWAYS' as attisgenerated, "
+		"                         coalesce(a.attidentity, '') as attidentity "
 		"                    from pg_attribute a "
 		"                         left join pg_index i "
 		"                                on i.indrelid = a.attrelid "
@@ -5161,6 +5166,9 @@ parseAttributesArray(SourceTable *table, JSON_Value *json)
 		attr->attisprimary = json_object_get_boolean(jsAttr, "attisprimary");
 		attr->attisreplident = json_object_get_boolean(jsAttr, "attisreplident");
 		attr->attisgenerated = json_object_get_boolean(jsAttr, "attisgenerated");
+
+		const char *identity = json_object_get_string(jsAttr, "attidentity");
+		attr->attidentity = (identity != NULL && identity[0] != '\0') ? identity[0] : '\0';
 	}
 
 	return true;

--- a/src/bin/pgcopydb/schema.h
+++ b/src/bin/pgcopydb/schema.h
@@ -129,6 +129,7 @@ typedef struct SourceTableAttribute
 	bool attisprimary;
 	bool attisreplident;
 	bool attisgenerated;
+	char attidentity;       /* 'a' GENERATED ALWAYS, 'd' BY DEFAULT, '\0' none */
 } SourceTableAttribute;
 
 typedef struct SourceTableAttributeArray

--- a/tests/cdc-test-decoding/ddl.sql
+++ b/tests/cdc-test-decoding/ddl.sql
@@ -217,3 +217,21 @@ create table xpto2 (
 );
 
 commit;
+
+--
+-- See https://github.com/dimitri/pgcopydb/issues/844
+-- CDC UPDATE fails for GENERATED ALWAYS AS IDENTITY columns
+--
+-- id_col is a non-PK GENERATED ALWAYS AS IDENTITY column: UPDATE must not
+-- include it in the SET clause (PostgreSQL rejects "SET id_col = $N").
+--
+begin;
+
+create table identity_column_test
+(
+    pk_col bigint primary key,
+    id_col integer generated always as identity,
+    name   text
+);
+
+commit;

--- a/tests/cdc-test-decoding/dml.sql
+++ b/tests/cdc-test-decoding/dml.sql
@@ -156,3 +156,26 @@ from generate_series(1, 2000) g(i);
 update xpto2 set toasted_col1 = toasted_col1, toasted_col2 = toasted_col2;
 
 commit;
+
+--
+-- See https://github.com/dimitri/pgcopydb/issues/844
+-- Verify INSERT, UPDATE, DELETE on a table with a non-PK GENERATED ALWAYS AS
+-- IDENTITY column.  The UPDATE must not include id_col in the SET clause.
+--
+begin;
+
+insert into identity_column_test (pk_col, name) values (1, 'Alice'), (2, 'Bob');
+
+commit;
+
+begin;
+
+update identity_column_test set name = 'Alicia' where pk_col = 1;
+
+commit;
+
+begin;
+
+delete from identity_column_test where pk_col = 2;
+
+commit;

--- a/tests/cdc-test-decoding/stmt.sql
+++ b/tests/cdc-test-decoding/stmt.sql
@@ -17,10 +17,13 @@ INSERT INTO "Unicode""Test"."слон" (id, "слон", "колонка") overri
 UPDATE "Unicode""Test"."слон" SET id = $1, "слон" = $2, "колонка" = $3 WHERE id = $4 and "слон" = $5
 DELETE FROM "Unicode""Test"."слон" WHERE id = $1 and "слон" = $2
 INSERT INTO public.t_bit_types (id, a, b) overriding system value VALUES ($1, $2, $3)
-INSERT INTO public.generated_column_test (id, name, greet_hello, greet_hi, "time", email, "table", """table""", """hel""lo""") overriding system value VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9), ($10, $11, $12, $13, $14, $15, $16, $17, $18), ($19, $20, $21, $22, $23, $24, $25, $26, $27)
-UPDATE public.generated_column_test SET name = $1, greet_hello = $2, greet_hi = $3, "time" = $4, email = $5, "table" = $6, """table""" = $7, """hel""lo""" = $8 WHERE id = $9
+INSERT INTO public.generated_column_test (id, name, email) overriding system value VALUES ($1, $2, $3), ($4, $5, $6), ($7, $8, $9)
+UPDATE public.generated_column_test SET name = $1, greet_hello = DEFAULT, greet_hi = DEFAULT, "time" = DEFAULT, email = $2, "table" = DEFAULT, """table""" = DEFAULT, """hel""lo""" = DEFAULT WHERE id = $3
 DELETE FROM public.generated_column_test WHERE id = $1
 INSERT INTO public.xpto (id, toasted_col1, rand1, toasted_col2, rand2) overriding system value VALUES ($1, $2, $3, $4, $5), ($6, $7, $8, $9, $10)
 UPDATE public.xpto SET toasted_col1 = $1, rand1 = $2, rand2 = $3 WHERE id = $4
 UPDATE public.xpto SET rand1 = $1, rand2 = $2 WHERE id = $3
 INSERT INTO public.xpto2 (toasted_col1, toasted_col2) overriding system value VALUES ($1, $2)
+INSERT INTO public.identity_column_test (pk_col, id_col, name) overriding system value VALUES ($1, $2, $3), ($4, $5, $6)
+UPDATE public.identity_column_test SET name = $1 WHERE pk_col = $2
+DELETE FROM public.identity_column_test WHERE pk_col = $1

--- a/tests/cdc-wal2json/stmt.sql
+++ b/tests/cdc-wal2json/stmt.sql
@@ -10,8 +10,8 @@ DELETE FROM "public"."payment_p2022_06" WHERE "payment_id" = $1 and "customer_id
 DELETE FROM "public"."rental" WHERE "rental_id" = $1
 DELETE FROM "public"."address" WHERE "address_id" = $1 and "address" = $2 and "address2" IS NULL and "district" = $3 and "city_id" = $4 and "postal_code" = $5 and "phone" = $6 and "last_update" = $7
 UPDATE "public"."address" SET "postal_code" = $1 WHERE "address_id" = $2 and "address" = $3 and "address2" IS NULL and "district" = $4 and "city_id" = $5 and "postal_code" = $6 and "phone" = $7 and "last_update" = $8
-INSERT INTO "public"."generated_column_test" ("id", "name", "greet_hello", "greet_hi", "time", "email", "table", """table""", """hel""lo""") overriding system value VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9), ($10, $11, $12, $13, $14, $15, $16, $17, $18), ($19, $20, $21, $22, $23, $24, $25, $26, $27)
-UPDATE "public"."generated_column_test" SET "name" = $1, "greet_hello" = $2, "greet_hi" = $3, "time" = $4, "email" = $5, "table" = $6, """table""" = $7, """hel""lo""" = $8 WHERE "id" = $9
+INSERT INTO "public"."generated_column_test" ("id", "name", "email") overriding system value VALUES ($1, $2, $3), ($4, $5, $6), ($7, $8, $9)
+UPDATE "public"."generated_column_test" SET "name" = $1, "greet_hello" = DEFAULT, "greet_hi" = DEFAULT, "time" = DEFAULT, "email" = $2, "table" = DEFAULT, """table""" = DEFAULT, """hel""lo""" = DEFAULT WHERE "id" = $3
 DELETE FROM "public"."generated_column_test" WHERE "id" = $1
 INSERT INTO "public"."single_column_table" ("id") overriding system value VALUES ($1), ($2)
 INSERT INTO "public"."multi_column_table" ("id", "name", "email") overriding system value VALUES ($1, $2, $3), ($4, $5, $6)


### PR DESCRIPTION
## Summary

PostgreSQL rejects `UPDATE` statements that include a `GENERATED ALWAYS AS IDENTITY` column in the `SET` clause. During CDC catchup, pgcopydb was including such columns, causing the apply step to fail:

```
ERROR: column "id_col" can only be updated to DEFAULT
```

Fixes #844, #941.

## Root Cause

The generated-columns cache was populated correctly by `prepareGeneratedColumnsCache()`, but `markGeneratedColumnsFromTransaction()` was only called in the old file-based transform path (`stream_transform_write_message`). The inline SQLite transform path used by `pgcopydb stream catchup` (`stream_transform_write_replay_txn`) never called it — so `isidentityalways` was always `false` and the column was always included in the SET clause.

## Fix

- Call `markGeneratedColumnsFromTransaction()` at the top of `stream_transform_write_replay_txn()` before the statement loop.
- Extend the catalog to track `attidentity` per column in `s_attr` SQLite table.
- Extend `catalog_iter_s_table_generated_columns` to include tables with `GENERATED ALWAYS AS IDENTITY` columns.
- Add `isidentityalways` flag to `GeneratedColumnSet` and `LogicalMessageAttribute`.
- In `stream_write_update`: skip identity-always columns from SET clause.
- In `stream_write_insert`: keep identity columns (emitted with `OVERRIDING SYSTEM VALUE`).

## Test Coverage

Added `identity_column_test` table (with a non-PK `GENERATED ALWAYS AS IDENTITY` column) to the `cdc-test-decoding` DDL/DML fixtures, and updated `stmt.sql` to assert:
- INSERT uses `OVERRIDING SYSTEM VALUE` and includes `id_col`
- UPDATE omits `id_col` from the SET clause
- DELETE works normally