### PR TITLE
fix: make extension copy resumable using summary table (#742)

### DIFF
--- a/src/bin/pgcopydb/catalog.c
+++ b/src/bin/pgcopydb/catalog.c
@@ -178,11 +178,14 @@ static char *sourceDBcreateDDLs[] = {
 	"  partnum integer, "
 	"  indexoid integer references s_index(oid), "
 	"  conoid integer references s_constraint(oid), "
+	"  extoid integer, "
 	"  start_time_epoch integer, done_time_epoch integer, duration integer, "
 	"  bytes integer, "
 	"  command text, "
 	"  unique(tableoid, partnum)"
 	")",
+
+	"create unique index summary_extoid on summary(extoid) where extoid is not null",
 
 	"create table vacuum_summary("
 	"  pid integer, "
@@ -412,6 +415,7 @@ static char *filterDBcreateDDLs[] = {
 	"  partnum integer, "
 	"  indexoid integer references s_index(oid), "
 	"  conoid integer references s_constraint(oid), "
+	"  extoid integer, "
 	"  start_time_epoch integer, done_time_epoch integer, duration integer, "
 	"  bytes integer, "
 	"  command text, "

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -712,6 +712,17 @@ bool summary_add_constraint(DatabaseCatalog *catalog,
 bool summary_finish_constraint(DatabaseCatalog *catalog,
 							   CopyIndexSpec *indexSpecs);
 
+bool summary_lookup_extension(DatabaseCatalog *catalog,
+							  CopyExtensionSummary *extSummary);
+
+bool summary_extension_fetch(SQLiteQuery *query);
+
+bool summary_add_extension(DatabaseCatalog *catalog,
+						   CopyExtensionSummary *extSummary);
+
+bool summary_finish_extension(DatabaseCatalog *catalog,
+							  CopyExtensionSummary *extSummary);
+
 bool summary_table_count_indexes_left(DatabaseCatalog *catalog,
 									  CopyTableDataSpec *tableSpecs);
 

--- a/src/bin/pgcopydb/extensions.c
+++ b/src/bin/pgcopydb/extensions.c
@@ -93,6 +93,7 @@ copydb_start_extension_data_process(CopyDataSpec *specs, bool createExtensions)
 typedef struct CopyExtensionsContext
 {
 	DatabaseCatalog *filtersDB;
+	DatabaseCatalog *sourceDB;
 	PGSQL *src;
 	PGSQL *dst;
 	bool createExtensions;
@@ -147,6 +148,7 @@ copydb_copy_extensions(CopyDataSpec *copySpecs, bool createExtensions)
 
 	CopyExtensionsContext context = {
 		.filtersDB = filtersDB,
+		.sourceDB = &(copySpecs->catalogs.source),
 		.src = &(copySpecs->sourceSnapshot.pgsql),
 		.dst = &dst,
 		.createExtensions = createExtensions,
@@ -284,6 +286,22 @@ copydb_copy_extensions_hook(void *ctx, SourceExtension *ext)
 		}
 	}
 
+	/* resume: skip this extension if it was fully copied in a previous run */
+	CopyExtensionSummary extSummary = { .extoid = ext->oid };
+
+	if (!summary_lookup_extension(context->sourceDB, &extSummary))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	if (extSummary.doneTime > 0)
+	{
+		log_debug("Skipping extension \"%s\": already done in a previous run",
+				  ext->extname);
+		return true;
+	}
+
 	if (context->createExtensions)
 	{
 		PQExpBuffer sql = createPQExpBuffer();
@@ -333,6 +351,18 @@ copydb_copy_extensions_hook(void *ctx, SourceExtension *ext)
 
 	if (ext->config.count > 0)
 	{
+		if (!summary_add_extension(context->sourceDB, &extSummary))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+
+		if (!pgsql_begin(dst))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+
 		for (int i = 0; i < ext->config.count; i++)
 		{
 			SourceExtensionConfig *config = &(ext->config.array[i]);
@@ -364,6 +394,7 @@ copydb_copy_extensions_hook(void *ctx, SourceExtension *ext)
 											   config->condition))
 					{
 						/* errors have already been logged */
+						(void) pgsql_rollback(dst);
 						return false;
 					}
 
@@ -382,6 +413,7 @@ copydb_copy_extensions_hook(void *ctx, SourceExtension *ext)
 												  qname))
 					{
 						/* errors have already been logged */
+						(void) pgsql_rollback(dst);
 						return false;
 					}
 
@@ -401,9 +433,40 @@ copydb_copy_extensions_hook(void *ctx, SourceExtension *ext)
 							  (char) config->relkind,
 							  ext->extname,
 							  qname);
+					(void) pgsql_rollback(dst);
 					return false;
 				}
 			}
