### PR TITLE
fix: skip source URI check in catalog for list databases (#897)

### DIFF
--- a/src/bin/pgcopydb/catalog.c
+++ b/src/bin/pgcopydb/catalog.c
@@ -763,12 +763,23 @@ catalog_register_setup_from_specs(CopyDataSpec *copySpecs)
 
 		if (!streq(spguri.pguri, setup->source_pguri))
 		{
-			log_error("Catalogs at \"%s\" have been setup for "
-					  "Postgres source \"%s\" and current source is \"%s\"",
-					  sourceDB->dbfile,
-					  setup->source_pguri,
-					  spguri.pguri);
-			return false;
+			if (copySpecs->skipSourceURICheck)
+			{
+				log_debug("Catalogs at \"%s\" have been setup for "
+						  "a different Postgres source \"%s\", "
+						  "ignoring for this read-only command",
+						  sourceDB->dbfile,
+						  setup->source_pguri);
+			}
+			else
+			{
+				log_error("Catalogs at \"%s\" have been setup for "
+						  "Postgres source \"%s\" and current source is \"%s\"",
+						  sourceDB->dbfile,
+						  setup->source_pguri,
+						  spguri.pguri);
+				return false;
+			}
 		}
 
 		/*

--- a/src/bin/pgcopydb/cli_list.c
+++ b/src/bin/pgcopydb/cli_list.c
@@ -594,6 +594,13 @@ cli_list_databases(int argc, char **argv)
 	}
 
 	/*
+	 * list databases is a stateless read-only query; it must not be blocked by
+	 * a stale source.db left over from a previous run against a different
+	 * server.
+	 */
+	copySpecs.skipSourceURICheck = true;
+
+	/*
 	 * Prepare our internal catalogs for storing the source database catalog
 	 * query results. When --force is used then we fetch the catalogs again.
 	 */

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -310,6 +310,7 @@ typedef struct CopyDataSpec
 
 	bool fetchCatalogs;         /* cache invalidation of local catalogs db */
 	bool fetchFilteredOids;     /* allow bypassing dump/restore filter prep */
+	bool skipSourceURICheck;    /* skip source URI mismatch check on open */
 
 	bool follow;                /* pgcopydb fork --follow */
 	bool allDatabases;          /* pgcopydb clone --all-databases */

--- a/tests/unit/expected/6-list-databases-stale-catalog.out
+++ b/tests/unit/expected/6-list-databases-stale-catalog.out
@@ -1,0 +1,1 @@
+found postgres database

--- a/tests/unit/script/6-list-databases-stale-catalog.sh
+++ b/tests/unit/script/6-list-databases-stale-catalog.sh
@@ -1,0 +1,31 @@
+#! /bin/bash
+
+set -x
+set -e
+
+# This script expects the following environment variables to be set:
+#
+#  - PGCOPYDB_SOURCE_PGURI
+
+# Simulate issue #897: a source.db left over from a previous run against a
+# different source URI must not block `pgcopydb list databases`.
+#
+# Steps:
+#  1. Run `pgcopydb list tables` against the real source to populate source.db.
+#  2. Replace the registered source URI in the catalog with a fake one.
+#  3. Run `pgcopydb list databases` — it must succeed despite the mismatch.
+
+WORKDIR=/tmp/list-databases-stale-catalog
+SOURCEDB=${WORKDIR}/schema/source.db
+
+# 1. Populate a work directory using the real source URI.
+pgcopydb list tables --dir ${WORKDIR} > /dev/null 2>&1 || true
+
+# 2. Overwrite the stored source URI with a fake server address.
+sqlite3 -init /dev/null ${SOURCEDB} \
+  "UPDATE setup SET source_pg_uri = 'postgres://fake-host/fakedb' WHERE id = 1;"
+
+# 3. list databases with the real source URI must succeed even though source.db
+#    was registered for a different one.
+pgcopydb list databases --dir ${WORKDIR} 2>/dev/null \
+  | awk '/postgres/ { print "found postgres database"; exit }'


### PR DESCRIPTION
## Problem

`pgcopydb list databases` fails if a `source.db` exists in the work directory from a previous run against a different source URI:

```
ERROR  catalog.c:766  Catalogs at "…/source.db" have been setup for
       Postgres source "postgres://old-host/db" and current source is "postgres://new-host/db"
```

This is a regression in usability: `list databases` is a stateless, read-only query against the server. It should not be coupled to whatever migration happened to use the same work directory last.

## Fix

Add `CopyDataSpec.skipSourceURICheck` (a one-line bool flag) and set it to `true` in `cli_list_databases` before calling `copydb_fetch_schema_and_prepare_specs`.

The URI mismatch check in `catalog_register_setup_from_specs` now logs a `DEBUG` message and continues when the flag is set, instead of returning false.

## Test

New unit test `tests/unit/script/6-list-databases-stale-catalog.sh`:
1. Runs `pgcopydb list tables` to populate `source.db`
2. Corrupts the stored `source_pg_uri` to a fake address via SQLite
3. Runs `pgcopydb list databases` — must succeed despite the mismatch

Closes #897