### PR TITLE
Fix stale comment in sentinel_update_write_flush_lsn

### DIFF
--- a/src/bin/pgcopydb/sentinel.c
+++ b/src/bin/pgcopydb/sentinel.c
@@ -274,7 +274,9 @@ sentinel_update_apply(DatabaseCatalog *catalog, bool apply)
 
 /*
  * sentinel_update_write_flush_lsn updates the current sentinel values for
- * write_lsn and flush_lsn, and startpos too.
+ * write_lsn and flush_lsn. startpos is intentionally NOT updated here; it
+ * records the static replication slot creation LSN for the lifetime of the
+ * migration.
  */
 bool
 sentinel_update_write_flush_lsn(DatabaseCatalog *catalog,


### PR DESCRIPTION
## Problem

Issue #893 reported that `pgcopydb stream sentinel get` showed `startpos` updating alongside `write_lsn` and `flush_lsn` during streaming, when it should remain static.

## Root Cause

In v0.17, `sentinel_update_write_flush_lsn()` ran:
```sql
UPDATE sentinel SET startpos = $1, write_lsn = $2, flush_lsn = $3 WHERE id = 1
```
with `$1 = flush_lsn`. The function comment described this as intentional: *"Update startpos to flush_lsn, which is our safe restart point."*

This was wrong: `startpos` should record the **static replication slot creation LSN** for the lifetime of the migration. The correct restart point is tracked by PostgreSQL's own `confirmed_flush_lsn` on the slot, which pgcopydb advances by feeding back `replay_lsn` as the flush position.

## Fix

The code bug was already fixed in commits `3cad2c8` (#715) and `4926e4a` (#961) — the SQL was changed to only update `write_lsn` and `flush_lsn`, and an explanatory comment was added inside the function.

This PR fixes the **stale function-level comment** that still said *"and startpos too"*, which no longer matches the actual behavior and would mislead future readers.

Closes #893