### PR TITLE
feat: add [exclude-extension] and [include-only-extension] filter sections (#740)

### DIFF
--- a/docs/ref/pgcopydb_config.rst
+++ b/docs/ref/pgcopydb_config.rst
@@ -59,6 +59,9 @@ Here is an exclusion based filter configuration example:
   public.bar
   nsitra.test1
 
+  [exclude-extension]
+  aiven_extras
+
 Filtering can be done with pgcopydb by using the following rules, which are
 also the name of the sections of the INI file.
 
@@ -129,6 +132,39 @@ names. The schema, index, constraints, etc of the table are still copied
 over.
 
 NOTE: Materialized views are also considered as tables during the filtering.
+
+exclude-extension
+^^^^^^^^^^^^^^^^^
+
+This section allows to skip specific PostgreSQL extensions by name. The
+listed extensions are not created on the target database and their
+configuration tables are not copied.
+
+Each entry is a bare extension name (no schema prefix), one per line::
+
+  [exclude-extension]
+  aiven_extras
+  timescaledb
+
+This section is not allowed when the section ``include-only-extension`` is
+used at the same time.
+
+include-only-extension
+^^^^^^^^^^^^^^^^^^^^^^
+
+This section restricts extension handling to only the listed extensions.
+All other extensions found in the source database are skipped — they are
+not created on the target and their configuration tables are not copied.
+
+Each entry is a bare extension name (no schema prefix), one per line::
+
+  [include-only-extension]
+  postgis
+  uuid-ossp
+
+This section is not allowed when the section ``exclude-extension`` is
+used at the same time, and it cannot be combined with ``--skip-extensions``
+(which skips all extensions).
 
 Reviewing and Debugging the filters
 -----------------------------------

--- a/src/bin/pgcopydb/catalog.c
+++ b/src/bin/pgcopydb/catalog.c
@@ -395,6 +395,13 @@ static char *filterDBcreateDDLs[] = {
 	"create index filter_rlname on filter(restore_list_name)",
 
 	/*
+	 * extension_filter stores the user's [exclude-extension] and
+	 * [include-only-extension] configuration so that catalog_prepare_filter
+	 * can read it internally without needing it passed as C pointers.
+	 */
+	"create table extension_filter(extname text primary key, action text)",
+
+	/*
 	 * While we don't use a summary table in the filter database, some queries
 	 * that are meant to work on both filters database and source database use
 	 * LEFT JOIN summary.
@@ -953,6 +960,37 @@ catalog_register_setup_from_specs(CopyDataSpec *copySpecs)
 
 				return false;
 			}
+		}
+	}
+
+	/*
+	 * Populate extension_filter in the filter catalog from the in-memory
+	 * filter configuration so that catalog_prepare_filter can read it via
+	 * SQL without needing the C lists as parameters.
+	 */
+	DatabaseCatalog *filtersDB = &(copySpecs->catalogs.filter);
+
+	for (int i = 0; i < filters->excludeExtensionList.count; i++)
+	{
+		if (!catalog_add_extension_filter(
+				filtersDB,
+				filters->excludeExtensionList.array[i].extname,
+				"exclude"))
+		{
+			json_free_serialized_string(json);
+			return false;
+		}
+	}
+
+	for (int i = 0; i < filters->includeOnlyExtensionList.count; i++)
+	{
+		if (!catalog_add_extension_filter(
+				filtersDB,
+				filters->includeOnlyExtensionList.array[i].extname,
+				"include-only"))
+		{
+			json_free_serialized_string(json);
+			return false;
 		}
 	}
 
@@ -5772,6 +5810,52 @@ catalog_fetch_catnames(DatabaseCatalog *filterDB, PGSQL *pgsql)
 
 
 /*
+ * catalog_add_extension_filter stores one entry from [exclude-extension] or
+ * [include-only-extension] in the filter catalog's extension_filter table.
+ * catalog_prepare_filter reads this table instead of accepting the C lists
+ * as parameters, keeping its signature stable.
+ */
+bool
+catalog_add_extension_filter(DatabaseCatalog *catalog,
+							 const char *extname,
+							 const char *action)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_add_extension_filter: db is NULL");
+		return false;
+	}
+
+	char *sql =
+		"insert or replace into extension_filter(extname, action) "
+		"values ($1, $2)";
+
+	SQLiteQuery query = { 0 };
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	BindParam params[2] = {
+		{ BIND_PARAMETER_TYPE_TEXT, "extname", 0, (char *) extname },
+		{ BIND_PARAMETER_TYPE_TEXT, "action", 0, (char *) action }
+	};
+
+	if (!catalog_sql_bind(&query, params, 2))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return catalog_sql_execute_once(&query);
+}
+
+
+/*
  * catalog_prepare_filter prepares our filter Hash-Table, that used to be an
  * in-memory only thing, and now is a SQLite table with indexes, so that it can
  * spill to disk when we have giant database catalogs to take care of.
@@ -5779,9 +5863,7 @@ catalog_fetch_catnames(DatabaseCatalog *filterDB, PGSQL *pgsql)
 bool
 catalog_prepare_filter(DatabaseCatalog *catalog,
 					   bool skipExtensions,
-					   bool skipCollations,
-					   SourceFilterExtensionList *excludeExtensionList,
-					   SourceFilterExtensionList *includeOnlyExtensionList)
+					   bool skipCollations)
 {
 	sqlite3 *db = catalog->db;
 
@@ -5954,114 +6036,79 @@ catalog_prepare_filter(DatabaseCatalog *catalog,
 	}
 
 	/*
-	 * Implement [exclude-extension]: insert each named extension into the
-	 * filter table so that copydb_objectid_is_filtered_out skips its TOC
-	 * entry during the pg_restore list pass.
+	 * Implement [exclude-extension]: join s_extension against
+	 * extension_filter (action = 'exclude') to insert named extensions into
+	 * the filter table so that copydb_objectid_is_filtered_out skips their
+	 * TOC entries during the pg_restore list pass.
 	 */
