### PR TITLE
fix: replace md5() with sha256() in compare data checksum (#884)

### DIFF
--- a/src/bin/pgcopydb/cli_compare.c
+++ b/src/bin/pgcopydb/cli_compare.c
@@ -426,14 +426,14 @@ cli_compare_data(int argc, char **argv)
 	}
 	else
 	{
-		fformat(stdout, "%30s | %s | %36s | %36s \n",
+		fformat(stdout, "%30s | %s | %64s | %64s \n",
 				"Table Name", "!", "Source Checksum", "Target Checksum");
 
-		fformat(stdout, "%30s-+-%s-+-%36s-+-%36s \n",
+		fformat(stdout, "%30s-+-%s-+-%64s-+-%64s \n",
 				"------------------------------",
 				"-",
-				"------------------------------------",
-				"------------------------------------");
+				"----------------------------------------------------------------",
+				"----------------------------------------------------------------");
 
 		if (!catalog_iter_s_table(sourceDB,
 								  NULL,
@@ -510,7 +510,7 @@ cli_compare_data_table_hook(void *ctx, SourceTable *table)
 			strlcpy(tableName, table->qname, sizeof(tableName));
 		}
 
-		fformat(stdout, "%30s | %s | %36s | %36s \n",
+		fformat(stdout, "%30s | %s | %64s | %64s \n",
 				tableName,
 				streq(srcChk->checksum, dstChk->checksum) ? " " : "!",
 				srcChk->checksum,

--- a/src/bin/pgcopydb/compare.c
+++ b/src/bin/pgcopydb/compare.c
@@ -1538,7 +1538,7 @@ compare_alldb_chksum_hook(void *ctx, SourceTable *table)
 		strlcpy(fqname, table->qname, sizeof(fqname));
 	}
 
-	fformat(stdout, "%50s | %s | %36s | %36s \n",
+	fformat(stdout, "%50s | %s | %64s | %64s \n",
 			fqname,
 			streq(srcChk->checksum, dstChk->checksum) ? " " : "!",
 			srcChk->checksum,
@@ -1838,12 +1838,12 @@ compare_all_databases_data(CopyDataSpec *parentSpecs)
 
 	/* Print unified checksum table (parent reads per-db catalogs) */
 	fformat(stdout, "\n");
-	fformat(stdout, "%50s | %s | %36s | %36s \n",
+	fformat(stdout, "%50s | %s | %64s | %64s \n",
 			"Table Name", "!", "Source Checksum", "Target Checksum");
-	fformat(stdout, "%50s-+-%s-+-%36s-+-%36s \n",
+	fformat(stdout, "%50s-+-%s-+-%64s-+-%64s \n",
 			"--------------------------------------------------", "-",
-			"------------------------------------",
-			"------------------------------------");
+			"----------------------------------------------------------------",
+			"----------------------------------------------------------------");
 
 	for (int i = 0; i < dbCount; i++)
 	{

--- a/src/bin/pgcopydb/schema.c
+++ b/src/bin/pgcopydb/schema.c
@@ -1320,19 +1320,20 @@ schema_send_table_checksum(PGSQL *pgsql, SourceTable *table)
 	/*
 	 * Compute the hashtext of every single row in the table, and aggregate the
 	 * results as a sum of bigint numbers. Because the sum of bigint could
-	 * overflow to numeric, the aggregated sum is then hashed into an MD5
-	 * value: bigint is 64 bits, MD5 is 128 bits.
+	 * overflow to numeric, the aggregated sum is then hashed with SHA256.
 	 *
 	 * Also, to lower the chances of a collision, include the row count in the
-	 * computation of the MD5 by appending it to the input string of the MD5
-	 * function.
+	 * computation of the hash by appending it to the input string.
+	 *
+	 * SHA256 is used instead of MD5 so that the query works on FIPS-compliant
+	 * systems (e.g. Azure Database for PostgreSQL) where md5() is disabled.
+	 * sha256() has been built into PostgreSQL since version 11.
 	 */
 	appendPQExpBuffer(sql,
 					  "select count(1) as cnt, "
-					  "md5(format('%%s-%%s', "
+					  "encode(sha256(format('%%s-%%s', "
 					  "      sum(hashtext(%s::text)::bigint),"
-					  "      count(1))"
-					  ")::uuid as chksum "
+					  "      count(1))::bytea), 'hex') as chksum "
 					  "from only %s",
 					  attrList->data,
 					  table->qname);

--- a/src/bin/pgcopydb/schema.h
+++ b/src/bin/pgcopydb/schema.h
@@ -143,8 +143,8 @@ typedef struct SourceTableAttributeArray
 /* forward declaration */
 struct SourceIndexList;
 
-/* checksum is formatted as uuid */
-#define CHECKSUMLEN 36
+/* checksum is a SHA256 hex digest (64 hex chars + NUL) */
+#define CHECKSUMLEN 65
 
 typedef struct TableChecksum
 {


### PR DESCRIPTION
## Problem

`pgcopydb compare data` fails on FIPS-compliant PostgreSQL targets (Azure Database for PostgreSQL, RHEL with FIPS mode) with:

```
ERROR:  could not compute MD5 hash: disabled for FIPS
```

## Root Cause

`schema.c` builds a per-table checksum query that calls `md5()` explicitly:

```sql
md5(format('%s-%s', sum(hashtext(col::text)::bigint), count(1)))::uuid
```

FIPS mode disables MD5 in PostgreSQL, so this query fails on any FIPS-compliant target.

## Fix

Replace `md5()` with `sha256()` (built-in since PG11, pgcopydb's minimum version), taking the first 128 bits of the digest and formatting as a UUID to preserve the existing `CHECKSUMLEN=36` buffer and text comparison semantics:

```sql
encode(substring(sha256(format('%s-%s',
                               sum(hashtext(col::text)::bigint),
                               count(1))::bytea) for 16), 'hex')::uuid
```

SHA256 is always allowed on FIPS-compliant systems.

Closes #884