### PR TITLE
Fix list table-parts always reporting 0 parts

### DIFF
--- a/src/bin/pgcopydb/cli_list.c
+++ b/src/bin/pgcopydb/cli_list.c
@@ -1344,6 +1344,89 @@ cli_list_table_parts(int argc, char **argv)
 		exit(EXIT_CODE_QUIT);
 	}
 
+	/*
+	 * Check whether the parts section was already cached from a previous run.
+	 * If so, re-use the catalog rows directly; otherwise compute them now and
+	 * store them so the next call is instant.
+	 */
+	CatalogSection partsSection = {
+		.section = DATA_SECTION_TABLE_DATA_PARTS
+	};
+
+	if (!catalog_section_state(sourceDB, &partsSection))
+	{
+		/* errors have already been logged */
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
+
+	if (!partsSection.fetched)
+	{
+		PGSQL pgsql = { 0 };
+		ConnStrings *dsn = &(listDBoptions.connStrings);
+
+		if (!pgsql_init(&pgsql, dsn->source_pguri, PGSQL_CONN_SOURCE))
+		{
+			/* errors have already been logged */
+			exit(EXIT_CODE_SOURCE);
+		}
+
+		/*
+		 * For CTID-based splits we need fresh relpages from pg_class.
+		 * Run ANALYZE first (unless the user asked for estimates only) so that
+		 * the page count reflects the current table size.
+		 */
+		if (streq(table->partKey, "ctid"))
+		{
+			if (!copySpecs.estimateTableSizes)
+			{
+				char sql[BUFSIZE] = { 0 };
+
+				sformat(sql, sizeof(sql), "ANALYZE %s", table->qname);
+				log_notice("%s", sql);
+
+				if (!pgsql_execute(&pgsql, sql))
+				{
+					log_error("Failed to refresh table %s statistics",
+							  table->qname);
+					exit(EXIT_CODE_INTERNAL_ERROR);
+				}
+			}
+
+			if (!schema_list_relpages(&pgsql, table, sourceDB))
+			{
+				log_error("Failed to fetch table %s relpages", table->qname);
+				exit(EXIT_CODE_INTERNAL_ERROR);
+			}
+		}
+
+		TopLevelTiming timing = {
+			.label = CopyDataSectionToString(DATA_SECTION_TABLE_DATA_PARTS)
+		};
+
+		(void) catalog_start_timing(&timing);
+
+		if (!schema_list_partitions(&pgsql,
+									sourceDB,
+									table,
+									listDBoptions.splitTablesLargerThan.bytes,
+									listDBoptions.splitMaxParts))
+		{
+			log_error("Failed to compute partitions for table %s",
+					  table->qname);
+			exit(EXIT_CODE_INTERNAL_ERROR);
+		}
+
+		(void) catalog_stop_timing(&timing);
+
+		if (!catalog_register_section(sourceDB, &timing))
+		{
+			/* errors have already been logged */
+			exit(EXIT_CODE_INTERNAL_ERROR);
+		}
+
+		pgsql_finish(&pgsql);
+	}
+
 	log_info("Table %s COPY will be split %d-ways",
 			 table->qname,
 			 table->partition.partCount);


### PR DESCRIPTION
## Problem

`pgcopydb list table-parts` always printed **"Table … COPY will be split 0-ways"** and showed an empty table, regardless of table size or `--split-tables-larger-than` value.

Closes #872.

## Root cause

`cli_list_table_parts` looked up the table from the SQLite catalog and set `partKey` for the CTID case, but then **never called `schema_list_partitions`**. The `s_table_part` catalog table was always empty when read by `catalog_iter_s_table_parts`, and `table->partition.partCount` (also from the empty catalog) was always 0.

The full copy path (`copydb_prepare_table_specs_hook` in `copydb_schema.c`) does call `schema_list_partitions` and correctly stores the result — but `list table-parts` bypassed that entire step.

## Fix

After the `partKey` setup block and before the display loop, add the missing computation:

1. **Cache check** — call `catalog_section_state` for `DATA_SECTION_TABLE_DATA_PARTS`. If already marked `fetched` (a previous invocation stored the rows), go straight to iteration. The invalidation logic already in `catalog_register_setup_from_specs` ensures the cache is invalidated when `--split-tables-larger-than` or `--split-max-parts` changes.

2. **Compute** (section not yet fetched) — open a source connection and run the same logic as the full copy path:
   - For CTID: optionally `ANALYZE` the table (skipped with `--estimate-table-sizes`), then `schema_list_relpages` for a fresh page count.
   - `schema_list_partitions` — writes every part to `s_table_part` and sets `table->partition.partCount`.
   - `catalog_register_section` — marks the section done so future calls use the cache.

After this, `log_info("Table %s COPY will be split %d-ways")` prints the correct count and `catalog_iter_s_table_parts` iterates real rows.