-	if (excludeExtensionList != NULL && excludeExtensionList->count > 0)
+	char *s_excl_ext_sql =
+		"insert or ignore into filter(catoid, oid, restore_list_name, kind) "
+		"     select (select oid from catnames where catname = 'pg_extension'),"
+		"            e.oid, e.extname, 'extension' "
+		"       from s_extension e "
+		"      where exists "
+		"            (select 1 from extension_filter ef "
+		"              where ef.extname = e.extname "
+		"                and ef.action = 'exclude')";
+
+	if (!catalog_sql_prepare(db, s_excl_ext_sql, &query))
 	{
-		char *s_excl_ext_sql =
-			"insert or ignore into filter(catoid, oid, restore_list_name, kind) "
-			"     select (select oid from catnames where catname = 'pg_extension'),"
-			"            oid, extname, 'extension' "
-			"       from s_extension "
-			"      where extname = $1 ";
+		/* errors have already been logged */
+		return false;
+	}
 
-		for (int i = 0; i < excludeExtensionList->count; i++)
-		{
-			SQLiteQuery extQuery = { 0 };
-
-			if (!catalog_sql_prepare(db, s_excl_ext_sql, &extQuery))
-			{
-				/* errors have already been logged */
-				return false;
-			}
-
-			BindParam params[1] = {
-				{
-					BIND_PARAMETER_TYPE_TEXT,
-					"extname",
-					0,
-					excludeExtensionList->array[i].extname
-				}
-			};
-
-			if (!catalog_sql_bind(&extQuery, params, 1))
-			{
-				/* errors have already been logged */
-				return false;
-			}
-
-			if (!catalog_sql_execute_once(&extQuery))
-			{
-				/* errors have already been logged */
-				return false;
-			}
-		}
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
 	}
 
 	/*
 	 * Implement [include-only-extension]: insert ALL extensions into the
-	 * filter table, then remove the ones we want to keep, so that only
-	 * the excluded extensions remain in the filter.
+	 * filter table, then remove the ones listed in extension_filter (action =
+	 * 'include-only'), so that only the non-listed extensions remain in the
+	 * filter and are therefore excluded from the copy.
 	 */
-	if (includeOnlyExtensionList != NULL && includeOnlyExtensionList->count > 0)
+	char *s_all_ext_sql =
+		"insert or ignore into filter(catoid, oid, restore_list_name, kind) "
+		"     select (select oid from catnames where catname = 'pg_extension'),"
+		"            e.oid, e.extname, 'extension' "
+		"       from s_extension e "
+		"      where (select count(*) from extension_filter "
+		"              where action = 'include-only') > 0";
+
+	if (!catalog_sql_prepare(db, s_all_ext_sql, &query))
 	{
-		char *s_all_ext_sql =
-			"insert or ignore into filter(catoid, oid, restore_list_name, kind) "
-			"     select (select oid from catnames where catname = 'pg_extension'),"
-			"            oid, extname, 'extension' "
-			"       from s_extension ";
+		/* errors have already been logged */
+		return false;
+	}
 
-		if (!catalog_sql_prepare(db, s_all_ext_sql, &query))
-		{
-			/* errors have already been logged */
-			return false;
-		}
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
 
