### PR TITLE
fix: prevent segfault in compare schema when table/index/seq missing on target (#895)

### DIFF
--- a/src/bin/pgcopydb/compare.c
+++ b/src/bin/pgcopydb/compare.c
@@ -659,7 +659,7 @@ compare_schemas_table_hook(void *ctx, SourceTable *sourceTable)
 				  "internal target catalogs",
 				  sourceTable->nspname,
 				  sourceTable->relname);
-
+		free(targetTable);
 		return false;
 	}
 
@@ -668,6 +668,8 @@ compare_schemas_table_hook(void *ctx, SourceTable *sourceTable)
 		++context->diffCount;
 		log_error("Failed to find table %s in target database",
 				  sourceTable->qname);
+		free(targetTable);
+		return true;
 	}
 
 	/* now fetch table attributes lists */
@@ -677,8 +679,11 @@ compare_schemas_table_hook(void *ctx, SourceTable *sourceTable)
 		log_error("Failed to fetch table %s attribute list, "
 				  "see above for details",
 				  sourceTable->qname);
+		free(targetTable);
 		return false;
 	}
+
+	int diffsBefore = context->diffCount;
 
 	/* check table columns */
 	if (sourceTable->attributes.count != targetTable->attributes.count)
@@ -688,32 +693,58 @@ compare_schemas_table_hook(void *ctx, SourceTable *sourceTable)
 				  sourceTable->qname,
 				  sourceTable->attributes.count,
 				  targetTable->attributes.count);
+
+		/*
+		 * TODO: a future improvement could let the caller choose a
+		 * reconciliation strategy — for example, allowing extra columns on the
+		 * target (added post-migration) to be ignored.  For now we match
+		 * columns by name so the caller still learns about individual missing
+		 * columns even when the total counts differ.
+		 */
 	}
 
-	for (int c = 0; c < sourceTable->attributes.count; c++)
+	/*
+	 * Compare columns by name rather than by position.  We scan the target
+	 * attribute list for each source column (N*M loop).  This is correct when
+	 * column order or column sets differ, and is fast enough because tables
+	 * have a small, bounded number of attributes in practice.
+	 *
+	 * A cross-database SQLite JOIN (via ATTACH) could do this in a single
+	 * query, but it would require exposing the catalog file path and managing
+	 * an ATTACH/DETACH around the lookup; the extra complexity is not worth it
+	 * given the small N.
+	 */
+	for (int s = 0; s < sourceTable->attributes.count; s++)
 	{
-		char *srcAttName = sourceTable->attributes.array[c].attname;
-		char *tgtAttName = targetTable->attributes.array[c].attname;
+		SourceTableAttribute *srcAttr = &sourceTable->attributes.array[s];
+		SourceTableAttribute *tgtAttr = NULL;
 
-		if (!streq(srcAttName, tgtAttName))
+		for (int t = 0; t < targetTable->attributes.count; t++)
+		{
+			if (streq(srcAttr->attname, targetTable->attributes.array[t].attname))
+			{
+				tgtAttr = &targetTable->attributes.array[t];
+				break;
+			}
+		}
+
+		if (tgtAttr == NULL)
 		{
 			++context->diffCount;
-			log_error("Table %s attribute number %d "
-					  "has name \"%s\" (%d) on source and "
-					  "has name \"%s\" (%d) on target",
+			log_error("Table %s column \"%s\" exists on source but not on target",
 					  sourceTable->qname,
-					  c,
-					  srcAttName,
-					  sourceTable->attributes.array[c].attnum,
-					  tgtAttName,
-					  targetTable->attributes.array[c].attnum);
+					  srcAttr->attname);
 		}
 	}
 
+	if (context->diffCount == diffsBefore)
+	{
+		log_notice("Matched table %s with %d columns ok",
+				   sourceTable->qname,
+				   sourceTable->attributes.count);
+	}
 
-	log_notice("Matched table %s with %d columns ok",
-			   sourceTable->qname,
-			   sourceTable->attributes.count);
+	free(targetTable);
 
 	return true;
 }
@@ -744,7 +775,7 @@ compare_schemas_index_hook(void *ctx, SourceIndex *sourceIndex)
 				  "internal target catalogs",
 				  sourceIndex->indexNamespace,
 				  sourceIndex->indexRelname);
-
+		free(targetIndex);
 		return false;
 	}
 
@@ -753,7 +784,11 @@ compare_schemas_index_hook(void *ctx, SourceIndex *sourceIndex)
 		++context->diffCount;
 		log_error("Failed to find index %s in target database",
 				  sourceIndex->indexQname);
