### PR TITLE
fix: silence spurious filter-mismatch warning for list/sentinel commands (#869)

### DIFF
--- a/src/bin/pgcopydb/catalog.c
+++ b/src/bin/pgcopydb/catalog.c
@@ -884,23 +884,21 @@ catalog_register_setup_from_specs(CopyDataSpec *copySpecs)
 
 		if (!streq(json, setup->filters))
 		{
-			log_info("Current filtering setup is: %s", json);
-			log_info("Catalog filtering setup is: %s", setup->filters);
-
-			/* If catalog has no filters but current command does, it's probably a clone command
-			 * after another command (like snapshot). Use the filters from the current command
-			 */
 			if (strstr(setup->filters, "SOURCE_FILTER_TYPE_NONE") != NULL &&
 				strstr(json, "SOURCE_FILTER_TYPE_NONE") == NULL)
 			{
-				log_warn("Catalogs at \"%s\" have been setup for a different "
-						 "filtering than the current command, "
-						 "see above for details",
+				/*
+				 * Catalog was created without filters (e.g. by pgcopydb
+				 * snapshot) and the current command uses filters (e.g.
+				 * pgcopydb clone --filters). Update the stored filter so
+				 * subsequent commands see the right setup.
+				 */
+				log_info("Current filtering setup is: %s", json);
+				log_info("Catalog filtering setup is: %s", setup->filters);
+				log_warn("Catalogs at \"%s\" have been setup without filters; "
+						 "updating to current command filters",
 						 sourceDB->dbfile);
-				log_warn("Updating catalog filters from \"%s\" to \"%s\"",
-						 setup->filters, json);
 
-				/* Update the filters in the catalog database */
 				if (!catalog_update_filters(sourceDB, json))
 				{
 					log_error("Failed to update filters in catalog database");
@@ -908,19 +906,20 @@ catalog_register_setup_from_specs(CopyDataSpec *copySpecs)
 					return false;
 				}
 
-				/* Update the local setup structure */
 				if (setup->filters != NULL)
 				{
 					free(setup->filters);
 				}
 				setup->filters = strdup(json);
 
-				log_warn("Successfully updated catalog filters");
+				log_info("Catalog filters updated to: %s", setup->filters);
 			}
 			else if (strstr(setup->filters, "SOURCE_FILTER_TYPE_NONE") == NULL &&
 					 strstr(json, "SOURCE_FILTER_TYPE_NONE") == NULL)
 			{
-				/* If both have different filters, something is wrong */
+				/* Both sides have filters but they differ — genuine conflict. */
+				log_info("Current filtering setup is: %s", json);
+				log_info("Catalog filtering setup is: %s", setup->filters);
 				log_error("Catalogs at \"%s\" have been setup for a different "
 						  "filtering than the current command, "
 						  "see above for details",
@@ -931,17 +930,22 @@ catalog_register_setup_from_specs(CopyDataSpec *copySpecs)
 			else if (strstr(setup->filters, "SOURCE_FILTER_TYPE_NONE") == NULL &&
 					 strstr(json, "SOURCE_FILTER_TYPE_NONE") != NULL)
 			{
-				/* If the catalog has filters but current command doesn't, it's probably a command
-				 * (like stream or list) after a clone. Continue with previously used filters in the catalog */
-				log_warn("Catalogs at \"%s\" have been setup for a different "
-						 "filtering than the current command, "
-						 "see above for details",
-						 sourceDB->dbfile);
-				log_warn("Using previously configured filters");
+				/*
+				 * Catalog was created with filters; the current command has
+				 * none (e.g. pgcopydb list table-parts, pgcopydb stream
+				 * sentinel). These read-only commands operate on the already-
+				 * filtered catalog data and do not need --filters repeated.
+				 * Silently adopt the catalog's stored filter.
+				 */
+				log_debug("Adopting catalog's stored filters for this command "
+						  "(catalog: %s)",
+						  setup->filters);
 			}
 			else
 			{
-				/* Any other unanticipated mismatch, default to an error*/
+				/* Unanticipated mismatch. */
+				log_info("Current filtering setup is: %s", json);
+				log_info("Catalog filtering setup is: %s", setup->filters);
 				log_error("Catalogs at \"%s\" have been setup for a different "
 						  "filtering than the current command, "
 						  "see above for details",


### PR DESCRIPTION
## Problem

Running `pgcopydb list table-parts` or any `pgcopydb stream sentinel` subcommand after a `clone --filters` produces a confusing warning on every invocation:

```
ERROR  Catalogs at ".pgcopydb/schema/source.db" have been setup for a different filtering than the current command, see above for details
```

In v0.17 this was a hard error (exit). PR #952 (commit de42e87) fixed the exit but kept `log_warn` with the same alarming message, plus two `log_info` lines dumping the full filter JSON — making every `stream sentinel get` look like something went wrong.

## Root Cause

`catalog_register_setup_from_specs` in `catalog.c` handles four mismatch cases. Case 3 (catalog has filters, current command has none) is the expected scenario for read-only commands that don't accept `--filters`: they operate on already-filtered catalog data and don't need the flag repeated. The fix in #952 correctly continued without error but left two `log_warn` calls and unconditionally logged the filter JSON at `log_info` level for all mismatch cases including this benign one.

## Fix

- Move the two `log_info` filter-JSON lines out of the shared mismatch block and into Case 1, Case 2, and the default (error) arms only — they are useful context when something is actually wrong, not when silently adopting the catalog filter.
- Replace Case 3's two `log_warn` calls with a single `log_debug` describing what happened: "Adopting catalog's stored filters for this command".

The invariant enforced: read-only commands (list, sentinel) that work against an existing catalog require no filter re-specification and produce no output at normal log levels.

Closes #869