-		if (!catalog_sql_execute_once(&query))
-		{
-			/* errors have already been logged */
-			return false;
-		}
+	char *s_keep_ext_sql =
+		"delete from filter "
+		" where catoid = (select oid from catnames "
+		"                  where catname = 'pg_extension') "
+		"   and kind = 'extension' "
+		"   and exists "
+		"       (select 1 from extension_filter ef "
+		"         where ef.extname = filter.restore_list_name "
+		"           and ef.action = 'include-only')";
 
-		char *s_keep_ext_sql =
-			"delete from filter "
-			" where catoid = (select oid from catnames "
-			"                  where catname = 'pg_extension') "
-			"   and restore_list_name = $1 ";
+	if (!catalog_sql_prepare(db, s_keep_ext_sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
 
-		for (int i = 0; i < includeOnlyExtensionList->count; i++)
-		{
-			SQLiteQuery keepQuery = { 0 };
-
-			if (!catalog_sql_prepare(db, s_keep_ext_sql, &keepQuery))
-			{
-				/* errors have already been logged */
-				return false;
-			}
-
-			BindParam params[1] = {
-				{
-					BIND_PARAMETER_TYPE_TEXT,
-					"extname",
-					0,
-					includeOnlyExtensionList->array[i].extname
-				}
-			};
-
-			if (!catalog_sql_bind(&keepQuery, params, 1))
-			{
-				/* errors have already been logged */
-				return false;
-			}
-
-			if (!catalog_sql_execute_once(&keepQuery))
-			{
-				/* errors have already been logged */
-				return false;
-			}
-		}
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
 	}
 
 	/*

--- a/src/bin/pgcopydb/catalog.c
+++ b/src/bin/pgcopydb/catalog.c
@@ -5779,7 +5779,9 @@ catalog_fetch_catnames(DatabaseCatalog *filterDB, PGSQL *pgsql)
 bool
 catalog_prepare_filter(DatabaseCatalog *catalog,
 					   bool skipExtensions,
-					   bool skipCollations)
+					   bool skipCollations,
+					   SourceFilterExtensionList *excludeExtensionList,
+					   SourceFilterExtensionList *includeOnlyExtensionList)
 {
 	sqlite3 *db = catalog->db;
 
@@ -5948,6 +5950,117 @@ catalog_prepare_filter(DatabaseCatalog *catalog,
 		{
 			/* errors have already been logged */
 			return false;
+		}
+	}
+
+	/*
+	 * Implement [exclude-extension]: insert each named extension into the
+	 * filter table so that copydb_objectid_is_filtered_out skips its TOC
+	 * entry during the pg_restore list pass.
+	 */
+	if (excludeExtensionList != NULL && excludeExtensionList->count > 0)
+	{
+		char *s_excl_ext_sql =
+			"insert or ignore into filter(catoid, oid, restore_list_name, kind) "
+			"     select (select oid from catnames where catname = 'pg_extension'),"
+			"            oid, extname, 'extension' "
+			"       from s_extension "
+			"      where extname = $1 ";
+
+		for (int i = 0; i < excludeExtensionList->count; i++)
+		{
+			SQLiteQuery extQuery = { 0 };
+
+			if (!catalog_sql_prepare(db, s_excl_ext_sql, &extQuery))
+			{
+				/* errors have already been logged */
+				return false;
+			}
+
+			BindParam params[1] = {
+				{
+					BIND_PARAMETER_TYPE_TEXT,
+					"extname",
+					0,
+					excludeExtensionList->array[i].extname
+				}
+			};
+
+			if (!catalog_sql_bind(&extQuery, params, 1))
+			{
+				/* errors have already been logged */
+				return false;
+			}
+
+			if (!catalog_sql_execute_once(&extQuery))
+			{
+				/* errors have already been logged */
+				return false;
+			}
+		}
+	}
+
+	/*
+	 * Implement [include-only-extension]: insert ALL extensions into the
+	 * filter table, then remove the ones we want to keep, so that only
+	 * the excluded extensions remain in the filter.
+	 */
+	if (includeOnlyExtensionList != NULL && includeOnlyExtensionList->count > 0)
+	{
+		char *s_all_ext_sql =
+			"insert or ignore into filter(catoid, oid, restore_list_name, kind) "
+			"     select (select oid from catnames where catname = 'pg_extension'),"
+			"            oid, extname, 'extension' "
+			"       from s_extension ";
+
+		if (!catalog_sql_prepare(db, s_all_ext_sql, &query))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+
+		if (!catalog_sql_execute_once(&query))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+
+		char *s_keep_ext_sql =
+			"delete from filter "
+			" where catoid = (select oid from catnames "
+			"                  where catname = 'pg_extension') "
+			"   and restore_list_name = $1 ";
+
+		for (int i = 0; i < includeOnlyExtensionList->count; i++)
+		{
+			SQLiteQuery keepQuery = { 0 };
+
+			if (!catalog_sql_prepare(db, s_keep_ext_sql, &keepQuery))
+			{
+				/* errors have already been logged */
+				return false;
+			}
+
+			BindParam params[1] = {
+				{
+					BIND_PARAMETER_TYPE_TEXT,
+					"extname",
+					0,
+					includeOnlyExtensionList->array[i].extname
+				}
+			};
+
+			if (!catalog_sql_bind(&keepQuery, params, 1))
+			{
+				/* errors have already been logged */
+				return false;
+			}
+
+			if (!catalog_sql_execute_once(&keepQuery))
+			{
+				/* errors have already been logged */
+				return false;
+			}
 		}
 	}
 

