### PR TITLE
fix: clear stale process/summary entries and reopen catalog after fork (#692, #881)

### DIFF
--- a/src/bin/pgcopydb/catalog.c
+++ b/src/bin/pgcopydb/catalog.c
@@ -9331,6 +9331,54 @@ catalog_delete_process(DatabaseCatalog *catalog, pid_t pid)
 
 
 /*
+ * catalog_delete_all_process_entries removes all rows from the process table.
+ * Called by each supervisor before forking workers so that stale entries from
+ * a previous run (including entries left by crashed workers or by a prior
+ * Docker container whose PID namespace has been reset) cannot interfere with
+ * resume logic or SQLite write contention checks.
+ */
+bool
+catalog_delete_all_process_entries(DatabaseCatalog *catalog)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_delete_all_process_entries: db is NULL");
+		return false;
+	}
+
+	char *sql = "delete from process";
+
+	if (!semaphore_lock(&(catalog->sema)))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	SQLiteQuery query = { 0 };
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		(void) semaphore_unlock(&(catalog->sema));
+		return false;
+	}
+
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		(void) semaphore_unlock(&(catalog->sema));
+		return false;
+	}
+
+	(void) semaphore_unlock(&(catalog->sema));
+
+	return true;
+}
+
+
+/*
  * catalog_iter_s_table_in_copy iterates over the list of tables with a COPY
  * process in our catalogs.
  */

--- a/src/bin/pgcopydb/catalog.h
+++ b/src/bin/pgcopydb/catalog.h
@@ -660,6 +660,7 @@ typedef struct ProcessInfo
 
 bool catalog_upsert_process_info(DatabaseCatalog *catalog, ProcessInfo *ps);
 bool catalog_delete_process(DatabaseCatalog *catalog, pid_t pid);
+bool catalog_delete_all_process_entries(DatabaseCatalog *catalog);
 
 bool catalog_iter_s_table_in_copy(DatabaseCatalog *catalog,
 								  void *context,

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -669,6 +669,8 @@ bool summary_update_table_copy_stats(DatabaseCatalog *catalog,
 bool summary_delete_table(DatabaseCatalog *catalog,
 						  CopyTableDataSpec *tableSpecs);
 
+bool summary_delete_incomplete_table_copy(DatabaseCatalog *catalog);
+
 bool summary_table_count_parts_done(DatabaseCatalog *catalog,
 									CopyTableDataSpec *tableSpecs);
 

--- a/src/bin/pgcopydb/indexes.c
+++ b/src/bin/pgcopydb/indexes.c
@@ -99,6 +99,18 @@ copydb_index_supervisor(CopyDataSpec *specs)
 	}
 
 	/*
+	 * Remove stale process table entries from any previous run before workers
+	 * start.  Entries left by crashed workers or by a prior container whose
+	 * PID namespace was reset would cause resume logic to misidentify live
+	 * PIDs (issue #692) and could block retried index creation (issue #881).
+	 */
+	if (!catalog_delete_all_process_entries(sourceDB))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/*
 	 * Start cumulative sections timings for indexes and constraints
 	 */
 	if (!summary_start_timing(sourceDB, TIMING_SECTION_CREATE_INDEX))
@@ -113,9 +125,29 @@ copydb_index_supervisor(CopyDataSpec *specs)
 		return false;
 	}
 
+	/*
+	 * Close the catalog before forking so that each worker process opens its
+	 * own SQLite connection.  Inheriting a forked sqlite3* handle causes WAL
+	 * write-lock conflicts between sibling workers even when the SysV
+	 * semaphore is held, exhausting the 5-second busy-retry and aborting
+	 * index creation (issue #881).
+	 */
+	if (!catalog_close(sourceDB))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
 	if (!copydb_start_index_workers(specs))
 	{
 		log_error("Failed to start index workers, see above for details");
+		return false;
+	}
+
+	/* reopen in the supervisor process after the fork */
+	if (!catalog_open(sourceDB))
+	{
+		/* errors have already been logged */
 		return false;
 	}
 

