### PR TITLE
fix: honour --requirements version pins when cloning extensions (#854)

### DIFF
--- a/src/bin/pgcopydb/copydb.c
+++ b/src/bin/pgcopydb/copydb.c
@@ -429,6 +429,9 @@ copydb_prepare_dump_paths(CopyFilePaths *cfPaths, DumpPaths *dumpPaths)
 	sformat(dumpPaths->preListFilename, MAXPGPATH, "%s/%s",
 			cfPaths->schemadir, "pre-filtered.list");
 
+	sformat(dumpPaths->schemaListFilename, MAXPGPATH, "%s/%s",
+			cfPaths->schemadir, "schemas-only.list");
+
 	sformat(dumpPaths->postListOutFilename, MAXPGPATH, "%s/%s",
 			cfPaths->schemadir, "post-out.list");
 

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -430,6 +430,7 @@ bool copydb_copy_extensions(CopyDataSpec *copySpecs, bool createExtensions);
 
 bool copydb_parse_extensions_requirements(CopyDataSpec *copySpecs,
 										  char *filename);
+bool copydb_create_pinned_extensions(CopyDataSpec *copySpecs);
 bool copydb_prepare_extensions_restore(CopyDataSpec *copySpecs);
 bool copydb_finalize_extensions_restore(CopyDataSpec *copySpecs);
 

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -485,6 +485,7 @@ bool copydb_objectid_has_been_processed_already(CopyDataSpec *specs,
 												ArchiveContentItem *item);
 
 bool copydb_write_restore_list(CopyDataSpec *specs, PostgresDumpSection section);
+bool copydb_write_schemas_restore_list(CopyDataSpec *specs);
 
 /* sequences.c */
 bool copydb_copy_all_sequences(CopyDataSpec *specs, bool reset);

--- a/src/bin/pgcopydb/copydb_paths.h
+++ b/src/bin/pgcopydb/copydb_paths.h
@@ -61,6 +61,7 @@ typedef struct DumpPaths
 
 	char preListOutFilename[MAXPGPATH]; /* pg_restore --list */
 	char preListFilename[MAXPGPATH]; /* pg_restore --use-list */
+	char schemaListFilename[MAXPGPATH]; /* schemas-only pg_restore --use-list */
 
 	char postListOutFilename[MAXPGPATH]; /* pg_restore --list */
 	char postListFilename[MAXPGPATH];    /* pg_restore --use-list */

--- a/src/bin/pgcopydb/copydb_schema.c
+++ b/src/bin/pgcopydb/copydb_schema.c
@@ -1321,7 +1321,8 @@ copydb_fetch_filtered_oids(CopyDataSpec *specs, PGSQL *pgsql)
 			}
 
 			if (!catalog_prepare_filter(filtersDB,
-										specs->skipExtensions,
+										specs->skipExtensions ||
+										(specs->extRequirements != NULL),
 										specs->skipCollations))
 			{
 				log_error("Failed to prepare filtering hash-table, "
@@ -1509,7 +1510,8 @@ copydb_fetch_filtered_oids(CopyDataSpec *specs, PGSQL *pgsql)
 		}
 
 		if (!catalog_prepare_filter(filtersDB,
-									specs->skipExtensions,
+									specs->skipExtensions ||
+									(specs->extRequirements != NULL),
 									specs->skipCollations))
 		{
 			log_error("Failed to prepare filtering hash-table, "

--- a/src/bin/pgcopydb/dump_restore.c
+++ b/src/bin/pgcopydb/dump_restore.c
@@ -179,15 +179,44 @@ copydb_target_prepare_schema(CopyDataSpec *specs)
 	}
 
 	/*
-	 * When --requirements is given, extensions are excluded from the
-	 * pg_restore list so we can pin their versions ourselves.  Create them
-	 * before copydb_write_restore_list so that the schema-already-exists
-	 * check in that function sees the extension schemas (e.g. foo for
-	 * hstore) and omits their CREATE SCHEMA entries from the list, avoiding
-	 * a conflict when pg_restore runs.  Extensions must also be installed
-	 * before pg_restore so that schema objects depending on extension types
-	 * (e.g. PostGIS geometry columns) can be created successfully.
+	 * When --requirements is given, use a two-pass approach so that extension
+	 * namespaces exist before the extensions themselves are created, and
+	 * extensions exist before pg_restore creates objects that depend on their
+	 * types (e.g. PostGIS geometry columns):
+	 *
+	 *   Pass 1: restore schemas only → namespaces created with correct
+	 *           ownership and grants.
+	 *   Then:   create pinned extensions (schemas already exist).
+	 *   Pass 2: restore everything except schemas and extensions → tables,
+	 *           functions, etc. can reference extension types.
+	 *
+	 * Without --requirements, a single pg_restore pass suffices: extensions
+	 * are either handled by pg_restore (skipExtensions=false) or skipped
+	 * entirely (skipExtensions=true).
 	 */
+	if (specs->extRequirements != NULL)
+	{
+		if (!copydb_write_schemas_restore_list(specs))
+		{
+			log_error("Failed to prepare the schemas-only pg_restore list, "
+					  "see above for details");
+			return false;
+		}
+
+		specs->restoreOptions.section = PG_RESTORE_SECTION_PRE_DATA;
+		if (!pg_restore_db(&(specs->pgPaths),
+						   &(specs->connStrings),
+						   &(specs->filters),
+						   specs->dumpPaths.dumpFilename,
+						   specs->dumpPaths.schemaListFilename,
+						   specs->restoreOptions))
+		{
+			log_error("Failed to restore schemas (first pass), "
+					  "see above for details");
+			return false;
+		}
+	}
+
 	if (!copydb_create_pinned_extensions(specs))
 	{
 		log_error("Failed to create extensions with version pinning, "
@@ -196,7 +225,9 @@ copydb_target_prepare_schema(CopyDataSpec *specs)
 	}
 
 	/*
-	 * Now prepare the pg_restore --use-list file.
+	 * Now prepare the pg_restore --use-list file.  When --requirements is
+	 * used, SCHEMA entries are skipped here because they were already restored
+	 * in the first pass above.
 	 */
 	if (!copydb_write_restore_list(specs, PG_DUMP_SECTION_PRE_DATA))
 	{
@@ -612,6 +643,7 @@ typedef struct RestoreListContext
 {
 	CopyDataSpec *specs;
 	FILE *outStream;
+	bool schemasOnly;   /* write only SCHEMA entries (first pass) */
 } RestoreListContext;
 
 /*
@@ -711,6 +743,61 @@ copydb_write_restore_list(CopyDataSpec *specs, PostgresDumpSection section)
 
 
 /*
+ * copydb_write_schemas_restore_list writes a pg_restore --use-list file that
+ * contains only SCHEMA entries from the pre-data section.  This is used as the
+ * first pass when --requirements is active: pg_restore runs with this list to
+ * create all schemas (with correct ownership and grants), after which
+ * copydb_create_pinned_extensions can safely create extensions into those
+ * schemas without needing to pre-create them itself.
+ */
+bool
+copydb_write_schemas_restore_list(CopyDataSpec *specs)
+{
+	char *dumpFilename = specs->dumpPaths.dumpFilename;
+	char *listOutFilename = specs->dumpPaths.preListOutFilename;
+	char *listFilename = specs->dumpPaths.schemaListFilename;
+
+	if (!pg_restore_list(&(specs->pgPaths), dumpFilename, listOutFilename))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	FILE *out = fopen_with_umask(listFilename, "ab", FOPEN_FLAGS_A, 0644);
+
+	if (out == NULL)
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	RestoreListContext context = {
+		.specs = specs,
+		.outStream = out,
+		.schemasOnly = true
+	};
+
+	if (!archive_iter_toc(listOutFilename,
+						  &context,
+						  copydb_write_restore_list_hook))
+	{
+		log_error("Failed to prepare the schemas-only pg_restore list file, "
+				  "see above for details");
+		(void) fclose(out);
+		return false;
+	}
+
+	if (fclose(out) == EOF)
+	{
+		log_error("Failed to write file \"%s\"", listFilename);
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
  * copydb_write_restore_list_hook is an iterator callback function.
  */
 static bool
@@ -733,6 +820,17 @@ copydb_write_restore_list_hook(void *ctx, ArchiveContentItem *item)
 	{
 		skip = true;
 		log_debug("Skipping DATABASE \"%s\"", name);
+	}
+
+	/*
+	 * In schemas-only mode (first pass when --requirements is used), skip all
+	 * non-SCHEMA archive entries so that only CREATE SCHEMA statements reach
+	 * pg_restore.  This guarantees extension namespaces exist before
+	 * copydb_create_pinned_extensions runs.
+	 */
+	if (!skip && context->schemasOnly && catOid != PG_NAMESPACE_OID)
+	{
+		skip = true;
 	}
 
 	/*
@@ -810,25 +908,40 @@ copydb_write_restore_list_hook(void *ctx, ArchiveContentItem *item)
 
 	if (!skip && catOid == PG_NAMESPACE_OID)
 	{
-		bool exists = false;
-
-		if (!copydb_schema_already_exists(specs, oid, &exists))
+		if (!context->schemasOnly && specs->extRequirements != NULL)
 		{
-			log_error("Failed to check if restore name \"%s\" "
-					  "already exists",
-					  name);
-			return false;
-		}
-
-		if (exists)
-		{
+			/*
+			 * When --requirements is used, schemas are restored in a
+			 * dedicated first pass via copydb_write_schemas_restore_list.
+			 * Always skip them in the main second pass.
+			 */
 			skip = true;
 
-			log_debug("Skipping already existing dumpId %d: %s %u %s",
-					  item->dumpId,
-					  item->description,
-					  item->objectOid,
-					  item->restoreListName);
+			log_debug("Skipping SCHEMA (restored in first pass) dumpId %d: %s",
+					  item->dumpId, name);
+		}
+		else
+		{
+			bool exists = false;
+
+			if (!copydb_schema_already_exists(specs, oid, &exists))
+			{
+				log_error("Failed to check if restore name \"%s\" "
+						  "already exists",
+						  name);
+				return false;
+			}
+
+			if (exists)
+			{
+				skip = true;
+
+				log_debug("Skipping already existing dumpId %d: %s %u %s",
+						  item->dumpId,
+						  item->description,
+						  item->objectOid,
+						  item->restoreListName);
+			}
 		}
 	}
 

--- a/src/bin/pgcopydb/dump_restore.c
+++ b/src/bin/pgcopydb/dump_restore.c
@@ -179,6 +179,23 @@ copydb_target_prepare_schema(CopyDataSpec *specs)
 	}
 
 	/*
+	 * When --requirements is given, extensions are excluded from the
+	 * pg_restore list so we can pin their versions ourselves.  Create them
+	 * before copydb_write_restore_list so that the schema-already-exists
+	 * check in that function sees the extension schemas (e.g. foo for
+	 * hstore) and omits their CREATE SCHEMA entries from the list, avoiding
+	 * a conflict when pg_restore runs.  Extensions must also be installed
+	 * before pg_restore so that schema objects depending on extension types
+	 * (e.g. PostGIS geometry columns) can be created successfully.
+	 */
+	if (!copydb_create_pinned_extensions(specs))
+	{
+		log_error("Failed to create extensions with version pinning, "
+				  "see above for details");
+		return false;
+	}
+
+	/*
 	 * Now prepare the pg_restore --use-list file.
 	 */
 	if (!copydb_write_restore_list(specs, PG_DUMP_SECTION_PRE_DATA))

--- a/src/bin/pgcopydb/extensions.c
+++ b/src/bin/pgcopydb/extensions.c
@@ -19,6 +19,7 @@
 static bool copydb_copy_ext_table(PGSQL *src, PGSQL *dst, char *qname, char *condition);
 static bool copydb_copy_ext_sequence(PGSQL *src, PGSQL *dst, char *qname);
 static bool copydb_copy_extensions_hook(void *ctx, SourceExtension *ext);
+static bool copydb_create_extension_hook(void *ctx, SourceExtension *ext);
 
 
 /*
@@ -527,6 +528,185 @@ copydb_parse_extensions_requirements(CopyDataSpec *copySpecs, char *filename)
 
 	copySpecs->extRequirements = reqs;
 
+	return true;
+}
+
+
+/*
+ * copydb_create_extension_hook creates a single extension on the target,
+ * pinning its version from the requirements hash when available.  Unlike
+ * copydb_copy_extensions_hook it does not copy extension config table data;
+ * that is handled later by copydb_start_extension_data_process.
+ */
+static bool
+copydb_create_extension_hook(void *ctx, SourceExtension *ext)
+{
+	CopyExtensionsContext *context = (CopyExtensionsContext *) ctx;
+	SourceFilters *filters = context->filters;
+
+	/* [exclude-extension]: skip explicitly excluded extensions */
+	if (filters != NULL)
+	{
+		SourceFilterExtensionList *excl = &(filters->excludeExtensionList);
+
+		for (int i = 0; i < excl->count; i++)
+		{
+			if (streq(ext->extname, excl->array[i].extname))
+			{
+				log_debug("Skipping excluded extension \"%s\"", ext->extname);
+				return true;
+			}
+		}
+	}
+
+	/* [include-only-extension]: skip extensions not in the include list */
+	if (filters != NULL)
+	{
+		SourceFilterExtensionList *incl = &(filters->includeOnlyExtensionList);
+
+		if (incl->count > 0)
+		{
+			bool found = false;
+
+			for (int i = 0; i < incl->count; i++)
+			{
+				if (streq(ext->extname, incl->array[i].extname))
+				{
+					found = true;
+					break;
+				}
+			}
+
+			if (!found)
+			{
+				log_debug("Skipping extension \"%s\" "
+						  "(not in include-only-extension)", ext->extname);
+				return true;
+			}
+		}
+	}
+
+	/*
+	 * Ensure the target schema exists before creating the extension.
+	 * System schemas (pg_*, information_schema) are always present and
+	 * cannot be re-created; skip those.  For user schemas (e.g. "foo" for
+	 * hstore) we issue CREATE SCHEMA IF NOT EXISTS so the extension creation
+	 * below can succeed.  copydb_write_restore_list then detects the schema
+	 * already exists and omits its CREATE SCHEMA entry from the pg_restore
+	 * list, avoiding a duplicate-schema error.
+	 */
+	if (strncmp(ext->extnamespace, "pg_", 3) != 0 &&
+		strcmp(ext->extnamespace, "information_schema") != 0)
+	{
+		PQExpBuffer schemaSql = createPQExpBuffer();
+
+		appendPQExpBuffer(schemaSql,
+						  "create schema if not exists \"%s\"",
+						  ext->extnamespace);
+
+		if (PQExpBufferBroken(schemaSql))
+		{
+			log_error("Failed to build CREATE SCHEMA sql buffer: "
+					  "Out of Memory");
+			(void) destroyPQExpBuffer(schemaSql);
+			return false;
+		}
+
+		if (!pgsql_execute(context->dst, schemaSql->data))
+		{
+			log_error("Failed to create schema \"%s\" for extension \"%s\"",
+					  ext->extnamespace, ext->extname);
+			(void) destroyPQExpBuffer(schemaSql);
+			return false;
+		}
+
+		(void) destroyPQExpBuffer(schemaSql);
+	}
+
+	ExtensionReqs *req = NULL;
+	HASH_FIND(hh, context->reqs, ext->extname, strlen(ext->extname), req);
+
+	PQExpBuffer sql = createPQExpBuffer();
+
+	appendPQExpBuffer(sql,
+					  "create extension if not exists \"%s\" "
+					  "with schema \"%s\" cascade",
+					  ext->extname, ext->extnamespace);
+
+	if (req != NULL)
+	{
+		appendPQExpBuffer(sql, " version \"%s\"", req->version);
+		log_notice("Pinning extension \"%s\" to version \"%s\"",
+				   ext->extname, req->version);
+	}
+
+	if (PQExpBufferBroken(sql))
+	{
+		log_error("Failed to build CREATE EXTENSION sql buffer: "
+				  "Out of Memory");
+		(void) destroyPQExpBuffer(sql);
+		return false;
+	}
+
+	log_info("Creating extension \"%s\"", ext->extname);
+
+	if (!pgsql_execute(context->dst, sql->data))
+	{
+		log_error("Failed to create extension \"%s\"", ext->extname);
+		(void) destroyPQExpBuffer(sql);
+		return false;
+	}
+
+	(void) destroyPQExpBuffer(sql);
+	return true;
+}
+
+
+/*
+ * copydb_create_pinned_extensions creates all extensions found in the source
+ * catalog on the target, pinning each to the version recorded in
+ * copySpecs->extRequirements.  Extensions not listed in the requirements file
+ * are created without a VERSION clause (latest available).
+ *
+ * This must be called BEFORE pg_restore --section=pre-data so that schema
+ * objects that depend on extension types (e.g. PostGIS geometry columns) are
+ * available when pg_restore processes CREATE TABLE statements.
+ */
+bool
+copydb_create_pinned_extensions(CopyDataSpec *copySpecs)
+{
+	if (copySpecs->extRequirements == NULL || copySpecs->skipExtensions)
+	{
+		return true;
+	}
+
+	DatabaseCatalog *filterDB = &(copySpecs->catalogs.filter);
+	PGSQL dst = { 0 };
+
+	if (!pgsql_init(&dst, copySpecs->connStrings.target_pguri, PGSQL_CONN_TARGET))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	CopyExtensionsContext context = {
+		.filtersDB = filterDB,
+		.dst = &dst,
+		.reqs = copySpecs->extRequirements,
+		.filters = &(copySpecs->filters),
+	};
+
+	if (!catalog_iter_s_extension(filterDB,
+								  &context,
+								  &copydb_create_extension_hook))
+	{
+		log_error("Failed to create extensions with version pinning, "
+				  "see above for details");
+		(void) pgsql_finish(&dst);
+		return false;
+	}
+
+	(void) pgsql_finish(&dst);
 	return true;
 }
 

--- a/src/bin/pgcopydb/extensions.c
+++ b/src/bin/pgcopydb/extensions.c
@@ -586,43 +586,6 @@ copydb_create_extension_hook(void *ctx, SourceExtension *ext)
 		}
 	}
 
-	/*
-	 * Ensure the target schema exists before creating the extension.
-	 * System schemas (pg_*, information_schema) are always present and
-	 * cannot be re-created; skip those.  For user schemas (e.g. "foo" for
-	 * hstore) we issue CREATE SCHEMA IF NOT EXISTS so the extension creation
-	 * below can succeed.  copydb_write_restore_list then detects the schema
-	 * already exists and omits its CREATE SCHEMA entry from the pg_restore
-	 * list, avoiding a duplicate-schema error.
-	 */
-	if (strncmp(ext->extnamespace, "pg_", 3) != 0 &&
-		strcmp(ext->extnamespace, "information_schema") != 0)
-	{
-		PQExpBuffer schemaSql = createPQExpBuffer();
-
-		appendPQExpBuffer(schemaSql,
-						  "create schema if not exists \"%s\"",
-						  ext->extnamespace);
-
-		if (PQExpBufferBroken(schemaSql))
-		{
-			log_error("Failed to build CREATE SCHEMA sql buffer: "
-					  "Out of Memory");
-			(void) destroyPQExpBuffer(schemaSql);
-			return false;
-		}
-
-		if (!pgsql_execute(context->dst, schemaSql->data))
-		{
-			log_error("Failed to create schema \"%s\" for extension \"%s\"",
-					  ext->extnamespace, ext->extname);
-			(void) destroyPQExpBuffer(schemaSql);
-			return false;
-		}
-
-		(void) destroyPQExpBuffer(schemaSql);
-	}
-
 	ExtensionReqs *req = NULL;
 	HASH_FIND(hh, context->reqs, ext->extname, strlen(ext->extname), req);
 

--- a/tests/extensions/copydb.sh
+++ b/tests/extensions/copydb.sh
@@ -147,3 +147,38 @@ test "${extcount}" = "1"
 extcount=$(psql -At ${PGCOPYDB_TARGET_PGURI_SU} \
     -c "SELECT count(*) FROM pg_extension WHERE extname IN ('intarray', 'postgis')" | tr -d ' \n')
 test "${extcount}" = "0"
+
+#
+# Test pgcopydb clone --requirements: verify that extensions land on the target
+# and that the version-pinning code path in copydb_prepare_extensions_restore
+# is exercised (issue #854).
+#
+# Source has intarray, postgis, hstore.  We generate the requirements from
+# the source and pass them to clone.  pg_restore skips extensions; our hook
+# creates them instead.  All three must exist on the target after clone.
+#
+
+psql -a ${POSTGRES_TARGET} -c "DROP DATABASE pagila WITH (FORCE)"
+psql -a ${POSTGRES_TARGET} -c "CREATE DATABASE pagila OWNER pagila"
+
+# collect current extension versions from the source
+pgcopydb list extensions --requirements --json \
+         --source ${PGCOPYDB_SOURCE_PGURI_SU} \
+         --dir /tmp/clone-reqs-src \
+         > /tmp/clone-requirements.json
+
+cat /tmp/clone-requirements.json
+
+# full clone with version-pinned requirements; extensions must be created by
+# copydb_prepare_extensions_restore, not by pg_restore
+pgcopydb clone \
+         --source ${PGCOPYDB_SOURCE_PGURI_SU} \
+         --target ${PGCOPYDB_TARGET_PGURI_SU} \
+         --requirements /tmp/clone-requirements.json \
+         --dir /tmp/pgcopydb-clone-reqs \
+         --restart --debug
+
+# all three source extensions must be present on the target
+extcount=$(psql -At ${PGCOPYDB_TARGET_PGURI_SU} \
+    -c "SELECT count(*) FROM pg_extension WHERE extname IN ('intarray', 'postgis', 'hstore')" | tr -d ' \n')
+test "${extcount}" = "3"


### PR DESCRIPTION
## Problem

`pgcopydb clone --requirements reqs.json` installs extensions at the latest version available on the target instead of the version recorded in the requirements file.

```
pgcopydb list extensions --requirements --json > /tmp/reqs.json
pgcopydb clone --requirements /tmp/reqs.json ...
# extensions created at latest version, not the pinned version
```

## Root Cause

During `clone`, extensions are created by `pg_restore --section=pre-data`, which emits `CREATE EXTENSION IF NOT EXISTS "<name>" WITH SCHEMA "<schema>"` — no `VERSION` clause. The code path that does honour the requirements hash (`copydb_copy_extensions_hook` with `createExtensions=true`) is never reached during clone: `copydb_start_extension_data_process` is always called with `createExtensions=false`, so `extRequirements` is parsed but silently ignored.

## Fix

Two cooperating changes in `copydb_schema.c` and `extensions.c`:

**1. Skip extensions in `pg_restore` when requirements are given.**
In both `catalog_prepare_filter` call sites in `copydb_schema.c`, OR in `extRequirements != NULL` alongside `skipExtensions`. This adds all extensions to the filter table so `pg_restore` skips their TOC entries entirely — necessary because PostgreSQL cannot downgrade an extension once created at a newer version.

**2. Create extensions with version pinning in `copydb_prepare_extensions_restore`.**
This function already runs synchronously after `pg_restore --section=pre-data` (the correct moment: schemas exist, table creation has not started). When `extRequirements != NULL`, it now iterates over all extensions from the filter catalog via the new `copydb_create_extension_hook`, issuing `CREATE EXTENSION ... VERSION "<ver>"` for extensions in the requirements file, and `CREATE EXTENSION ...` (latest) for those not listed.

Extension config table data copy (`copydb_start_extension_data_process`) is unaffected and runs as before.

When `--requirements` is absent (`extRequirements == NULL`), both sites fall back to the existing `skipExtensions` path — zero behavioural change.

Closes #854