--- a/src/bin/pgcopydb/catalog.h
+++ b/src/bin/pgcopydb/catalog.h
@@ -11,17 +11,6 @@
 #include "string_utils.h"
 
 /*
- * Forward declaration so that catalog_prepare_filter's signature can use
- * SourceFilterExtensionList without pulling in parson.h (which filtering.h
- * transitively needs via its filters_as_json declaration). Files that call
- * catalog_prepare_filter must include filtering.h for the full definition.
- */
-#ifndef FILTERING_H
-struct SourceFilterExtensionList;
-typedef struct SourceFilterExtensionList SourceFilterExtensionList;
-#endif
-
-/*
  * Internal infrastructure to bind values to SQLite prepared statements.
  */
 typedef struct SQLiteQuery SQLiteQuery;
@@ -419,11 +408,13 @@ bool catalog_fetch_catnames(DatabaseCatalog *filterDB, PGSQL *pgsql);
 bool catalog_add_catname(DatabaseCatalog *catalog, uint32_t oid,
 						 const char *catname);
 
+bool catalog_add_extension_filter(DatabaseCatalog *catalog,
+								  const char *extname,
+								  const char *action);
+
 bool catalog_prepare_filter(DatabaseCatalog *catalog,
 							bool skipExtensions,
-							bool skipCollations,
-							SourceFilterExtensionList *excludeExtensionList,
-							SourceFilterExtensionList *includeOnlyExtensionList);
+							bool skipCollations);
 
 typedef struct CatalogFilter
 {

--- a/src/bin/pgcopydb/catalog.h
+++ b/src/bin/pgcopydb/catalog.h
@@ -11,6 +11,17 @@
 #include "string_utils.h"
 
 /*
+ * Forward declaration so that catalog_prepare_filter's signature can use
+ * SourceFilterExtensionList without pulling in parson.h (which filtering.h
+ * transitively needs via its filters_as_json declaration). Files that call
+ * catalog_prepare_filter must include filtering.h for the full definition.
+ */
+#ifndef FILTERING_H
+struct SourceFilterExtensionList;
+typedef struct SourceFilterExtensionList SourceFilterExtensionList;
+#endif
+
+/*
  * Internal infrastructure to bind values to SQLite prepared statements.
  */
 typedef struct SQLiteQuery SQLiteQuery;
@@ -410,7 +421,9 @@ bool catalog_add_catname(DatabaseCatalog *catalog, uint32_t oid,
 
 bool catalog_prepare_filter(DatabaseCatalog *catalog,
 							bool skipExtensions,
-							bool skipCollations);
+							bool skipCollations,
+							SourceFilterExtensionList *excludeExtensionList,
+							SourceFilterExtensionList *includeOnlyExtensionList);
 
 typedef struct CatalogFilter
 {

--- a/src/bin/pgcopydb/copydb_schema.c
+++ b/src/bin/pgcopydb/copydb_schema.c
@@ -1322,7 +1322,9 @@ copydb_fetch_filtered_oids(CopyDataSpec *specs, PGSQL *pgsql)
 
 			if (!catalog_prepare_filter(filtersDB,
 										specs->skipExtensions,
-										specs->skipCollations))
+										specs->skipCollations,
+										&(specs->filters.excludeExtensionList),
+										&(specs->filters.includeOnlyExtensionList)))
 			{
 				log_error("Failed to prepare filtering hash-table, "
 						  "see above for details");
@@ -1510,7 +1512,9 @@ copydb_fetch_filtered_oids(CopyDataSpec *specs, PGSQL *pgsql)
 
 		if (!catalog_prepare_filter(filtersDB,
 									specs->skipExtensions,
-									specs->skipCollations))
+									specs->skipCollations,
+									&(specs->filters.excludeExtensionList),
+									&(specs->filters.includeOnlyExtensionList)))
 		{
 			log_error("Failed to prepare filtering hash-table, "
 					  "see above for details");

--- a/src/bin/pgcopydb/copydb_schema.c
+++ b/src/bin/pgcopydb/copydb_schema.c
@@ -1322,9 +1322,7 @@ copydb_fetch_filtered_oids(CopyDataSpec *specs, PGSQL *pgsql)
 
 			if (!catalog_prepare_filter(filtersDB,
 										specs->skipExtensions,
-										specs->skipCollations,
-										&(specs->filters.excludeExtensionList),
-										&(specs->filters.includeOnlyExtensionList)))
+										specs->skipCollations))
 			{
 				log_error("Failed to prepare filtering hash-table, "
 						  "see above for details");
@@ -1512,9 +1510,7 @@ copydb_fetch_filtered_oids(CopyDataSpec *specs, PGSQL *pgsql)
 
 		if (!catalog_prepare_filter(filtersDB,
 									specs->skipExtensions,
-									specs->skipCollations,
-									&(specs->filters.excludeExtensionList),
-									&(specs->filters.includeOnlyExtensionList)))
+									specs->skipCollations))
 		{
 			log_error("Failed to prepare filtering hash-table, "
 					  "see above for details");

--- a/src/bin/pgcopydb/dump_restore.c
+++ b/src/bin/pgcopydb/dump_restore.c
@@ -732,6 +732,65 @@ copydb_write_restore_list_hook(void *ctx, ArchiveContentItem *item)
 		log_debug("Skipping COMMENT ON EXTENSION \"%s\"", name);
 	}
 