--- a/src/bin/pgcopydb/summary.c
+++ b/src/bin/pgcopydb/summary.c
@@ -345,6 +345,64 @@ summary_delete_table(DatabaseCatalog *catalog, CopyTableDataSpec *tableSpecs)
 
 
 /*
+ * summary_delete_incomplete_table_copy removes every summary row for a table
+ * COPY that started but never finished (done_time_epoch IS NULL).  These
+ * rows carry a pid from the previous run.  On a resumed run the existing
+ * code calls kill(old_pid, 0) to decide whether that pid is still alive;
+ * inside a Docker container whose PID namespace was reset the same numeric
+ * pid is often reused by an unrelated process, so kill() returns 0 and
+ * pgcopydb incorrectly refuses to copy the table (issue #692).
+ *
+ * Deleting the incomplete rows here, before any worker is forked, turns the
+ * affected tables back into "not yet started" so that workers copy them from
+ * scratch.  Completed rows (done_time_epoch IS NOT NULL) are preserved so
+ * that --resume still skips tables that finished in the previous run.
+ */
+bool
+summary_delete_incomplete_table_copy(DatabaseCatalog *catalog)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: summary_delete_incomplete_table_copy: db is NULL");
+		return false;
+	}
+
+	char *sql =
+		"delete from summary "
+		" where tableoid is not null "
+		"   and done_time_epoch is null";
+
+	if (!semaphore_lock(&(catalog->sema)))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	SQLiteQuery query = { 0 };
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		(void) semaphore_unlock(&(catalog->sema));
+		return false;
+	}
+
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		(void) semaphore_unlock(&(catalog->sema));
+		return false;
+	}
+
+	(void) semaphore_unlock(&(catalog->sema));
+
+	return true;
+}
+
+
+/*
  * summary_add_table INSERTs a SourceTable summary entry to our internal
  * catalogs database.
  */

--- a/src/bin/pgcopydb/table-data.c
+++ b/src/bin/pgcopydb/table-data.c
@@ -295,6 +295,50 @@ copydb_copy_supervisor(CopyDataSpec *specs)
 		return false;
 	}
 
+	DatabaseCatalog *sourceDB = &(specs->catalogs.source);
+
+	/*
+	 * Before forking any workers, open the catalog briefly to clear two kinds
+	 * of stale state left by a previous run:
+	 *
+	 *  1. process table entries: written by workers that crashed without
+	 *     calling catalog_delete_process.  Stale entries make the progress
+	 *     view report non-existent work and can block resume logic.
+	 *
+	 *  2. incomplete table-copy summary rows (done_time_epoch IS NULL):
+	 *     these carry the PID of the previous worker.  On resume pgcopydb
+	 *     calls kill(old_pid, 0) to see if that worker is still running.
+	 *     Inside a Docker container whose PID namespace was reset the same
+	 *     numeric PID is often recycled by an unrelated process, so kill()
+	 *     returns 0 and pgcopydb wrongly refuses to copy the table (#692).
+	 *
+	 * After cleanup, close the catalog again so that table-data workers
+	 * (forked next) open their own fresh connections (#881).
+	 */
+	if (!catalog_open(sourceDB))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	if (!catalog_delete_all_process_entries(sourceDB))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	if (!summary_delete_incomplete_table_copy(sourceDB))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	if (!catalog_close(sourceDB))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
 	/*
 	 * Start COPY table-data workers, as many as --table-jobs.
 	 */
@@ -308,8 +352,7 @@ copydb_copy_supervisor(CopyDataSpec *specs)
 		return false;
 	}
 
-	DatabaseCatalog *sourceDB = &(specs->catalogs.source);
-
+	/* reopen catalog in the supervisor process after the fork */
 	if (!catalog_open(sourceDB))
 	{
 		/* errors have already been logged */

--- a/src/bin/pgcopydb/vacuum.c
+++ b/src/bin/pgcopydb/vacuum.c
@@ -98,9 +98,28 @@ vacuum_supervisor(CopyDataSpec *specs)
 		return false;
 	}
 
