### PR TITLE
ci: add Homebrew auto-bump workflow on stable release tags (#873)

### DIFF
--- a/.github/workflows/homebrew-bump.yml
+++ b/.github/workflows/homebrew-bump.yml
@@ -1,0 +1,20 @@
+name: Homebrew
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  bump-formula:
+    if: "!contains(github.ref_name, '-')"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mislav/bump-homebrew-formula-action@v3
+        with:
+          formula-name: pgcopydb
+          homebrew-tap: Homebrew/homebrew-core
+          tag-name: ${{ github.ref_name }}
+          create-pullrequest: true
+        env:
+          COMMITTER_TOKEN: ${{ secrets.HOMEBREW_CORE_TOKEN }}


### PR DESCRIPTION
## Problem

Updating the Homebrew formula after each release was a manual step. The formula already exists in homebrew-core (added in Homebrew/homebrew-core#181675) but bumping it required running `brew bump-formula-pr` by hand.

## Fix

Add `.github/workflows/homebrew-bump.yml` that fires on any `v*.*.*` tag push and calls `mislav/bump-homebrew-formula-action@v3` to open a PR against `Homebrew/homebrew-core` automatically.

The `if: "!contains(github.ref_name, '-')"` guard skips tags that contain a hyphen (e.g. `v0.18-rc1`), so only clean stable tags trigger the bump.

The workflow reads a repo secret named `HOMEBREW_CORE_TOKEN` — a GitHub personal access token with `public_repo` scope. **Before merging, add that PAT as a secret at Settings → Secrets and variables → Actions → New repository secret, name it `HOMEBREW_CORE_TOKEN`.**

Closes #873