+	/*
+	 * Skip COMMENT ON EXTENSION for extensions named in [exclude-extension].
+	 * Bare EXTENSION TOC entries are handled via the filter table in
+	 * copydb_objectid_is_filtered_out; COMMENT ON EXTENSION has objectOid=0
+	 * so it needs an explicit name-based check here.
+	 */
+	if (!skip &&
+		item->isCompositeTag &&
+		item->tagKind == ARCHIVE_TAG_KIND_COMMENT &&
+		item->tagType == ARCHIVE_TAG_TYPE_EXTENSION)
+	{
+		SourceFilterExtensionList *excl =
+			&(specs->filters.excludeExtensionList);
+
+		for (int i = 0; i < excl->count; i++)
+		{
+			if (streq(name, excl->array[i].extname))
+			{
+				skip = true;
+				log_debug("Skipping COMMENT ON EXTENSION \"%s\" "
+						  "(exclude-extension)", name);
+				break;
+			}
+		}
+	}
+
+	/*
+	 * Skip COMMENT ON EXTENSION for extensions not in [include-only-extension].
+	 */
+	if (!skip &&
+		item->isCompositeTag &&
+		item->tagKind == ARCHIVE_TAG_KIND_COMMENT &&
+		item->tagType == ARCHIVE_TAG_TYPE_EXTENSION)
+	{
+		SourceFilterExtensionList *incl =
+			&(specs->filters.includeOnlyExtensionList);
+
+		if (incl->count > 0)
+		{
+			bool found = false;
+
+			for (int i = 0; i < incl->count; i++)
+			{
+				if (streq(name, incl->array[i].extname))
+				{
+					found = true;
+					break;
+				}
+			}
+
+			if (!found)
+			{
+				skip = true;
+				log_debug("Skipping COMMENT ON EXTENSION \"%s\" "
+						  "(not in include-only-extension)", name);
+			}
+		}
+	}
+
 	if (!skip && catOid == PG_NAMESPACE_OID)
 	{
 		bool exists = false;

--- a/src/bin/pgcopydb/extensions.c
+++ b/src/bin/pgcopydb/extensions.c
@@ -31,6 +31,19 @@ copydb_start_extension_data_process(CopyDataSpec *specs, bool createExtensions)
 {
 	if (specs->skipExtensions)
 	{
+		if (specs->filters.excludeExtensionList.count > 0)
+		{
+			log_warn("--skip-extensions already skips all extensions; "
+					 "[exclude-extension] filter entries are redundant");
+		}
+
+		if (specs->filters.includeOnlyExtensionList.count > 0)
+		{
+			log_error("--skip-extensions and [include-only-extension] are "
+					  "contradictory; use one or the other");
+			return false;
+		}
+
 		return true;
 	}
 
@@ -84,6 +97,7 @@ typedef struct CopyExtensionsContext
 	PGSQL *dst;
 	bool createExtensions;
 	ExtensionReqs *reqs;
+	SourceFilters *filters;
 } CopyExtensionsContext;
 
 
@@ -136,7 +150,8 @@ copydb_copy_extensions(CopyDataSpec *copySpecs, bool createExtensions)
 		.src = &(copySpecs->sourceSnapshot.pgsql),
 		.dst = &dst,
 		.createExtensions = createExtensions,
-		.reqs = copySpecs->extRequirements
+		.reqs = copySpecs->extRequirements,
+		.filters = &(copySpecs->filters)
 	};
 
 	if (!catalog_iter_s_extension(filtersDB,
@@ -224,6 +239,50 @@ copydb_copy_extensions_hook(void *ctx, SourceExtension *ext)
 	CopyExtensionsContext *context = (CopyExtensionsContext *) ctx;
 	PGSQL *src = context->src;
 	PGSQL *dst = context->dst;
+
+	SourceFilters *filters = context->filters;
+
+	/* [exclude-extension]: skip explicitly excluded extensions */
+	if (filters != NULL)
+	{
+		SourceFilterExtensionList *excl = &(filters->excludeExtensionList);
+
+		for (int i = 0; i < excl->count; i++)
+		{
+			if (streq(ext->extname, excl->array[i].extname))
+			{
+				log_debug("Skipping excluded extension \"%s\"", ext->extname);
+				return true;
+			}
+		}
+	}
+
+	/* [include-only-extension]: skip extensions not in the include list */
+	if (filters != NULL)
+	{
+		SourceFilterExtensionList *incl = &(filters->includeOnlyExtensionList);
+
+		if (incl->count > 0)
+		{
+			bool found = false;
+
+			for (int i = 0; i < incl->count; i++)
+			{
+				if (streq(ext->extname, incl->array[i].extname))
+				{
+					found = true;
+					break;
+				}
+			}
+
+			if (!found)
+			{
+				log_debug("Skipping extension \"%s\" "
+						  "(not in include-only-extension)", ext->extname);
+				return true;
+			}
+		}
+	}
 
 	if (context->createExtensions)
 	{

--- a/src/bin/pgcopydb/filtering.c
+++ b/src/bin/pgcopydb/filtering.c
@@ -172,6 +172,8 @@ parse_filters(const char *filename, SourceFilters *filters)
 			SOURCE_FILTER_INCLUDE_ONLY_TABLE,
 			&(filters->includeOnlyTableList)
 		},
+		{ "exclude-extension", SOURCE_FILTER_EXCLUDE_EXTENSION, NULL },
+		{ "include-only-extension", SOURCE_FILTER_INCLUDE_ONLY_EXTENSION, NULL },
 		{ "", SOURCE_FILTER_UNKNOWN, NULL },
 	};
 
@@ -304,6 +306,64 @@ parse_filters(const char *filename, SourceFilters *filters)
 				break;
 			}
 
