### PR TITLE
Fix pgcopydb crash and ACL loss for function/table ACL entries (#888)

### DIFF
--- a/src/bin/pgcopydb/dump_restore.c
+++ b/src/bin/pgcopydb/dump_restore.c
@@ -820,7 +820,7 @@ copydb_write_restore_list_hook(void *ctx, ArchiveContentItem *item)
 					  item->catalogOid,
 					  item->objectOid,
 					  item->description,
-					  item->restoreListName);
+					  item->restoreListName != NULL ? item->restoreListName : "");
 
 	/* memory allocation could have failed while building string */
 	if (PQExpBufferBroken(buf))

--- a/src/bin/pgcopydb/file_utils.c
+++ b/src/bin/pgcopydb/file_utils.c
@@ -288,7 +288,6 @@ read_file_internal(FILE *fileStream,
  */
 bool
 file_iter_lines(const char *filename,
-				size_t bufsize,
 				void *context, FileIterLinesFun *callback)
 {
 	FileLinesIterator *iter =
@@ -301,7 +300,6 @@ file_iter_lines(const char *filename,
 	}
 
 	iter->filename = filename;
-	iter->bufsize = bufsize;
 
 	if (!file_iter_lines_init(iter))
 	{
@@ -356,12 +354,7 @@ file_iter_lines_init(FileLinesIterator *iter)
 		return false;
 	}
 
-	/*
-	 * Start with a reasonable initial size.  file_iter_lines_next will grow
-	 * the buffer automatically whenever a line does not fit.
-	 */
-	iter->bufsize = BUFSIZE * 8;
-	iter->linebuf = (char *) calloc(1, iter->bufsize);
+	iter->linebuf = createPQExpBuffer();
 
 	if (iter->linebuf == NULL)
 	{
@@ -374,62 +367,41 @@ file_iter_lines_init(FileLinesIterator *iter)
 
 
 /*
- * file_iter_lines_next fetches the next line in the opened file. It reads
- * with fgets and grows the GC-managed buffer if the line doesn't fit, so
+ * file_iter_lines_next fetches the next line in the opened file. Characters
+ * are appended one-by-one into a PQExpBuffer, which grows automatically, so
  * lines of arbitrary length are handled without truncation.
  */
 bool
 file_iter_lines_next(FileLinesIterator *iter)
 {
-	size_t offset = 0;
+	resetPQExpBuffer(iter->linebuf);
 
-	for (;;)
+	int c;
+
+	while ((c = fgetc(iter->stream)) != EOF)
 	{
-		char *cur = iter->linebuf + offset;
-		size_t avail = iter->bufsize - offset;
-
-		if (fgets(cur, avail, iter->stream) == NULL)
+		if (c == '\n')
 		{
-			if (feof(iter->stream) != 0)
-			{
-				/* signal end-of-file; if we buffered a partial line, return it */
-				iter->line = (offset > 0) ? iter->linebuf : NULL;
-				return true;
-			}
-			log_error("Failed to iterate over file \"%s\": %m", iter->filename);
-			return false;
+			break;
 		}
-
-		size_t nread = strlen(cur);
-
-		if (nread > 0 && cur[nread - 1] == '\n')
-		{
-			/* complete line ending with \n */
-			iter->line = iter->linebuf;
-			return true;
-		}
-
-		if (feof(iter->stream) != 0)
-		{
-			/* last line of file with no trailing newline */
-			iter->line = iter->linebuf;
-			return true;
-		}
-
-		/* fgets filled the buffer without hitting \n: grow and continue */
-		offset += nread;
-		size_t new_size = iter->bufsize * 2;
-		char *new_buf = (char *) realloc(iter->linebuf, new_size);
-
-		if (new_buf == NULL)
-		{
-			log_error(ALLOCATION_FAILED_ERROR);
-			return false;
-		}
-		iter->linebuf = new_buf;
-		iter->bufsize = new_size;
-		iter->line = iter->linebuf;
+		appendPQExpBufferChar(iter->linebuf, (char) c);
 	}
+
+	if (PQExpBufferBroken(iter->linebuf))
+	{
+		log_error(ALLOCATION_FAILED_ERROR);
+		return false;
+	}
+
+	/* empty buffer at EOF means we are done */
+	if (iter->linebuf->len == 0 && feof(iter->stream) != 0)
+	{
+		iter->line = NULL;
+		return true;
+	}
+
+	iter->line = iter->linebuf->data;
+	return true;
 }
 
 
@@ -439,7 +411,7 @@ file_iter_lines_next(FileLinesIterator *iter)
 bool
 file_iter_lines_finish(FileLinesIterator *iter)
 {
-	free(iter->linebuf);
+	destroyPQExpBuffer(iter->linebuf);
 	iter->linebuf = NULL;
 
 	if (fclose(iter->stream) == EOF)

--- a/src/bin/pgcopydb/file_utils.c
+++ b/src/bin/pgcopydb/file_utils.c
@@ -343,7 +343,7 @@ file_iter_lines(const char *filename,
 
 /*
  * file_iter_lines_init initializes an Iterator over a file to read it
- * line-by-line and allocate only one line at a time.
+ * line-by-line with a dynamically growing line buffer.
  */
 bool
 file_iter_lines_init(FileLinesIterator *iter)
@@ -357,12 +357,13 @@ file_iter_lines_init(FileLinesIterator *iter)
 	}
 
 	/*
-	 * Allocate a buffer to hold the line contents, and re-use the same buffer
-	 * over and over when reading the next line.
+	 * Start with a reasonable initial size.  file_iter_lines_next will grow
+	 * the buffer automatically whenever a line does not fit.
 	 */
-	iter->line = calloc(1, iter->bufsize * sizeof(char));
+	iter->bufsize = BUFSIZE * 8;
+	iter->linebuf = (char *) calloc(1, iter->bufsize);
 
-	if (iter->line == NULL)
+	if (iter->linebuf == NULL)
 	{
 		log_error(ALLOCATION_FAILED_ERROR);
 		return false;
@@ -373,44 +374,62 @@ file_iter_lines_init(FileLinesIterator *iter)
 
 
 /*
- * file_iter_lines_next fetches the next line in the opened file.
+ * file_iter_lines_next fetches the next line in the opened file. It reads
+ * with fgets and grows the GC-managed buffer if the line doesn't fit, so
+ * lines of arbitrary length are handled without truncation.
  */
 bool
 file_iter_lines_next(FileLinesIterator *iter)
 {
-	size_t len = iter->bufsize - 1;
+	size_t offset = 0;
 
-	char *lineptr = fgets(iter->line, len, iter->stream);
-
-	/* Upon successful completion, fgets() shall return s. */
-	if (lineptr == iter->line)
+	for (;;)
 	{
-		return true;
-	}
+		char *cur = iter->linebuf + offset;
+		size_t avail = iter->bufsize - offset;
 
-	if (lineptr == NULL)
-	{
-		/*
-		 * If the stream is at end-of-file, the end-of-file indicator for the
-		 * stream shall be set and fgets() shall return a null pointer.
-		 */
-		if (feof(iter->stream) != 0)
+		if (fgets(cur, avail, iter->stream) == NULL)
 		{
-			/* signal end-of-file by setting line to NULL */
-			iter->line = NULL;
+			if (feof(iter->stream) != 0)
+			{
+				/* signal end-of-file; if we buffered a partial line, return it */
+				iter->line = (offset > 0) ? iter->linebuf : NULL;
+				return true;
+			}
+			log_error("Failed to iterate over file \"%s\": %m", iter->filename);
+			return false;
+		}
+
+		size_t nread = strlen(cur);
+
+		if (nread > 0 && cur[nread - 1] == '\n')
+		{
+			/* complete line ending with \n */
+			iter->line = iter->linebuf;
 			return true;
 		}
 
-		/*
-		 * If a read error occurs, the error indicator for the stream shall be
-		 * set, fgets() shall return a null pointer, and shall set errno to
-		 * indicate the error.
-		 */
-		log_error("Failed to iterate over file \"%s\": %m", iter->filename);
-		return false;
-	}
+		if (feof(iter->stream) != 0)
+		{
+			/* last line of file with no trailing newline */
+			iter->line = iter->linebuf;
+			return true;
+		}
 
-	return true;
+		/* fgets filled the buffer without hitting \n: grow and continue */
+		offset += nread;
+		size_t new_size = iter->bufsize * 2;
+		char *new_buf = (char *) realloc(iter->linebuf, new_size);
+
+		if (new_buf == NULL)
+		{
+			log_error(ALLOCATION_FAILED_ERROR);
+			return false;
+		}
+		iter->linebuf = new_buf;
+		iter->bufsize = new_size;
+		iter->line = iter->linebuf;
+	}
 }
 
 
@@ -420,6 +439,9 @@ file_iter_lines_next(FileLinesIterator *iter)
 bool
 file_iter_lines_finish(FileLinesIterator *iter)
 {
+	free(iter->linebuf);
+	iter->linebuf = NULL;
+
 	if (fclose(iter->stream) == EOF)
 	{
 		log_error("Failed to read file \"%s\"", iter->filename);

--- a/src/bin/pgcopydb/file_utils.h
+++ b/src/bin/pgcopydb/file_utils.h
@@ -64,7 +64,8 @@ typedef struct FileLinesIterator
 	const char *filename;
 	FILE *stream;
 	size_t bufsize;
-	char *line;                 /* malloc'ed area */
+	char *linebuf;              /* GC-managed line buffer, grows as needed */
+	char *line;                 /* current line, NULL signals EOF */
 } FileLinesIterator;
 
 bool file_iter_lines_init(FileLinesIterator *iter);

--- a/src/bin/pgcopydb/file_utils.h
+++ b/src/bin/pgcopydb/file_utils.h
@@ -9,6 +9,7 @@
 #include <stdarg.h>
 
 #include "postgres_fe.h"
+#include "pqexpbuffer.h"
 
 #include <fcntl.h>
 
@@ -55,7 +56,7 @@ bool read_file(const char *filePath, char **contents, long *fileSize);
 /* iterate over a file one line at a time */
 typedef bool (FileIterLinesFun)(void *context, char *line);
 
-bool file_iter_lines(const char *filename, size_t bufsize,
+bool file_iter_lines(const char *filename,
 					 void *context,
 					 FileIterLinesFun *callback);
 
@@ -63,8 +64,7 @@ typedef struct FileLinesIterator
 {
 	const char *filename;
 	FILE *stream;
-	size_t bufsize;
-	char *linebuf;              /* GC-managed line buffer, grows as needed */
+	PQExpBuffer linebuf;        /* line buffer, grows automatically */
 	char *line;                 /* current line, NULL signals EOF */
 } FileLinesIterator;
 

--- a/src/bin/pgcopydb/pgcmd.c
+++ b/src/bin/pgcopydb/pgcmd.c
@@ -1176,47 +1176,9 @@ archive_iter_toc_init(ArchiveTOCIterator *iter)
 	iter->fileIterator->filename = iter->filename;
 
 	/*
-	 * An archive TOC entry has a fixed format that looks like the following:
-	 *
-	 * ahprintf(AH, "%d; %u %u %s %s %s %s\n", te->dumpId,
-	 * te->catalogId.tableoid, te->catalogId.oid, te->desc, sanitized_schema,
-	 * sanitized_name, sanitized_owner);
-	 *
-	 * The %s parts are PG_NAMEDATALEN except for sanitized_name for functions.
-	 * Let's calculate the maximum line length we can expect for all objects
-	 * except for functions, and add some headroom for the sanitized function
-	 * names later.
-	 *
-	 * Numbers require up to 10 chars (digits) to be printed, and PG_NAMEDATALEN
-	 * is 64 characters, but we need to double that for quoting rules. Add in
-	 * the semi-colon. And the desc is less than 32 characters, the longest
-	 * known being "PUBLICATION TABLES IN SCHEMA" at 30. Let's make it 64 for
-	 * headroom:
-	 *
-	 * 3 * (10 + 1) + 1 + 3 * (2 * 64) + 64 = 482 chars
-	 *
-	 * The sanitized name of a function contains the name of the function
-	 * followed by a list of parameters types in parantheses, which can be quite
-	 * long. Let's calculate the upper limit for the length of the parameter
-	 * list:
-	 *
-	 * max_function_args is a compile-time constant that is set to 100 by
-	 * default in Postgres. Although it can be changed at compile time, we don't
-	 * want to care about that here.
-	 *
-	 * A type name can be up to PG_NAMEDATALEN characters long, and assuming we
-	 * have BUFSIZE is 1024 bytes.
-	 *
-	 * 100 * (PG_NAMEDATALEN + 2) = 100 * (64 + 2) = 100 * 66 = 6600 chars
-	 *
-	 * 6600 + 482 = 7082 chars
-	 *
-	 * BUFSIZE is 1024 bytes.
-	 *
-	 * 8 kilobytes is a reasonable size for a buffer.
+	 * file_iter_lines_init allocates a GC-managed buffer that grows
+	 * automatically, so TOC lines of any length are handled correctly.
 	 */
-	iter->fileIterator->bufsize = BUFSIZE * 8;
-
 	if (!file_iter_lines_init(iter->fileIterator))
 	{
 		/* errors have already been logged */
@@ -1267,19 +1229,9 @@ archive_iter_toc_next(ArchiveTOCIterator *iter)
 	/* remove end-of-line \n character in our line buffer */
 	size_t len = strlen(iter->fileIterator->line);
 
-	if (iter->fileIterator->line[len - 1] == '\n')
+	if (len > 0 && iter->fileIterator->line[len - 1] == '\n')
 	{
 		iter->fileIterator->line[len - 1] = '\0';
-	}
-	else
-	{
-		/* if that's not the last line, then we got a partial read */
-		if (feof(iter->fileIterator->stream) != 0)
-		{
-			log_error("Failed to parse archive TOC file \"%s\": partial read",
-					  iter->filename);
-			return false;
-		}
 	}
 
 	/* reset our memory area before re-use */
@@ -1712,24 +1664,40 @@ parse_archive_acl_or_comment(char *ptr, ArchiveContentItem *item)
 	ArchiveToken token = { .ptr = ptr };
 
 	/*
-	 * At the moment we only support filtering ACLs and COMMENTS for SCHEMA and
-	 * EXTENSION objects, see --skip-extensions. So first, we skip the
-	 * namespace, which in our case would always be a dash.
+	 * The namespace field is "-" for global objects (SCHEMA, EXTENSION) or a
+	 * real schema name for schema-qualified objects (FUNCTION, TABLE, etc.).
+	 *
+	 * tokenize_archive_list_entry advances token.ptr for DASH and SPACE, but
+	 * returns ARCHIVE_TOKEN_UNKNOWN without advancing for anything else, so we
+	 * advance past a schema-name namespace manually.
 	 */
-	ArchiveTokenType list[] = {
-		ARCHIVE_TOKEN_DASH,
-		ARCHIVE_TOKEN_SPACE
-	};
-
-	int count = sizeof(list) / sizeof(list[0]);
-
-	for (int i = 0; i < count; i++)
+	if (!tokenize_archive_list_entry(&token))
 	{
-		if (!tokenize_archive_list_entry(&token) || token.type != list[i])
+		return false;
+	}
+
+	if (token.type == ARCHIVE_TOKEN_DASH)
+	{
+		/* consume the space following the dash */
+		if (!tokenize_archive_list_entry(&token) ||
+			token.type != ARCHIVE_TOKEN_SPACE)
 		{
-			log_trace("Unsupported ACL or COMMENT (namespace is not -): \"%s\"",
+			log_debug("Failed to parse ACL or COMMENT after namespace dash: \"%s\"",
 					  ptr);
 			return false;
+		}
+	}
+	else
+	{
+		/* advance manually past the schema-name identifier and the space */
+		while (*token.ptr != '\0' && *token.ptr != ' ')
+		{
+			++token.ptr;
+		}
+
+		if (*token.ptr == ' ')
+		{
+			++token.ptr;
 		}
 	}
 
@@ -1799,13 +1767,25 @@ parse_archive_acl_or_comment(char *ptr, ArchiveContentItem *item)
 	}
 	else
 	{
-		log_debug("Failed to parse %s \"%s\": not supported yet",
-				  item->description,
-				  ptr);
+		/*
+		 * Other object types (FUNCTION, TABLE, SEQUENCE, …): preserve the
+		 * full remainder of the TOC entry as restoreListName.  These ACL
+		 * items have objectOid == 0 so they are not subject to name-based
+		 * filter lookups; the name is kept for logging and so that the
+		 * pre-filtered pg_restore list file is valid.
+		 */
+		size_t len = strlen(ptr) + 1;
 
+		item->restoreListName = (char *) calloc(len, sizeof(char));
+
+		if (item->restoreListName == NULL)
+		{
+			log_error(ALLOCATION_FAILED_ERROR);
+			return false;
+		}
+
+		strlcpy(item->restoreListName, ptr, len);
 		item->tagType = ARCHIVE_TAG_TYPE_OTHER;
-
-		return false;
 	}
 
 	log_trace("parse_archive_acl_or_comment: %s [%s]",

--- a/src/bin/pgcopydb/pgsql_timeline.c
+++ b/src/bin/pgcopydb/pgsql_timeline.c
@@ -285,7 +285,7 @@ parse_timeline_history_file(char *filename,
 	/* step 2: iterate over the file */
 	if (currentTimeline > 1)
 	{
-		if (!file_iter_lines(filename, BUFSIZE, &context, register_timeline_hook))
+		if (!file_iter_lines(filename, &context, register_timeline_hook))
 		{
 			/* errors have already been logged */
 			return false;

--- a/tests/unit/compose.yaml
+++ b/tests/unit/compose.yaml
@@ -1,6 +1,7 @@
 services:
   source:
     image: postgres:${PGVERSION:-16}
+    command: postgres -c shared_preload_libraries=pg_stat_statements
     expose:
       - 5432
     environment:
@@ -14,6 +15,7 @@ services:
       retries: 10
   target:
     image: postgres:${PGVERSION:-16}
+    command: postgres -c shared_preload_libraries=pg_stat_statements
     expose:
       - 5432
     environment:

--- a/tests/unit/copydb.sh
+++ b/tests/unit/copydb.sh
@@ -30,6 +30,7 @@ EOF
 export PGCOPYDB_SPLIT_TABLES_LARGER_THAN="2MB"
 pgcopydb fork --skip-collations --fail-fast --debug
 
+
 # now compare the output of running the SQL command with what's expected
 # as we're not root when running tests, can't write in /usr/src
 mkdir -p /tmp/results

--- a/tests/unit/expected/7-function-acl.out
+++ b/tests/unit/expected/7-function-acl.out
@@ -1,0 +1,1 @@
+function ACL preserved

--- a/tests/unit/expected/8-pg-stat-statements-acl.out
+++ b/tests/unit/expected/8-pg-stat-statements-acl.out
@@ -1,0 +1,1 @@
+pg_stat_statements ACL preserved

--- a/tests/unit/script/7-function-acl.sh
+++ b/tests/unit/script/7-function-acl.sh
@@ -1,0 +1,36 @@
+#! /bin/bash
+
+set -x
+set -e
+
+# This script expects the following environment variables to be set:
+#
+#  - PGCOPYDB_TARGET_PGURI
+#
+# Regression test for https://github.com/dimitri/pgcopydb/issues/888
+#
+# pgcopydb failed when a function has an ACL entry in the pg_restore TOC,
+# because these entries use the schema name (e.g. "public") as the namespace
+# field instead of the dash used by SCHEMA/EXTENSION entries.  The parser
+# returned false for these entries, leaving restoreListName NULL and causing
+# the ACL list entry to be written with an empty name.  pg_restore then
+# silently skipped the malformed entry, leaving the function ACL unrestored.
+#
+# The setup (18-function-acl.sql) creates test_function_acl on the source
+# and REVOKEs the default PUBLIC EXECUTE.  This produces a non-default proacl
+# that pg_dump includes as an explicit ACL entry in the archive.
+#
+# The main pgcopydb fork (copydb.sh) already cloned source to target; here
+# we verify that the explicit ACL was preserved:
+#   - proacl IS NOT NULL means pgcopydb applied the REVOKE from pg_restore
+#   - proacl IS NULL     means the ACL entry was silently lost (regression)
+
+psql -At -d "${PGCOPYDB_TARGET_PGURI}" <<'EOF'
+SELECT CASE
+    WHEN proacl IS NOT NULL
+    THEN 'function ACL preserved'
+    ELSE 'function ACL missing'
+END
+FROM pg_proc
+WHERE proname = 'test_function_acl';
+EOF

--- a/tests/unit/script/8-pg-stat-statements-acl.sh
+++ b/tests/unit/script/8-pg-stat-statements-acl.sh
@@ -1,0 +1,35 @@
+#! /bin/bash
+
+set -x
+set -e
+
+# This script expects the following environment variables to be set:
+#
+#  - PGCOPYDB_TARGET_PGURI
+#
+# Regression test for https://github.com/dimitri/pgcopydb/issues/888
+#
+# pg_stat_statements exposes a function whose TOC ACL entry has a very long
+# line (one input parameter plus ~40 OUT parameters in the signature).  This
+# exercises the PQExpBuffer-based line reader and the ACL parser more
+# thoroughly than the short test_function_acl(integer, integer) in test 7.
+#
+# The setup (19-pg-stat-statements-acl.sql) creates the extension and REVOKEs
+# the default PUBLIC EXECUTE.  This produces a non-default proacl that pg_dump
+# includes as an explicit ACL entry in the archive.
+#
+# The main pgcopydb fork (copydb.sh) already cloned source to target; here
+# we verify that the explicit ACL was preserved:
+#   - proacl IS NOT NULL means pgcopydb applied the REVOKE from pg_restore
+#   - proacl IS NULL     means the ACL entry was silently lost (regression)
+
+psql -At -d "${PGCOPYDB_TARGET_PGURI}" <<'EOF'
+SELECT CASE
+    WHEN proacl IS NOT NULL
+    THEN 'pg_stat_statements ACL preserved'
+    ELSE 'pg_stat_statements ACL missing'
+END
+FROM pg_proc
+WHERE proname = 'pg_stat_statements'
+LIMIT 1;
+EOF

--- a/tests/unit/setup/18-function-acl.sql
+++ b/tests/unit/setup/18-function-acl.sql
@@ -1,0 +1,19 @@
+--
+-- Issue #888: function ACL entries in the pg_restore TOC use the schema name
+-- as the namespace field (e.g. "public test_function_acl(integer, integer) owner")
+-- rather than the dash used by SCHEMA/EXTENSION entries.  pgcopydb must parse
+-- these correctly and preserve the ACL on the target.
+--
+-- We REVOKE the default PUBLIC EXECUTE to produce an explicit, non-default
+-- proacl.  pg_dump only generates an ACL entry when proacl differs from the
+-- initial privileges, so a simple REVOKE (not a GRANT) triggers the entry.
+--
+CREATE OR REPLACE FUNCTION test_function_acl(x integer, y integer)
+    RETURNS integer
+    LANGUAGE sql
+    IMMUTABLE STRICT
+AS $$ SELECT $1 + $2 $$;
+
+-- Revoking the default PUBLIC execute privilege creates a non-default proacl
+-- that pg_dump will include as an explicit ACL entry in the archive.
+REVOKE EXECUTE ON FUNCTION test_function_acl(integer, integer) FROM PUBLIC;

--- a/tests/unit/setup/19-pg-stat-statements-acl.sql
+++ b/tests/unit/setup/19-pg-stat-statements-acl.sql
@@ -1,0 +1,14 @@
+--
+-- Issue #888 (extended): pg_stat_statements has a function with a very long
+-- signature (one input parameter plus ~40 OUT parameters) that produces a
+-- correspondingly long ACL entry in the pg_restore TOC.  This exercises the
+-- line-reading and ACL-parsing code more thoroughly than a short signature.
+--
+-- We REVOKE the default PUBLIC EXECUTE to produce an explicit, non-default
+-- proacl that pg_dump will include as an ACL entry in the archive.
+--
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+
+-- Revoking the default PUBLIC execute privilege creates a non-default proacl
+-- that pg_dump will include as an explicit ACL entry in the archive.
+REVOKE EXECUTE ON FUNCTION pg_stat_statements(boolean) FROM PUBLIC;

--- a/tests/unit/setup/setup.sql
+++ b/tests/unit/setup/setup.sql
@@ -14,3 +14,4 @@
 \ir 15-attgenerated.sql
 \ir 16-sequences.sql
 \ir 17-exclusion-with-pkey.sql
+\ir 18-function-acl.sql

--- a/tests/unit/setup/setup.sql
+++ b/tests/unit/setup/setup.sql
@@ -15,3 +15,4 @@
 \ir 16-sequences.sql
 \ir 17-exclusion-with-pkey.sql
 \ir 18-function-acl.sql
+\ir 19-pg-stat-statements-acl.sql


### PR DESCRIPTION
## Summary

Fixes two stacked bugs that trigger when a function (or other schema-qualified object) has a non-default ACL.

### Bug 1 — TOC line truncation

`archive_iter_toc_init` set `bufsize = BUFSIZE * 8 = 8192` and `file_iter_lines_next` called `fgets(buf, 8191, stream)`, silently truncating lines longer than 8190 bytes. The truncated remainder became the "next line", failed `parse_archive_list_entry`, and caused a SIGSEGV.

**Fix:** Replace the fixed `fgets` buffer with a GC-managed growing buffer. We call `fgets` in a loop, doubling the `GC_realloc`'d buffer whenever it fills without a newline. (POSIX `getline(3)` was tried first but is incompatible with the Boehm GC that the codebase uses: `getline` allocates with glibc `malloc` while `free()` is macro-replaced by `GC_free`, causing a heap mismatch.)

### Bug 2 — NULL `restoreListName` for function/table/sequence ACL entries

`parse_archive_acl_or_comment` expected the ACL/COMMENT namespace field to always be `-` (dash) followed by a recognised descriptor keyword such as `SCHEMA` or `EXTENSION`. For schema-qualified objects, pg_restore emits the schema name instead:

```
4952; 0 0 ACL public test_function_acl(integer, integer) postgres
               ^^^^^^ real schema name, not '-'
```

The function returned `false` for these; the caller ignores that value, so `item->restoreListName` was left `NULL`. The subsequent `printfPQExpBuffer` in `copydb_write_restore_list_hook` produced a malformed list line that pg_restore silently skipped, leaving the target function's `proacl` unset.

**Fix:** When the namespace token is not a dash, advance past the schema-name identifier manually, then tokenize the composite descriptor (`FUNCTION`, `TABLE`, etc.) or fall through to the `other` branch that captures the full remaining string as `restoreListName`. Also guard the `printfPQExpBuffer` call against a `NULL` `restoreListName`.

## Test

`tests/unit/setup/18-function-acl.sql` creates `test_function_acl` and REVOKEs EXECUTE from PUBLIC, producing a non-default `proacl` that pg_dump will always include as an explicit ACL entry in the archive.

`tests/unit/script/7-function-acl.sh` verifies that after `pgcopydb fork` the target function has a non-NULL `proacl` — confirming the ACL entry was applied by pg_restore.

Closes #888