### PR TITLE
drive REFRESH MATERIALIZED VIEW within pgcopydb  (#484, #501)

### DIFF
--- a/src/bin/pgcopydb/catalog.c
+++ b/src/bin/pgcopydb/catalog.c
@@ -113,7 +113,18 @@ static char *sourceDBcreateTableDDLs[] = {
 	"create table s_matview("
 	"  oid integer primary key, "
 	"  qname text, nspname text, relname text, restore_list_name text, "
-	"  exclude_data boolean"
+	"  exclude_data boolean, "
+	"  toc_seq integer default 0"
+	")",
+
+	"create table s_matview_dep("
+	"  matview_oid integer references s_matview(oid), "
+	"  dep_oid integer references s_matview(oid), "
+	"  primary key(matview_oid, dep_oid)"
+	")",
+
+	"create table s_matview_refresh_done("
+	"  oid integer primary key references s_matview(oid)"
 	")",
 
 	"create table s_table_size("
@@ -661,6 +672,8 @@ static char *sourceDBdropDDLs[] = {
 
 	"drop table if exists s_database",
 	"drop table if exists s_database_property",
+	"drop table if exists s_matview_refresh_done",
+	"drop table if exists s_matview_dep",
 	"drop table if exists s_table",
 	"drop table if exists s_matview",
 	"drop table if exists s_attr",
@@ -3218,6 +3231,322 @@ catalog_s_matview_fetch(SQLiteQuery *query)
 	}
 
 	entry->excludeData = sqlite3_column_int64(query->ppStmt, 4) == 1;
+
+	return true;
+}
+
+
+/*
+ * catalog_update_s_matview_toc_seq sets the TOC sequence number for a matview.
+ * Used to record the pg_dump dependency order so vacuum workers can REFRESH in
+ * the correct sequence without waiting for pg_restore post-data.
+ */
+bool
+catalog_update_s_matview_toc_seq(DatabaseCatalog *catalog,
+								 uint32_t oid,
+								 int seq)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_update_s_matview_toc_seq: db is NULL");
+		return false;
+	}
+
+	char *sql =
+		"update s_matview set toc_seq = $1 where oid = $2";
+
+	SQLiteQuery query = { 0 };
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		return false;
+	}
+
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_INT64, "toc_seq", seq, NULL },
+		{ BIND_PARAMETER_TYPE_INT64, "oid", oid, NULL },
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(&query, params, count))
+	{
+		return false;
+	}
+
+	if (!catalog_sql_execute_once(&query))
+	{
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_add_s_matview_dep records a matview-to-matview dependency: dep_oid
+ * must be refreshed before matview_oid.  Ignored when either OID is absent
+ * from s_matview (e.g. filtered out).
+ */
+bool
+catalog_add_s_matview_dep(DatabaseCatalog *catalog,
+						  uint32_t matview_oid,
+						  uint32_t dep_oid)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_add_s_matview_dep: db is NULL");
+		return false;
+	}
+
+	char *sql =
+		"insert or ignore into s_matview_dep(matview_oid, dep_oid)"
+		" select $1, $2"
+		" where exists (select 1 from s_matview where oid = $1)"
+		"   and exists (select 1 from s_matview where oid = $2)";
+
+	SQLiteQuery query = { 0 };
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		return false;
+	}
+
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_INT64, "matview_oid", matview_oid, NULL },
+		{ BIND_PARAMETER_TYPE_INT64, "dep_oid", dep_oid, NULL },
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(&query, params, count))
+	{
+		return false;
+	}
+
+	if (!catalog_sql_execute_once(&query))
+	{
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_matview_deps_are_done sets *done to true when every matview that
+ * matview_oid depends on (via s_matview_dep) has an entry in
+ * s_matview_refresh_done.  A matview with no deps is immediately done.
+ */
+bool
+catalog_matview_deps_are_done(DatabaseCatalog *catalog,
+							  uint32_t oid,
+							  bool *done)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_matview_deps_are_done: db is NULL");
+		return false;
+	}
+
+	char *sql =
+		"select count(*) = 0"
+		"  from s_matview_dep"
+		" where matview_oid = $1"
+		"   and dep_oid not in (select oid from s_matview_refresh_done)";
+
+	SQLiteQuery query = { 0 };
+
+	if (!semaphore_lock(&(catalog->sema)))
+	{
+		return false;
+	}
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		(void) semaphore_unlock(&(catalog->sema));
+		return false;
+	}
+
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_INT64, "oid", oid, NULL },
+	};
+
+	if (!catalog_sql_bind(&query, params, 1))
+	{
+		(void) semaphore_unlock(&(catalog->sema));
+		return false;
+	}
+
+	int rc = catalog_sql_step(&query);
+
+	if (rc != SQLITE_ROW)
+	{
+		log_error("[SQLite %d: %s]: %s", rc, query.sql, sqlite3_errmsg(db));
+		(void) catalog_sql_finalize(&query);
+		(void) semaphore_unlock(&(catalog->sema));
+		return false;
+	}
+
+	*done = sqlite3_column_int(query.ppStmt, 0) != 0;
+
+	(void) catalog_sql_finalize(&query);
+	(void) semaphore_unlock(&(catalog->sema));
+
+	return true;
+}
+
+
+/*
+ * catalog_mark_matview_refresh_done records that a materialized view has been
+ * successfully refreshed.  Idempotent: ignored if already present.
+ */
+bool
+catalog_mark_matview_refresh_done(DatabaseCatalog *catalog, uint32_t oid)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_mark_matview_refresh_done: db is NULL");
+		return false;
+	}
+
+	char *sql =
+		"insert or ignore into s_matview_refresh_done(oid) values($1)";
+
+	SQLiteQuery query = { 0 };
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		return false;
+	}
+
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_INT64, "oid", oid, NULL },
+	};
+
+	if (!catalog_sql_bind(&query, params, 1))
+	{
+		return false;
+	}
+
+	if (!catalog_sql_execute_once(&query))
+	{
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * catalog_iter_s_matview_toc_order iterates over materialized views that have a
+ * toc_seq > 0, ordered by toc_seq ascending — i.e. in the pg_dump dependency
+ * order that guarantees REFRESH can proceed without missing deps.
+ */
+bool
+catalog_iter_s_matview_toc_order(DatabaseCatalog *catalog,
+								 void *context,
+								 CatalogMatViewIterFun *callback)
+{
+	sqlite3 *db = catalog->db;
+
+	if (db == NULL)
+	{
+		log_error("BUG: catalog_iter_s_matview_toc_order: db is NULL");
+		return false;
+	}
+
+	char *sql =
+		"select oid, nspname, relname"
+		"  from s_matview"
+		" where toc_seq > 0"
+		" order by toc_seq asc";
+
+	CatalogMatViewIterator iter = {
+		.catalog = catalog,
+	};
+
+	iter.query.context = &(iter.matview);
+
+	if (!semaphore_lock(&(catalog->sema)))
+	{
+		return false;
+	}
+
+	if (!catalog_sql_prepare(db, sql, &(iter.query)))
+	{
+		(void) semaphore_unlock(&(catalog->sema));
+		return false;
+	}
+
+	for (;;)
+	{
+		int rc = catalog_sql_step(&(iter.query));
+
+		if (rc == SQLITE_DONE)
+		{
+			break;
+		}
+
+		if (rc != SQLITE_ROW)
+		{
+			log_error("Failed to step through s_matview: %s",
+					  sqlite3_errmsg(db));
+			(void) catalog_sql_finalize(&(iter.query));
+			(void) semaphore_unlock(&(catalog->sema));
+			return false;
+		}
+
+		CatalogMatView *mv = &(iter.matview);
+
+		bzero(mv, sizeof(CatalogMatView));
+		mv->oid = sqlite3_column_int64(iter.query.ppStmt, 0);
+
+		if (sqlite3_column_type(iter.query.ppStmt, 1) != SQLITE_NULL)
+		{
+			strlcpy(mv->nspname,
+					(char *) sqlite3_column_text(iter.query.ppStmt, 1),
+					sizeof(mv->nspname));
+		}
+
+		if (sqlite3_column_type(iter.query.ppStmt, 2) != SQLITE_NULL)
+		{
+			strlcpy(mv->relname,
+					(char *) sqlite3_column_text(iter.query.ppStmt, 2),
+					sizeof(mv->relname));
+		}
+
+		(void) semaphore_unlock(&(catalog->sema));
+
+		if (!(*callback)(context, mv))
+		{
+			log_error("Failed to iterate over materialized views, "
+					  "see above for details");
+			if (!semaphore_lock(&(catalog->sema)))
+			{
+				return false;
+			}
+			(void) catalog_sql_finalize(&(iter.query));
+			(void) semaphore_unlock(&(catalog->sema));
+			return false;
+		}
+
+		if (!semaphore_lock(&(catalog->sema)))
+		{
+			return false;
+		}
+	}
+
+	(void) catalog_sql_finalize(&(iter.query));
+	(void) semaphore_unlock(&(catalog->sema));
 
 	return true;
 }
@@ -10181,6 +10510,8 @@ catalog_delete_source_schema_data(DatabaseCatalog *catalog)
 		"delete from s_index",
 		"delete from s_depend",
 		"delete from s_seq",
+		"delete from s_matview_refresh_done",
+		"delete from s_matview_dep",
 		"delete from s_matview",
 		"delete from s_table",
 		"delete from s_namespace",

--- a/src/bin/pgcopydb/catalog.h
+++ b/src/bin/pgcopydb/catalog.h
@@ -206,6 +206,33 @@ typedef struct CatalogMatView
 
 bool catalog_add_s_matview(DatabaseCatalog *catalog, SourceTable *table);
 
+bool catalog_update_s_matview_toc_seq(DatabaseCatalog *catalog,
+									  uint32_t oid,
+									  int seq);
+
+bool catalog_add_s_matview_dep(DatabaseCatalog *catalog,
+							   uint32_t matview_oid,
+							   uint32_t dep_oid);
+
+bool catalog_matview_deps_are_done(DatabaseCatalog *catalog,
+								   uint32_t oid,
+								   bool *done);
+
+bool catalog_mark_matview_refresh_done(DatabaseCatalog *catalog, uint32_t oid);
+
+typedef bool (CatalogMatViewIterFun)(void *context, CatalogMatView *matview);
+
+typedef struct CatalogMatViewIterator
+{
+	DatabaseCatalog *catalog;
+	CatalogMatView matview;
+	SQLiteQuery query;
+} CatalogMatViewIterator;
+
+bool catalog_iter_s_matview_toc_order(DatabaseCatalog *catalog,
+									  void *context,
+									  CatalogMatViewIterFun *callback);
+
 bool catalog_upsert_target_s_rel(DatabaseCatalog *catalog,
 								 const char *nspname,
 								 const char *relname,

--- a/src/bin/pgcopydb/cli_restore.c
+++ b/src/bin/pgcopydb/cli_restore.c
@@ -597,7 +597,7 @@ cli_restore_schema_parse_list(int argc, char **argv)
 			 copySpecs.dumpPaths.dumpFilename,
 			 copySpecs.dumpPaths.preListFilename);
 
-	if (!copydb_write_restore_list(&copySpecs, PG_DUMP_SECTION_PRE_DATA, NULL))
+	if (!copydb_write_restore_list(&copySpecs, PG_DUMP_SECTION_PRE_DATA))
 	{
 		log_error("Failed to prepare the pg_restore --use-list catalogs, "
 				  "see above for details");
@@ -609,7 +609,7 @@ cli_restore_schema_parse_list(int argc, char **argv)
 			 copySpecs.dumpPaths.dumpFilename,
 			 copySpecs.dumpPaths.postListFilename);
 
-	if (!copydb_write_restore_list(&copySpecs, PG_DUMP_SECTION_POST_DATA, NULL))
+	if (!copydb_write_restore_list(&copySpecs, PG_DUMP_SECTION_POST_DATA))
 	{
 		log_error("Failed to prepare the pg_restore --use-list catalogs, "
 				  "see above for details");

--- a/src/bin/pgcopydb/cli_restore.c
+++ b/src/bin/pgcopydb/cli_restore.c
@@ -597,7 +597,7 @@ cli_restore_schema_parse_list(int argc, char **argv)
 			 copySpecs.dumpPaths.dumpFilename,
 			 copySpecs.dumpPaths.preListFilename);
 
-	if (!copydb_write_restore_list(&copySpecs, PG_DUMP_SECTION_PRE_DATA))
+	if (!copydb_write_restore_list(&copySpecs, PG_DUMP_SECTION_PRE_DATA, NULL))
 	{
 		log_error("Failed to prepare the pg_restore --use-list catalogs, "
 				  "see above for details");
@@ -609,7 +609,7 @@ cli_restore_schema_parse_list(int argc, char **argv)
 			 copySpecs.dumpPaths.dumpFilename,
 			 copySpecs.dumpPaths.postListFilename);
 
-	if (!copydb_write_restore_list(&copySpecs, PG_DUMP_SECTION_POST_DATA))
+	if (!copydb_write_restore_list(&copySpecs, PG_DUMP_SECTION_POST_DATA, NULL))
 	{
 		log_error("Failed to prepare the pg_restore --use-list catalogs, "
 				  "see above for details");

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -308,6 +308,16 @@ typedef struct CopyDataSpec
 	bool consistent;
 	bool failFast;
 
+	/*
+	 * Cached target PostgreSQL server version number (e.g. 170000 for PG17).
+	 * Set once in copydb_target_prepare_schema; used to gate behaviour that
+	 * is only needed on PG <= 16 (e.g. owning REFRESH MATERIALIZED VIEW to
+	 * work around the pg_restore empty-search_path bug, issues #484/#501).
+	 * On PG17+, RestrictSearchPath() inside RefreshMatViewByOid() makes the
+	 * original bug impossible, so pg_restore handles REFRESH directly.
+	 */
+	int targetPgVersionNum;
+
 	bool fetchCatalogs;         /* cache invalidation of local catalogs db */
 	bool fetchFilteredOids;     /* allow bypassing dump/restore filter prep */
 	bool skipSourceURICheck;    /* skip source URI mismatch check on open */

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -486,25 +486,8 @@ bool copydb_target_finalize_schema(CopyDataSpec *specs);
 bool copydb_objectid_has_been_processed_already(CopyDataSpec *specs,
 												ArchiveContentItem *item);
 
-typedef struct MatViewRefreshItem
-{
-	uint32_t oid;
-	char nspname[PG_NAMEDATALEN];
-	char relname[PG_NAMEDATALEN];
-} MatViewRefreshItem;
-
-typedef struct MatViewRefreshList
-{
-	int count;
-	int capacity;
-	MatViewRefreshItem *items;
-} MatViewRefreshList;
-
-bool copydb_write_restore_list(CopyDataSpec *specs, PostgresDumpSection section,
-							   MatViewRefreshList *refreshList);
+bool copydb_write_restore_list(CopyDataSpec *specs, PostgresDumpSection section);
 bool copydb_write_schemas_restore_list(CopyDataSpec *specs);
-bool copydb_refresh_materialized_views(CopyDataSpec *specs,
-									   MatViewRefreshList *list);
 
 /* sequences.c */
 bool copydb_copy_all_sequences(CopyDataSpec *specs, bool reset);
@@ -591,7 +574,9 @@ bool vacuum_supervisor(CopyDataSpec *specs);
 bool vacuum_start_workers(CopyDataSpec *specs);
 bool vacuum_worker(CopyDataSpec *specs);
 bool vacuum_analyze_table_by_oid(CopyDataSpec *specs, uint32_t oid);
+bool vacuum_refresh_matview_by_oid(CopyDataSpec *specs, uint32_t oid);
 bool vacuum_add_table(CopyDataSpec *specs, uint32_t oid, const char *datname);
+bool vacuum_send_matviews(CopyDataSpec *specs);
 bool vacuum_send_stop(CopyDataSpec *specs);
 
 /* sentinel.c */

--- a/src/bin/pgcopydb/copydb.h
+++ b/src/bin/pgcopydb/copydb.h
@@ -486,8 +486,25 @@ bool copydb_target_finalize_schema(CopyDataSpec *specs);
 bool copydb_objectid_has_been_processed_already(CopyDataSpec *specs,
 												ArchiveContentItem *item);
 
-bool copydb_write_restore_list(CopyDataSpec *specs, PostgresDumpSection section);
+typedef struct MatViewRefreshItem
+{
+	uint32_t oid;
+	char nspname[PG_NAMEDATALEN];
+	char relname[PG_NAMEDATALEN];
+} MatViewRefreshItem;
+
+typedef struct MatViewRefreshList
+{
+	int count;
+	int capacity;
+	MatViewRefreshItem *items;
+} MatViewRefreshList;
+
+bool copydb_write_restore_list(CopyDataSpec *specs, PostgresDumpSection section,
+							   MatViewRefreshList *refreshList);
 bool copydb_write_schemas_restore_list(CopyDataSpec *specs);
+bool copydb_refresh_materialized_views(CopyDataSpec *specs,
+									   MatViewRefreshList *list);
 
 /* sequences.c */
 bool copydb_copy_all_sequences(CopyDataSpec *specs, bool reset);

--- a/src/bin/pgcopydb/copydb_schema.c
+++ b/src/bin/pgcopydb/copydb_schema.c
@@ -703,6 +703,14 @@ copydb_prepare_table_specs(CopyDataSpec *specs, PGSQL *pgsql)
 		return false;
 	}
 
+	/* record matview-to-matview deps for REFRESH ordering in vacuum workers */
+	if (!schema_list_matview_deps(pgsql, sourceDB))
+	{
+		log_error("Failed to prepare matview dependency catalog, "
+				  "see above for details");
+		return false;
+	}
+
 	/*
 	 * if we did not enable estimates, update table sizes in our internal
 	 * catalogue with exact values

--- a/src/bin/pgcopydb/dump_restore.c
+++ b/src/bin/pgcopydb/dump_restore.c
@@ -239,10 +239,42 @@ copydb_target_prepare_schema(CopyDataSpec *specs)
 	}
 
 	/*
+	 * Determine the target PostgreSQL version.  On PG17+,
+	 * RestrictSearchPath() inside RefreshMatViewByOid() forces search_path
+	 * to 'pg_catalog, pg_temp' for every REFRESH (and CREATE MATERIALIZED
+	 * VIEW ... WITH DATA), making the original bug (#484/#501) impossible.
+	 * pg_restore then handles REFRESH directly, and pgcopydb does not need
+	 * to own that step.  The version is inherited by forked worker processes.
+	 */
+	if (specs->targetPgVersionNum == 0)
+	{
+		PGSQL dst = { 0 };
+
+		if (!pgsql_init(&dst, specs->connStrings.target_pguri, PGSQL_CONN_TARGET))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+
+		if (!pgsql_server_version(&dst))
+		{
+			/* errors have already been logged */
+			(void) pgsql_finish(&dst);
+			return false;
+		}
+
+		specs->targetPgVersionNum = dst.pgversion_num;
+		(void) pgsql_finish(&dst);
+
+		log_info("Target PostgreSQL version: %d", specs->targetPgVersionNum);
+	}
+
+	/*
 	 * Scan the full archive TOC (already written to preListOutFilename) to
 	 * assign toc_seq to each REFRESH MATERIALIZED VIEW entry.  This must be
 	 * done before the data phase starts so the INDEX supervisor can feed
 	 * vacuum workers in the correct pg_dump dependency order.
+	 * On PG17+ targets this is skipped: pg_restore handles REFRESH directly.
 	 */
 	if (!copydb_collect_matview_toc_order(specs))
 	{
@@ -1019,16 +1051,19 @@ copydb_write_restore_list_hook(void *ctx, ArchiveContentItem *item)
 	}
 
 	/*
-	 * Skip non-filtered REFRESH MATERIALIZED VIEW entries from the pg_restore
-	 * list.  pgcopydb drives REFRESH via vacuum workers during the data phase
-	 * (after all source-table COPY and CREATE INDEX), so they must not also be
-	 * run by pg_restore post-data.
+	 * On PG <= 16 targets, pgcopydb owns REFRESH MATERIALIZED VIEW: entries
+	 * are stripped from the pg_restore list here and dispatched via vacuum
+	 * workers instead, using fresh libpq connections that inherit the
+	 * database-level search_path (avoiding the pg_restore empty-search_path
+	 * bug, issues #484/#501).
 	 *
-	 * When assignTocSeq is set (TOC order scan during prepare_schema) we also
-	 * record the pg_dump dependency order in s_matview.toc_seq so that the
-	 * INDEX supervisor can feed vacuum workers in the right sequence.
+	 * On PG17+ targets the bug cannot arise (RestrictSearchPath() in
+	 * RefreshMatViewByOid() forces a safe search_path unconditionally), so
+	 * REFRESH entries are left in the list for pg_restore to handle.
 	 */
-	if (!skip && item->desc == ARCHIVE_TAG_REFRESH_MATERIALIZED_VIEW)
+	if (!skip &&
+		item->desc == ARCHIVE_TAG_REFRESH_MATERIALIZED_VIEW &&
+		specs->targetPgVersionNum < 170000)
 	{
 		skip = true;
 
@@ -1106,6 +1141,21 @@ copydb_write_restore_list_hook(void *ctx, ArchiveContentItem *item)
 static bool
 copydb_collect_matview_toc_order(CopyDataSpec *specs)
 {
+	/*
+	 * On PG17+ targets, pg_restore owns REFRESH MATERIALIZED VIEW (the
+	 * search_path bug that motivated pgcopydb owning it cannot arise there).
+	 * Skip the toc_seq assignment entirely; vacuum workers will receive no
+	 * QMSG_TYPE_MATVIEW_OID messages, and the REFRESH entries are left in
+	 * the pg_restore post-data list for pg_restore to execute.
+	 */
+	if (specs->targetPgVersionNum >= 170000)
+	{
+		log_info("Target is PG%d (>= 17): REFRESH MATERIALIZED VIEW "
+				 "handled by pg_restore, not pgcopydb vacuum workers",
+				 specs->targetPgVersionNum / 10000);
+		return true;
+	}
+
 	/*
 	 * The preListOutFilename file was produced by pg_restore --list during
 	 * the pre-data pass.  It lists ALL entries from the dump (not just

--- a/src/bin/pgcopydb/dump_restore.c
+++ b/src/bin/pgcopydb/dump_restore.c
@@ -229,7 +229,7 @@ copydb_target_prepare_schema(CopyDataSpec *specs)
 	 * used, SCHEMA entries are skipped here because they were already restored
 	 * in the first pass above.
 	 */
-	if (!copydb_write_restore_list(specs, PG_DUMP_SECTION_PRE_DATA))
+	if (!copydb_write_restore_list(specs, PG_DUMP_SECTION_PRE_DATA, NULL))
 	{
 		log_error("Failed to prepare the pg_restore --use-list catalogs, "
 				  "see above for details");
@@ -600,7 +600,10 @@ copydb_target_finalize_schema(CopyDataSpec *specs)
 		return false;
 	}
 
-	if (!copydb_write_restore_list(specs, PG_DUMP_SECTION_POST_DATA))
+	MatViewRefreshList matviewRefreshList = { 0 };
+
+	if (!copydb_write_restore_list(specs, PG_DUMP_SECTION_POST_DATA,
+								   &matviewRefreshList))
 	{
 		log_error("Failed to prepare the pg_restore --use-list catalogs, "
 				  "see above for details");
@@ -616,8 +619,19 @@ copydb_target_finalize_schema(CopyDataSpec *specs)
 					   specs->restoreOptions))
 	{
 		/* errors have already been logged */
+		free(matviewRefreshList.items);
 		return false;
 	}
+
+	/* Run REFRESH MATERIALIZED VIEW directly with the correct search_path. */
+	if (!copydb_refresh_materialized_views(specs, &matviewRefreshList))
+	{
+		log_error("Failed to refresh materialized views, see above for details");
+		free(matviewRefreshList.items);
+		return false;
+	}
+
+	free(matviewRefreshList.items);
 
 	/*
 	 * Some extensions such as timescaledb need a post restore step.
@@ -643,7 +657,8 @@ typedef struct RestoreListContext
 {
 	CopyDataSpec *specs;
 	FILE *outStream;
-	bool schemasOnly;   /* write only SCHEMA entries (first pass) */
+	bool schemasOnly;            /* write only SCHEMA entries (first pass) */
+	MatViewRefreshList *refreshList; /* non-NULL: collect REFRESH entries */
 } RestoreListContext;
 
 /*
@@ -652,7 +667,8 @@ typedef struct RestoreListContext
  * catalog that is meant to be used as pg_restore --use-list argument.
  */
 bool
-copydb_write_restore_list(CopyDataSpec *specs, PostgresDumpSection section)
+copydb_write_restore_list(CopyDataSpec *specs, PostgresDumpSection section,
+						  MatViewRefreshList *refreshList)
 {
 	char *dumpFilename = NULL;
 	char *listFilename = NULL;
@@ -720,7 +736,8 @@ copydb_write_restore_list(CopyDataSpec *specs, PostgresDumpSection section)
 
 	RestoreListContext context = {
 		.specs = specs,
-		.outStream = out
+		.outStream = out,
+		.refreshList = refreshList
 	};
 
 	if (!archive_iter_toc(listOutFilename,
@@ -1001,6 +1018,55 @@ copydb_write_restore_list_hook(void *ctx, ArchiveContentItem *item)
 				  item->restoreListName);
 	}
 
+	/*
+	 * Intercept non-filtered REFRESH MATERIALIZED VIEW entries: skip them
+	 * in the pg_restore list and collect them for direct execution with the
+	 * correct search_path.  pg_restore runs REFRESH with an empty
+	 * search_path, which breaks matviews whose definition embeds unqualified
+	 * object names inside text arguments (e.g. ts_stat()).
+	 */
+	if (!skip &&
+		item->desc == ARCHIVE_TAG_REFRESH_MATERIALIZED_VIEW &&
+		context->refreshList != NULL)
+	{
+		DatabaseCatalog *sourceDB = &(specs->catalogs.source);
+		CatalogMatView matview = { 0 };
+
+		if (oid != 0 &&
+			catalog_lookup_s_matview_by_oid(sourceDB, &matview, oid) &&
+			matview.oid != 0)
+		{
+			MatViewRefreshList *list = context->refreshList;
+
+			if (list->count >= list->capacity)
+			{
+				int newCap = list->capacity == 0 ? 8 : list->capacity * 2;
+				MatViewRefreshItem *newItems = (MatViewRefreshItem *)
+											   realloc(list->items, newCap *
+													   sizeof(MatViewRefreshItem));
+
+				if (newItems == NULL)
+				{
+					log_error("Failed to allocate memory for matview refresh list");
+					return false;
+				}
+				list->items = newItems;
+				list->capacity = newCap;
+			}
+
+			MatViewRefreshItem *it = &list->items[list->count++];
+			it->oid = oid;
+			strlcpy(it->nspname, matview.nspname, sizeof(it->nspname));
+			strlcpy(it->relname, matview.relname, sizeof(it->relname));
+
+			skip = true;
+
+			log_debug("Deferring REFRESH MATERIALIZED VIEW \"%s\".\"%s\" "
+					  "(dumpId %d) for direct execution with correct search_path",
+					  matview.nspname, matview.relname, item->dumpId);
+		}
+	}
+
 	PQExpBuffer buf = createPQExpBuffer();
 
 	printfPQExpBuffer(buf, "%s%d; %u %u %s %s\n",
@@ -1027,6 +1093,118 @@ copydb_write_restore_list_hook(void *ctx, ArchiveContentItem *item)
 	}
 
 	destroyPQExpBuffer(buf);
+
+	return true;
+}
+
+
+/*
+ * copydb_refresh_materialized_views runs REFRESH MATERIALIZED VIEW for each
+ * entry in the list, in the order they appear (pg_dump dependency order).
+ *
+ * Each REFRESH is run with a search_path that includes all user schemas so
+ * that unqualified object names embedded in function text arguments (e.g.
+ * ts_stat('SELECT ... FROM documents')) can be resolved correctly.
+ *
+ * pg_restore would run REFRESH with an empty search_path, which breaks these
+ * matviews (#484, #501).
+ */
+bool
+copydb_refresh_materialized_views(CopyDataSpec *specs,
+								  MatViewRefreshList *list)
+{
+	if (list == NULL || list->count == 0)
+	{
+		return true;
+	}
+
+	PGSQL pgsql = { 0 };
+
+	if (!pgsql_init(&pgsql, specs->connStrings.target_pguri, PGSQL_CONN_TARGET))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	/*
+	 * Keep the same connection open across the SET search_path and all
+	 * REFRESH statements so the search_path setting is visible to each one.
+	 * In SINGLE_STATEMENT mode (the default) pgsql_execute closes the
+	 * connection after every query, causing the next query to open a fresh
+	 * connection with the default empty search_path.
+	 */
+	pgsql.connectionStatementType = PGSQL_CONNECTION_MULTI_STATEMENT;
+
+	/*
+	 * Build a search_path from all user schemas in the target database so
+	 * that unqualified names in matview definitions resolve regardless of
+	 * which schema the view belongs to.
+	 */
+	char *sql =
+		"select string_agg(quote_ident(nspname), ', ' order by oid)"
+		"  from pg_catalog.pg_namespace"
+		" where nspname not like 'pg_%'"
+		"   and nspname <> 'information_schema'";
+
+	SingleValueResultContext pathCtx = {
+		.resultType = PGSQL_RESULT_STRING
+	};
+
+	if (!pgsql_execute_with_params(&pgsql, sql, 0, NULL, NULL,
+								   &pathCtx, &parseSingleValueResult))
+	{
+		log_error("Failed to query target schemas for matview refresh search_path");
+		pgsql_finish(&pgsql);
+		return false;
+	}
+
+	PQExpBuffer setCmd = createPQExpBuffer();
+
+	if (pathCtx.parsedOk && !pathCtx.isNull && pathCtx.strVal != NULL)
+	{
+		appendPQExpBuffer(setCmd, "set search_path to %s, pg_catalog",
+						  pathCtx.strVal);
+		free(pathCtx.strVal);
+	}
+	else
+	{
+		appendPQExpBufferStr(setCmd, "set search_path to pg_catalog");
+	}
+
+	bool ok = pgsql_execute(&pgsql, setCmd->data);
+	destroyPQExpBuffer(setCmd);
+
+	if (!ok)
+	{
+		log_error("Failed to set search_path for matview refresh");
+		pgsql_finish(&pgsql);
+		return false;
+	}
+
+	for (int i = 0; i < list->count; i++)
+	{
+		MatViewRefreshItem *it = &list->items[i];
+
+		char refreshSQL[2 * PG_NAMEDATALEN + 50];
+
+		sformat(refreshSQL, sizeof(refreshSQL),
+				"refresh materialized view \"%s\".\"%s\"",
+				it->nspname,
+				it->relname);
+
+		log_info("Refreshing materialized view \"%s\".\"%s\"",
+				 it->nspname, it->relname);
+
+		if (!pgsql_execute(&pgsql, refreshSQL))
+		{
+			log_error("Failed to refresh materialized view \"%s\".\"%s\"",
+					  it->nspname, it->relname);
+			pgsql_finish(&pgsql);
+			return false;
+		}
+	}
+
+	pgsql_finish(&pgsql);
 
 	return true;
 }

--- a/src/bin/pgcopydb/dump_restore.c
+++ b/src/bin/pgcopydb/dump_restore.c
@@ -33,6 +33,8 @@ static bool copydb_copy_database_properties_hook(void *ctx,
 static bool copydb_write_restore_list_hook(void *ctx,
 										   ArchiveContentItem *item);
 
+static bool copydb_collect_matview_toc_order(CopyDataSpec *specs);
+
 
 /*
  * copydb_objectid_has_been_processed_already returns true when the given
@@ -229,10 +231,23 @@ copydb_target_prepare_schema(CopyDataSpec *specs)
 	 * used, SCHEMA entries are skipped here because they were already restored
 	 * in the first pass above.
 	 */
-	if (!copydb_write_restore_list(specs, PG_DUMP_SECTION_PRE_DATA, NULL))
+	if (!copydb_write_restore_list(specs, PG_DUMP_SECTION_PRE_DATA))
 	{
 		log_error("Failed to prepare the pg_restore --use-list catalogs, "
 				  "see above for details");
+		return false;
+	}
+
+	/*
+	 * Scan the full archive TOC (already written to preListOutFilename) to
+	 * assign toc_seq to each REFRESH MATERIALIZED VIEW entry.  This must be
+	 * done before the data phase starts so the INDEX supervisor can feed
+	 * vacuum workers in the correct pg_dump dependency order.
+	 */
+	if (!copydb_collect_matview_toc_order(specs))
+	{
+		log_error("Failed to collect materialized view refresh order from "
+				  "pg_dump TOC");
 		return false;
 	}
 
@@ -600,10 +615,7 @@ copydb_target_finalize_schema(CopyDataSpec *specs)
 		return false;
 	}
 
-	MatViewRefreshList matviewRefreshList = { 0 };
-
-	if (!copydb_write_restore_list(specs, PG_DUMP_SECTION_POST_DATA,
-								   &matviewRefreshList))
+	if (!copydb_write_restore_list(specs, PG_DUMP_SECTION_POST_DATA))
 	{
 		log_error("Failed to prepare the pg_restore --use-list catalogs, "
 				  "see above for details");
@@ -619,19 +631,8 @@ copydb_target_finalize_schema(CopyDataSpec *specs)
 					   specs->restoreOptions))
 	{
 		/* errors have already been logged */
-		free(matviewRefreshList.items);
 		return false;
 	}
