### PR TITLE
Fix --skip-collations crash when a collation is referenced by multiple objects (#889)

### DIFF
--- a/src/bin/pgcopydb/schema.c
+++ b/src/bin/pgcopydb/schema.c
@@ -619,6 +619,19 @@ schema_list_collations(PGSQL *pgsql, DatabaseCatalog *catalog)
 {
 	SourceCollationArrayContext parseContext = { { 0 }, catalog, false };
 
+	/*
+	 * Each arm of the UNION may return the same colloid multiple times (once
+	 * per column or index that references it).  UNION deduplicates only fully
+	 * identical rows, so two rows that differ only in their description column
+	 * (e.g. two views that both use collation "C") both survive.  Inserting
+	 * them into s_coll, which has oid as PRIMARY KEY, then fails with a
+	 * SQLite constraint error.
+	 *
+	 * The all_colls CTE collects every usage row, and the outer SELECT uses
+	 * DISTINCT ON (colloid) to return exactly one row per collation OID.  The
+	 * description column is informational only (shown by pgcopydb list
+	 * collations) so any single value among the multiple usages is fine.
+	 */
 	char *sql =
 		"with indcols as "
 		" ( "
@@ -628,51 +641,58 @@ schema_list_collations(PGSQL *pgsql, DatabaseCatalog *catalog)
 		"     join pg_namespace n on n.oid = c.relnamespace, "
 		"          unnest(indcollation) with ordinality as t (colloid, n) "
 		"    where n.nspname !~ '^pg_' and n.nspname <> 'information_schema' "
+		" ), "
+		"all_colls as "
+		" ( "
+		"   select colloid, collname, "
+		"          pg_describe_object('pg_class'::regclass, indexrelid, 0) "
+		"              as description, "
+		"          format('%s %s %s', "
+		"                 regexp_replace(n.nspname, '[\\n\\r]', ' '), "
+		"                 regexp_replace(c.collname, '[\\n\\r]', ' '), "
+		"                 regexp_replace(auth.rolname, '[\\n\\r]', ' ')) "
+		"              as restore_list_name "
+		"     from indcols "
+		"          join pg_collation c on c.oid = colloid "
+		"          join pg_roles auth ON auth.oid = c.collowner "
+		"          join pg_namespace n on n.oid = c.collnamespace "
+		"    where colloid <> 0 "
+		"      and collname <> 'default' "
+		"   union "
+		"   select c.oid as colloid, c.collname, "
+		"          format('database %s', d.datname) as description, "
+		"          format('%s %s %s', "
+		"                 regexp_replace(n.nspname, '[\\n\\r]', ' '), "
+		"                 regexp_replace(c.collname, '[\\n\\r]', ' '), "
+		"                 regexp_replace(auth.rolname, '[\\n\\r]', ' ')) "
+		"              as restore_list_name "
+		"     from pg_database d "
+		"          join pg_collation c on c.collname = d.datcollate "
+		"          join pg_roles auth ON auth.oid = c.collowner "
+		"          join pg_namespace n on n.oid = c.collnamespace "
+		"    where d.datname = current_database() "
+		"   union "
+		"   select coll.oid as colloid, coll.collname, "
+		"          pg_describe_object('pg_class'::regclass, attrelid, attnum) "
+		"              as description, "
+		"          format('%s %s %s', "
+		"                 regexp_replace(cn.nspname, '[\\n\\r]', ' '), "
+		"                 regexp_replace(coll.collname, '[\\n\\r]', ' '), "
+		"                 regexp_replace(auth.rolname, '[\\n\\r]', ' ')) "
+		"              as restore_list_name "
+		"     from pg_attribute a "
+		"          join pg_class c on c.oid = a.attrelid "
+		"          join pg_namespace n on n.oid = c.relnamespace "
+		"          join pg_collation coll on coll.oid = attcollation "
+		"          join pg_roles auth ON auth.oid = coll.collowner "
+		"          join pg_namespace cn on cn.oid = coll.collnamespace "
+		"    where collname <> 'default' "
+		"      and n.nspname !~ '^pg_' and n.nspname <> 'information_schema' "
 		" ) "
-		"select colloid, collname, "
-		"       pg_describe_object('pg_class'::regclass, indexrelid, 0), "
-		"       format('%s %s %s', "
-		"              regexp_replace(n.nspname, '[\\n\\r]', ' '), "
-		"              regexp_replace(c.collname, '[\\n\\r]', ' '), "
-		"              regexp_replace(auth.rolname, '[\\n\\r]', ' ')) "
-		"  from indcols "
-		"       join pg_collation c on c.oid = colloid "
-		"       join pg_roles auth ON auth.oid = c.collowner "
-		"       join pg_namespace n on n.oid = c.collnamespace "
-		" where colloid <> 0 "
-		"   and collname <> 'default' "
-
-		"union "
-
-		"select c.oid as colloid, c.collname, "
-		"       format('database %s', d.datname) as desc, "
-		"       format('%s %s %s', "
-		"              regexp_replace(n.nspname, '[\\n\\r]', ' '), "
-		"              regexp_replace(c.collname, '[\\n\\r]', ' '), "
-		"              regexp_replace(auth.rolname, '[\\n\\r]', ' ')) "
-		"  from pg_database d "
-		"       join pg_collation c on c.collname = d.datcollate "
-		"       join pg_roles auth ON auth.oid = c.collowner "
-		"       join pg_namespace n on n.oid = c.collnamespace "
-		" where d.datname = current_database() "
-
-		"union "
-
-		"select coll.oid as colloid, coll.collname, "
-		"       pg_describe_object('pg_class'::regclass, attrelid, attnum), "
-		"       format('%s %s %s', "
-		"              regexp_replace(cn.nspname, '[\\n\\r]', ' '), "
-		"              regexp_replace(coll.collname, '[\\n\\r]', ' '), "
-		"              regexp_replace(auth.rolname, '[\\n\\r]', ' ')) "
-		"  from pg_attribute a "
-		"       join pg_class c on c.oid = a.attrelid "
-		"       join pg_namespace n on n.oid = c.relnamespace "
-		"       join pg_collation coll on coll.oid = attcollation "
-		"       join pg_roles auth ON auth.oid = coll.collowner "
-		"       join pg_namespace cn on cn.oid = coll.collnamespace "
-		" where collname <> 'default' "
-		"   and n.nspname !~ '^pg_' and n.nspname <> 'information_schema' "
-		"order by colloid";
+		"select distinct on (colloid) colloid, collname, description, "
+		"       restore_list_name "
+		"  from all_colls "
+		"order by colloid, description";
 
 	if (!pgsql_execute_with_params(pgsql, sql,
 								   0, NULL, NULL,

--- a/tests/unit/expected/18-collation-multi-use.out
+++ b/tests/unit/expected/18-collation-multi-use.out
@@ -1,0 +1,5 @@
+-[ RECORD 1 ]----------
+viewname | v_coll_test
+-[ RECORD 2 ]----------
+viewname | v_coll_test2
+

--- a/tests/unit/expected/3-collations.out
+++ b/tests/unit/expected/3-collations.out
@@ -1,5 +1,6 @@
                  Name | Object name
 ----------------------+---------------------
+                    C | column ?column? of view v_coll_test
            en_US.utf8 | database postgres
           de-DE-x-icu | column f2 of table colls
           en-US-x-icu | column f2 of table mycoltab

--- a/tests/unit/setup/20-collation-multi-use.sql
+++ b/tests/unit/setup/20-collation-multi-use.sql
@@ -1,0 +1,15 @@
+--
+-- Regression test for https://github.com/dimitri/pgcopydb/issues/889
+--
+-- Two views that both reference the same built-in "C" collation cause
+-- schema_list_collations() to return two rows with the same colloid (one per
+-- view column) but different description values.  UNION does not collapse them
+-- because the description differs, so catalog_add_s_coll() receives two INSERT
+-- attempts for the same OID and fails with a SQLite PRIMARY KEY constraint
+-- error.
+--
+-- The fix wraps the UNION in SELECT DISTINCT ON (colloid) so that only one row
+-- per collation OID is inserted into s_coll.
+--
+CREATE VIEW v_coll_test AS SELECT 'foo' COLLATE "C";
+CREATE VIEW v_coll_test2 AS SELECT * FROM v_coll_test;

--- a/tests/unit/setup/setup.sql
+++ b/tests/unit/setup/setup.sql
@@ -16,3 +16,4 @@
 \ir 17-exclusion-with-pkey.sql
 \ir 18-function-acl.sql
 \ir 19-pg-stat-statements-acl.sql
+\ir 20-collation-multi-use.sql

--- a/tests/unit/sql/18-collation-multi-use.sql
+++ b/tests/unit/sql/18-collation-multi-use.sql
@@ -1,0 +1,5 @@
+select viewname
+  from pg_views
+ where viewname like 'v_coll_test%'
+   and schemaname = 'public'
+order by viewname;


### PR DESCRIPTION
## Problem

When cloning with `--skip-collations`, if the source database has two or more objects (views, table columns, indexes) that both reference the same collation, `pgcopydb` fails at Step 1 with:

```
ERROR  Failed to execute statement: insert into s_coll(oid, collname, description, restore_list_name) values($1, $2, $3, $4)
ERROR  [SQLite 19] constraint failed
ERROR  Failed to list non-default collations in use in database
```

Minimal reproduction:
```sql
CREATE VIEW v  AS SELECT 'foo' COLLATE "C";
CREATE VIEW v2 AS SELECT * FROM v;
```

## Root Cause

`schema_list_collations()` builds a three-arm `UNION`:

| Arm | Produces |
|-----|----------|
| 1 — index collations | one row per (index, colloid) pair |
| 2 — database collation | at most one row |
| 3 — column collations | one row per (column, colloid) pair |

`UNION` deduplicates only fully identical rows. Arm 3 calls `pg_describe_object(attrelid, attnum)` for the description, which is unique per column. Two views that both use `COLLATE "C"` produce two rows with the same `colloid` (950) but different description strings — both survive the `UNION`.

`catalog_add_s_coll()` then tries to `INSERT` each row into `s_coll`, which has `oid INTEGER PRIMARY KEY`. The second insert fails with SQLite constraint error 19.

## Fix

Add an `all_colls` CTE that collects every row from all three arms, then wrap with `SELECT DISTINCT ON (colloid)` to return exactly one row per collation OID. `ORDER BY colloid, description` makes the selection deterministic when multiple objects reference the same collation. The `description` field is informational only (`pgcopydb list collations` display) so any consistent single value is correct.

No changes to `catalog_add_s_coll`, `s_coll` schema, or any consumer — this is a pure SQL fix.

## Test

`tests/unit/setup/20-collation-multi-use.sql` creates the exact two-view chain from the bug report. The `pgcopydb fork --skip-collations` in `copydb.sh` would abort at Step 1 before this fix. `tests/unit/sql/18-collation-multi-use.sql` verifies both views are present on the target after a successful fork.

Closes #889