+			case SOURCE_FILTER_EXCLUDE_EXTENSION:
+			{
+				filters->excludeExtensionList.count = optionCount;
+				filters->excludeExtensionList.array =
+					(SourceFilterExtension *) calloc(optionCount,
+													 sizeof(SourceFilterExtension));
+
+				if (filters->excludeExtensionList.array == NULL)
+				{
+					log_error(ALLOCATION_FAILED_ERROR);
+					return false;
+				}
+
+				for (int o = 0; o < optionCount; o++)
+				{
+					SourceFilterExtension *extension =
+						&(filters->excludeExtensionList.array[o]);
+
+					const char *optionName =
+						ini_property_name(ini, sectionIndex, o);
+
+					strlcpy(extension->extname, optionName,
+							sizeof(extension->extname));
+
+					log_debug("excluding extension \"%s\"", extension->extname);
+				}
+				break;
+			}
+
+			case SOURCE_FILTER_INCLUDE_ONLY_EXTENSION:
+			{
+				filters->includeOnlyExtensionList.count = optionCount;
+				filters->includeOnlyExtensionList.array =
+					(SourceFilterExtension *) calloc(optionCount,
+													 sizeof(SourceFilterExtension));
+
+				if (filters->includeOnlyExtensionList.array == NULL)
+				{
+					log_error(ALLOCATION_FAILED_ERROR);
+					return false;
+				}
+
+				for (int o = 0; o < optionCount; o++)
+				{
+					SourceFilterExtension *extension =
+						&(filters->includeOnlyExtensionList.array[o]);
+
+					const char *optionName =
+						ini_property_name(ini, sectionIndex, o);
+
+					strlcpy(extension->extname, optionName,
+							sizeof(extension->extname));
+
+					log_debug("including only extension \"%s\"", extension->extname);
+				}
+				break;
+			}
+
 			default:
 			{
 				log_error("BUG: unknown section number %d", i);
@@ -368,6 +428,20 @@ parse_filters(const char *filename, SourceFilters *filters)
 				 "include-only-table",
 				 filters->excludeSchemaList.count,
 				 "exclude-schema");
