### PR TITLE
fix: list commands are snapshot-agnostic; accept clone snapshot (closes #1006)

### DIFF
--- a/src/bin/pgcopydb/catalog.c
+++ b/src/bin/pgcopydb/catalog.c
@@ -810,13 +810,25 @@ catalog_register_setup_from_specs(CopyDataSpec *copySpecs)
 		 * from "an owner explicitly ran without filters".  The latter case
 		 * (SOURCE_FILTER_TYPE_NONE stored by a real owner) requires catalog
 		 * invalidation; the former does not.
+		 *
+		 * Snapshot-agnostic commands (list tables, list sequences, etc.)
+		 * register setup with snapshot = NULL for the same reason: a
+		 * subsequent clone command must be able to distinguish "no snapshot
+		 * owner has claimed this catalog yet" (NULL) from "an owner
+		 * explicitly set snapshot X" (non-empty string).
 		 */
 		const char *filterJson = copySpecs->skipFilterCheck ? NULL : json;
+
+		const char *snapStr =
+			(copySpecs->skipSnapshotCheck ||
+			 IS_EMPTY_STRING_BUFFER(copySpecs->sourceSnapshot.snapshot))
+			? NULL
+			: copySpecs->sourceSnapshot.snapshot;
 
 		if (!catalog_register_setup(sourceDB,
 									spguri.pguri,
 									tpguri.pguri,
-									copySpecs->sourceSnapshot.snapshot,
+									snapStr,
 									copySpecs->splitTablesLargerThan.bytes,
 									copySpecs->splitMaxParts,
 									filterJson))
@@ -873,10 +885,49 @@ catalog_register_setup_from_specs(CopyDataSpec *copySpecs)
 			return false;
 		}
 
-		/* skip comparing snapshots when --not-consistent is used */
-		if (copySpecs->consistent)
+		/*
+		 * Skip snapshot comparison for snapshot-agnostic commands (e.g. list
+		 * tables, list sequences): they never export a snapshot and have no
+		 * stake in snapshot consistency.
+		 *
+		 * For snapshot-owner commands (e.g. clone), apply the check only when
+		 * --not-consistent is not in effect.
+		 */
+		if (copySpecs->skipSnapshotCheck)
 		{
-			if (!streq(copySpecs->sourceSnapshot.snapshot, setup->snapshot))
+			log_debug("Skipping snapshot consistency check for "
+					  "snapshot-agnostic command");
+		}
+		else if (copySpecs->consistent)
+		{
+			if (IS_EMPTY_STRING_BUFFER(setup->snapshot))
+			{
+				/*
+				 * Case 0: catalog was first registered by a snapshot-agnostic
+				 * command (e.g. pgcopydb list tables), which stored snapshot =
+				 * NULL as a sentinel meaning "no snapshot owner has ever
+				 * claimed this catalog yet".
+				 *
+				 * Accept the current snapshot and persist it so future
+				 * commands can validate consistency against it.
+				 */
+				log_info("Catalog snapshot not yet set; "
+						 "registering current snapshot \"%s\"",
+						 copySpecs->sourceSnapshot.snapshot);
+
+				if (!catalog_setup_replication(sourceDB,
+											   copySpecs->sourceSnapshot.snapshot))
+				{
+					/* errors have already been logged */
+					json_free_serialized_string(json);
+					return false;
+				}
+
+				strlcpy(setup->snapshot,
+						copySpecs->sourceSnapshot.snapshot,
+						sizeof(setup->snapshot));
+			}
+			else if (!streq(copySpecs->sourceSnapshot.snapshot, setup->snapshot))
 			{
 				log_error("Catalogs at \"%s\" have been setup for "
 						  "snapshot \"%s\" and current snapshot is \"%s\"",

--- a/src/bin/pgcopydb/cli_list.c
+++ b/src/bin/pgcopydb/cli_list.c
@@ -2174,5 +2174,8 @@ copydb_init_specs_from_listdboptions(CopyDataSpec *copySpecs,
 		exit(EXIT_CODE_INTERNAL_ERROR);
 	}
 
+	/* list commands never export a snapshot; they are snapshot-agnostic */
+	copySpecs->skipSnapshotCheck = true;
+
 	return true;
 }

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -312,6 +312,7 @@ typedef struct CopyDataSpec
 	bool fetchFilteredOids;     /* allow bypassing dump/restore filter prep */
 	bool skipSourceURICheck;    /* skip source URI mismatch check on open */
 	bool skipFilterCheck;       /* skip filter consistency check (agnostic cmds) */
+	bool skipSnapshotCheck;     /* skip snapshot consistency check (list cmds) */
 
 	bool follow;                /* pgcopydb fork --follow */
 	bool allDatabases;          /* pgcopydb clone --all-databases */


### PR DESCRIPTION
## Problem

`pgcopydb list tables` (and all other `list` subcommands) never export a PostgreSQL snapshot, so they register `snapshot = NULL` in the catalog setup table. When `pgcopydb clone` subsequently runs with the same `--dir`, it creates a real snapshot and the consistency check fails:

```
ERROR  Catalogs at "/tmp/pgcopydb/source.db" have been setup for snapshot "" and current snapshot is "00000006-00000002-1"
```

This breaks the workflow of pre-warming the catalog with `pgcopydb list tables` before a `pgcopydb clone`.

## Root Cause

`catalog_register_setup_from_specs` in `src/bin/pgcopydb/catalog.c` has no concept of "snapshot-agnostic" commands. The empty-string `copySpecs->sourceSnapshot.snapshot` is stored as SQL `NULL` (via `IS_EMPTY_STRING_BUFFER` → `sqlite3_bind_null` in `catalog_sql_bind`). When `clone` runs next, the check at line 888:

```c
if (copySpecs->consistent)
{
    if (!streq(copySpecs->sourceSnapshot.snapshot, setup->snapshot))
        ...error...
}
```

fires because `streq("00000006-...", "")` is false.

The filter system already handles this exact situation with `skipFilterCheck` and a "Case 0" reconciliation: when a filter-agnostic command first opens a fresh catalog it stores `filters = NULL`, and when a filter-owner command arrives later and finds `NULL` it accepts the situation and writes its own filter data. The snapshot field needs the same treatment.

## Fix

- Add `bool skipSnapshotCheck` to `CopyDataSpec` in `copydb.h` (parallel to `skipFilterCheck`)
- Set `skipSnapshotCheck = true` in `copydb_init_specs_from_listdboptions` in `cli_list.c`, which is the single entry point for all `pgcopydb list *` subcommands
- Fresh-catalog path in `catalog_register_setup_from_specs`: compute `snapStr = NULL` when `skipSnapshotCheck` is true, making the intent explicit (the empty-string binding already became `NULL` via `IS_EMPTY_STRING_BUFFER`, but now it is deliberate and documented)
- Existing-catalog path: add "Case 0" reconciliation — when a snapshot-owner command (`clone`) arrives and finds `setup->snapshot == ""`, accept the current snapshot and persist it via the existing `catalog_setup_replication` function so future commands can validate consistency against it

Closes #1006