### PR TITLE
fix: single-quote escaping for VARCHAR/text columns in test_decoding CDC (#969)

### DIFF
--- a/src/bin/pgcopydb/ld_test_decoding.c
+++ b/src/bin/pgcopydb/ld_test_decoding.c
@@ -895,8 +895,16 @@ parseNextColumn(TestDecodingColumns *cols,
 	{
 		cols->isQuoted = true;
 
-		/* this column has quoted string value */
+		/*
+		 * Set oid to TEXTOID for any quoted string value, regardless of the
+		 * declared SQL type.  test_decoding uses SQL single-quote escaping
+		 * (doubling '' to represent a literal ') for all quoted types —
+		 * text, varchar, bpchar, name, etc.  The listToTuple() function
+		 * checks oid == TEXTOID to decide whether to unescape those doubled
+		 * single-quotes before storing the value.
+		 */
 		cols->oid = TEXTOID;
+
 		/* skip the opening single-quote now */
 		char *cur = ptr + 1;
 
@@ -1095,7 +1103,15 @@ listToTuple(LogicalMessageTuple *tuple, TestDecodingColumns *cols, int count)
 				char *ptr = cur->valueStart + pidx;
 				char *nxt = cur->valueStart + pidx + 1;
 
-				/* unescape the single-quotes */
+				/*
+				 * Unescape doubled single-quotes ('' → '), but only when
+				 * the second quote is not the closing delimiter of the
+				 * value.  Without the bounds check, a value ending in a
+				 * single-quote (e.g. "test'", encoded as 'test''' in the
+				 * stream) would have its final character silently dropped:
+				 * the trailing ' would be consumed as the first half of an
+				 * escaped pair rather than treated as a literal character.
+				 */
 				if (*ptr == '\'' && *nxt == '\'' && pidx < cur->valueLen - 1)
 				{
 					continue;

--- a/src/bin/pgcopydb/ld_test_decoding.c
+++ b/src/bin/pgcopydb/ld_test_decoding.c
@@ -876,11 +876,6 @@ parseNextColumn(TestDecodingColumns *cols,
 
 	sformat(typname, sizeof(typname), "%.*s", typLen, typStart);
 
-	if (streq(typname, "text"))
-	{
-		cols->oid = TEXTOID;
-	}
-
 	cols->colnameStart = ptr;
 	cols->colnameLen = typA - ptr;
 
@@ -900,6 +895,8 @@ parseNextColumn(TestDecodingColumns *cols,
 	{
 		cols->isQuoted = true;
 
+		/* this column has quoted string value */
+		cols->oid = TEXTOID;
 		/* skip the opening single-quote now */
 		char *cur = ptr + 1;
 
@@ -1099,7 +1096,7 @@ listToTuple(LogicalMessageTuple *tuple, TestDecodingColumns *cols, int count)
 				char *nxt = cur->valueStart + pidx + 1;
 
 				/* unescape the single-quotes */
-				if (*ptr == '\'' && *nxt == '\'')
+				if (*ptr == '\'' && *nxt == '\'' && pidx < cur->valueLen - 1)
 				{
 					continue;
 				}

--- a/tests/cdc-test-decoding/copydb.sh
+++ b/tests/cdc-test-decoding/copydb.sh
@@ -92,5 +92,15 @@ tgt_count=`psql -AtqX -d ${PGCOPYDB_TARGET_PGURI} -c "select count(*) from actor
 echo "source actor count: ${src_count}, target actor count: ${tgt_count}"
 test "${src_count}" -eq "${tgt_count}"
 
+# Verify that single-quote characters inside VARCHAR and TEXT values are
+# preserved correctly after CDC replay (issue #969).
+psql -AtqX -d ${PGCOPYDB_SOURCE_PGURI} \
+     -c "select id, varchar_col, text_col from quote_escaping_test order by id" \
+     > /tmp/src_quotes.txt
+psql -AtqX -d ${PGCOPYDB_TARGET_PGURI} \
+     -c "select id, varchar_col, text_col from quote_escaping_test order by id" \
+     > /tmp/tgt_quotes.txt
+diff /tmp/src_quotes.txt /tmp/tgt_quotes.txt
+
 # cleanup
 pgcopydb stream cleanup

--- a/tests/cdc-test-decoding/ddl.sql
+++ b/tests/cdc-test-decoding/ddl.sql
@@ -219,6 +219,27 @@ create table xpto2 (
 commit;
 
 --
+-- See https://github.com/dimitri/pgcopydb/issues/969
+-- Single-quote escaping for varchar/text columns via test_decoding.
+-- Two bugs were fixed:
+--   1. VARCHAR (and other non-text quoted types) had their '' pairs left
+--      doubled in the generated SQL instead of being unescaped to a single '.
+--   2. A value ending in a single-quote had its last character silently
+--      dropped because the unescaping loop consumed the closing ' as the
+--      first half of a doubled-quote pair.
+--
+begin;
+
+create table if not exists quote_escaping_test
+(
+    id bigint primary key,
+    varchar_col varchar(100),
+    text_col text
+);
+
+commit;
+
+--
 -- See https://github.com/dimitri/pgcopydb/issues/844
 -- CDC UPDATE fails for GENERATED ALWAYS AS IDENTITY columns
 --

--- a/tests/cdc-test-decoding/dml.sql
+++ b/tests/cdc-test-decoding/dml.sql
@@ -179,3 +179,28 @@ begin;
 delete from identity_column_test where pk_col = 2;
 
 commit;
+
+--
+-- See https://github.com/dimitri/pgcopydb/issues/969
+-- Single-quote escaping: VARCHAR columns with embedded quotes, and values
+-- whose last character is a single-quote.
+--
+begin;
+
+insert into quote_escaping_test(id, varchar_col, text_col) values
+(1, 'It''s a varchar', 'It''s a text'),
+(2, 'trailing quote''', 'also trailing''');
+
+commit;
+
+begin;
+
+update quote_escaping_test set varchar_col = 'updated ''varchar' where id = 1;
+
+commit;
+
+begin;
+
+delete from quote_escaping_test where id = 2;
+
+commit;

--- a/tests/cdc-test-decoding/stmt.sql
+++ b/tests/cdc-test-decoding/stmt.sql
@@ -27,3 +27,6 @@ INSERT INTO public.xpto2 (toasted_col1, toasted_col2) overriding system value VA
 INSERT INTO public.identity_column_test (pk_col, id_col, name) overriding system value VALUES ($1, $2, $3), ($4, $5, $6)
 UPDATE public.identity_column_test SET name = $1 WHERE pk_col = $2
 DELETE FROM public.identity_column_test WHERE pk_col = $1
+INSERT INTO public.quote_escaping_test (id, varchar_col, text_col) overriding system value VALUES ($1, $2, $3), ($4, $5, $6)
+UPDATE public.quote_escaping_test SET varchar_col = $1, text_col = $2 WHERE id = $3
+DELETE FROM public.quote_escaping_test WHERE id = $1


### PR DESCRIPTION
Closes #969. This is a replacement for #969 from @igorfedorov (original commits preserved with authorship, style fixes and test coverage added on top).

## What was broken

Two bugs in the test_decoding CDC parser ([ld_test_decoding.c](src/bin/pgcopydb/ld_test_decoding.c)):

1. **VARCHAR unescaped incorrectly**: `cols->oid = TEXTOID` was only set when the SQL type name was exactly `"text"`. For `varchar`, `bpchar`, `name`, and other quoted types the flag stayed at 0, so the doubled single-quotes written by test_decoding (e.g. `'It''s a varchar'`) were stored as-is instead of being unescaped to a single `'`.

2. **Trailing single-quote silently dropped**: the unescape loop compared `*ptr == '\'' && *nxt == '\''` without a bounds guard, so a value ending in `'` (stored as e.g. `'trailing quote'''` in the stream) had its last character consumed as the first half of a doubled pair, producing `trailing quote` instead of `trailing quote'`.

## Fix (commit 1 — Igor Fedorov, author preserved)

- Set `cols->oid = TEXTOID` whenever the value is single-quoted (`*ptr == '\''`), regardless of the declared SQL type.
- Add `pidx < cur->valueLen - 1` guard so the final `'` of a trailing-quote value is copied, not skipped.

## Style / comments (commit 2)

Added block comments explaining *why* TEXTOID is set for all quoted types (not just `text`) and why the bounds check is necessary.

## Test coverage (commit 3)

Extended the existing `cdc-test-decoding` integration test with a `quote_escaping_test` table that has `varchar(100)` and `text` columns. The DML exercises:

- embedded single-quote: `It's a varchar`
- trailing single-quote: `trailing quote'`
- UPDATE of a VARCHAR column with a quoted value
- DELETE

The test verifies that source and target rows match after full CDC prefetch + catchup replay.