### PR TITLE
fix: build compatibility with PostgreSQL 16-19 meson-built installations (#970)

### DIFF
--- a/Dockerfile.pg-src
+++ b/Dockerfile.pg-src
@@ -1,0 +1,103 @@
+# syntax=docker/dockerfile:latest
+# Build pgcopydb against PostgreSQL compiled from source.
+# Used to diagnose build compatibility with unreleased PG versions
+# before packages are available in PGDG apt/yum.
+#
+# Usage:
+#   docker build -f Dockerfile.pg-src \
+#     --build-arg PGVERSION=19 \
+#     --build-arg PGTARBALL=https://ftp.postgresql.org/pub/source/v19beta1/postgresql-19beta1.tar.bz2 \
+#     --progress=plain \
+#     -t pgcopydb-pg-src .
+#
+# --progress=plain ensures full compiler output is visible.
+# The build will fail at the pgcopydb compile step if there are errors;
+# all warnings and errors from both stages appear in the output.
+
+FROM debian:12-slim AS pg-build
+
+ARG PGVERSION=19
+ARG PGTARBALL=https://ftp.postgresql.org/pub/source/v19beta1/postgresql-19beta1.tar.bz2
+ARG PGINSTALL=/opt/pgsrc
+
+# PostgreSQL meson build dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bison \
+    build-essential \
+    ca-certificates \
+    curl \
+    flex \
+    gettext \
+    libicu-dev \
+    liblz4-dev \
+    libncurses-dev \
+    libpam-dev \
+    libreadline-dev \
+    libssl-dev \
+    libxml2-dev \
+    libxslt1-dev \
+    libzstd-dev \
+    meson \
+    ninja-build \
+    perl \
+    pkg-config \
+    python3 \
+    python3-pip \
+    zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/src/postgresql
+
+RUN curl -fsSL "${PGTARBALL}" | tar -xj --strip-components=1
+
+# Build PostgreSQL with meson/ninja and install to ${PGINSTALL}
+RUN meson setup build \
+        --prefix="${PGINSTALL}" \
+        -Dssl=openssl \
+        -Dreadline=enabled \
+        -Dicu=enabled \
+        -Dlz4=enabled \
+        -Dzstd=enabled \
+        -Dlibxml=enabled \
+        -Dnls=disabled \
+        -Dtap_tests=disabled \
+        -Dplpython=disabled \
+        -Dplperl=disabled \
+        -Dpltcl=disabled \
+  && ninja -C build install
+
+# Verify install
+RUN "${PGINSTALL}/bin/pg_config" --version
+
+
+FROM pg-build AS pgcopydb-build
+
+# pgcopydb additional build dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libgc-dev \
+    libpq-dev \
+    make \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/src/pgcopydb
+
+COPY Makefile GIT-VERSION-GEN GIT-VERSION-FILE version ./
+
+COPY src/bin/lib/sqlite src/bin/lib/sqlite
+RUN make -C src/bin/lib/sqlite clean sqlite3.o sqlite3
+
+COPY src/bin/lib/jenkins src/bin/lib/jenkins
+COPY src/bin/lib/libs    src/bin/lib/libs
+COPY src/bin/lib/log     src/bin/lib/log
+COPY src/bin/lib/parson  src/bin/lib/parson
+COPY src/bin/lib/pg      src/bin/lib/pg
+COPY src/bin/lib/subcommands.c src/bin/lib/subcommands.c
+COPY src/bin/lib/uthash  src/bin/lib/uthash
+COPY src/bin/Makefile    src/bin/Makefile
+COPY src/bin/pgcopydb    src/bin/pgcopydb
+
+# Build pgcopydb against the from-source PostgreSQL installation.
+# PG_CONFIG points to the freshly-built pg_config.
+# We do NOT silence warnings so that all build issues are visible.
+# The build will fail here if there are compilation errors.
+RUN PG_CONFIG="${PGINSTALL}/bin/pg_config" make -s -j$(nproc) 2>&1

--- a/Dockerfile.pg-src
+++ b/Dockerfile.pg-src
@@ -1,26 +1,25 @@
-# syntax=docker/dockerfile:latest
-# Build pgcopydb against PostgreSQL compiled from source.
-# Used to diagnose build compatibility with unreleased PG versions
+# Build pgcopydb against multiple PostgreSQL versions compiled from source.
+# Used to diagnose and verify build compatibility with unreleased PG versions
 # before packages are available in PGDG apt/yum.
 #
-# Usage:
-#   docker build -f Dockerfile.pg-src \
-#     --build-arg PGVERSION=19 \
-#     --build-arg PGTARBALL=https://ftp.postgresql.org/pub/source/v19beta1/postgresql-19beta1.tar.bz2 \
-#     --progress=plain \
-#     -t pgcopydb-pg-src .
+# Each PG version is a separate FROM stage so BuildKit can build them all in
+# parallel and cache them independently.
 #
-# --progress=plain ensures full compiler output is visible.
-# The build will fail at the pgcopydb compile step if there are errors;
-# all warnings and errors from both stages appear in the output.
+# Usage:
+#   docker build -f Dockerfile.pg-src --progress=plain -t pgcopydb-pg-src .
+#
+# Override a specific version tarball:
+#   docker build -f Dockerfile.pg-src \
+#     --build-arg PG19_TARBALL=https://ftp.postgresql.org/pub/source/v19beta2/postgresql-19beta2.tar.bz2 \
+#     --progress=plain -t pgcopydb-pg-src .
+#
+# --progress=plain shows full compiler output including warnings and errors.
 
-FROM debian:12-slim AS pg-build
+# ---------------------------------------------------------------------------
+# Common build dependencies (shared base for all PG source builds)
+# ---------------------------------------------------------------------------
+FROM debian:12-slim AS pg-deps
 
-ARG PGVERSION=19
-ARG PGTARBALL=https://ftp.postgresql.org/pub/source/v19beta1/postgresql-19beta1.tar.bz2
-ARG PGINSTALL=/opt/pgsrc
-
-# PostgreSQL meson build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     bison \
     build-essential \
@@ -46,38 +45,85 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /usr/src/postgresql
+# ---------------------------------------------------------------------------
+# Common meson options shared across all PG versions
+# ---------------------------------------------------------------------------
+ARG MESON_COMMON_OPTS="\
+  -Dtap_tests=disabled \
+  -Ddocs=disabled \
+  -Dplpython=disabled \
+  -Dplperl=disabled \
+  -Dpltcl=disabled"
 
-RUN curl -fsSL "${PGTARBALL}" | tar -xj --strip-components=1
+# ---------------------------------------------------------------------------
+# PG 16 — latest stable
+# Each PG version uses its own src/ + an out-of-source build/ directory.
+# PG16 release tarballs ship pre-generated catalog headers, node support
+# files, parser outputs, etc. which conflict with meson's "non-clean source
+# directory" check.  We use a two-pass approach: first pass collects the
+# list of conflicting files from meson's error message, then we delete them
+# and retry — meson regenerates them in the out-of-source build directory.
+# ---------------------------------------------------------------------------
+FROM pg-deps AS pg16-build
+ARG PG16_TARBALL=https://ftp.postgresql.org/pub/source/v16.14/postgresql-16.14.tar.bz2
+WORKDIR /usr/src/pg16
+RUN curl -fsSL "${PG16_TARBALL}" | tar -xj --strip-components=1
+RUN MOPTS="-Dtap_tests=disabled -Ddocs=disabled -Dplpython=disabled -Dplperl=disabled -Dpltcl=disabled"; \
+    meson setup /usr/build/pg16 --prefix=/opt/pgsql/16 $MOPTS >/tmp/meson16.log 2>&1 || \
+    ( tr ' ' '\n' </tmp/meson16.log | grep "^/usr/src/pg16/" | xargs -r rm -f \
+      && meson setup /usr/build/pg16 --prefix=/opt/pgsql/16 $MOPTS ) \
+    && ninja -C /usr/build/pg16 install
+RUN /opt/pgsql/16/bin/pg_config --version
 
-# Build PostgreSQL with meson/ninja and install to ${PGINSTALL}
-RUN meson setup build \
-        --prefix="${PGINSTALL}" \
-        -Dssl=openssl \
-        -Dreadline=enabled \
-        -Dicu=enabled \
-        -Dlz4=enabled \
-        -Dzstd=enabled \
-        -Dlibxml=enabled \
-        -Dnls=disabled \
-        -Dtap_tests=disabled \
-        -Dplpython=disabled \
-        -Dplperl=disabled \
-        -Dpltcl=disabled \
-  && ninja -C build install
+# ---------------------------------------------------------------------------
+# PG 17 — latest stable
+# ---------------------------------------------------------------------------
+FROM pg-deps AS pg17-build
+ARG PG17_TARBALL=https://ftp.postgresql.org/pub/source/v17.10/postgresql-17.10.tar.bz2
+WORKDIR /usr/src/pg17
+RUN curl -fsSL "${PG17_TARBALL}" | tar -xj --strip-components=1
+RUN meson setup /usr/build/pg17 --prefix=/opt/pgsql/17 ${MESON_COMMON_OPTS} \
+  && ninja -C /usr/build/pg17 install
+RUN /opt/pgsql/17/bin/pg_config --version
 
-# Verify install
-RUN "${PGINSTALL}/bin/pg_config" --version
+# ---------------------------------------------------------------------------
+# PG 18 — latest stable
+# ---------------------------------------------------------------------------
+FROM pg-deps AS pg18-build
+ARG PG18_TARBALL=https://ftp.postgresql.org/pub/source/v18.4/postgresql-18.4.tar.bz2
+WORKDIR /usr/src/pg18
+RUN curl -fsSL "${PG18_TARBALL}" | tar -xj --strip-components=1
+RUN meson setup /usr/build/pg18 --prefix=/opt/pgsql/18 ${MESON_COMMON_OPTS} \
+  && ninja -C /usr/build/pg18 install
+RUN /opt/pgsql/18/bin/pg_config --version
 
+# ---------------------------------------------------------------------------
+# PG 19 — beta / development
+# ---------------------------------------------------------------------------
+FROM pg-deps AS pg19-build
+ARG PG19_TARBALL=https://ftp.postgresql.org/pub/source/v19beta1/postgresql-19beta1.tar.bz2
+WORKDIR /usr/src/pg19
+RUN curl -fsSL "${PG19_TARBALL}" | tar -xj --strip-components=1
+RUN meson setup /usr/build/pg19 --prefix=/opt/pgsql/19 ${MESON_COMMON_OPTS} \
+  && ninja -C /usr/build/pg19 install
+RUN /opt/pgsql/19/bin/pg_config --version
 
-FROM pg-build AS pgcopydb-build
+# ---------------------------------------------------------------------------
+# pgcopydb build — compile against each installed PG version in a loop
+# ---------------------------------------------------------------------------
+FROM pg-deps AS pgcopydb-build
 
-# pgcopydb additional build dependencies
+# Additional deps needed only for pgcopydb (not for PG itself)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libgc-dev \
-    libpq-dev \
     make \
     && rm -rf /var/lib/apt/lists/*
+
+# Collect all four PG installations from their respective build stages
+COPY --from=pg16-build /opt/pgsql/16 /opt/pgsql/16
+COPY --from=pg17-build /opt/pgsql/17 /opt/pgsql/17
+COPY --from=pg18-build /opt/pgsql/18 /opt/pgsql/18
+COPY --from=pg19-build /opt/pgsql/19 /opt/pgsql/19
 
 WORKDIR /usr/src/pgcopydb
 
@@ -86,18 +132,30 @@ COPY Makefile GIT-VERSION-GEN GIT-VERSION-FILE version ./
 COPY src/bin/lib/sqlite src/bin/lib/sqlite
 RUN make -C src/bin/lib/sqlite clean sqlite3.o sqlite3
 
-COPY src/bin/lib/jenkins src/bin/lib/jenkins
-COPY src/bin/lib/libs    src/bin/lib/libs
-COPY src/bin/lib/log     src/bin/lib/log
-COPY src/bin/lib/parson  src/bin/lib/parson
-COPY src/bin/lib/pg      src/bin/lib/pg
+COPY src/bin/lib/jenkins  src/bin/lib/jenkins
+COPY src/bin/lib/libs     src/bin/lib/libs
+COPY src/bin/lib/log      src/bin/lib/log
+COPY src/bin/lib/parson   src/bin/lib/parson
+COPY src/bin/lib/pg       src/bin/lib/pg
 COPY src/bin/lib/subcommands.c src/bin/lib/subcommands.c
-COPY src/bin/lib/uthash  src/bin/lib/uthash
-COPY src/bin/Makefile    src/bin/Makefile
-COPY src/bin/pgcopydb    src/bin/pgcopydb
+COPY src/bin/lib/uthash   src/bin/lib/uthash
+COPY src/bin/Makefile     src/bin/Makefile
+COPY src/bin/pgcopydb     src/bin/pgcopydb
 
-# Build pgcopydb against the from-source PostgreSQL installation.
-# PG_CONFIG points to the freshly-built pg_config.
-# We do NOT silence warnings so that all build issues are visible.
-# The build will fail here if there are compilation errors.
-RUN PG_CONFIG="${PGINSTALL}/bin/pg_config" make -s -j$(nproc) 2>&1
+# Build pgcopydb against each PG version.
+# On failure, print a clear header then re-run without -s to show full errors.
+RUN for v in 16 17 18 19; do \
+      echo ""; \
+      echo "=========================================================="; \
+      echo " Building pgcopydb against PostgreSQL $v"; \
+      echo " pg_config: $(/opt/pgsql/$v/bin/pg_config --version)"; \
+      echo "=========================================================="; \
+      make -s clean; \
+      PG_CONFIG="/opt/pgsql/$v/bin/pg_config" make -j$(nproc) 2>&1 || { \
+        echo "FAILED for PG$v — re-running without -s for full output:" >&2; \
+        make clean; \
+        PG_CONFIG="/opt/pgsql/$v/bin/pg_config" make -j$(nproc); \
+        exit 1; \
+      }; \
+      echo "OK: pgcopydb built successfully against PG$v"; \
+    done

--- a/src/bin/lib/pg/snprintf.c
+++ b/src/bin/lib/pg/snprintf.c
@@ -449,6 +449,7 @@ nextch2:
 				if (accum == 0 && !pointflag)
 					zpad = '0';
 				/* FALL THRU */
+				__attribute__((fallthrough));
 			case '1':
 			case '2':
 			case '3':

--- a/src/bin/lib/sqlite/Makefile
+++ b/src/bin/lib/sqlite/Makefile
@@ -7,7 +7,7 @@ OBJS = $(patsubst %.c,%.o,$(SRC))
 PG_CONFIG ?= pg_config
 
 CC = $(shell $(PG_CONFIG) --cc)
-DEFAULT_CFLAGS = $(shell $(PG_CONFIG) --cflags)
+DEFAULT_CFLAGS = -Wformat $(shell $(PG_CONFIG) --cflags)
 
 ifdef DEBUG
 # Use optimization option that provides good debugging experience

--- a/src/bin/lib/subcommands.c/runprogram.h
+++ b/src/bin/lib/subcommands.c/runprogram.h
@@ -435,7 +435,7 @@ free_program(Program *prog)
  * and stdout and exits with the exit code EXIT_CODE_INTERNAL_ERROR.
  */
 static void
-exit_internal_error()
+exit_internal_error(void)
 {
 	fprintf(stdout, "%s\n", strerror(errno));
 	fprintf(stderr, "%s\n", strerror(errno));

--- a/src/bin/lib/uthash/uthash.h
+++ b/src/bin/lib/uthash/uthash.h
@@ -670,17 +670,17 @@ do {                                                                            
   }                                                                              \
   hashv += (unsigned)(keylen);                                                   \
   switch ( _hj_k ) {                                                             \
-    case 11: hashv += ( (unsigned)_hj_key[10] << 24 ); /* FALLTHROUGH */         \
-    case 10: hashv += ( (unsigned)_hj_key[9] << 16 );  /* FALLTHROUGH */         \
-    case 9:  hashv += ( (unsigned)_hj_key[8] << 8 );   /* FALLTHROUGH */         \
-    case 8:  _hj_j += ( (unsigned)_hj_key[7] << 24 );  /* FALLTHROUGH */         \
-    case 7:  _hj_j += ( (unsigned)_hj_key[6] << 16 );  /* FALLTHROUGH */         \
-    case 6:  _hj_j += ( (unsigned)_hj_key[5] << 8 );   /* FALLTHROUGH */         \
-    case 5:  _hj_j += _hj_key[4];                      /* FALLTHROUGH */         \
-    case 4:  _hj_i += ( (unsigned)_hj_key[3] << 24 );  /* FALLTHROUGH */         \
-    case 3:  _hj_i += ( (unsigned)_hj_key[2] << 16 );  /* FALLTHROUGH */         \
-    case 2:  _hj_i += ( (unsigned)_hj_key[1] << 8 );   /* FALLTHROUGH */         \
-    case 1:  _hj_i += _hj_key[0];                      /* FALLTHROUGH */         \
+    case 11: hashv += ( (unsigned)_hj_key[10] << 24 ); __attribute__((fallthrough)); \
+    case 10: hashv += ( (unsigned)_hj_key[9] << 16 );  __attribute__((fallthrough)); \
+    case 9:  hashv += ( (unsigned)_hj_key[8] << 8 );   __attribute__((fallthrough)); \
+    case 8:  _hj_j += ( (unsigned)_hj_key[7] << 24 );  __attribute__((fallthrough)); \
+    case 7:  _hj_j += ( (unsigned)_hj_key[6] << 16 );  __attribute__((fallthrough)); \
+    case 6:  _hj_j += ( (unsigned)_hj_key[5] << 8 );   __attribute__((fallthrough)); \
+    case 5:  _hj_j += _hj_key[4];                      __attribute__((fallthrough)); \
+    case 4:  _hj_i += ( (unsigned)_hj_key[3] << 24 );  __attribute__((fallthrough)); \
+    case 3:  _hj_i += ( (unsigned)_hj_key[2] << 16 );  __attribute__((fallthrough)); \
+    case 2:  _hj_i += ( (unsigned)_hj_key[1] << 8 );   __attribute__((fallthrough)); \
+    case 1:  _hj_i += _hj_key[0];                      __attribute__((fallthrough)); \
     default: ;                                                                   \
   }                                                                              \
   HASH_JEN_MIX(_hj_i, _hj_j, hashv);                                             \

--- a/src/bin/pgcopydb/Makefile
+++ b/src/bin/pgcopydb/Makefile
@@ -43,11 +43,11 @@ COMMON_LIBS += -I${SRC_DIR}../lib/sqlite/
 CC = $(shell $(PG_CONFIG) --cc)
 
 DEFAULT_CFLAGS = -std=c99 -D_GNU_SOURCE -g
+DEFAULT_CFLAGS += -Wformat
 DEFAULT_CFLAGS += -I $(shell $(PG_CONFIG) --includedir)
 DEFAULT_CFLAGS += -I $(shell $(PG_CONFIG) --includedir-server)
 DEFAULT_CFLAGS += -I $(shell $(PG_CONFIG) --pkgincludedir)/internal
 DEFAULT_CFLAGS += $(shell $(PG_CONFIG) --cflags)
-DEFAULT_CFLAGS += -Wformat
 DEFAULT_CFLAGS += -Wall
 DEFAULT_CFLAGS += -Werror=implicit-int
 DEFAULT_CFLAGS += -Werror=implicit-function-declaration
@@ -98,6 +98,11 @@ LIBS += $(shell $(PG_CONFIG) --libs)
 LIBS += -lpq
 LIBS += -lncurses
 LIBS += -lgc
+# meson-built PostgreSQL leaves pg_config --libs empty (PG16 through PG19+);
+# we must link libpgcommon and libpgport explicitly for strlcpy, pg_usleep, etc.
+LIBS += -lpgcommon
+LIBS += -lpgport
+LIBS += -lm
 
 # Needed for ARM64 based OSX
 ifeq ($(shell uname -s),Darwin)

--- a/src/bin/pgcopydb/copydb.c
+++ b/src/bin/pgcopydb/copydb.c
@@ -689,7 +689,7 @@ copydb_init_table_specs(CopyTableDataSpec *tableSpecs,
  * until all the known subprocess are finished, then returns true.
  */
 bool
-copydb_fatal_exit()
+copydb_fatal_exit(void)
 {
 	log_fatal("Terminating all processes in our process group");
 

--- a/src/bin/pgcopydb/main.c
+++ b/src/bin/pgcopydb/main.c
@@ -151,7 +151,7 @@ main(int argc, char **argv)
  * as using colors in an interactive terminal and the default log level.
  */
 static void
-set_logger()
+set_logger(void)
 {
 	log_set_level(LOG_INFO);
 

--- a/src/bin/pgcopydb/signals.c
+++ b/src/bin/pgcopydb/signals.c
@@ -8,12 +8,24 @@
 #include <string.h>
 #include <unistd.h>
 
-#include "postgres_fe.h"        /* pqsignal, portable sigaction wrapper */
+#include "postgres_fe.h"        /* pqsignal, SIGNAL_ARGS, pqsigfunc */
 
 #include "defaults.h"
 #include "lock_utils.h"
 #include "log.h"
 #include "signals.h"
+
+/*
+ * PG19 introduced PG_SIG_IGN / PG_SIG_DFL as properly typed casts of SIG_IGN
+ * and SIG_DFL to pqsigfunc (whose signature grew a second arg in PG19).
+ * Define them here for older PG versions so the call sites are uniform.
+ */
+#ifndef PG_SIG_IGN
+#define PG_SIG_IGN ((pqsigfunc) SIG_IGN)
+#endif
+#ifndef PG_SIG_DFL
+#define PG_SIG_DFL ((pqsigfunc) SIG_DFL)
+#endif
 
 /* This flag controls termination of the main loop. */
 volatile sig_atomic_t asked_to_stop = 0;      /* SIGTERM */
@@ -36,7 +48,7 @@ set_signal_handlers(bool exitOnQuit)
 	pqsignal(SIGTERM, catch_term);
 
 	/* ignore SIGPIPE so that EPIPE is returned instead */
-	pqsignal(SIGPIPE, SIG_IGN);
+	pqsignal(SIGPIPE, PG_SIG_IGN);
 
 	if (exitOnQuit)
 	{
@@ -53,8 +65,10 @@ set_signal_handlers(bool exitOnQuit)
  * catch_reload receives the SIGHUP signal.
  */
 void
-catch_reload(int sig)
+catch_reload(SIGNAL_ARGS)
 {
+	int sig = postgres_signal_arg;
+
 	asked_to_reload = 1;
 	pqsignal(sig, catch_reload);
 }
@@ -64,8 +78,10 @@ catch_reload(int sig)
  * catch_int receives the SIGINT signal.
  */
 void
-catch_int(int sig)
+catch_int(SIGNAL_ARGS)
 {
+	int sig = postgres_signal_arg;
+
 	asked_to_stop_fast = 1;
 	pqsignal(sig, catch_int);
 }
@@ -75,8 +91,10 @@ catch_int(int sig)
  * catch_stop receives SIGTERM signal.
  */
 void
-catch_term(int sig)
+catch_term(SIGNAL_ARGS)
 {
+	int sig = postgres_signal_arg;
+
 	asked_to_stop = 1;
 	pqsignal(sig, catch_term);
 }
@@ -86,8 +104,10 @@ catch_term(int sig)
  * catch_quit receives the SIGQUIT signal.
  */
 void
-catch_quit(int sig)
+catch_quit(SIGNAL_ARGS)
 {
+	int sig = postgres_signal_arg;
+
 	/* default signal handler disposition is to core dump, we don't */
 	asked_to_quit = 1;
 	pqsignal(sig, catch_quit);
@@ -98,7 +118,7 @@ catch_quit(int sig)
  * quit_and_exit exit(EXIT_CODE_QUIT) upon receiving the SIGQUIT signal.
  */
 void
-catch_quit_and_exit(int sig)
+catch_quit_and_exit(SIGNAL_ARGS)
 {
 	/* default signal handler disposition is to core dump, we don't */
 	log_warn("SIGQUIT");
@@ -136,7 +156,7 @@ get_current_signal(int defaultSignal)
  * re-processing an exit flag that is currently being processed already.
  */
 void
-unset_signal_flags()
+unset_signal_flags(void)
 {
 	asked_to_stop = 0;
 	asked_to_stop_fast = 0;

--- a/src/bin/pgcopydb/signals.h
+++ b/src/bin/pgcopydb/signals.h
@@ -9,6 +9,8 @@
 #include <inttypes.h>
 #include <signal.h>
 
+#include "postgres_fe.h"   /* SIGNAL_ARGS, pqsigfunc */
+
 /* This flag controls termination of the main loop. */
 extern volatile sig_atomic_t asked_to_stop;      /* SIGTERM */
 extern volatile sig_atomic_t asked_to_stop_fast; /* SIGINT */
@@ -19,11 +21,11 @@ extern volatile sig_atomic_t asked_to_quit;      /* SIGQUIT */
 }
 
 void set_signal_handlers(bool exitOnQuit);
-void catch_reload(int sig);
-void catch_int(int sig);
-void catch_term(int sig);
-void catch_quit(int sig);
-void catch_quit_and_exit(int sig);
+void catch_reload(SIGNAL_ARGS);
+void catch_int(SIGNAL_ARGS);
+void catch_term(SIGNAL_ARGS);
+void catch_quit(SIGNAL_ARGS);
+void catch_quit_and_exit(SIGNAL_ARGS);
 void unset_signal_flags(void);
 
 int get_current_signal(int defaultSignal);


### PR DESCRIPTION
## Problem

pgcopydb 0.17 fails to build against PostgreSQL 19 beta1 (and also against PG16-18 when built from source with meson). The error list is large, spanning four distinct categories of incompatibility.

Reported by Devrim Gündüz in the context of PGDG RPM packaging: https://github.com/pgdg-packaging/pgdg-rpms/issues/213

## Root Cause

Four separate incompatibilities introduced by PostgreSQL's meson build system and PG19 compiler flag changes:

**1. Signal handler signature (PG19)**
PG19 changed `SIGNAL_ARGS` from `int postgres_signal_arg` to `int postgres_signal_arg, const pg_signal_info *pg_siginfo`. All five pgcopydb signal handlers had `void f(int sig)` signatures that became type-incompatible with `pqsigfunc`, causing implicit cast errors. `PG_SIG_IGN` / `PG_SIG_DFL` are also PG19-only additions.

**2. K&R function definitions (PG19 `-Wold-style-definition`)**
PG19 adds `-Wold-style-definition` to `pg_config --cflags`, which rejects empty `()` parameter lists as errors. Four functions were affected: `copydb_fatal_exit()`, `set_logger()`, `exit_internal_error()`, `unset_signal_flags()`.

**3. Implicit fallthrough (PG19 `-Wimplicit-fallthrough=5`)**
PG19 uses the strictest fallthrough warning level. `/* FALLTHROUGH */` comments do not satisfy level 5 — only `__attribute__((fallthrough))` does. One location in `snprintf.c` and eleven in `uthash.h`'s Duff's device were affected.

**4. Missing `libpgcommon` / `libpgport` (all meson-built PG16-19)**
meson-built PostgreSQL intentionally leaves `pg_config --libs` empty. autoconf builds returned `-lpgcommon -lpgport -lm` etc. here. Without explicit linking, `strlcpy`, `pg_usleep`, `pg_logging_init` and related symbols are undefined at link time.

**5. `-Wformat-security` ordering**
`pg_config --cflags` from PG16-18 injects `-Wformat-security` before our `-Wformat`, causing a spurious cc1 diagnostic. Fixed by prepending `-Wformat` before `$(PG_CONFIG) --cflags` in both the main and sqlite Makefiles.

## Fix

- `signals.h` / `signals.c`: adopt `SIGNAL_ARGS` macro for all handler signatures; add `PG_SIG_IGN`/`PG_SIG_DFL` compat defines for PG16-18
- `copydb.c`, `main.c`, `subcommands.c/runprogram.h`, `signals.c`: change four K&R `()` to explicit `(void)`
- `src/bin/lib/pg/snprintf.c`, `src/bin/lib/uthash/uthash.h`: replace `/* FALLTHROUGH */` comments with `__attribute__((fallthrough))`
- `src/bin/pgcopydb/Makefile`: add `-lpgcommon`, `-lpgport`, `-lm` explicitly; move `-Wformat` before `pg_config --cflags`
- `src/bin/lib/sqlite/Makefile`: same `-Wformat` ordering fix

Also adds `Dockerfile.pg-src` — a multi-stage parallel Dockerfile that builds PG16, 17, 18, and 19 from source tarballs using meson/ninja (installed to `/opt/pgsql/XY`) then compiles pgcopydb against each version in a loop. Used to diagnose and verify this fix. PG16 release tarballs required a two-pass meson workaround (pre-generated parser/catalog files in the tarball conflict with meson's clean-source check).

Closes #970