+		free(targetIndex);
+		return true;
 	}
+
+	int diffsBefore = context->diffCount;
 
 	if (!streq(sourceIndex->indexNamespace, targetIndex->indexNamespace) ||
 		!streq(sourceIndex->indexRelname, targetIndex->indexRelname))
@@ -837,11 +872,15 @@ compare_schemas_index_hook(void *ctx, SourceIndex *sourceIndex)
 				 targetIndex->constraintDef);
 	}
 
+	if (context->diffCount == diffsBefore)
+	{
+		log_notice("Matched index %s ok (%s, %s)",
+				   sourceIndex->indexQname,
+				   sourceIndex->isPrimary ? "primary" : "not primary",
+				   sourceIndex->isUnique ? "unique" : "not unique");
+	}
 
-	log_notice("Matched index %s ok (%s, %s)",
-			   sourceIndex->indexQname,
-			   sourceIndex->isPrimary ? "primary" : "not primary",
-			   sourceIndex->isUnique ? "unique" : "not unique");
+	free(targetIndex);
 
 	return true;
 }
@@ -873,7 +912,7 @@ compare_schemas_seq_hook(void *ctx, SourceSequence *sourceSeq)
 				  "internal target catalogs",
 				  sourceSeq->nspname,
 				  sourceSeq->relname);
-
+		free(targetSeq);
 		return false;
 	}
 
@@ -882,7 +921,11 @@ compare_schemas_seq_hook(void *ctx, SourceSequence *sourceSeq)
 		++context->diffCount;
 		log_error("Failed to find seq %s in target database",
 				  sourceSeq->qname);
+		free(targetSeq);
+		return true;
 	}
+
+	int diffsBefore = context->diffCount;
 
 	if (sourceSeq->lastValue != targetSeq->lastValue)
 	{
@@ -902,10 +945,14 @@ compare_schemas_seq_hook(void *ctx, SourceSequence *sourceSeq)
 				  targetSeq->isCalled ? "yes" : "no");
 	}
 
-	log_notice("Matched sequence %s (last value %lld)",
-			   sourceSeq->qname,
-			   (long long) sourceSeq->lastValue);
+	if (context->diffCount == diffsBefore)
+	{
+		log_notice("Matched sequence %s (last value %lld)",
+				   sourceSeq->qname,
+				   (long long) sourceSeq->lastValue);
+	}
 
+	free(targetSeq);
 
 	return true;
 }


### PR DESCRIPTION
## Problem

Fixes #895.

When `pgcopydb compare schema` encounters a table (or index/sequence) that exists on the source but not on the target, `catalog_lookup_s_table_by_name` returns `true` with `targetTable->oid == 0`. The old code fell through to the attribute comparison loop which immediately dereferenced `targetTable->attributes.array` — a NULL pointer in the zero-initialised struct — causing a SIGSEGV.

The same pattern was present in all three object hooks: table, index and sequence.

## Fix

Three changes across `compare_schemas_table_hook`, `compare_schemas_index_hook`, and `compare_schemas_seq_hook`:

### 1. Early return when object is missing on target

When `oid == 0` (object not found), increment `diffCount`, emit the error message, free the heap allocation, and `return true` immediately so comparison continues with the next object.

### 2. Free on all paths

The heap-allocated target struct was leaked on both error and success paths. All three hooks now `free()` unconditionally at the end, with additional `free()` calls on the early-return paths.

### 3. Column comparison by name instead of by position

The old table hook compared columns positionally (`array[c]` vs `array[c]`), which crashes with an out-of-bounds read when the target has fewer columns than the source. The new implementation does an N×M scan: for each source column, search the target list for a column with the same name. This is correct regardless of column order or count differences.

When attribute counts differ, a diff is still emitted at the table level, and individual per-column diffs are still reported for each source column absent from the target. A TODO comment notes a future reconciliation strategy (tolerating extra columns added post-migration).

### 4. Suppress spurious "Matched ok" notice on diffs

A `diffsBefore` guard ensures the success notice is only logged when no new differences were found during comparison.

## Testing

- `sh ./ci/banned.h.sh` — passes
- `docker run --rm -v $(pwd):/work -w /work citus/stylechecker:no-py citus_indent` — all PASS
- `make tests/pagila` — passes, `pgcopydb schema inspection is successful`
- `make tests/filtering` — passes
- `make tests/cdc-test-decoding` — passes