+		}
+
+		if (!pgsql_commit(dst))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+
+		if (!summary_finish_extension(context->sourceDB, &extSummary))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+	}
+	else
+	{
+		/*
+		 * Extension has no config tables to copy; stamp it done immediately so
+		 * a subsequent --resume skips the CREATE EXTENSION as well.
+		 */
+		if (!summary_add_extension(context->sourceDB, &extSummary))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+
+		if (!summary_finish_extension(context->sourceDB, &extSummary))
+		{
+			/* errors have already been logged */
+			return false;
 		}
 	}
 

--- a/src/bin/pgcopydb/summary.c
+++ b/src/bin/pgcopydb/summary.c
@@ -1619,6 +1619,264 @@ summary_finish_constraint(DatabaseCatalog *catalog, CopyIndexSpec *indexSpecs)
 
 
 /*
+ * summary_lookup_extension looks-up an extension summary in our catalogs, in
+ * case the given extension has already been done in a previous run.
+ */
+bool
+summary_lookup_extension(DatabaseCatalog *catalog,
+						 CopyExtensionSummary *extSummary)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: summary_lookup_extension: db is NULL");
+		return false;
+	}
+
+	char *sql =
+		"  select pid, start_time_epoch, done_time_epoch, duration "
+		"    from summary "
+		"   where extoid = $1";
+
+	if (!semaphore_lock(&(catalog->sema)))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	SQLiteQuery query = {
+		.context = extSummary,
+		.fetchFunction = &summary_extension_fetch
+	};
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		(void) semaphore_unlock(&(catalog->sema));
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_INT64, "extoid", extSummary->extoid, NULL }
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(&query, params, count))
+	{
+		/* errors have already been logged */
+		(void) semaphore_unlock(&(catalog->sema));
+		return false;
+	}
+
+	/* now execute the query, which return exactly one row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		(void) semaphore_unlock(&(catalog->sema));
+		return false;
+	}
+
+	(void) semaphore_unlock(&(catalog->sema));
+
+	return true;
+}
+
+
+/*
+ * summary_extension_fetch fetches a CopyExtensionSummary entry from a SQLite
+ * ppStmt result set.
+ */
+bool
+summary_extension_fetch(SQLiteQuery *query)
+{
+	CopyExtensionSummary *extSummary = (CopyExtensionSummary *) query->context;
+
+	extSummary->pid = sqlite3_column_int64(query->ppStmt, 0);
+	extSummary->startTime = sqlite3_column_int64(query->ppStmt, 1);
+	extSummary->doneTime = sqlite3_column_int64(query->ppStmt, 2);
+	extSummary->durationMs = sqlite3_column_int64(query->ppStmt, 3);
+
+	extSummary->startTimeInstr = (instr_time) {
+		0
+	};
+	extSummary->durationInstr = (instr_time) {
+		0
+	};
+
+	INSTR_TIME_SET_CURRENT(extSummary->startTimeInstr);
+
+	return true;
+}
+
+
+/*
+ * summary_add_extension INSERTs an extension summary entry to our internal
+ * catalogs database, recording that this extension's copy has started.
+ */
+bool
+summary_add_extension(DatabaseCatalog *catalog,
+					  CopyExtensionSummary *extSummary)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: summary_add_extension: db is NULL");
+		return false;
+	}
+
+	extSummary->pid = getpid();
+	extSummary->startTime = time(NULL);
+	extSummary->doneTime = 0;
+	extSummary->durationMs = 0;
+
+	extSummary->startTimeInstr = (instr_time) {
+		0
+	};
+	extSummary->durationInstr = (instr_time) {
+		0
+	};
+
+	INSTR_TIME_SET_CURRENT(extSummary->startTimeInstr);
+
+	char *sql =
+		"insert or ignore into summary(pid, extoid, start_time_epoch) "
+		"values($1, $2, $3)";
+
+	if (!semaphore_lock(&(catalog->sema)))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	SQLiteQuery query = { 0 };
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		(void) semaphore_unlock(&(catalog->sema));
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_INT64, "pid", extSummary->pid, NULL },
+		{ BIND_PARAMETER_TYPE_INT64, "extoid", extSummary->extoid, NULL },
+
+		{
+			BIND_PARAMETER_TYPE_INT64, "start_time_epoch",
+			extSummary->startTime, NULL
+		}
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(&query, params, count))
+	{
+		/* errors have already been logged */
+		(void) semaphore_unlock(&(catalog->sema));
+		return false;
+	}
+
+	/* now execute the query, which does not return any row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		(void) semaphore_unlock(&(catalog->sema));
+		return false;
+	}
+
+	(void) semaphore_unlock(&(catalog->sema));
+
+	return true;
+}
+
+
+/*
+ * summary_finish_extension UPDATEs an extension summary entry in our internal
+ * catalogs database to record that the extension's copy has completed.
+ */
+bool
+summary_finish_extension(DatabaseCatalog *catalog,
+						 CopyExtensionSummary *extSummary)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: summary_finish_extension: db is NULL");
+		return false;
+	}
+
+	extSummary->doneTime = time(NULL);
+
+	INSTR_TIME_SET_CURRENT(extSummary->durationInstr);
+	INSTR_TIME_SUBTRACT(extSummary->durationInstr, extSummary->startTimeInstr);
+
+	extSummary->durationMs = INSTR_TIME_GET_MILLISEC(extSummary->durationInstr);
+
+	char *sql =
+		"update summary set done_time_epoch = $1, duration = $2 "
+		"where pid = $3 and extoid = $4";
+
+	if (!semaphore_lock(&(catalog->sema)))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	SQLiteQuery query = { 0 };
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		(void) semaphore_unlock(&(catalog->sema));
+		return false;
+	}
+
+	/* bind our parameters now */
+	BindParam params[] = {
+		{
+			BIND_PARAMETER_TYPE_INT64, "done_time_epoch",
+			extSummary->doneTime, NULL
+		},
+
+		{
+			BIND_PARAMETER_TYPE_INT64, "duration",
+			extSummary->durationMs, NULL
+		},
+
+		{ BIND_PARAMETER_TYPE_INT64, "pid", extSummary->pid, NULL },
+		{ BIND_PARAMETER_TYPE_INT64, "extoid", extSummary->extoid, NULL }
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(&query, params, count))
+	{
+		/* errors have already been logged */
+		(void) semaphore_unlock(&(catalog->sema));
+		return false;
+	}
+
+	/* now execute the query, which does not return any row */
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		(void) semaphore_unlock(&(catalog->sema));
+		return false;
+	}
+
+	(void) semaphore_unlock(&(catalog->sema));
+
+	return true;
+}
+
+
+/*
  * summary_table_all_indexes_done sets tableSpecs->allIndexesAreDone to true
  * when all the indexes have already been done in the summary table of our
  * internal catalogs.

--- a/src/bin/pgcopydb/summary.h
+++ b/src/bin/pgcopydb/summary.h
@@ -69,6 +69,17 @@ typedef struct CopyOidSummary
 	uint64_t durationMs;        /* instr_time duration in milliseconds */
 } CopyOidSummary;
 
