### PR TITLE
tests: add --remove-orphans to all docker compose run/down/up invocations

### DIFF
--- a/tests/all-databases/Makefile
+++ b/tests/all-databases/Makefile
@@ -4,10 +4,10 @@
 test: down run down ;
 
 run: build
-	docker compose run test
+	docker compose run --remove-orphans test
 
 down:
-	docker compose down
+	docker compose down --remove-orphans
 
 build:
 	docker compose build --quiet

--- a/tests/blobs/Makefile
+++ b/tests/blobs/Makefile
@@ -4,10 +4,10 @@
 test: down run down ;
 
 run: build
-	docker compose run test
+	docker compose run --remove-orphans test
 
 down:
-	docker compose down
+	docker compose down --remove-orphans
 
 build:
 	docker compose build --quiet

--- a/tests/cdc-endpos-in-multi-wal-txn/Makefile
+++ b/tests/cdc-endpos-in-multi-wal-txn/Makefile
@@ -4,10 +4,10 @@
 test: down run down ;
 
 run: build
-	docker compose run test
+	docker compose run --remove-orphans test
 
 down:
-	docker compose down
+	docker compose down --remove-orphans
 
 build:
 	docker compose build --quiet

--- a/tests/cdc-endpos-mid-txn/Makefile
+++ b/tests/cdc-endpos-mid-txn/Makefile
@@ -4,10 +4,10 @@
 test: down run down ;
 
 run: build
-	docker compose run test
+	docker compose run --remove-orphans test
 
 down:
-	docker compose down
+	docker compose down --remove-orphans
 
 build:
 	docker compose build --quiet

--- a/tests/cdc-file-rotation/Makefile
+++ b/tests/cdc-file-rotation/Makefile
@@ -4,10 +4,10 @@
 test: down run down ;
 
 run: build
-	docker compose run test
+	docker compose run --remove-orphans test
 
 down:
-	docker compose down
+	docker compose down --remove-orphans
 
 build:
 	docker compose build --quiet

--- a/tests/cdc-filtering-pgoutput/Makefile
+++ b/tests/cdc-filtering-pgoutput/Makefile
@@ -6,13 +6,13 @@ COMPOSE_EXIT = --exit-code-from=test --abort-on-container-exit
 test: down run down ;
 
 up: down build
-	docker compose up $(COMPOSE_EXIT)
+	docker compose up --remove-orphans $(COMPOSE_EXIT)
 
 run: build
-	docker compose run --rm test
+	docker compose run --rm --remove-orphans test
 
 down:
-	docker compose down -v
+	docker compose down -v --remove-orphans
 
 build:
 	docker compose build --quiet

--- a/tests/cdc-low-level/Makefile
+++ b/tests/cdc-low-level/Makefile
@@ -4,10 +4,10 @@
 test: down run down ;
 
 run: build
-	docker compose run test
+	docker compose run --remove-orphans test
 
 down:
-	docker compose down
+	docker compose down --remove-orphans
 
 build:
 	docker compose build --quiet

--- a/tests/cdc-matview/Makefile
+++ b/tests/cdc-matview/Makefile
@@ -4,10 +4,10 @@
 test: down run down ;
 
 run: build
-	docker compose run test
+	docker compose run --remove-orphans test
 
 down:
-	docker compose down
+	docker compose down --remove-orphans
 
 build:
 	docker compose build --quiet

--- a/tests/cdc-partitioned-target/Makefile
+++ b/tests/cdc-partitioned-target/Makefile
@@ -4,10 +4,10 @@
 test: down run down ;
 
 run: build
-	docker compose run test
+	docker compose run --remove-orphans test
 
 down:
-	docker compose down
+	docker compose down --remove-orphans
 
 build:
 	docker compose build --quiet

--- a/tests/cdc-pgoutput/Makefile
+++ b/tests/cdc-pgoutput/Makefile
@@ -6,13 +6,13 @@ COMPOSE_EXIT = --exit-code-from=test --abort-on-container-exit
 test: down run down ;
 
 up: down build
-	docker compose up $(COMPOSE_EXIT)
+	docker compose up --remove-orphans $(COMPOSE_EXIT)
 
 run: build
-	docker compose run --rm test
+	docker compose run --rm --remove-orphans test
 
 down:
-	docker compose down -v
+	docker compose down -v --remove-orphans
 
 build:
 	docker compose build --quiet