+	}
+
+	if (filters->includeOnlyExtensionList.count > 0 &&
+		filters->excludeExtensionList.count > 0)
+	{
+		log_error("Filtering setup in \"%s\" contains %d entries "
+				  "in section \"%s\" and %d entries in section \"%s\", "
+				  "please use only one of these sections.",
+				  filename,
+				  filters->includeOnlyExtensionList.count,
+				  "include-only-extension",
+				  filters->excludeExtensionList.count,
+				  "exclude-extension");
+		return false;
 	}
 
 	/*
@@ -584,6 +658,38 @@ filters_as_json(SourceFilters *filters, JSON_Value *jsFilter)
 				json_object_set_string(jsTableObj, "name", table->relname);
 
 				json_array_append_value(jsListArray, jsTable);
+			}
+
+			json_object_set_value(jsFilterObj, sectionName, jsList);
+		}
+	}
+
+	/* extension filter lists */
+	struct extsection
+	{
+		char name[PG_NAMEDATALEN];
+		SourceFilterExtensionList *list;
+	};
+
+	struct extsection extsections[] = {
+		{ "exclude-extension", &(filters->excludeExtensionList) },
+		{ "include-only-extension", &(filters->includeOnlyExtensionList) },
+		{ "", NULL },
+	};
+
+	for (int i = 0; extsections[i].list != NULL; i++)
+	{
+		char *sectionName = extsections[i].name;
+		SourceFilterExtensionList *list = extsections[i].list;
+
+		if (list->count > 0)
+		{
+			JSON_Value *jsList = json_value_init_array();
+			JSON_Array *jsListArray = json_value_get_array(jsList);
+
+			for (int j = 0; j < list->count; j++)
+			{
+				json_array_append_string(jsListArray, list->array[j].extname);
 			}
 
 			json_object_set_value(jsFilterObj, sectionName, jsList);

--- a/src/bin/pgcopydb/filtering.h
+++ b/src/bin/pgcopydb/filtering.h
@@ -22,7 +22,9 @@ typedef enum
 	SOURCE_FILTER_EXCLUDE_TABLE,
 	SOURCE_FILTER_EXCLUDE_TABLE_DATA,
 	SOURCE_FILTER_EXCLUDE_INDEX,
-	SOURCE_FILTER_INCLUDE_ONLY_TABLE
+	SOURCE_FILTER_INCLUDE_ONLY_TABLE,
+	SOURCE_FILTER_EXCLUDE_EXTENSION,
+	SOURCE_FILTER_INCLUDE_ONLY_EXTENSION
 } SourceFilterSection;
 
 typedef struct SourceFilterSchema
@@ -49,6 +51,18 @@ typedef struct SourceFilterTableList
 	int count;
 	SourceFilterTable *array;   /* malloc'ed area */
 } SourceFilterTableList;
