### PR TITLE
fix: use named column access for IDENTIFY_SYSTEM to support AlloyDB (#896)

### DIFF
--- a/src/bin/pgcopydb/pgsql_timeline.c
+++ b/src/bin/pgcopydb/pgsql_timeline.c
@@ -152,11 +152,19 @@ writeTimelineHistoryFile(char *filename, char *content)
 static void
 parseIdentifySystemResult(IdentifySystemResult *context, PGresult *result)
 {
-	if (PQnfields(result) != 4)
+	if (PQnfields(result) < 4)
 	{
-		log_error("Query returned %d columns, expected 4", PQnfields(result));
+		log_error("Query returned %d columns, expected at least 4",
+				  PQnfields(result));
 		context->parsedOk = false;
 		return;
+	}
+
+	if (PQnfields(result) > 4)
+	{
+		log_debug("IDENTIFY_SYSTEM returned %d columns, expected 4: "
+				  "ignoring extra columns from non-standard server",
+				  PQnfields(result));
 	}
 
 	if (PQntuples(result) == 0)
@@ -172,8 +180,23 @@ parseIdentifySystemResult(IdentifySystemResult *context, PGresult *result)
 		return;
 	}
 
+	int fn_systemid = PQfnumber(result, "systemid");
+	int fn_timeline = PQfnumber(result, "timeline");
+	int fn_xlogpos = PQfnumber(result, "xlogpos");
+	int fn_dbname = PQfnumber(result, "dbname");
+
+	if (fn_systemid < 0 || fn_timeline < 0 ||
+		fn_xlogpos < 0 || fn_dbname < 0)
+	{
+		log_error("IDENTIFY_SYSTEM response is missing a required column "
+				  "(systemid=%d, timeline=%d, xlogpos=%d, dbname=%d)",
+				  fn_systemid, fn_timeline, fn_xlogpos, fn_dbname);
+		context->parsedOk = false;
+		return;
+	}
+
 	/* systemid (text) */
-	char *value = PQgetvalue(result, 0, 0);
+	char *value = PQgetvalue(result, 0, fn_systemid);
 	if (!stringToUInt64(value, &(context->system->identifier)))
 	{
 		log_error("Failed to parse system_identifier \"%s\"", value);
@@ -182,7 +205,7 @@ parseIdentifySystemResult(IdentifySystemResult *context, PGresult *result)
 	}
 
 	/* timeline (int4) */
-	value = PQgetvalue(result, 0, 1);
+	value = PQgetvalue(result, 0, fn_timeline);
 	if (!stringToUInt32(value, &(context->system->timeline)))
 	{
 		log_error("Failed to parse timeline \"%s\"", value);
@@ -191,13 +214,13 @@ parseIdentifySystemResult(IdentifySystemResult *context, PGresult *result)
 	}
 
 	/* xlogpos (text) */
-	value = PQgetvalue(result, 0, 2);
+	value = PQgetvalue(result, 0, fn_xlogpos);
 	strlcpy(context->system->xlogpos, value, PG_LSN_MAXLENGTH);
 
-	/* dbname (text) Database connected to or null */
-	if (!PQgetisnull(result, 0, 3))
+	/* dbname (text) — may be null for non-database walsenders */
+	if (!PQgetisnull(result, 0, fn_dbname))
 	{
-		value = PQgetvalue(result, 0, 3);
+		value = PQgetvalue(result, 0, fn_dbname);
 		strlcpy(context->system->dbname, value, NAMEDATALEN);
 	}
 
@@ -214,11 +237,19 @@ static void
 parseTimelineHistoryResult(TimelineHistoryResult *context, PGresult *result,
 						   char *cdcPathDir)
 {
-	if (PQnfields(result) != 2)
+	if (PQnfields(result) < 2)
 	{
-		log_error("Query returned %d columns, expected 2", PQnfields(result));
+		log_error("Query returned %d columns, expected at least 2",
+				  PQnfields(result));
 		context->parsedOk = false;
 		return;
+	}
+
+	if (PQnfields(result) > 2)
+	{
+		log_debug("TIMELINE_HISTORY returned %d columns, expected 2: "
+				  "ignoring extra columns from non-standard server",
+				  PQnfields(result));
 	}
 
 	if (PQntuples(result) == 0)
@@ -235,8 +266,20 @@ parseTimelineHistoryResult(TimelineHistoryResult *context, PGresult *result,
 		return;
 	}
 
+	int fn_filename = PQfnumber(result, "filename");
+	int fn_content = PQfnumber(result, "content");
+
+	if (fn_filename < 0 || fn_content < 0)
+	{
+		log_error("TIMELINE_HISTORY response is missing a required column "
+				  "(filename=%d, content=%d)",
+				  fn_filename, fn_content);
+		context->parsedOk = false;
+		return;
+	}
+
 	/* filename (text) */
-	char *value = PQgetvalue(result, 0, 0);
+	char *value = PQgetvalue(result, 0, fn_filename);
 	sformat(context->filename, sizeof(context->filename), "%s/%s", cdcPathDir, value);
 
 	/*
@@ -245,7 +288,7 @@ parseTimelineHistoryResult(TimelineHistoryResult *context, PGresult *result,
 	 * We do not want to store this value in memory. Instead we write it to disk
 	 * as it is.
 	 */
-	value = PQgetvalue(result, 0, 1);
+	value = PQgetvalue(result, 0, fn_content);
 	if (!writeTimelineHistoryFile(context->filename, value))
 	{
 		log_error("Failed to write timeline history file \"%s\"", context->filename);


### PR DESCRIPTION
## Problem

`pgcopydb clone --follow` fails immediately against Google AlloyDB with:

```
Query returned 5 columns, expected 4
Failed to get result from IDENTIFY_SYSTEM
```

AlloyDB extends the replication protocol by adding an `authtoken` column to `IDENTIFY_SYSTEM`. The strict equality check (`!= 4`) aborts before any column data is read, making CDC-mode entirely unusable for AlloyDB users.

## Root Cause

`parseIdentifySystemResult()` in `src/bin/pgcopydb/pgsql_timeline.c` (line 155) checked `PQnfields(result) != 4` and returned false on mismatch. All four column values were then fetched by position (0–3). The same pattern existed in `parseTimelineHistoryResult()` with `!= 2`.

## Fix

Replace the strict equality guards with minimum-count guards (`< 4`, `< 2`). Switch all column accesses from positional indices to `PQfnumber()` lookups by name (`systemid`, `timeline`, `xlogpos`, `dbname` for `IDENTIFY_SYSTEM`; `filename`, `content` for `TIMELINE_HISTORY`). Extra columns beyond the known set are logged at DEBUG level and ignored. If any required column is absent by name, an explicit error is logged identifying which column is missing.

Zero behavioural change against standard PostgreSQL — `PQfnumber` returns the same indices 0–3 that the code used before.

Closes #896