--- a/tests/cdc-replica-identity-index/Makefile
+++ b/tests/cdc-replica-identity-index/Makefile
@@ -4,10 +4,10 @@
 test: down run down ;
 
 run: build
-	docker compose run test
+	docker compose run --remove-orphans test
 
 down:
-	docker compose down
+	docker compose down --remove-orphans
 
 build:
 	docker compose build --quiet

--- a/tests/cdc-test-decoding/Makefile
+++ b/tests/cdc-test-decoding/Makefile
@@ -4,10 +4,10 @@
 test: down run down ;
 
 run: build
-	docker compose run test
+	docker compose run --remove-orphans test
 
 down:
-	docker compose down
+	docker compose down --remove-orphans
 
 build:
 	docker compose build --quiet

--- a/tests/cdc-wal2json/Makefile
+++ b/tests/cdc-wal2json/Makefile
@@ -6,13 +6,13 @@ COMPOSE_EXIT = --exit-code-from=test --abort-on-container-exit
 test: down run down ;
 
 up: down build
-	docker compose up $(COMPOSE_EXIT)
+	docker compose up --remove-orphans $(COMPOSE_EXIT)
 
 run: build
-	docker compose run --rm test
+	docker compose run --rm --remove-orphans test
 
 down:
-	docker compose down -v
+	docker compose down -v --remove-orphans
 
 build:
 	docker compose build --quiet

--- a/tests/extensions/Makefile
+++ b/tests/extensions/Makefile
@@ -4,10 +4,10 @@
 test: down run down ;
 
 run: build
-	docker compose run test
+	docker compose run --remove-orphans test
 
 down:
-	docker compose down
+	docker compose down --remove-orphans
 
 build:
 	docker compose build --quiet

--- a/tests/filtering/Makefile
+++ b/tests/filtering/Makefile
@@ -4,10 +4,10 @@
 test: down run down ;
 
 run: build
-	docker compose run test
+	docker compose run --remove-orphans test
 
 down:
-	docker compose down
+	docker compose down --remove-orphans
 
 build:
 	docker compose build --quiet

--- a/tests/follow-9.6/Makefile
+++ b/tests/follow-9.6/Makefile
@@ -9,13 +9,13 @@ COMPOSE_EXIT = --exit-code-from=test --abort-on-container-exit
 test: down run down ;
 
 up: down build
-	docker compose up $(COMPOSE_EXIT)
+	docker compose up --remove-orphans $(COMPOSE_EXIT)
 
 run: build
 	# --use-aliases gives the one-off run container its "test" network alias so
 	# the inject container can reach the follow coordinator at test:5442.
 	# No fix-volumes: this test no longer shares a SQLite catalog volume.
-	docker compose run --use-aliases test
+	docker compose run --remove-orphans --use-aliases test
 
 down:
 	docker compose down --volumes --remove-orphans

--- a/tests/follow-data-only/Makefile
+++ b/tests/follow-data-only/Makefile
@@ -6,13 +6,13 @@ COMPOSE_EXIT = --exit-code-from=test --abort-on-container-exit
 test: down run down ;
 
 up: down build
-	docker compose up $(COMPOSE_EXIT)
+	docker compose up --remove-orphans $(COMPOSE_EXIT)
 
 run: build
 	# --use-aliases gives the run container its "test" network alias so the
 	# inject container can reach the follow coordinator at test:5442.
 	# No fix-volumes: this test no longer shares a SQLite catalog volume.
-	docker compose run --use-aliases test
+	docker compose run --remove-orphans --use-aliases test
 
 down:
 	docker compose down --volumes --remove-orphans

--- a/tests/follow-filtering/Makefile
+++ b/tests/follow-filtering/Makefile
@@ -6,12 +6,12 @@ COMPOSE_EXIT = --exit-code-from=test --abort-on-container-exit
 test: down run down ;
 
 up: down build
-	docker compose up $(COMPOSE_EXIT)
+	docker compose up --remove-orphans $(COMPOSE_EXIT)
 
 run: build
 	# --use-aliases gives the one-off `run` container its "test" network alias
 	# so the inject container can reach the follow coordinator at test:5442.
-	docker compose run --use-aliases test
+	docker compose run --remove-orphans --use-aliases test
 
 down:
 	docker compose down --volumes --remove-orphans

--- a/tests/follow-pgoutput/Makefile
+++ b/tests/follow-pgoutput/Makefile
@@ -6,12 +6,12 @@ COMPOSE_EXIT = --exit-code-from=test --abort-on-container-exit
 test: down run down ;
 
 up: down build