+typedef struct CopyExtensionSummary
+{
+	pid_t pid;                  /* pid */
+	uint32_t extoid;            /* oid */
+	uint64_t startTime;         /* time(NULL) at start time */
+	uint64_t doneTime;          /* time(NULL) at done time */
+	uint64_t durationMs;        /* instr_time duration in milliseconds */
+	instr_time startTimeInstr;  /* internal instr_time tracker */
+	instr_time durationInstr;   /* internal instr_time tracker */
+} CopyExtensionSummary;
+
 #define COPY_BLOBS_SUMMARY_LINES 3
 
 typedef struct CopyBlobsSummary


### PR DESCRIPTION
## Problem

When `pgcopydb copy extensions` (or `pgcopydb clone`) is interrupted and restarted with `--resume`, the extension copy step runs again unconditionally. `CREATE EXTENSION IF NOT EXISTS` is idempotent, so that part is harmless, but the `COPY` statements for extension configuration tables (e.g. PostGIS's `spatial_ref_sys`) are re-run without any deduplication, resulting in duplicate rows on the target.

## Root Cause

`copydb_copy_extensions_hook` in `extensions.c` had no resume tracking. Every invocation unconditionally re-ran CREATE EXTENSION and re-copied all configuration tables. The codebase uses a `summary` table with `done_time_epoch` to track completion of tables and indexes, but extensions were not wired into that mechanism.

## Fix

Extend the `summary` table with an `extoid integer` column (plus a partial unique index on it) and add three functions—`summary_lookup_extension`, `summary_add_extension`, `summary_finish_extension`—that follow the same pattern as the existing table and index summary functions.

The hook now:
- Checks `summary_lookup_extension`: if `done_time_epoch > 0`, the extension was fully copied in a previous run and is skipped.
- Before copying config tables, stamps a start row via `summary_add_extension` (using `INSERT OR IGNORE` so concurrent processes don't race).
- Wraps all config table copies in a single `BEGIN`/`COMMIT` on the target, so an interruption mid-copy rolls back the partial data and leaves `done_time_epoch` unset.
- After commit, stamps `done_time_epoch` via `summary_finish_extension`.

Extensions with no config tables are stamped done immediately after CREATE EXTENSION.

Closes #742