### PR TITLE
fix: validate and normalize filter names against source catalogs (#942)

### DIFF
--- a/src/bin/pgcopydb/filtering.h
+++ b/src/bin/pgcopydb/filtering.h
@@ -27,7 +27,8 @@ typedef enum
 
 typedef struct SourceFilterSchema
 {
-	char nspname[PG_NAMEDATALEN];
+	char nspname[PG_NAMEDATALEN];        /* bare name from pg_namespace (after normalization) */
+	char restoreListName[PG_NAMEDATALEN]; /* quote_ident form for pg_dump/pg_restore args */
 } SourceFilterSchema;
 
 typedef struct SourceFilterSchemaList
@@ -86,6 +87,7 @@ typedef enum
 typedef struct SourceFilters
 {
 	bool prepared;
+	bool normalized;
 	SourceFilterType type;
 	SourceFilterSchemaList includeOnlySchemaList;
 	SourceFilterSchemaList excludeSchemaList;
@@ -98,6 +100,7 @@ typedef struct SourceFilters
 char * filterTypeToString(SourceFilterType type);
 SourceFilterType filterTypeComplement(SourceFilterType type);
 bool parse_filters(const char *filebname, SourceFilters *filters);
+bool filters_validate_and_normalize(PGSQL *pgsql, SourceFilters *filters);
 
 bool filters_as_json(SourceFilters *filters, JSON_Value *jsFilter);
 

--- a/src/bin/pgcopydb/pgcmd.c
+++ b/src/bin/pgcopydb/pgcmd.c
@@ -407,7 +407,8 @@ pg_dump_db(PostgresPaths *pgPaths,
 	/* apply [include-only-schema] filtering */
 	for (int i = 0; i < filters->includeOnlySchemaList.count; i++)
 	{
-		char *nspname = filters->includeOnlySchemaList.array[i].nspname;
+		char *restoreListName =
+			filters->includeOnlySchemaList.array[i].restoreListName;
 
 		/* check that we still have room for --includeOnly-schema args */
 		if (PG_CMD_MAX_ARG < (argsIndex + 2))
@@ -419,13 +420,14 @@ pg_dump_db(PostgresPaths *pgPaths,
 		}
 
 		args[argsIndex++] = "--schema";
-		args[argsIndex++] = nspname;
+		args[argsIndex++] = restoreListName;
 	}
 
 	/* apply [exclude-schema] filtering */
 	for (int i = 0; i < filters->excludeSchemaList.count; i++)
 	{
-		char *nspname = filters->excludeSchemaList.array[i].nspname;
+		char *restoreListName =
+			filters->excludeSchemaList.array[i].restoreListName;
 
 		/* check that we still have room for --exclude-schema args */
 		if (PG_CMD_MAX_ARG < (argsIndex + 6))
@@ -438,7 +440,7 @@ pg_dump_db(PostgresPaths *pgPaths,
 		}
 
 		args[argsIndex++] = "--exclude-schema";
-		args[argsIndex++] = nspname;
+		args[argsIndex++] = restoreListName;
 	}
 
 	args[argsIndex++] = "--file";
@@ -976,7 +978,8 @@ pg_restore_db(PostgresPaths *pgPaths,
 	/* apply [exclude-schema] filtering */
 	for (int i = 0; i < filters->excludeSchemaList.count; i++)
 	{
-		char *nspname = filters->excludeSchemaList.array[i].nspname;
+		char *restoreListName =
+			filters->excludeSchemaList.array[i].restoreListName;
 
 		/* check that we still have room for --exclude-schema args */
 		if (PG_CMD_MAX_ARG < (argsIndex + 2))
@@ -989,7 +992,7 @@ pg_restore_db(PostgresPaths *pgPaths,
 		}
 
 		args[argsIndex++] = "--exclude-schema";
-		args[argsIndex++] = nspname;
+		args[argsIndex++] = restoreListName;
 	}
 
 	if (listFilename != NULL)

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -5693,6 +5693,19 @@ typedef struct FilterNormalizeContext
  * parseFilterNormalize processes one (or more, in non-single-row mode) result
  * rows from the validation query and writes the canonical names back into the
  * SourceFilters struct.
+ *
+ * Column layout:
+ *   0  kind            ('schema' | 'table')
+ *   1  input           (user-supplied name, used as the match key)
+ *   2  is_include_only (boolean: true = include-only list, false = exclude list)
+ *   3  nspname         (NULL when not found)
+ *   4  relname         (NULL when not a table hit, or not found)
+ *   5  quoted_nspname  (quote_ident output; NULL when nspname is NULL)
+ *   6  quoted_relname  (quote_ident output; NULL when relname is NULL)
+ *
+ * NULL nspname means the object was not found in the catalog.  For include-only
+ * entries that is a hard error.  For exclude entries it is a no-op (pg_dump
+ * silently ignores exclusion patterns that match nothing).
  */
 static void
 parseFilterNormalize(void *ctx, PGresult *result)
@@ -5716,20 +5729,30 @@ parseFilterNormalize(void *ctx, PGresult *result)
 	{
 		char *kind = PQgetvalue(result, row, 0);
 		char *input = PQgetvalue(result, row, 1);
-		bool nspIsNull = PQgetisnull(result, row, 2);
-		char *nspname = nspIsNull ? NULL : PQgetvalue(result, row, 2);
-		bool relIsNull = PQgetisnull(result, row, 3);
-		char *relname = relIsNull ? NULL : PQgetvalue(result, row, 3);
-		char *quotedNsp = PQgetisnull(result, row, 4) ? NULL : PQgetvalue(result, row, 4);
-		char *quotedRel = PQgetisnull(result, row, 5) ? NULL : PQgetvalue(result, row, 5);
+		bool isIncludeOnly = strcmp(PQgetvalue(result, row, 2), "t") == 0;
+		bool nspIsNull = PQgetisnull(result, row, 3);
+		char *nspname = nspIsNull ? NULL : PQgetvalue(result, row, 3);
+		bool relIsNull = PQgetisnull(result, row, 4);
+		char *relname = relIsNull ? NULL : PQgetvalue(result, row, 4);
+		char *quotedNsp = PQgetisnull(result, row, 5) ? NULL : PQgetvalue(result, row, 5);
+		char *quotedRel = PQgetisnull(result, row, 6) ? NULL : PQgetvalue(result, row, 6);
 
 		if (nspIsNull)
 		{
-			log_error("Failed to find %s \"%s\" in the source database catalogs; "
-					  "check that the name exists and is correctly quoted "
-					  "(uppercase and special characters require double-quotes)",
-					  kind, input);
-			++context->errorCount;
+			if (isIncludeOnly)
+			{
+				log_error("Failed to find %s \"%s\" in the source database catalogs; "
+						  "check that the name exists and is correctly quoted "
+						  "(uppercase and special characters require double-quotes)",
+						  kind, input);
+				++context->errorCount;
+			}
+			else
+			{
+				log_notice("Exclude filter %s \"%s\" does not exist in the source "
+						   "database — exclusion is a no-op",
+						   kind, input);
+			}
 			continue;
 		}
 
@@ -5784,7 +5807,7 @@ parseFilterNormalize(void *ctx, PGresult *result)
 						strlcpy(table->nspname, nspname, sizeof(table->nspname));
 						strlcpy(table->relname, relname, sizeof(table->relname));
 
-						(void) quotedRel; /* used only for logging if needed */
+						(void) quotedRel;
 					}
 				}
 			}
@@ -5800,8 +5823,13 @@ parseFilterNormalize(void *ctx, PGresult *result)
  *   schemas  → to_regnamespace()  → returns nspname + quote_ident(nspname)
  *   tables   → to_regclass()      → returns nspname + relname (from pg_class)
  *
- * Any entry that produces NULL (object not found) is reported as an error and
- * the function returns false.  On success every SourceFilterSchema gets:
+ * A NULL result (object not found) is treated differently depending on the
+ * filter list:
+ *
+ *   include-only lists  → hard error; the copy would silently include nothing
+ *   exclude lists       → notice + no-op (pg_dump ignores unknown patterns)
+ *
+ * On success every SourceFilterSchema gets:
  *
  *   .nspname         – bare name as stored in pg_namespace (canonical)
  *   .restoreListName – quote_ident(nspname) ready for pg_dump/pg_restore args
@@ -5836,6 +5864,30 @@ filters_validate_and_normalize(PGSQL *pgsql, SourceFilters *filters)
 		return true;
 	}
 
+	/*
+	 * Pre-initialize every schema's restoreListName with a synthetic
+	 * double-quoted form so that exclude entries which are not found in the
+	 * catalog still produce a valid (if harmless) pg_dump argument instead of
+	 * an empty string.  The catalog query below will overwrite this with the
+	 * proper quote_ident() output for schemas that do exist.
+	 */
+	SourceFilterSchemaList *allSchemaLists[2] = {
+		&filters->includeOnlySchemaList,
+		&filters->excludeSchemaList
+	};
+
+	for (int li = 0; li < 2; li++)
+	{
+		for (int i = 0; i < allSchemaLists[li]->count; i++)
+		{
+			SourceFilterSchema *schema = &allSchemaLists[li]->array[i];
+
+			sformat(schema->restoreListName,
+					sizeof(schema->restoreListName),
+					"\"%s\"", schema->nspname);
+		}
+	}
+
 	PQExpBuffer query = createPQExpBuffer();
 
 	if (query == NULL)
@@ -5850,12 +5902,16 @@ filters_validate_and_normalize(PGSQL *pgsql, SourceFilters *filters)
 	 * Schema branch: resolve every schema name via to_regnamespace().
 	 * The user may write either a bare name (case-insensitive, PostgreSQL
 	 * will fold to lowercase) or a double-quoted name (case-sensitive).
+	 *
+	 * The is_include_only column is true for includeOnlySchemaList entries
+	 * (li == 0) and false for excludeSchemaList entries (li == 1).
 	 */
 	if (totalSchemas > 0)
 	{
 		appendPQExpBufferStr(query,
 							 "SELECT 'schema'::text AS kind,"
 							 " v.input,"
+							 " v.is_include_only,"
 							 " n.nspname,"
 							 " NULL::name AS relname,"
 							 " quote_ident(n.nspname) AS quoted_nspname,"
@@ -5871,6 +5927,8 @@ filters_validate_and_normalize(PGSQL *pgsql, SourceFilters *filters)
 
 		for (int li = 0; li < 2; li++)
 		{
+			const char *boolLit = (li == 0) ? "true" : "false";
+
 			for (int i = 0; i < schemaLists[li]->count; i++)
 			{
 				if (!first)
@@ -5880,13 +5938,14 @@ filters_validate_and_normalize(PGSQL *pgsql, SourceFilters *filters)
 
 				appendPQExpBufferChar(query, '(');
 				appendStringLiteralPub(query, schemaLists[li]->array[i].nspname);
+				appendPQExpBuffer(query, ",%s", boolLit);
 				appendPQExpBufferChar(query, ')');
 				first = false;
 			}
 		}
 
 		appendPQExpBufferStr(query,
-							 ") AS v(input)"
+							 ") AS v(input, is_include_only)"
 							 " LEFT JOIN pg_namespace n"
 							 " ON n.oid = to_regnamespace(v.input)");
 
@@ -5900,6 +5959,8 @@ filters_validate_and_normalize(PGSQL *pgsql, SourceFilters *filters)
 	 * correctly round-trips even names that contain internal double-quote
 	 * characters because parse_filter_quoted_table_name() preserves the "" SQL
 	 * escaping when it strips the outer quotes.
+	 *
+	 * The is_include_only column is true only for includeOnlyTableList (li == 0).
 	 */
 	if (totalTables > 0)
 	{
@@ -5911,6 +5972,7 @@ filters_validate_and_normalize(PGSQL *pgsql, SourceFilters *filters)
 		appendPQExpBufferStr(query,
 							 "SELECT 'table'::text AS kind,"
 							 " v.input,"
+							 " v.is_include_only,"
 							 " n.nspname,"
 							 " c.relname,"
 							 " quote_ident(n.nspname) AS quoted_nspname,"
@@ -5928,6 +5990,8 @@ filters_validate_and_normalize(PGSQL *pgsql, SourceFilters *filters)
 
 		for (int li = 0; li < 4; li++)
 		{
+			const char *boolLit = (li == 0) ? "true" : "false";
+
 			for (int i = 0; i < tableLists[li]->count; i++)
 			{
 				SourceFilterTable *table = &tableLists[li]->array[i];
@@ -5944,13 +6008,14 @@ filters_validate_and_normalize(PGSQL *pgsql, SourceFilters *filters)
 
 				appendPQExpBufferChar(query, '(');
 				appendStringLiteralPub(query, tableInput);
+				appendPQExpBuffer(query, ",%s", boolLit);
 				appendPQExpBufferChar(query, ')');
 				first = false;
 			}
 		}
 
 		appendPQExpBufferStr(query,
-							 ") AS v(input)"
+							 ") AS v(input, is_include_only)"
 							 " LEFT JOIN pg_class c"
 							 " ON c.oid = to_regclass(v.input)"
 							 " LEFT JOIN pg_namespace n"

--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -5675,3 +5675,306 @@ pgsql_escape_identifier(PGSQL *pgsql, char *src)
 
 	return escapedIdentifierCopy;
 }
+
+
+/*
+ * FilterNormalizeContext is the callback context for parseFilterNormalize.
+ */
+typedef struct FilterNormalizeContext
+{
+	char sqlstate[SQLSTATE_LENGTH];
+	SourceFilters *filters;
+	bool parsedOk;
+	int errorCount;
+} FilterNormalizeContext;
+
+
+/*
+ * parseFilterNormalize processes one (or more, in non-single-row mode) result
+ * rows from the validation query and writes the canonical names back into the
+ * SourceFilters struct.
+ */
+static void
+parseFilterNormalize(void *ctx, PGresult *result)
+{
+	FilterNormalizeContext *context = (FilterNormalizeContext *) ctx;
+	SourceFilters *filters = context->filters;
+
+	ExecStatusType status = PQresultStatus(result);
+
+	if (status != PGRES_TUPLES_OK && status != PGRES_SINGLE_TUPLE)
+	{
+		log_error("Failed to validate filter names: %s",
+				  PQresultErrorMessage(result));
+		context->parsedOk = false;
+		return;
+	}
+
+	int ntuples = PQntuples(result);
+
+	for (int row = 0; row < ntuples; row++)
+	{
+		char *kind = PQgetvalue(result, row, 0);
+		char *input = PQgetvalue(result, row, 1);
+		bool nspIsNull = PQgetisnull(result, row, 2);
+		char *nspname = nspIsNull ? NULL : PQgetvalue(result, row, 2);
+		bool relIsNull = PQgetisnull(result, row, 3);
+		char *relname = relIsNull ? NULL : PQgetvalue(result, row, 3);
+		char *quotedNsp = PQgetisnull(result, row, 4) ? NULL : PQgetvalue(result, row, 4);
+		char *quotedRel = PQgetisnull(result, row, 5) ? NULL : PQgetvalue(result, row, 5);
+
+		if (nspIsNull)
+		{
+			log_error("Failed to find %s \"%s\" in the source database catalogs; "
+					  "check that the name exists and is correctly quoted "
+					  "(uppercase and special characters require double-quotes)",
+					  kind, input);
+			++context->errorCount;
+			continue;
+		}
+
+		if (strcmp(kind, "schema") == 0)
+		{
+			SourceFilterSchemaList *schemaLists[2] = {
+				&filters->includeOnlySchemaList,
+				&filters->excludeSchemaList
+			};
+
+			for (int li = 0; li < 2; li++)
+			{
+				for (int i = 0; i < schemaLists[li]->count; i++)
+				{
+					SourceFilterSchema *schema = &schemaLists[li]->array[i];
+
+					if (streq(schema->nspname, input))
+					{
+						strlcpy(schema->nspname,
+								nspname,
+								sizeof(schema->nspname));
+						strlcpy(schema->restoreListName,
+								quotedNsp,
+								sizeof(schema->restoreListName));
+					}
+				}
+			}
+		}
+		else
+		{
+			/* table — match by reconstructed "nspname"."relname" key */
+			SourceFilterTableList *tableLists[4] = {
+				&filters->includeOnlyTableList,
+				&filters->excludeTableList,
+				&filters->excludeTableDataList,
+				&filters->excludeIndexList
+			};
+
+			for (int li = 0; li < 4; li++)
+			{
+				for (int i = 0; i < tableLists[li]->count; i++)
+				{
+					SourceFilterTable *table = &tableLists[li]->array[i];
+
+					char tableInput[PG_NAMEDATALEN_FQ];
+
+					sformat(tableInput, sizeof(tableInput), "\"%s\".\"%s\"",
+							table->nspname, table->relname);
+
+					if (streq(tableInput, input))
+					{
+						strlcpy(table->nspname, nspname, sizeof(table->nspname));
+						strlcpy(table->relname, relname, sizeof(table->relname));
+
+						(void) quotedRel; /* used only for logging if needed */
+					}
+				}
+			}
+		}
+	}
+}
+
+
+/*
+ * filters_validate_and_normalize resolves every name in the filters config
+ * against the live source-database catalogs using a single UNION ALL query:
+ *
+ *   schemas  → to_regnamespace()  → returns nspname + quote_ident(nspname)
+ *   tables   → to_regclass()      → returns nspname + relname (from pg_class)
+ *
+ * Any entry that produces NULL (object not found) is reported as an error and
+ * the function returns false.  On success every SourceFilterSchema gets:
+ *
+ *   .nspname         – bare name as stored in pg_namespace (canonical)
+ *   .restoreListName – quote_ident(nspname) ready for pg_dump/pg_restore args
+ *
+ * And every SourceFilterTable gets its .nspname / .relname overwritten with
+ * the canonical forms from pg_namespace / pg_class.
+ *
+ * The function is idempotent: if filters->normalized is already true it
+ * returns immediately.  It must be called before prepareFilters() pushes
+ * names into PostgreSQL temp tables, and before pg_dump_db() builds its
+ * --schema / --exclude-schema argument list.
+ */
+bool
+filters_validate_and_normalize(PGSQL *pgsql, SourceFilters *filters)
+{
+	if (filters->normalized)
+	{
+		return true;
+	}
+
+	int totalSchemas = filters->includeOnlySchemaList.count +
+					   filters->excludeSchemaList.count;
+
+	int totalTables = filters->includeOnlyTableList.count +
+					  filters->excludeTableList.count +
+					  filters->excludeTableDataList.count +
+					  filters->excludeIndexList.count;
+
+	if (totalSchemas == 0 && totalTables == 0)
+	{
+		filters->normalized = true;
+		return true;
+	}
+
+	PQExpBuffer query = createPQExpBuffer();
+
+	if (query == NULL)
+	{
+		log_error(ALLOCATION_FAILED_ERROR);
+		return false;
+	}
+
+	bool firstBranch = true;
+
+	/*
+	 * Schema branch: resolve every schema name via to_regnamespace().
+	 * The user may write either a bare name (case-insensitive, PostgreSQL
+	 * will fold to lowercase) or a double-quoted name (case-sensitive).
+	 */
+	if (totalSchemas > 0)
+	{
+		appendPQExpBufferStr(query,
+							 "SELECT 'schema'::text AS kind,"
+							 " v.input,"
+							 " n.nspname,"
+							 " NULL::name AS relname,"
+							 " quote_ident(n.nspname) AS quoted_nspname,"
+							 " NULL::text AS quoted_relname"
+							 " FROM (VALUES ");
+
+		bool first = true;
+
+		SourceFilterSchemaList *schemaLists[2] = {
+			&filters->includeOnlySchemaList,
+			&filters->excludeSchemaList
+		};
+
+		for (int li = 0; li < 2; li++)
+		{
+			for (int i = 0; i < schemaLists[li]->count; i++)
+			{
+				if (!first)
+				{
+					appendPQExpBufferChar(query, ',');
+				}
+
+				appendPQExpBufferChar(query, '(');
+				appendStringLiteralPub(query, schemaLists[li]->array[i].nspname);
+				appendPQExpBufferChar(query, ')');
+				first = false;
+			}
+		}
+
+		appendPQExpBufferStr(query,
+							 ") AS v(input)"
+							 " LEFT JOIN pg_namespace n"
+							 " ON n.oid = to_regnamespace(v.input)");
+
+		firstBranch = false;
+	}
+
+	/*
+	 * Table branch: resolve every schema.table name via to_regclass().
+	 * We reconstruct a double-quoted "nspname"."relname" key from the already
+	 * quote-stripped fields stored by parse_filter_quoted_table_name().  This
+	 * correctly round-trips even names that contain internal double-quote
+	 * characters because parse_filter_quoted_table_name() preserves the "" SQL
+	 * escaping when it strips the outer quotes.
+	 */
+	if (totalTables > 0)
+	{
+		if (!firstBranch)
+		{
+			appendPQExpBufferStr(query, " UNION ALL ");
+		}
+
+		appendPQExpBufferStr(query,
+							 "SELECT 'table'::text AS kind,"
+							 " v.input,"
+							 " n.nspname,"
+							 " c.relname,"
+							 " quote_ident(n.nspname) AS quoted_nspname,"
+							 " quote_ident(c.relname) AS quoted_relname"
+							 " FROM (VALUES ");
+
+		bool first = true;
+
+		SourceFilterTableList *tableLists[4] = {
+			&filters->includeOnlyTableList,
+			&filters->excludeTableList,
+			&filters->excludeTableDataList,
+			&filters->excludeIndexList
+		};
+
+		for (int li = 0; li < 4; li++)
+		{
+			for (int i = 0; i < tableLists[li]->count; i++)
+			{
+				SourceFilterTable *table = &tableLists[li]->array[i];
+
+				char tableInput[PG_NAMEDATALEN_FQ];
+
+				sformat(tableInput, sizeof(tableInput), "\"%s\".\"%s\"",
+						table->nspname, table->relname);
+
+				if (!first)
+				{
+					appendPQExpBufferChar(query, ',');
+				}
+
+				appendPQExpBufferChar(query, '(');
+				appendStringLiteralPub(query, tableInput);
+				appendPQExpBufferChar(query, ')');
+				first = false;
+			}
+		}
+
+		appendPQExpBufferStr(query,
+							 ") AS v(input)"
+							 " LEFT JOIN pg_class c"
+							 " ON c.oid = to_regclass(v.input)"
+							 " LEFT JOIN pg_namespace n"
+							 " ON n.oid = c.relnamespace");
+	}
+
+	FilterNormalizeContext context = {
+		.filters = filters,
+		.parsedOk = true,
+		.errorCount = 0
+	};
+
+	bool ok = pgsql_execute_with_params(pgsql, query->data, 0, NULL, NULL,
+										&context, &parseFilterNormalize);
+
+	destroyPQExpBuffer(query);
+
+	if (!ok || !context.parsedOk || context.errorCount > 0)
+	{
+		log_error("Failed to validate filter names against source catalogs");
+		return false;
+	}
+
+	filters->normalized = true;
+
+	return true;
+}

--- a/src/bin/pgcopydb/schema.c
+++ b/src/bin/pgcopydb/schema.c
@@ -3560,6 +3560,21 @@ prepareFilters(PGSQL *pgsql, SourceFilters *filters)
 		return false;
 	}
 
+	/*
+	 * Resolve and normalise every filter name against the live source
+	 * catalogs before using them in temp-table uploads or pg_dump args.
+	 * The function is idempotent: it sets filters->normalized = true on
+	 * first success and returns immediately on subsequent calls.
+	 */
+	if (!filters->normalized)
+	{
+		if (!filters_validate_and_normalize(pgsql, filters))
+		{
+			log_error("Failed to validate and normalize filter names");
+			return false;
+		}
+	}
+
 	/* if the filters have already been prepared, we're good */
 	if (filters->prepared)
 	{


### PR DESCRIPTION
## Problem

When using `--filter` with schema names that contain uppercase letters (e.g. `MySchema`), `pgcopydb clone` silently copies nothing from those schemas. The root cause: the raw name from the config file is passed directly to `pg_dump --schema MySchema`, which PostgreSQL case-folds to `myschema` and finds no match.

Fixes #942.

## Solution

Introduce `filters_validate_and_normalize()`, called from `prepareFilters()` before any `pg_dump` invocation. It runs a single UNION ALL query against the live source database:

```sql
SELECT 'schema' AS kind, v.input,
       n.nspname,
       NULL AS relname,
       quote_ident(n.nspname) AS quoted_nspname,
       NULL AS quoted_relname
FROM (VALUES ('MySchema'), ('public')) AS v(input)
LEFT JOIN pg_namespace n ON n.oid = to_regnamespace(v.input)
UNION ALL
SELECT 'table' AS kind, v.input,
       n.nspname, c.relname,
       quote_ident(n.nspname), quote_ident(c.relname)
FROM (VALUES ('"MySchema".users')) AS v(input)
LEFT JOIN pg_class c ON c.oid = to_regclass(v.input)
LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
```

- **NULL result** → object not found → informative error + early abort (no silent no-op)
- **Non-null result** → canonical `nspname`/`relname` stored back into the filter struct; `quote_ident()` output stored in the new `restoreListName` field

All three `pg_dump`/`pg_restore` call sites in `pgcmd.c` now pass `restoreListName` (e.g. `"MySchema"`) instead of the raw `nspname`, so pg_dump's pattern matching works for any valid PostgreSQL identifier.

## Changes

| File | What changed |
|---|---|
| `filtering.h` | New `restoreListName` field in `SourceFilterSchema`; new `normalized` flag and `filters_validate_and_normalize()` declaration |
| `pgsql.c` | Implementation of `filters_validate_and_normalize()` (UNION ALL query + callback) |
| `schema.c` | Call `filters_validate_and_normalize()` at the top of `prepareFilters()` |
| `pgcmd.c` | 3 call sites: use `restoreListName` instead of `nspname` for pg_dump/pg_restore `--schema`/`--exclude-schema` args |

## Testing

- `make tests/pagila` ✅
- `make tests/filtering` ✅
- `make tests/cdc-test-decoding` ✅
- `sh ./ci/banned.h.sh` ✅
- Docker style checker ✅