-	docker compose up $(COMPOSE_EXIT)
+	docker compose up --remove-orphans $(COMPOSE_EXIT)
 
 run: build
 	# --use-aliases gives the one-off `run` container its "test" network alias
 	# so the inject container can reach the follow coordinator at test:5442.
-	docker compose run --use-aliases test
+	docker compose run --remove-orphans --use-aliases test
 
 down:
 	docker compose down --volumes --remove-orphans

--- a/tests/follow-wal2json/Makefile
+++ b/tests/follow-wal2json/Makefile
@@ -6,13 +6,13 @@ COMPOSE_EXIT = --exit-code-from=test --abort-on-container-exit
 test: down run down ;
 
 up: down build
-	docker compose up $(COMPOSE_EXIT)
+	docker compose up --remove-orphans $(COMPOSE_EXIT)
 
 run: build
 	# --use-aliases gives the one-off `run` container its "test" network alias
 	# so the inject container can reach the follow coordinator at test:5442.
 	# No fix-volumes: this test no longer shares a SQLite catalog volume.
-	docker compose run --use-aliases test
+	docker compose run --remove-orphans --use-aliases test
 
 down:
 	docker compose down --volumes --remove-orphans

--- a/tests/pagila-multi-steps/Makefile
+++ b/tests/pagila-multi-steps/Makefile
@@ -4,10 +4,10 @@
 test: down run down ;
 
 run: build
-	docker compose run test
+	docker compose run --remove-orphans test
 
 down:
-	docker compose down
+	docker compose down --remove-orphans
 
 build:
 	docker compose build --quiet

--- a/tests/pagila-standby/Makefile
+++ b/tests/pagila-standby/Makefile
@@ -4,10 +4,10 @@
 test: down run down ;
 
 run: build
-	docker compose run test
+	docker compose run --remove-orphans test
 
 down:
-	docker compose down
+	docker compose down --remove-orphans
 
 build:
 	docker compose build --quiet

--- a/tests/pagila/Makefile
+++ b/tests/pagila/Makefile
@@ -4,10 +4,10 @@
 test: down run down ;
 
 run: build
-	docker compose run test
+	docker compose run --remove-orphans test
 
 down:
-	docker compose down
+	docker compose down --remove-orphans
 
 build:
 	docker compose build --quiet

--- a/tests/partitioned-target/Makefile
+++ b/tests/partitioned-target/Makefile
@@ -4,10 +4,10 @@
 test: down run down ;
 
 run: build
-	docker compose run test
+	docker compose run --remove-orphans test
 
 down:
-	docker compose down
+	docker compose down --remove-orphans
 
 build:
 	docker compose build --quiet

--- a/tests/three-databases/Makefile
+++ b/tests/three-databases/Makefile
@@ -4,10 +4,10 @@
 test: down run down ;
 
 run: build
-	docker compose run test
+	docker compose run --remove-orphans test
 
 down:
-	docker compose down -v
+	docker compose down -v --remove-orphans
 
 build:
 	docker compose build --quiet

--- a/tests/timescaledb/Makefile
+++ b/tests/timescaledb/Makefile
@@ -6,13 +6,13 @@ COMPOSE_EXIT = --exit-code-from=test --abort-on-container-exit
 test: down run down ;
 
 up: down build
-	docker compose up $(COMPOSE_EXIT)
+	docker compose up --remove-orphans $(COMPOSE_EXIT)
 
 run: build
-	docker compose run test
+	docker compose run --remove-orphans test
 
 down:
-	docker compose down
+	docker compose down --remove-orphans
 
 build:
 	docker compose build --quiet

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -4,10 +4,10 @@
 test: down run down ;
 
 run: build
-	docker compose run test
+	docker compose run --remove-orphans test
 
 down:
-	docker compose down
+	docker compose down --remove-orphans
 
 build:
 	docker compose build --quiet


### PR DESCRIPTION
## Problem

Several test suite Makefiles were calling `docker compose run`, `docker compose down`, and `docker compose up` without `--remove-orphans`. When a previous test run left containers behind (e.g. due to a crash or timeout), the next run would see those containers as orphans, causing confusing error output and occasionally blocking port binding.

## Fix

Add `--remove-orphans` consistently to all `docker compose run`, `docker compose down`, and `docker compose up` calls across the test suite Makefiles. This ensures each test run starts with a clean slate regardless of what the previous run left behind.

This change was originally committed as part of the regex filter feature branch (#665) but is independently useful and has no dependency on that work.