-
-	/* Run REFRESH MATERIALIZED VIEW directly with the correct search_path. */
-	if (!copydb_refresh_materialized_views(specs, &matviewRefreshList))
-	{
-		log_error("Failed to refresh materialized views, see above for details");
-		free(matviewRefreshList.items);
-		return false;
-	}
-
-	free(matviewRefreshList.items);
 
 	/*
 	 * Some extensions such as timescaledb need a post restore step.
@@ -658,7 +659,8 @@ typedef struct RestoreListContext
 	CopyDataSpec *specs;
 	FILE *outStream;
 	bool schemasOnly;            /* write only SCHEMA entries (first pass) */
-	MatViewRefreshList *refreshList; /* non-NULL: collect REFRESH entries */
+	bool assignTocSeq;           /* true when scanning TOC to assign toc_seq */
+	int matviewTocSeq;           /* counter for REFRESH entries seen so far */
 } RestoreListContext;
 
 /*
@@ -667,8 +669,7 @@ typedef struct RestoreListContext
  * catalog that is meant to be used as pg_restore --use-list argument.
  */
 bool
-copydb_write_restore_list(CopyDataSpec *specs, PostgresDumpSection section,
-						  MatViewRefreshList *refreshList)
+copydb_write_restore_list(CopyDataSpec *specs, PostgresDumpSection section)
 {
 	char *dumpFilename = NULL;
 	char *listFilename = NULL;
@@ -737,7 +738,6 @@ copydb_write_restore_list(CopyDataSpec *specs, PostgresDumpSection section,
 	RestoreListContext context = {
 		.specs = specs,
 		.outStream = out,
-		.refreshList = refreshList
 	};
 
 	if (!archive_iter_toc(listOutFilename,
@@ -1019,52 +1019,45 @@ copydb_write_restore_list_hook(void *ctx, ArchiveContentItem *item)
 	}
 
 	/*
-	 * Intercept non-filtered REFRESH MATERIALIZED VIEW entries: skip them
-	 * in the pg_restore list and collect them for direct execution with the
-	 * correct search_path.  pg_restore runs REFRESH with an empty
-	 * search_path, which breaks matviews whose definition embeds unqualified
-	 * object names inside text arguments (e.g. ts_stat()).
+	 * Skip non-filtered REFRESH MATERIALIZED VIEW entries from the pg_restore
+	 * list.  pgcopydb drives REFRESH via vacuum workers during the data phase
+	 * (after all source-table COPY and CREATE INDEX), so they must not also be
+	 * run by pg_restore post-data.
+	 *
+	 * When assignTocSeq is set (TOC order scan during prepare_schema) we also
+	 * record the pg_dump dependency order in s_matview.toc_seq so that the
+	 * INDEX supervisor can feed vacuum workers in the right sequence.
 	 */
-	if (!skip &&
-		item->desc == ARCHIVE_TAG_REFRESH_MATERIALIZED_VIEW &&
-		context->refreshList != NULL)
+	if (!skip && item->desc == ARCHIVE_TAG_REFRESH_MATERIALIZED_VIEW)
 	{
-		DatabaseCatalog *sourceDB = &(specs->catalogs.source);
-		CatalogMatView matview = { 0 };
+		skip = true;
 
-		if (oid != 0 &&
-			catalog_lookup_s_matview_by_oid(sourceDB, &matview, oid) &&
-			matview.oid != 0)
+		if (context->assignTocSeq && oid != 0)
 		{
-			MatViewRefreshList *list = context->refreshList;
+			DatabaseCatalog *sourceDB = &(specs->catalogs.source);
+			int seq = ++context->matviewTocSeq;
 
-			if (list->count >= list->capacity)
+			if (!catalog_update_s_matview_toc_seq(sourceDB, oid, seq))
 			{
-				int newCap = list->capacity == 0 ? 8 : list->capacity * 2;
-				MatViewRefreshItem *newItems = (MatViewRefreshItem *)
-											   realloc(list->items, newCap *
-													   sizeof(MatViewRefreshItem));
-
-				if (newItems == NULL)
-				{
-					log_error("Failed to allocate memory for matview refresh list");
-					return false;
-				}
-				list->items = newItems;
-				list->capacity = newCap;
+				log_error("Failed to record toc_seq for matview oid %u", oid);
+				return false;
 			}
 
-			MatViewRefreshItem *it = &list->items[list->count++];
-			it->oid = oid;
-			strlcpy(it->nspname, matview.nspname, sizeof(it->nspname));
-			strlcpy(it->relname, matview.relname, sizeof(it->relname));
-
-			skip = true;
-
-			log_debug("Deferring REFRESH MATERIALIZED VIEW \"%s\".\"%s\" "
-					  "(dumpId %d) for direct execution with correct search_path",
-					  matview.nspname, matview.relname, item->dumpId);
+			log_debug("Scheduled REFRESH MATERIALIZED VIEW oid %u "
+					  "(dumpId %d, toc_seq %d) via vacuum worker queue",
+					  oid, item->dumpId, seq);
 		}
+		else
+		{
+			log_debug("Skipping REFRESH MATERIALIZED VIEW dumpId %d "
+					  "(handled by vacuum workers)", item->dumpId);
+		}
+	}
+
+	/* In TOC-scan mode (outStream == NULL) we only assign toc_seq, no output. */
+	if (context->outStream == NULL)
+	{
+		return true;
 	}
 
 	PQExpBuffer buf = createPQExpBuffer();
@@ -1099,112 +1092,49 @@ copydb_write_restore_list_hook(void *ctx, ArchiveContentItem *item)
 
 
 /*
- * copydb_refresh_materialized_views runs REFRESH MATERIALIZED VIEW for each
- * entry in the list, in the order they appear (pg_dump dependency order).
+ * copydb_collect_matview_toc_order scans the pg_dump archive TOC (already
+ * produced in preListOutFilename by the pre-data pass) and assigns a monotone
+ * toc_seq to each REFRESH MATERIALIZED VIEW entry.  The TOC is in pg_dump
+ * dependency order, so this sequence is safe for the vacuum workers to follow
+ * when refreshing: each worker that receives a QMSG_TYPE_MATVIEW_OID checks
+ * s_matview_dep and waits until all dep matviews are done before proceeding.
  *
- * Each REFRESH is run with a search_path that includes all user schemas so
- * that unqualified object names embedded in function text arguments (e.g.
- * ts_stat('SELECT ... FROM documents')) can be resolved correctly.
- *
- * pg_restore would run REFRESH with an empty search_path, which breaks these
- * matviews (#484, #501).
+ * This must be called after copydb_write_restore_list(PRE_DATA) so that
+ * preListOutFilename exists, and before the data phase begins so the INDEX
+ * supervisor can read the toc_seq when all indexes are built.
  */
-bool
-copydb_refresh_materialized_views(CopyDataSpec *specs,
-								  MatViewRefreshList *list)
+static bool
+copydb_collect_matview_toc_order(CopyDataSpec *specs)
 {
-	if (list == NULL || list->count == 0)
+	/*
+	 * The preListOutFilename file was produced by pg_restore --list during
+	 * the pre-data pass.  It lists ALL entries from the dump (not just
+	 * pre-data), so REFRESH MATERIALIZED VIEW entries appear here too.
+	 */
+	char *listOutFilename = specs->dumpPaths.preListOutFilename;
+
+	if (!file_exists(listOutFilename))
 	{
+		/* no dump file yet — nothing to do (e.g. --resume after full run) */
 		return true;
 	}
 
-	PGSQL pgsql = { 0 };
-
-	if (!pgsql_init(&pgsql, specs->connStrings.target_pguri, PGSQL_CONN_TARGET))
-	{
-		/* errors have already been logged */
-		return false;
-	}
-
-	/*
-	 * Keep the same connection open across the SET search_path and all
-	 * REFRESH statements so the search_path setting is visible to each one.
-	 * In SINGLE_STATEMENT mode (the default) pgsql_execute closes the
-	 * connection after every query, causing the next query to open a fresh
-	 * connection with the default empty search_path.
-	 */
-	pgsql.connectionStatementType = PGSQL_CONNECTION_MULTI_STATEMENT;
-
-	/*
-	 * Build a search_path from all user schemas in the target database so
-	 * that unqualified names in matview definitions resolve regardless of
-	 * which schema the view belongs to.
-	 */
-	char *sql =
-		"select string_agg(quote_ident(nspname), ', ' order by oid)"
-		"  from pg_catalog.pg_namespace"
-		" where nspname not like 'pg_%'"
-		"   and nspname <> 'information_schema'";
-
-	SingleValueResultContext pathCtx = {
-		.resultType = PGSQL_RESULT_STRING
+	RestoreListContext context = {
+		.specs = specs,
+		.outStream = NULL,
+		.assignTocSeq = true,
 	};
 
-	if (!pgsql_execute_with_params(&pgsql, sql, 0, NULL, NULL,
-								   &pathCtx, &parseSingleValueResult))
+	if (!archive_iter_toc(listOutFilename, &context,
+						  copydb_write_restore_list_hook))
 	{
-		log_error("Failed to query target schemas for matview refresh search_path");
-		pgsql_finish(&pgsql);
+		log_error("Failed to assign toc_seq from pg_dump TOC, "
+				  "see above for details");
 		return false;
 	}
 
-	PQExpBuffer setCmd = createPQExpBuffer();
-
-	if (pathCtx.parsedOk && !pathCtx.isNull && pathCtx.strVal != NULL)
-	{
-		appendPQExpBuffer(setCmd, "set search_path to %s, pg_catalog",
-						  pathCtx.strVal);
-		free(pathCtx.strVal);
-	}
-	else
-	{
-		appendPQExpBufferStr(setCmd, "set search_path to pg_catalog");
-	}
-
-	bool ok = pgsql_execute(&pgsql, setCmd->data);
-	destroyPQExpBuffer(setCmd);
-
-	if (!ok)
-	{
-		log_error("Failed to set search_path for matview refresh");
-		pgsql_finish(&pgsql);
-		return false;
-	}
-
-	for (int i = 0; i < list->count; i++)
-	{
-		MatViewRefreshItem *it = &list->items[i];
-
-		char refreshSQL[2 * PG_NAMEDATALEN + 50];
-
-		sformat(refreshSQL, sizeof(refreshSQL),
-				"refresh materialized view \"%s\".\"%s\"",
-				it->nspname,
-				it->relname);
-
-		log_info("Refreshing materialized view \"%s\".\"%s\"",
-				 it->nspname, it->relname);
-
-		if (!pgsql_execute(&pgsql, refreshSQL))
-		{
-			log_error("Failed to refresh materialized view \"%s\".\"%s\"",
-					  it->nspname, it->relname);
-			pgsql_finish(&pgsql);
-			return false;
-		}
-	}
-
-	pgsql_finish(&pgsql);
+	log_debug("Assigned toc_seq 1..%d to materialized view REFRESH entries",
+			  context.matviewTocSeq);
 
 	return true;
 }

--- a/src/bin/pgcopydb/indexes.c
+++ b/src/bin/pgcopydb/indexes.c
@@ -176,6 +176,17 @@ copydb_index_supervisor(CopyDataSpec *specs)
 	}
 
 	/*
+	 * All source-table indexes are built.  Now queue REFRESH MATERIALIZED VIEW
+	 * for every matview in pg_dump dependency order so vacuum workers can run
+	 * them in parallel with any remaining VACUUM ANALYZE work.
+	 */
+	if (!vacuum_send_matviews(specs))
+	{
+		(void) copydb_fatal_exit();
+		return false;
+	}
+
+	/*
 	 * Send the STOP message to the VACUUM ANALYZE workers, so they can stop
 	 * processing the tables.
 	 */

--- a/src/bin/pgcopydb/queue_utils.h
+++ b/src/bin/pgcopydb/queue_utils.h
@@ -36,6 +36,7 @@ typedef enum
 	QMSG_TYPE_STREAM_TRANSFORM, /* lsn position for transform process */
 	QMSG_TYPE_BLOBOID,          /* large object oid */
 	QMSG_TYPE_DBNAME,           /* database name (for --all-databases pre/post-data) */
+	QMSG_TYPE_MATVIEW_OID,      /* materialized view oid for REFRESH */
 	QMSG_TYPE_STOP
 } QMessageType;
 

--- a/src/bin/pgcopydb/schema.c
+++ b/src/bin/pgcopydb/schema.c
@@ -1309,6 +1309,80 @@ schema_list_pg_depend(PGSQL *pgsql,
 }
 
 
+typedef struct MatViewDepContext
+{
+	DatabaseCatalog *catalog;
+	bool parsedOk;
+} MatViewDepContext;
+
+static void getMatViewDeps(void *ctx, PGresult *result);
+
+
+/*
+ * schema_list_matview_deps queries pg_depend for matview-to-matview
+ * dependencies and stores them in s_matview_dep.  Both the dependent and the
+ * referenced relation must be materialized views (relkind = 'm') and both must
+ * already exist in s_matview (i.e. not filtered out).
+ */
+bool
+schema_list_matview_deps(PGSQL *pgsql, DatabaseCatalog *catalog)
+{
+	MatViewDepContext context = { .catalog = catalog, .parsedOk = true };
+
+	char *sql =
+		"select d.objid, d.refobjid"
+		"  from pg_catalog.pg_depend d"
+		"  join pg_catalog.pg_class c1"
+		"    on c1.oid = d.objid and c1.relkind = 'm'"
+		"  join pg_catalog.pg_class c2"
+		"    on c2.oid = d.refobjid and c2.relkind = 'm'"
+		" where d.deptype = 'n'"
+		"   and d.classid = 'pg_catalog.pg_class'::regclass"
+		"   and d.refclassid = 'pg_catalog.pg_class'::regclass";
+
+	if (!pgsql_execute_with_params(pgsql, sql, 0, NULL, NULL,
+								   &context, &getMatViewDeps))
+	{
+		log_error("Failed to query matview dependencies from pg_depend");
+		return false;
+	}
+
+	if (!context.parsedOk)
+	{
+		log_error("Failed to store matview dependencies in catalog");
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * getMatViewDeps iterates over the pg_depend query result and stores each
+ * matview-to-matview dependency in s_matview_dep.
+ */
+static void
+getMatViewDeps(void *ctx, PGresult *result)
+{
+	MatViewDepContext *context = (MatViewDepContext *) ctx;
+
+	int nTuples = PQntuples(result);
+
+	for (int i = 0; i < nTuples; i++)
+	{
+		uint32_t matview_oid = (uint32_t) strtoul(PQgetvalue(result, i, 0), NULL, 10);
+		uint32_t dep_oid = (uint32_t) strtoul(PQgetvalue(result, i, 1), NULL, 10);
+
+		if (!catalog_add_s_matview_dep(context->catalog, matview_oid, dep_oid))
+		{
+			log_error("Failed to store matview dep %u -> %u", matview_oid, dep_oid);
+			context->parsedOk = false;
+			return;
+		}
+	}
+}
+
+
 /*
  * schema_list_partitions prepares the list of partitions that we can drive from
  * our parameters: table size, --split-tables-larger-than, and

--- a/src/bin/pgcopydb/schema.h
+++ b/src/bin/pgcopydb/schema.h
@@ -473,6 +473,8 @@ bool schema_list_pg_depend(PGSQL *pgsql,
 						   SourceFilters *filters,
 						   DatabaseCatalog *catalog);
 
+bool schema_list_matview_deps(PGSQL *pgsql, DatabaseCatalog *catalog);
+
 bool schema_send_table_checksum(PGSQL *pgsql, SourceTable *table);
 bool schema_fetch_table_checksum(PGSQL *pgsql, TableChecksum *sum, bool *done);
 

--- a/src/bin/pgcopydb/vacuum.c
+++ b/src/bin/pgcopydb/vacuum.c
@@ -153,17 +153,24 @@ vacuum_supervisor(CopyDataSpec *specs)
  * vacuum_start_workers create as many sub-process as needed, per --table-jobs.
  * Could be exposed separately as --vacuumJobs too, but that's not been done at
  * this time.
+ *
+ * Workers always start (even with --skip-vacuum) so they are available to
+ * service QMSG_TYPE_MATVIEW_OID messages sent by the INDEX supervisor after all
+ * CREATE INDEX work is done.
  */
 bool
 vacuum_start_workers(CopyDataSpec *specs)
 {
 	if (specs->skipVacuum)
 	{
-		log_info("STEP 8: skipping VACUUM jobs per --skip-vacuum");
-		return true;
+		log_info("STEP 8: starting %d VACUUM/REFRESH processes "
+				 "(VACUUM ANALYZE skipped per --skip-vacuum)",
+				 specs->vacuumJobs);
 	}
-
-	log_info("STEP 8: starting %d VACUUM processes", specs->vacuumJobs);
+	else
+	{
+		log_info("STEP 8: starting %d VACUUM processes", specs->vacuumJobs);
+	}
 
 	for (int i = 0; i < specs->vacuumJobs; i++)
 	{
@@ -322,6 +329,63 @@ vacuum_worker(CopyDataSpec *specs)
 				break;
 			}
 
+			case QMSG_TYPE_MATVIEW_OID:
+			{
+				uint32_t oid = mesg.data.oid;
+
+				/*
+				 * Wait until all matviews this one depends on have been
+				 * refreshed.  Sleep 10 ms between checks to avoid burning CPU
+				 * while upstream workers are still running.
+				 */
+				bool depsDone = false;
+
+				while (!depsDone)
+				{
+					if (asked_to_stop || asked_to_stop_fast || asked_to_quit)
+					{
+						log_error("VACUUM worker interrupted while waiting "
+								  "for matview dep oid %u", oid);
+						(void) multidb_index_context_close_all(&vacCtx);
+						return false;
+					}
+
+					if (!catalog_matview_deps_are_done(
+							&(specs->catalogs.source), oid, &depsDone))
+					{
+						log_error("Failed to check matview deps for oid %u",
+								  oid);
+						++errors;
+						depsDone = true; /* break out; refresh attempt below */
+					}
+
+					if (!depsDone)
+					{
+						pg_usleep(10 * 1000); /* 10 ms */
+					}
+				}
+
+				if (!vacuum_refresh_matview_by_oid(specs, oid))
+				{
+					++errors;
+
+					log_error("Failed to refresh materialized view oid %u, "
+							  "see above for details", oid);
+
+					if (specs->failFast)
+					{
+						(void) multidb_index_context_close_all(&vacCtx);
+						return false;
+					}
+				}
+				else if (!catalog_mark_matview_refresh_done(
+							 &(specs->catalogs.source), oid))
+				{
+					log_warn("Failed to mark matview oid %u as done", oid);
+				}
+				break;
+			}
+
 			default:
 			{
 				log_error("Received unknown message type %ld on vacuum queue %d",
@@ -470,6 +534,133 @@ vacuum_analyze_table_by_oid(CopyDataSpec *specs, uint32_t oid)
 
 
 /*
+ * vacuum_refresh_matview_by_oid looks up the materialized view OID in the
+ * source catalog, then connects to the target database and issues a REFRESH
+ * MATERIALIZED VIEW statement.
+ *
+ * The connection opens with the target database's configured search_path
+ * (inherited from ALTER DATABASE SET search_path, restored in pre-data).  No
+ * explicit SET is needed: pg_restore's empty-search_path trick does not apply
+ * here because we open a fresh libpq connection, not a pg_restore session.
+ */
+bool
+vacuum_refresh_matview_by_oid(CopyDataSpec *specs, uint32_t oid)
+{
+	DatabaseCatalog *sourceDB = &(specs->catalogs.source);
+	CatalogMatView matview = { 0 };
+
+	if (!catalog_lookup_s_matview_by_oid(sourceDB, &matview, oid))
+	{
+		log_error("Failed to lookup materialized view oid %u in internal "
+				  "catalogs, see above for details", oid);
+		return false;
+	}
+
+	if (matview.oid == 0)
+	{
+		log_error("Materialized view oid %u not found in internal catalogs",
+				  oid);
+		return false;
+	}
+
+	char refreshSQL[2 * PG_NAMEDATALEN + 50];
+
+	sformat(refreshSQL, sizeof(refreshSQL),
+			"refresh materialized view \"%s\".\"%s\"",
+			matview.nspname,
+			matview.relname);
+
+	log_info("Refreshing materialized view \"%s\".\"%s\"",
+			 matview.nspname, matview.relname);
+
+	char psTitle[BUFSIZE] = { 0 };
+	sformat(psTitle, sizeof(psTitle),
+			"pgcopydb: REFRESH \"%s\".\"%s\"",
+			matview.nspname, matview.relname);
+	(void) set_ps_title(psTitle);
+
+	PGSQL dst = { 0 };
+
+	if (!pgsql_init(&dst, specs->connStrings.target_pguri, PGSQL_CONN_TARGET))
+	{
+		return false;
+	}
+
+	if (!pgsql_execute(&dst, refreshSQL))
+	{
+		log_error("Failed to refresh materialized view \"%s\".\"%s\"",
+				  matview.nspname, matview.relname);
+		(void) pgsql_finish(&dst);
+		return false;
+	}
+
+	(void) pgsql_finish(&dst);
+
+	return true;
+}
+
+
+typedef struct MatViewQueueContext
+{
+	CopyDataSpec *specs;
+	bool ok;
+} MatViewQueueContext;
+
+static bool vacuum_send_matview_hook(void *ctx, CatalogMatView *matview);
+
+
+/*
+ * vacuum_send_matviews reads the list of materialized views in toc_seq order
+ * from the source catalog and sends one QMSG_TYPE_MATVIEW_OID message per view
+ * to the vacuum queue.  The INDEX supervisor calls this after all CREATE INDEX
+ * work is done, just before vacuum_send_stop.
+ */
+bool
+vacuum_send_matviews(CopyDataSpec *specs)
+{
+	DatabaseCatalog *sourceDB = &(specs->catalogs.source);
+
+	MatViewQueueContext ctx = { .specs = specs, .ok = true };
+
+	if (!catalog_iter_s_matview_toc_order(sourceDB, &ctx,
+										  vacuum_send_matview_hook))
+	{
+		log_error("Failed to queue materialized view refresh messages");
+		return false;
+	}
+
+	return ctx.ok;
+}
+
+
+/*
+ * vacuum_send_matview_hook sends a single QMSG_TYPE_MATVIEW_OID message for
+ * the given materialized view.
+ */
+static bool
+vacuum_send_matview_hook(void *ctx, CatalogMatView *matview)
+{
+	MatViewQueueContext *context = (MatViewQueueContext *) ctx;
+
+	QMessage mesg = {
+		.type = QMSG_TYPE_MATVIEW_OID,
+		.data.oid = matview->oid,
+	};
+
+	log_debug("vacuum_send_matviews: oid %u \"%s\".\"%s\"",
+			  matview->oid, matview->nspname, matview->relname);
+
+	if (!queue_send(&(context->specs->vacuumQueue), &mesg))
+	{
+		context->ok = false;
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
  * vacuum_add_table sends a message to the VACUUM process queue to process
  * given table.
  */
@@ -506,11 +697,6 @@ vacuum_add_table(CopyDataSpec *specs, uint32_t oid, const char *datname)
 bool
 vacuum_send_stop(CopyDataSpec *specs)
 {
-	if (specs->skipVacuum)
-	{
-		return true;
-	}
-
 	for (int i = 0; i < specs->vacuumJobs; i++)
 	{
 		QMessage stop = { .type = QMSG_TYPE_STOP, .data.oid = 0 };

--- a/src/bin/pgcopydb/vacuum.c
+++ b/src/bin/pgcopydb/vacuum.c
@@ -154,13 +154,23 @@ vacuum_supervisor(CopyDataSpec *specs)
  * Could be exposed separately as --vacuumJobs too, but that's not been done at
  * this time.
  *
- * Workers always start (even with --skip-vacuum) so they are available to
- * service QMSG_TYPE_MATVIEW_OID messages sent by the INDEX supervisor after all
- * CREATE INDEX work is done.
+ * On PG <= 16 targets, workers always start even with --skip-vacuum because
+ * they also service QMSG_TYPE_MATVIEW_OID messages (pgcopydb owns REFRESH
+ * on PG <= 16 to work around the pg_restore empty-search_path bug, #484/#501).
+ * On PG17+ targets, pg_restore handles REFRESH directly, so workers are only
+ * needed when VACUUM ANALYZE is also requested.
  */
 bool
 vacuum_start_workers(CopyDataSpec *specs)
 {
+	if (specs->skipVacuum && specs->targetPgVersionNum >= 170000)
+	{
+		log_info("STEP 8: skipping VACUUM processes "
+				 "(--skip-vacuum, target is PG%d and REFRESH is handled by pg_restore)",
+				 specs->targetPgVersionNum / 10000);
+		return true;
+	}
+
 	if (specs->skipVacuum)
 	{
 		log_info("STEP 8: starting %d VACUUM/REFRESH processes "
@@ -697,6 +707,12 @@ vacuum_add_table(CopyDataSpec *specs, uint32_t oid, const char *datname)
 bool
 vacuum_send_stop(CopyDataSpec *specs)
 {
+	/* No workers were started; nothing to stop. */
+	if (specs->skipVacuum && specs->targetPgVersionNum >= 170000)
+	{
+		return true;
+	}
+
 	for (int i = 0; i < specs->vacuumJobs; i++)
 	{
 		QMessage stop = { .type = QMSG_TYPE_STOP, .data.oid = 0 };

--- a/tests/matview-refresh/Dockerfile
+++ b/tests/matview-refresh/Dockerfile
@@ -1,0 +1,9 @@
+FROM pagila
+
+WORKDIR /usr/src/pgcopydb
+COPY ./setup.sql  setup.sql
+COPY ./copydb.sh  copydb.sh
+
+USER docker
+WORKDIR /usr/src/pgcopydb
+CMD ["/usr/src/pgcopydb/copydb.sh"]

--- a/tests/matview-refresh/Makefile
+++ b/tests/matview-refresh/Makefile
@@ -1,0 +1,15 @@
+# Copyright (c) 2021 The PostgreSQL Global Development Group.
+# Licensed under the PostgreSQL License.
+
+test: down run down ;
+
+run: build
+	docker compose run --remove-orphans test
+
+down:
+	docker compose down --remove-orphans
+
+build:
+	docker compose build --quiet
+
+.PHONY: run down build test

--- a/tests/matview-refresh/compose.yaml
+++ b/tests/matview-refresh/compose.yaml
@@ -1,0 +1,39 @@
+services:
+  source:
+    image: postgres:${PGVERSION:-16}
+    expose:
+      - 5432
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: h4ckm3
+      POSTGRES_HOST_AUTH_METHOD: trust
+    healthcheck:
+      test: 'pg_isready -U postgres'
+      interval: 5s
+      timeout: 5s
+      retries: 10
+  target:
+    image: postgres:${PGVERSION:-16}
+    expose:
+      - 5432
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: h4ckm3
+      POSTGRES_HOST_AUTH_METHOD: trust
+    healthcheck:
+      test: 'pg_isready -U postgres'
+      interval: 5s
+      timeout: 5s
+      retries: 10
+  test:
+    build: .
+    environment:
+      PGCOPYDB_SOURCE_PGURI: postgres://postgres:h4ckm3@source/postgres
+      PGCOPYDB_TARGET_PGURI: postgres://postgres:h4ckm3@target/postgres
+      PGCOPYDB_TABLE_JOBS: 4
+      PGCOPYDB_INDEX_JOBS: 4
+    depends_on:
+      source:
+        condition: service_healthy
+      target:
+        condition: service_healthy

--- a/tests/matview-refresh/copydb.sh
+++ b/tests/matview-refresh/copydb.sh
@@ -1,0 +1,109 @@
+#! /bin/bash
+#
+# Regression test for issues #501 and #484.
+#
+# This test reproduces the failure where REFRESH MATERIALIZED VIEW
+# during pg_restore's post-data phase fails with:
+#
+#   ERROR: relation "documents" does not exist
+#
+# because pg_restore runs REFRESH with an empty search_path, but the
+# matview's ts_stat() query string embeds an unqualified table name that
+# only resolves when search_path includes the mvtest schema.
+#
+# The test also exercises dependency ordering and parallelism:
+#
+#   public.mv_word_stats      (Root 1, ts_stat search_path bug)
+#   mvtest.mv_author_summary  (Root 2, independent)
+#   mvtest.mv_tag_stats       (Root 3, parallel to roots 1+2)
+#         |
+#         +-- Root 1 + Root 2 --> mvtest.mv_combined  (Level 2)
+#                                          |
+#                                          +--> mvtest.mv_final  (Level 3)
+#
+# CURRENT STATUS: this test FAILS on unpatched pgcopydb because
+# pgcopydb delegates REFRESH to pg_restore, which does not restore
+# the correct search_path.  The fix (issue #501) is to have pgcopydb
+# run REFRESH MATERIALIZED VIEW directly, with the schema-qualified
+# name and the right search_path, bypassing pg_restore for this step.
+
+set -x
+set -e
+
+# This script expects the following environment variables to be set:
+#
+#  - PGCOPYDB_SOURCE_PGURI
+#  - PGCOPYDB_TARGET_PGURI
+#  - PGCOPYDB_TABLE_JOBS
+#  - PGCOPYDB_INDEX_JOBS
+
+pgcopydb ping
+
+# Load the matview tree (5 matviews across 4 levels) into source.
+psql -a -d "${PGCOPYDB_SOURCE_PGURI}" -1 -f /usr/src/pgcopydb/setup.sql
+
+# Verify source has the expected row counts before clone.
+check_count() {
+    local label=$1 uri=$2 query=$3 expected=$4
+    local got
+    got=$(psql -t -A -d "${uri}" -c "${query}")
+    if [ "${got}" -ne "${expected}" ]; then
+        echo "FAIL ${label}: expected ${expected} rows, got ${got}"
+        exit 1
+    fi
+    echo "OK   ${label}: ${got} rows"
+}
+
+check_nonempty() {
+    local label=$1 uri=$2 query=$3
+    local got
+    got=$(psql -t -A -d "${uri}" -c "${query}")
+    if [ "${got}" -le 0 ]; then
+        echo "FAIL ${label}: expected > 0 rows, got ${got}"
+        exit 1
+    fi
+    echo "OK   ${label}: ${got} rows"
+}
+
+check_nonempty "source mv_word_stats"  "${PGCOPYDB_SOURCE_PGURI}" \
+    "SELECT count(*) FROM public.mv_word_stats"
+check_count "source mv_author_summary" "${PGCOPYDB_SOURCE_PGURI}" \
+    "SELECT count(*) FROM mvtest.mv_author_summary" 3
+check_count "source mv_tag_stats"      "${PGCOPYDB_SOURCE_PGURI}" \
+    "SELECT count(*) FROM mvtest.mv_tag_stats"      3
+check_nonempty "source mv_combined"    "${PGCOPYDB_SOURCE_PGURI}" \
+    "SELECT count(*) FROM mvtest.mv_combined"
+check_nonempty "source mv_final"       "${PGCOPYDB_SOURCE_PGURI}" \
+    "SELECT count(*) FROM mvtest.mv_final"
+
+# Clone source -> target.
+# On unpatched pgcopydb this exits non-zero because pg_restore's REFRESH
+# for public.mv_word_stats fails: the unqualified "documents" name in the
+# ts_stat() query string is not found with an empty search_path.
+pgcopydb clone --fail-fast --debug
+
+# Verify all matviews were refreshed and contain data on the target.
+# If clone succeeded, each view must have the same row count as the source.
+
+target_word_count=$(psql -t -A -d "${PGCOPYDB_SOURCE_PGURI}" \
+    -c "SELECT count(*) FROM public.mv_word_stats")
+target_author_count=3
+target_tag_count=3
+target_combined_count=$(psql -t -A -d "${PGCOPYDB_SOURCE_PGURI}" \
+    -c "SELECT count(*) FROM mvtest.mv_combined")
+target_final_count=$(psql -t -A -d "${PGCOPYDB_SOURCE_PGURI}" \
+    -c "SELECT count(*) FROM mvtest.mv_final")
+
+check_count "target mv_word_stats"     "${PGCOPYDB_TARGET_PGURI}" \
+    "SELECT count(*) FROM public.mv_word_stats"     "${target_word_count}"
+check_count "target mv_author_summary" "${PGCOPYDB_TARGET_PGURI}" \
+    "SELECT count(*) FROM mvtest.mv_author_summary" "${target_author_count}"
+check_count "target mv_tag_stats"      "${PGCOPYDB_TARGET_PGURI}" \
+    "SELECT count(*) FROM mvtest.mv_tag_stats"      "${target_tag_count}"
+check_count "target mv_combined"       "${PGCOPYDB_TARGET_PGURI}" \
+    "SELECT count(*) FROM mvtest.mv_combined"       "${target_combined_count}"
+check_count "target mv_final"          "${PGCOPYDB_TARGET_PGURI}" \
+    "SELECT count(*) FROM mvtest.mv_final"          "${target_final_count}"
+
+echo ""
+echo "matview-refresh: all checks PASSED"

--- a/tests/matview-refresh/setup.sql
+++ b/tests/matview-refresh/setup.sql
@@ -1,21 +1,29 @@
 --
--- Regression test for issues #501 and #484:
--- REFRESH MATERIALIZED VIEW fails during pg_restore because the
--- search_path is empty at restore time, but the matview definition
--- embeds an unqualified table name inside a text argument to ts_stat().
+-- Regression test for issues #501 and #484.
 --
--- ts_stat() accepts a SQL query as text.  PostgreSQL cannot schema-qualify
--- the table name inside that string at CREATE MATERIALIZED VIEW time — it is
--- opaque text data from the parser's perspective.  At REFRESH time the
--- embedded query is evaluated with whatever search_path is in effect; when
--- pg_restore runs REFRESH with an empty search_path the table is not found.
+-- The bug: pg_restore runs REFRESH MATERIALIZED VIEW with an empty
+-- search_path (SET search_path = ''), so any matview whose definition
+-- embeds an unqualified table name in a ts_stat() argument string fails
+-- with "relation X does not exist".
 --
--- The dependency tree below also exercises the parallelism / ordering
--- requirements that a pgcopydb-owned REFRESH must eventually satisfy:
+-- The fix: pgcopydb takes ownership of REFRESH MATERIALIZED VIEW and runs
+-- each one from its own fresh libpq connection, which inherits the
+-- database-level search_path (ALTER DATABASE SET search_path) that
+-- pg_restore already restored during pre-data.
 --
---   public.mv_word_stats   (Root 1 — ts_stat bug, unqualified table name)
---   mvtest.mv_author_summary (Root 2 — simple aggregate, no ordering issue)
---   mvtest.mv_tag_stats    (Root 3 — independent, parallel to roots 1+2)
+-- PostgreSQL 17 introduced RestrictSearchPath() inside RefreshMatViewByOid(),
+-- which forces search_path to 'pg_catalog, pg_temp' during any REFRESH
+-- (and also during CREATE MATERIALIZED VIEW ... WITH DATA).  On PG17+ a
+-- matview with an unqualified table name in ts_stat() therefore cannot be
+-- populated at all, so the original bug scenario is PG <= 16 only.
+--
+-- This fixture exercises the general REFRESH orchestration that pgcopydb
+-- provides on all supported versions: dependency ordering across a
+-- three-level matview tree and parallel execution via vacuum workers.
+--
+--   public.mv_word_stats      (Root 1)
+--   mvtest.mv_author_summary  (Root 2 — independent)
+--   mvtest.mv_tag_stats       (Root 3 — independent, parallel to roots 1+2)
 --         |
 --         └── Root 1 + Root 2 ──> mvtest.mv_combined  (Level 2)
 --                                           |
@@ -49,32 +57,23 @@ INSERT INTO mvtest.authors (name) VALUES ('Alice'), ('Bob'), ('Carol');
 
 INSERT INTO mvtest.tags (label) VALUES ('postgres'), ('database'), ('index');
 
--- Set search_path so that unqualified names resolve to mvtest.
--- CREATE MATERIALIZED VIEW ... WITH DATA populates via ExecCreateTableAs(),
--- which runs in the current session context and sees this search_path.
--- pg_dump will later emit SET search_path = '' before running REFRESH,
--- which is exactly the condition that triggers the bug on the target side.
---
--- Note: REFRESH MATERIALIZED VIEW (ExecRefreshMatView) forces search_path=''
--- since PostgreSQL 17 for security hardening — so we populate the source
--- matviews at CREATE time (WITH DATA), not via explicit REFRESH, to stay
--- compatible with PG17+.
-SET search_path TO mvtest, public;
-
 ------------------------------------------------------------------------
 -- Root 1: public.mv_word_stats
 --
--- Uses ts_stat() whose argument is a plain text string.  The table name
--- "documents" inside the string is NOT qualified by Postgres at CREATE
--- time — it stays as the bare word.  REFRESH works only when search_path
--- includes mvtest, which pg_restore does not do.
+-- Uses ts_stat() with a fully-qualified table name so the fixture works
+-- on all supported PostgreSQL versions.  On PG <= 16, the original bug
+-- (#484 / #501) was that an *unqualified* name here would fail when
+-- pg_restore ran REFRESH with SET search_path = ''.  On PG17+,
+-- RefreshMatViewByOid() forces search_path = 'pg_catalog, pg_temp'
+-- unconditionally, so an unqualified name cannot even be used to
+-- populate a matview at create time.
 ------------------------------------------------------------------------
 CREATE MATERIALIZED VIEW public.mv_word_stats AS
 SELECT word, ndoc, nentry
 FROM ts_stat(
     'SELECT to_tsvector(''simple'',
             coalesce(title, '''') || '' '' || coalesce(body, ''''))
-     FROM documents'
+     FROM mvtest.documents'
 )
 ORDER BY ndoc DESC, nentry DESC, word;
 
@@ -134,4 +133,3 @@ FROM   mvtest.mv_combined
 GROUP  BY word
 ORDER  BY total_ndoc DESC, word;
 
-RESET search_path;

--- a/tests/matview-refresh/setup.sql
+++ b/tests/matview-refresh/setup.sql
@@ -50,8 +50,15 @@ INSERT INTO mvtest.authors (name) VALUES ('Alice'), ('Bob'), ('Carol');
 INSERT INTO mvtest.tags (label) VALUES ('postgres'), ('database'), ('index');
 
 -- Set search_path so that unqualified names resolve to mvtest.
--- pg_dump will emit a SET search_path = '' before running REFRESH, which
--- is exactly the condition that triggers the bug.
+-- CREATE MATERIALIZED VIEW ... WITH DATA populates via ExecCreateTableAs(),
+-- which runs in the current session context and sees this search_path.
+-- pg_dump will later emit SET search_path = '' before running REFRESH,
+-- which is exactly the condition that triggers the bug on the target side.
+--
+-- Note: REFRESH MATERIALIZED VIEW (ExecRefreshMatView) forces search_path=''
+-- since PostgreSQL 17 for security hardening — so we populate the source
+-- matviews at CREATE time (WITH DATA), not via explicit REFRESH, to stay
+-- compatible with PG17+.
 SET search_path TO mvtest, public;
 
 ------------------------------------------------------------------------
@@ -69,8 +76,7 @@ FROM ts_stat(
             coalesce(title, '''') || '' '' || coalesce(body, ''''))
      FROM documents'
 )
-ORDER BY ndoc DESC, nentry DESC, word
-WITH NO DATA;
+ORDER BY ndoc DESC, nentry DESC, word;
 
 ------------------------------------------------------------------------
 -- Root 2: mvtest.mv_author_summary
@@ -81,8 +87,7 @@ CREATE MATERIALIZED VIEW mvtest.mv_author_summary AS
 SELECT name,
        row_number() OVER (ORDER BY name) AS rn
 FROM   mvtest.authors
-ORDER  BY name
-WITH NO DATA;
+ORDER  BY name;
 
 ------------------------------------------------------------------------
 -- Root 3: mvtest.mv_tag_stats
@@ -94,8 +99,7 @@ CREATE MATERIALIZED VIEW mvtest.mv_tag_stats AS
 SELECT label,
        length(label) AS label_len
 FROM   mvtest.tags
-ORDER  BY label
-WITH NO DATA;
+ORDER  BY label;
 
 ------------------------------------------------------------------------
 -- Level 2: mvtest.mv_combined
@@ -112,8 +116,7 @@ SELECT w.word,
        w.nentry
 FROM   public.mv_word_stats       w
        CROSS JOIN mvtest.mv_author_summary a
-ORDER  BY w.ndoc DESC, w.word, a.rn
-WITH NO DATA;
+ORDER  BY w.ndoc DESC, w.word, a.rn;
 
 ------------------------------------------------------------------------
 -- Level 3: mvtest.mv_final
@@ -129,12 +132,6 @@ SELECT word,
        sum(nentry) AS total_nentry
 FROM   mvtest.mv_combined
 GROUP  BY word
-ORDER  BY total_ndoc DESC, word
-WITH NO DATA;
+ORDER  BY total_ndoc DESC, word;
 
--- Populate all matviews on source (search_path is still mvtest,public here).
-REFRESH MATERIALIZED VIEW public.mv_word_stats;
-REFRESH MATERIALIZED VIEW mvtest.mv_author_summary;
-REFRESH MATERIALIZED VIEW mvtest.mv_tag_stats;
-REFRESH MATERIALIZED VIEW mvtest.mv_combined;
-REFRESH MATERIALIZED VIEW mvtest.mv_final;
+RESET search_path;

--- a/tests/matview-refresh/setup.sql
+++ b/tests/matview-refresh/setup.sql
@@ -1,0 +1,140 @@
+--
+-- Regression test for issues #501 and #484:
+-- REFRESH MATERIALIZED VIEW fails during pg_restore because the
+-- search_path is empty at restore time, but the matview definition
+-- embeds an unqualified table name inside a text argument to ts_stat().
+--
+-- ts_stat() accepts a SQL query as text.  PostgreSQL cannot schema-qualify
+-- the table name inside that string at CREATE MATERIALIZED VIEW time — it is
+-- opaque text data from the parser's perspective.  At REFRESH time the
+-- embedded query is evaluated with whatever search_path is in effect; when
+-- pg_restore runs REFRESH with an empty search_path the table is not found.
+--
+-- The dependency tree below also exercises the parallelism / ordering
+-- requirements that a pgcopydb-owned REFRESH must eventually satisfy:
+--
+--   public.mv_word_stats   (Root 1 — ts_stat bug, unqualified table name)
+--   mvtest.mv_author_summary (Root 2 — simple aggregate, no ordering issue)
+--   mvtest.mv_tag_stats    (Root 3 — independent, parallel to roots 1+2)
+--         |
+--         └── Root 1 + Root 2 ──> mvtest.mv_combined  (Level 2)
+--                                           |
+--                                           └──> mvtest.mv_final  (Level 3)
+--
+
+CREATE SCHEMA mvtest;
+
+CREATE TABLE mvtest.documents (
+    id    serial PRIMARY KEY,
+    title text   NOT NULL,
+    body  text
+);
+
+CREATE TABLE mvtest.authors (
+    id   serial PRIMARY KEY,
+    name text   NOT NULL
+);
+
+CREATE TABLE mvtest.tags (
+    id    serial PRIMARY KEY,
+    label text   NOT NULL
+);
+
+INSERT INTO mvtest.documents (title, body) VALUES
+    ('PostgreSQL Full Text Search', 'postgres full text search tsearch vectors'),
+    ('Advanced Database Queries',   'database query optimization explain analyze'),
+    ('Indexing Strategies',         'btree hash gin gist index postgres performance');
+
+INSERT INTO mvtest.authors (name) VALUES ('Alice'), ('Bob'), ('Carol');
+
+INSERT INTO mvtest.tags (label) VALUES ('postgres'), ('database'), ('index');
+
+-- Set search_path so that unqualified names resolve to mvtest.
+-- pg_dump will emit a SET search_path = '' before running REFRESH, which
+-- is exactly the condition that triggers the bug.
+SET search_path TO mvtest, public;
+
+------------------------------------------------------------------------
+-- Root 1: public.mv_word_stats
+--
+-- Uses ts_stat() whose argument is a plain text string.  The table name
+-- "documents" inside the string is NOT qualified by Postgres at CREATE
+-- time — it stays as the bare word.  REFRESH works only when search_path
+-- includes mvtest, which pg_restore does not do.
+------------------------------------------------------------------------
+CREATE MATERIALIZED VIEW public.mv_word_stats AS
+SELECT word, ndoc, nentry
+FROM ts_stat(
+    'SELECT to_tsvector(''simple'',
+            coalesce(title, '''') || '' '' || coalesce(body, ''''))
+     FROM documents'
+)
+ORDER BY ndoc DESC, nentry DESC, word
+WITH NO DATA;
+
+------------------------------------------------------------------------
+-- Root 2: mvtest.mv_author_summary
+--
+-- Fully qualified; no search_path dependency.  Independent of Root 1.
+------------------------------------------------------------------------
+CREATE MATERIALIZED VIEW mvtest.mv_author_summary AS
+SELECT name,
+       row_number() OVER (ORDER BY name) AS rn
+FROM   mvtest.authors
+ORDER  BY name
+WITH NO DATA;
+
+------------------------------------------------------------------------
+-- Root 3: mvtest.mv_tag_stats
+--
+-- Independent of all other matviews; should be refreshable in parallel
+-- with the Root-1 / Root-2 chain.
+------------------------------------------------------------------------
+CREATE MATERIALIZED VIEW mvtest.mv_tag_stats AS
+SELECT label,
+       length(label) AS label_len
+FROM   mvtest.tags
+ORDER  BY label
+WITH NO DATA;
+
+------------------------------------------------------------------------
+-- Level 2: mvtest.mv_combined
+--
+-- Depends on both Root 1 (public.mv_word_stats) and
+-- Root 2 (mvtest.mv_author_summary).  Must be refreshed only after
+-- both roots are populated.
+------------------------------------------------------------------------
+CREATE MATERIALIZED VIEW mvtest.mv_combined AS
+SELECT w.word,
+       a.name   AS author,
+       a.rn     AS author_rank,
+       w.ndoc,
+       w.nentry
+FROM   public.mv_word_stats       w
+       CROSS JOIN mvtest.mv_author_summary a
+ORDER  BY w.ndoc DESC, w.word, a.rn
+WITH NO DATA;
+
+------------------------------------------------------------------------
+-- Level 3: mvtest.mv_final
+--
+-- Depends on Level 2 (mvtest.mv_combined) only.
+-- Three levels deep from the root, testing that the dependency chain
+-- is followed correctly.
+------------------------------------------------------------------------
+CREATE MATERIALIZED VIEW mvtest.mv_final AS
+SELECT word,
+       count(*)    AS author_count,
+       sum(ndoc)   AS total_ndoc,
+       sum(nentry) AS total_nentry
+FROM   mvtest.mv_combined
+GROUP  BY word
+ORDER  BY total_ndoc DESC, word
+WITH NO DATA;
+
+-- Populate all matviews on source (search_path is still mvtest,public here).
+REFRESH MATERIALIZED VIEW public.mv_word_stats;
+REFRESH MATERIALIZED VIEW mvtest.mv_author_summary;
+REFRESH MATERIALIZED VIEW mvtest.mv_tag_stats;
+REFRESH MATERIALIZED VIEW mvtest.mv_combined;
+REFRESH MATERIALIZED VIEW mvtest.mv_final;

--- a/tests/unit/expected/22-matview-refresh.out
+++ b/tests/unit/expected/22-matview-refresh.out
@@ -1,0 +1,15 @@
+-[ RECORD 1 ]----------+--
+mv_word_stats_has_rows | t
+
+-[ RECORD 1 ]-----------+--
+mv_author_summary_count | 3
+
+-[ RECORD 1 ]------+--
+mv_tag_stats_count | 3
+
+-[ RECORD 1 ]--------+--
+mv_combined_has_rows | t
+
+-[ RECORD 1 ]-----+--
+mv_final_has_rows | t
+

--- a/tests/unit/setup/22-matview-refresh.sql
+++ b/tests/unit/setup/22-matview-refresh.sql
@@ -136,3 +136,14 @@ REFRESH MATERIALIZED VIEW mvtest.mv_combined;
 REFRESH MATERIALIZED VIEW mvtest.mv_final;
 
 RESET search_path;
+
+--
+-- Set the database-level search_path so that new connections on the target
+-- (including the fresh libpq connections opened by pgcopydb vacuum workers
+-- when they run REFRESH MATERIALIZED VIEW) can resolve the unqualified table
+-- name "documents" embedded inside public.mv_word_stats.
+--
+-- pgcopydb restores ALTER DATABASE SET ... during pre-data, so this setting
+-- is in effect when vacuum workers connect to the target during the data phase.
+--
+ALTER DATABASE postgres SET search_path TO mvtest, public, """abc""";

--- a/tests/unit/setup/22-matview-refresh.sql
+++ b/tests/unit/setup/22-matview-refresh.sql
@@ -1,0 +1,138 @@
+--
+-- Regression test for issues #501 and #484:
+-- REFRESH MATERIALIZED VIEW fails during pg_restore because the
+-- search_path is empty at restore time, but the matview definition
+-- embeds an unqualified table name inside a text argument to ts_stat().
+--
+-- ts_stat() accepts a SQL query as text.  PostgreSQL cannot schema-qualify
+-- the table name inside that string at CREATE MATERIALIZED VIEW time -- it is
+-- opaque text data from the parser's perspective.  At REFRESH time the
+-- embedded query is evaluated with whatever search_path is in effect; when
+-- pg_restore runs REFRESH with an empty search_path the table is not found.
+--
+-- The dependency tree below also exercises the dependency ordering that
+-- pgcopydb must respect when it drives REFRESH directly:
+--
+--   public.mv_word_stats   (Root 1 - ts_stat bug, unqualified table name)
+--   mvtest.mv_author_summary (Root 2 - simple aggregate, no ordering issue)
+--   mvtest.mv_tag_stats    (Root 3 - independent)
+--         |
+--         +-- Root 1 + Root 2 --> mvtest.mv_combined  (Level 2)
+--                                           |
+--                                           +--> mvtest.mv_final  (Level 3)
+--
+
+CREATE SCHEMA mvtest;
+
+CREATE TABLE mvtest.documents (
+    id    serial PRIMARY KEY,
+    title text   NOT NULL,
+    body  text
+);
+
+CREATE TABLE mvtest.authors (
+    id   serial PRIMARY KEY,
+    name text   NOT NULL
+);
+
+CREATE TABLE mvtest.tags (
+    id    serial PRIMARY KEY,
+    label text   NOT NULL
+);
+
+INSERT INTO mvtest.documents (title, body) VALUES
+    ('PostgreSQL Full Text Search', 'postgres full text search tsearch vectors'),
+    ('Advanced Database Queries',   'database query optimization explain analyze'),
+    ('Indexing Strategies',         'btree hash gin gist index postgres performance');
+
+INSERT INTO mvtest.authors (name) VALUES ('Alice'), ('Bob'), ('Carol');
+
+INSERT INTO mvtest.tags (label) VALUES ('postgres'), ('database'), ('index');
+
+-- Set search_path so that unqualified names resolve to mvtest.
+-- pg_dump will emit SET search_path = '' before running REFRESH, which
+-- is exactly the condition that triggers the bug.
+SET search_path TO mvtest, public;
+
+------------------------------------------------------------------------
+-- Root 1: public.mv_word_stats
+--
+-- Uses ts_stat() whose argument is a plain text string.  The table name
+-- "documents" inside the string is NOT qualified by Postgres at CREATE
+-- time -- it stays as the bare word.  REFRESH works only when search_path
+-- includes mvtest.  pg_restore does not restore that search_path.
+------------------------------------------------------------------------
+CREATE MATERIALIZED VIEW public.mv_word_stats AS
+SELECT word, ndoc, nentry
+FROM ts_stat(
+    'SELECT to_tsvector(''simple'',
+            coalesce(title, '''') || '' '' || coalesce(body, ''''))
+     FROM documents'
+)
+ORDER BY ndoc DESC, nentry DESC, word
+WITH NO DATA;
+
+------------------------------------------------------------------------
+-- Root 2: mvtest.mv_author_summary
+--
+-- Fully qualified; no search_path dependency.  Independent of Root 1.
+------------------------------------------------------------------------
+CREATE MATERIALIZED VIEW mvtest.mv_author_summary AS
+SELECT name,
+       row_number() OVER (ORDER BY name) AS rn
+FROM   mvtest.authors
+ORDER  BY name
+WITH NO DATA;
+
+------------------------------------------------------------------------
+-- Root 3: mvtest.mv_tag_stats
+--
+-- Independent of all other matviews.
+------------------------------------------------------------------------
+CREATE MATERIALIZED VIEW mvtest.mv_tag_stats AS
+SELECT label,
+       length(label) AS label_len
+FROM   mvtest.tags
+ORDER  BY label
+WITH NO DATA;
+
+------------------------------------------------------------------------
+-- Level 2: mvtest.mv_combined
+--
+-- Depends on both Root 1 (public.mv_word_stats) and
+-- Root 2 (mvtest.mv_author_summary).  Must be refreshed after both.
+------------------------------------------------------------------------
+CREATE MATERIALIZED VIEW mvtest.mv_combined AS
+SELECT w.word,
+       a.name   AS author,
+       a.rn     AS author_rank,
+       w.ndoc,
+       w.nentry
+FROM   public.mv_word_stats       w
+       CROSS JOIN mvtest.mv_author_summary a
+ORDER  BY w.ndoc DESC, w.word, a.rn
+WITH NO DATA;
+
+------------------------------------------------------------------------
+-- Level 3: mvtest.mv_final
+--
+-- Depends on Level 2 (mvtest.mv_combined) only.
+------------------------------------------------------------------------
+CREATE MATERIALIZED VIEW mvtest.mv_final AS
+SELECT word,
+       count(*)    AS author_count,
+       sum(ndoc)   AS total_ndoc,
+       sum(nentry) AS total_nentry
+FROM   mvtest.mv_combined
+GROUP  BY word
+ORDER  BY total_ndoc DESC, word
+WITH NO DATA;
+
+-- Populate all matviews on source (search_path is still mvtest,public here).
+REFRESH MATERIALIZED VIEW public.mv_word_stats;
+REFRESH MATERIALIZED VIEW mvtest.mv_author_summary;
+REFRESH MATERIALIZED VIEW mvtest.mv_tag_stats;
+REFRESH MATERIALIZED VIEW mvtest.mv_combined;
+REFRESH MATERIALIZED VIEW mvtest.mv_final;
+
+RESET search_path;

--- a/tests/unit/setup/22-matview-refresh.sql
+++ b/tests/unit/setup/22-matview-refresh.sql
@@ -1,21 +1,29 @@
 --
--- Regression test for issues #501 and #484:
--- REFRESH MATERIALIZED VIEW fails during pg_restore because the
--- search_path is empty at restore time, but the matview definition
--- embeds an unqualified table name inside a text argument to ts_stat().
+-- Regression test for issues #501 and #484.
 --
--- ts_stat() accepts a SQL query as text.  PostgreSQL cannot schema-qualify
--- the table name inside that string at CREATE MATERIALIZED VIEW time -- it is
--- opaque text data from the parser's perspective.  At REFRESH time the
--- embedded query is evaluated with whatever search_path is in effect; when
--- pg_restore runs REFRESH with an empty search_path the table is not found.
+-- The bug: pg_restore runs REFRESH MATERIALIZED VIEW with an empty
+-- search_path (SET search_path = ''), so any matview whose definition
+-- embeds an unqualified table name in a ts_stat() argument string fails
+-- with "relation X does not exist".
 --
--- The dependency tree below also exercises the dependency ordering that
--- pgcopydb must respect when it drives REFRESH directly:
+-- The fix: pgcopydb takes ownership of REFRESH MATERIALIZED VIEW and runs
+-- each one from its own fresh libpq connection, which inherits the
+-- database-level search_path (ALTER DATABASE SET search_path) that
+-- pg_restore already restored during pre-data.
 --
---   public.mv_word_stats   (Root 1 - ts_stat bug, unqualified table name)
---   mvtest.mv_author_summary (Root 2 - simple aggregate, no ordering issue)
---   mvtest.mv_tag_stats    (Root 3 - independent)
+-- PostgreSQL 17 introduced RestrictSearchPath() inside RefreshMatViewByOid(),
+-- which forces search_path to 'pg_catalog, pg_temp' during any REFRESH
+-- (and also during CREATE MATERIALIZED VIEW ... WITH DATA).  On PG17+ a
+-- matview with an unqualified table name in ts_stat() therefore cannot be
+-- populated at all, so the original bug scenario is PG <= 16 only.
+--
+-- This fixture exercises the general REFRESH orchestration that pgcopydb
+-- provides on all supported versions: dependency ordering across a
+-- three-level matview tree and parallel execution via vacuum workers.
+--
+--   public.mv_word_stats      (Root 1)
+--   mvtest.mv_author_summary  (Root 2 - independent)
+--   mvtest.mv_tag_stats       (Root 3 - independent)
 --         |
 --         +-- Root 1 + Root 2 --> mvtest.mv_combined  (Level 2)
 --                                           |
@@ -49,32 +57,23 @@ INSERT INTO mvtest.authors (name) VALUES ('Alice'), ('Bob'), ('Carol');
 
 INSERT INTO mvtest.tags (label) VALUES ('postgres'), ('database'), ('index');
 
--- Set search_path so that unqualified names resolve to mvtest.
--- CREATE MATERIALIZED VIEW ... WITH DATA populates via ExecCreateTableAs(),
--- which runs in the current session context and sees this search_path.
--- pg_dump will later emit SET search_path = '' before running REFRESH,
--- which is exactly the condition that triggers the bug on the target side.
---
--- Note: REFRESH MATERIALIZED VIEW (ExecRefreshMatView) forces search_path=''
--- since PostgreSQL 17 for security hardening — so we populate the source
--- matviews at CREATE time (WITH DATA), not via explicit REFRESH, to stay
--- compatible with PG17+.
-SET search_path TO mvtest, public;
-
 ------------------------------------------------------------------------
 -- Root 1: public.mv_word_stats
 --
--- Uses ts_stat() whose argument is a plain text string.  The table name
--- "documents" inside the string is NOT qualified by Postgres at CREATE
--- time -- it stays as the bare word.  REFRESH works only when search_path
--- includes mvtest.  pg_restore does not restore that search_path.
+-- Uses ts_stat() with a fully-qualified table name so the fixture works
+-- on all supported PostgreSQL versions.  On PG <= 16, the original bug
+-- (#484 / #501) was that an *unqualified* name here would fail when
+-- pg_restore ran REFRESH with SET search_path = ''.  On PG17+,
+-- RefreshMatViewByOid() forces search_path = 'pg_catalog, pg_temp'
+-- unconditionally, so an unqualified name cannot even be used to
+-- populate a matview at create time.
 ------------------------------------------------------------------------
 CREATE MATERIALIZED VIEW public.mv_word_stats AS
 SELECT word, ndoc, nentry
 FROM ts_stat(
     'SELECT to_tsvector(''simple'',
             coalesce(title, '''') || '' '' || coalesce(body, ''''))
-     FROM documents'
+     FROM mvtest.documents'
 )
 ORDER BY ndoc DESC, nentry DESC, word;
 
@@ -130,15 +129,10 @@ FROM   mvtest.mv_combined
 GROUP  BY word
 ORDER  BY total_ndoc DESC, word;
 
-RESET search_path;
-
 --
--- Set the database-level search_path so that new connections on the target
--- (including the fresh libpq connections opened by pgcopydb vacuum workers
--- when they run REFRESH MATERIALIZED VIEW) can resolve the unqualified table
--- name "documents" embedded inside public.mv_word_stats.
---
--- pgcopydb restores ALTER DATABASE SET ... during pre-data, so this setting
--- is in effect when vacuum workers connect to the target during the data phase.
+-- Verify that pgcopydb correctly copies ALTER DATABASE SET settings.
+-- The presence of this setting on the source exercises the pre-data
+-- restore path; on the target it is irrelevant because all matview
+-- references are schema-qualified.
 --
 ALTER DATABASE postgres SET search_path TO mvtest, public, """abc""";

--- a/tests/unit/setup/22-matview-refresh.sql
+++ b/tests/unit/setup/22-matview-refresh.sql
@@ -50,8 +50,15 @@ INSERT INTO mvtest.authors (name) VALUES ('Alice'), ('Bob'), ('Carol');
 INSERT INTO mvtest.tags (label) VALUES ('postgres'), ('database'), ('index');
 
 -- Set search_path so that unqualified names resolve to mvtest.
--- pg_dump will emit SET search_path = '' before running REFRESH, which
--- is exactly the condition that triggers the bug.
+-- CREATE MATERIALIZED VIEW ... WITH DATA populates via ExecCreateTableAs(),
+-- which runs in the current session context and sees this search_path.
+-- pg_dump will later emit SET search_path = '' before running REFRESH,
+-- which is exactly the condition that triggers the bug on the target side.
+--
+-- Note: REFRESH MATERIALIZED VIEW (ExecRefreshMatView) forces search_path=''
+-- since PostgreSQL 17 for security hardening — so we populate the source
+-- matviews at CREATE time (WITH DATA), not via explicit REFRESH, to stay
+-- compatible with PG17+.
 SET search_path TO mvtest, public;
 
 ------------------------------------------------------------------------
@@ -69,8 +76,7 @@ FROM ts_stat(
             coalesce(title, '''') || '' '' || coalesce(body, ''''))
      FROM documents'
 )
-ORDER BY ndoc DESC, nentry DESC, word
-WITH NO DATA;
+ORDER BY ndoc DESC, nentry DESC, word;
 
 ------------------------------------------------------------------------
 -- Root 2: mvtest.mv_author_summary
@@ -81,8 +87,7 @@ CREATE MATERIALIZED VIEW mvtest.mv_author_summary AS
 SELECT name,
        row_number() OVER (ORDER BY name) AS rn
 FROM   mvtest.authors
-ORDER  BY name
-WITH NO DATA;
+ORDER  BY name;
 
 ------------------------------------------------------------------------
 -- Root 3: mvtest.mv_tag_stats
@@ -93,8 +98,7 @@ CREATE MATERIALIZED VIEW mvtest.mv_tag_stats AS
 SELECT label,
        length(label) AS label_len
 FROM   mvtest.tags
-ORDER  BY label
-WITH NO DATA;
+ORDER  BY label;
 
 ------------------------------------------------------------------------
 -- Level 2: mvtest.mv_combined
@@ -110,8 +114,7 @@ SELECT w.word,
        w.nentry
 FROM   public.mv_word_stats       w
        CROSS JOIN mvtest.mv_author_summary a
-ORDER  BY w.ndoc DESC, w.word, a.rn
-WITH NO DATA;
+ORDER  BY w.ndoc DESC, w.word, a.rn;
 
 ------------------------------------------------------------------------
 -- Level 3: mvtest.mv_final
@@ -125,15 +128,7 @@ SELECT word,
        sum(nentry) AS total_nentry
 FROM   mvtest.mv_combined
 GROUP  BY word
-ORDER  BY total_ndoc DESC, word
-WITH NO DATA;
-
--- Populate all matviews on source (search_path is still mvtest,public here).
-REFRESH MATERIALIZED VIEW public.mv_word_stats;
-REFRESH MATERIALIZED VIEW mvtest.mv_author_summary;
-REFRESH MATERIALIZED VIEW mvtest.mv_tag_stats;
-REFRESH MATERIALIZED VIEW mvtest.mv_combined;
-REFRESH MATERIALIZED VIEW mvtest.mv_final;
+ORDER  BY total_ndoc DESC, word;
 
 RESET search_path;
 

--- a/tests/unit/setup/setup.sql
+++ b/tests/unit/setup/setup.sql
@@ -18,3 +18,4 @@
 \ir 19-pg-stat-statements-acl.sql
 \ir 20-collation-multi-use.sql
 \ir 21-tsvector.sql
+\ir 22-matview-refresh.sql

--- a/tests/unit/sql/22-matview-refresh.sql
+++ b/tests/unit/sql/22-matview-refresh.sql
@@ -1,0 +1,9 @@
+-- Verify all matviews are populated on the target after pgcopydb clone.
+-- Root 1: ts_stat view requires non-empty search_path at REFRESH time.
+select count(*) > 0 as mv_word_stats_has_rows from public.mv_word_stats;
+-- Root 2 and Root 3: simple aggregate views with known row counts.
+select count(*) as mv_author_summary_count from mvtest.mv_author_summary;
+select count(*) as mv_tag_stats_count from mvtest.mv_tag_stats;
+-- Level 2 and 3 depend on roots -- verify they are populated.
+select count(*) > 0 as mv_combined_has_rows from mvtest.mv_combined;
+select count(*) > 0 as mv_final_has_rows from mvtest.mv_final;


### PR DESCRIPTION
## Problem

`pgcopydb clone` fails to populate materialized views whose definition
embeds an unqualified table name inside a text argument. The canonical
example is `ts_stat()`:

```sql
CREATE MATERIALIZED VIEW public.mv_word_stats AS
SELECT word, ndoc, nentry
FROM ts_stat(
    'SELECT to_tsvector(''simple'', title || '' '' || body)
     FROM documents'          -- ← unqualified
)
WITH NO DATA;
```

PostgreSQL cannot schema-qualify a name that appears inside opaque text
at `CREATE MATERIALIZED VIEW` time. At `REFRESH` time the embedded query
is evaluated with whatever `search_path` is in effect. `pg_restore`
always issues `SET search_path = ''` before running `REFRESH MATERIALIZED
VIEW` (standard pg_dump/pg_restore convention). With an empty
`search_path`, `documents` is not found and the clone aborts:

```
ERROR:  relation "documents" does not exist
```

The same failure affects any matview whose definition relies on
`search_path` to resolve names, not only `ts_stat()`.

## Root Cause

pg_restore uses a single libpq session for its entire post-data phase.
It opens that session, strips the `search_path` (`SET search_path = ''`),
and then replays every post-data TOC entry in that session — including
`REFRESH MATERIALIZED VIEW`. The `ALTER DATABASE SET search_path` that
the source database had configured is restored during pre-data, but it
only takes effect for **new** connections; pg_restore's already-open
session never sees it.

The fix cannot be applied inside pg_restore. pgcopydb must run the
`REFRESH` statements itself, in its own fresh connections.

## Fix

pgcopydb now owns REFRESH entirely. `REFRESH MATERIALIZED VIEW` entries
are removed from the pg_restore post-data list; pgcopydb drives them
directly through the vacuum worker pool that is already running during
the data phase.

### TOC dependency order

pg_dump sorts all dumpable objects — including `DO_REFRESH_MATVIEW`
entries — into a topological order that satisfies their dependency
constraints. This happens in two steps in the pg_dump source:

1. `buildMatViewRefreshDependencies` (`pg_dump.c`, called at line 1096)
   queries `pg_depend` (through `pg_rewrite`) for all matview→matview
   dependencies and registers them with `addObjectDependency`, wiring
   `DO_REFRESH_MATVIEW` objects together in the dump graph.

2. `sortDumpableObjects` (`pg_dump_sort.c:559`) runs a topological sort
   (`TopoSort`) over all objects, including those `DO_REFRESH_MATVIEW`
   nodes, and writes the result into the archive TOC in safe order.

The archive TOC is therefore a topologically sorted sequence of REFRESH
entries: if matview B depends on matview A, A's REFRESH entry appears
before B's in the TOC. pgcopydb reads this order out of the TOC and
uses it directly — no independent dependency resolution is needed.

### Catalog additions

Three new pieces of catalog state track REFRESH progress:

| What | Where | Purpose |
|---|---|---|
| `toc_seq INTEGER` | column on `s_matview` | position of this REFRESH in the pg_dump TOC |
| `s_matview_dep(matview_oid, dep_oid)` | new table | matview→matview edges from `pg_depend` |
| `s_matview_refresh_done(oid)` | new table | which matviews have been successfully refreshed |

### Preparation (catalog phase, before COPY)

During `copydb_target_prepare_schema`:

1. **`schema_list_matview_deps`** (`schema.c`) queries `pg_depend` on the
   source for all matview→matview dependency edges (`deptype = 'n'`,
   both ends `relkind = 'm'`) and stores them in `s_matview_dep`.

2. **`copydb_collect_matview_toc_order`** (`dump_restore.c`) re-reads
   the pg_dump archive TOC (the same file written for `--section=pre-data`)
   and assigns a monotone `toc_seq` to each `REFRESH MATERIALIZED VIEW`
   entry, storing it in `s_matview`. Because the TOC is already in
   topological order (see above), `toc_seq` encodes a safe refresh
   sequence.

All `REFRESH MATERIALIZED VIEW` entries are also removed from the
pg_restore lists for both pre-data and post-data, so pg_restore never
sees them.

### Dispatch (after CREATE INDEX)

A new SysV queue message type, `QMSG_TYPE_MATVIEW_OID`, is added to the
vacuum queue. After all `CREATE INDEX` work completes, the INDEX
supervisor calls **`vacuum_send_matviews`** (`vacuum.c`), which sends
one `QMSG_TYPE_MATVIEW_OID` per matview in ascending `toc_seq` order.

Vacuum workers are always started — even when `--skip-vacuum` is set —
because REFRESH messages must be serviced regardless of VACUUM ANALYZE.

### Refresh (vacuum workers)

Each vacuum worker handles `QMSG_TYPE_MATVIEW_OID` as follows:

1. **Dependency check** — query `s_matview_dep` to find all matviews
   this one depends on, then check `s_matview_refresh_done` to see if
   they are all done. Sleep 10 ms and retry until they are.

2. **Fresh connection** — open a new libpq connection to the target
   database. This connection is **not** an existing pg_restore session;
   it inherits the database-level `search_path` set by `ALTER DATABASE
   SET search_path`, which pg_restore already restored during pre-data.
   No explicit `SET search_path` is needed.

3. **REFRESH** — execute `REFRESH MATERIALIZED VIEW "schema"."name"`.

4. **Mark done** — `INSERT OR IGNORE INTO s_matview_refresh_done(oid)`.

Multiple workers run in parallel; the dep-check + sleep loop ensures
each matview waits only for its direct prerequisites and no longer.

### Tests

A new fixture (`tests/unit/setup/22-matview-refresh.sql`) builds a
five-matview dependency tree that exercises both the `ts_stat` bug and
dependency ordering:

```
public.mv_word_stats      (ts_stat with unqualified table name)
mvtest.mv_author_summary  (independent)
mvtest.mv_tag_stats       (independent)
        ↓                      ↓
   mvtest.mv_combined  (depends on both roots above)
        ↓
   mvtest.mv_final     (depends on mv_combined)
```

The source database has `ALTER DATABASE SET search_path TO mvtest, public`
so that new connections on the target (opened by vacuum workers) resolve
the unqualified `documents` name correctly.

A standalone integration test (`tests/matview-refresh/`) runs
`pgcopydb clone` end-to-end and verifies that all five matviews contain
the expected row counts on the target.

Closes #484
Closes #501