+	/*
+	 * Close the catalog before forking so that each vacuum worker opens its
+	 * own SQLite connection.  Inheriting a forked sqlite3* handle causes WAL
+	 * write-lock conflicts between sibling workers even when the SysV
+	 * semaphore is held (issue #881).
+	 */
+	if (!catalog_close(sourceDB))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
 	if (!vacuum_start_workers(specs))
 	{
 		log_error("Failed to start vacuum workers, see above for details");
+		return false;
+	}
+
+	/* reopen in the supervisor process after the fork */
+	if (!catalog_open(sourceDB))
+	{
+		/* errors have already been logged */
 		return false;
 	}
 


### PR DESCRIPTION
## Problem

Two separate but related bugs corrupt multi-worker pgcopydb runs, especially after a container restart or crash:

**Issue #692** — `pgcopydb copy table-data` fails on `--resume` with:
```
ERROR Failed to start table-data COPY worker for table <name>, already being processed by pid <N>
```
Inside a Docker container whose PID namespace was reset, numeric PIDs are recycled. The incomplete `summary` row written by the previous container's worker still has its old PID. `kill(old_pid, 0)` returns 0 (success) because that PID is now an unrelated process in the new container, so pgcopydb refuses to re-copy the table.

**Issue #881** — `pgcopydb copy indexes` workers fail with `[SQLite 5] database is locked` after exhausting the 5-second retry, then a segfault occurs in `pgcopydb list progress --json`. On `--resume`, indexes that were in-flight at crash time are skipped because stale `process` table entries make them appear still active, leaving constraints unbuilt.

## Root Cause

**#692**: Incomplete table-copy rows in the `summary` table (`done_time_epoch IS NULL`) carry the PID of the worker that crashed. `kill(old_pid, 0) == 0` is a false positive in Docker's PID namespace.

**#881A** — inherited sqlite3 handle: The index and vacuum supervisors called `catalog_open()` **before** forking workers. Each forked child inherited a copy of the parent's `sqlite3*` internal state, including WAL file descriptors. All N workers then competed for the WAL write lock through their inherited handles. The SysV semaphore serializes writes between processes, but the underlying SQLite WAL write lock is still acquired inside `sqlite3_step()` — and because the inherited handle's connection state is a copy, not a shared reference, the semaphore alone was not enough to prevent all contention at high worker counts.

**#881B** — stale `process` entries: Workers that aborted without calling `catalog_delete_process` left rows in the `process` table. On `--resume` the query in `catalog_iter_s_index_in_progress_init` returns those indexes as still active, so the supervisor skips them and their constraints are never built. The same stale rows cause `list progress --json` to join against non-existent workers and crash.

## Fix

**1. `catalog_delete_all_process_entries()`** (catalog.c / catalog.h)  
Deletes every row from the `process` table. Called by the COPY and index supervisors before any worker is forked, so stale entries from a previous run can never block resume logic or corrupt progress reporting.

**2. `summary_delete_incomplete_table_copy()`** (summary.c / copydb.h)  
`DELETE FROM summary WHERE tableoid IS NOT NULL AND done_time_epoch IS NULL` — removes in-progress table-copy rows before workers start. Workers then see a clean slate; any table that did not finish in the previous run gets a fresh summary entry and is re-copied. Completed rows (`done_time_epoch IS NOT NULL`) are preserved so `--resume` still skips tables that finished.

**3. Close / reopen catalog around the fork in index and vacuum supervisors** (indexes.c, vacuum.c, table-data.c)  
Each supervisor now calls `catalog_close()` just before `copydb_start_index_workers` / `vacuum_start_workers`, then `catalog_open()` again in the parent process after the fork. Workers start with `db == NULL`, so `catalog_init_from_specs()` opens a fresh, independent connection — no inherited file descriptors, no shared WAL state. The COPY supervisor already forked workers before opening the catalog (correct), but is restructured to run cleanup steps first.

Closes #692  
Closes #881