+
+
+typedef struct SourceFilterExtension
+{
+	char extname[PG_NAMEDATALEN];
+} SourceFilterExtension;
+
+typedef struct SourceFilterExtensionList
+{
+	int count;
+	SourceFilterExtension *array;   /* malloc'ed area */
+} SourceFilterExtensionList;
 
 
 /*
@@ -95,6 +109,8 @@ typedef struct SourceFilters
 	SourceFilterTableList excludeTableList;
 	SourceFilterTableList excludeTableDataList;
 	SourceFilterTableList excludeIndexList;
+	SourceFilterExtensionList excludeExtensionList;
+	SourceFilterExtensionList includeOnlyExtensionList;
 } SourceFilters;
 
 char * filterTypeToString(SourceFilterType type);

--- a/tests/extensions/Dockerfile
+++ b/tests/extensions/Dockerfile
@@ -4,6 +4,8 @@ WORKDIR /usr/src/pgcopydb
 COPY ./copydb.sh copydb.sh
 COPY ./ddl.sql ddl.sql
 COPY ./countries.sql countries.sql
+COPY ./exclude-extension.ini exclude-extension.ini
+COPY ./include-only-extension.ini include-only-extension.ini
 
 USER docker
 CMD ["/usr/src/pgcopydb/copydb.sh"]

--- a/tests/extensions/copydb.sh
+++ b/tests/extensions/copydb.sh
@@ -99,3 +99,51 @@ pgcopydb compare data
 
 pgcopydb list extensions --source ${PGCOPYDB_SOURCE_PGURI} --dir /tmp/check/source --debug
 pgcopydb list extensions --source ${PGCOPYDB_TARGET_PGURI} --dir /tmp/check/target
+
+#
+# Test [exclude-extension] filter: copy extensions excluding intarray.
+# Source has: intarray, postgis, hstore.  Target should get: postgis, hstore.
+#
+
+psql -a ${POSTGRES_TARGET} -c "DROP DATABASE pagila WITH (FORCE)"
+psql -a ${POSTGRES_TARGET} -c "CREATE DATABASE pagila OWNER pagila"
+psql -a ${PGCOPYDB_TARGET_PGURI_SU} -c "CREATE SCHEMA foo"
+
+pgcopydb copy extensions \
+         --source ${PGCOPYDB_SOURCE_PGURI_SU} \
+         --target ${PGCOPYDB_TARGET_PGURI_SU} \
+         --filters /usr/src/pgcopydb/exclude-extension.ini \
+         --dir /tmp/pgcopydb-exclude-ext \
+         --restart --debug
+
+extcount=$(psql -At ${PGCOPYDB_TARGET_PGURI_SU} \
+    -c "SELECT count(*) FROM pg_extension WHERE extname = 'intarray'" | tr -d ' \n')
+test "${extcount}" = "0"
+
+extcount=$(psql -At ${PGCOPYDB_TARGET_PGURI_SU} \
+    -c "SELECT count(*) FROM pg_extension WHERE extname IN ('postgis', 'hstore')" | tr -d ' \n')
+test "${extcount}" = "2"
+
+#
+# Test [include-only-extension] filter: copy only hstore.
+# Source has: intarray, postgis, hstore.  Target should get: hstore only.
+#
+
+psql -a ${POSTGRES_TARGET} -c "DROP DATABASE pagila WITH (FORCE)"
+psql -a ${POSTGRES_TARGET} -c "CREATE DATABASE pagila OWNER pagila"
+psql -a ${PGCOPYDB_TARGET_PGURI_SU} -c "CREATE SCHEMA foo"
+
+pgcopydb copy extensions \
+         --source ${PGCOPYDB_SOURCE_PGURI_SU} \
+         --target ${PGCOPYDB_TARGET_PGURI_SU} \
+         --filters /usr/src/pgcopydb/include-only-extension.ini \
+         --dir /tmp/pgcopydb-include-only-ext \
+         --restart --debug
+
+extcount=$(psql -At ${PGCOPYDB_TARGET_PGURI_SU} \
+    -c "SELECT count(*) FROM pg_extension WHERE extname = 'hstore'" | tr -d ' \n')
+test "${extcount}" = "1"
+
+extcount=$(psql -At ${PGCOPYDB_TARGET_PGURI_SU} \
+    -c "SELECT count(*) FROM pg_extension WHERE extname IN ('intarray', 'postgis')" | tr -d ' \n')
+test "${extcount}" = "0"

--- a/tests/extensions/exclude-extension.ini
+++ b/tests/extensions/exclude-extension.ini
@@ -1,0 +1,2 @@
+[exclude-extension]
+intarray

--- a/tests/extensions/include-only-extension.ini
+++ b/tests/extensions/include-only-extension.ini
@@ -1,0 +1,2 @@
+[include-only-extension]
+hstore


### PR DESCRIPTION
## Problem

There is no way to exclude specific extensions by name when running `pgcopydb clone`. The existing `--skip-extensions` flag is all-or-nothing. Users who need to exclude platform-managed extensions (e.g. `aiven_extras`, which is auto-recreated by the Aiven controller and cannot be migrated) while keeping all other extensions have no recourse.

## Root Cause

The `SourceFilters` struct had no extension lists. The filter pipeline (`catalog_prepare_filter`, `copydb_copy_extensions`, `dump_restore`) only knew about `bool skipExtensions` which skips everything.

A WIP patch existed in a fork (arajkumar/pgcopydb@d3297962) but was never ported to main because it predated the SQLite catalog architecture.

## Fix

Two new INI filter sections, symmetric with the existing table/schema filter pairs:

```ini
[exclude-extension]
aiven_extras
timescaledb

[include-only-extension]
postgis
uuid-ossp
```

Each entry is a bare extension name, one per line. The two sections are mutually exclusive; combining `[include-only-extension]` with `--skip-extensions` is an error; combining `[exclude-extension]` with `--skip-extensions` emits a warning (redundant).

**Implementation touches three parts of the extension filter pipeline:**

1. **`catalog_prepare_filter`** (SQLite filter table): `[exclude-extension]` inserts named extensions into the filter table with `kind='extension'` so that `copydb_objectid_is_filtered_out` correctly skips bare `EXTENSION` TOC entries during `pg_restore` list generation. `[include-only-extension]` inserts all extensions then deletes the ones to keep, leaving only the excluded ones in the filter.

2. **`dump_restore.c`**: `COMMENT ON EXTENSION` entries have `objectOid=0` and cannot be caught by the OID-based filter table lookup. Explicit name-based checks are added in `copydb_write_restore_list_hook` for both cases. Bare `EXTENSION` TOC entries flow through the existing `copydb_objectid_is_filtered_out` path (no change needed there).

3. **`extensions.c`**: `copydb_copy_extensions_hook` skips extensions matching either filter before creating them or copying their configuration tables.

Closes #740