### PR TITLE
feat: add Citus-to-Citus migration support (#671)

### DIFF
--- a/src/bin/pgcopydb/extensions.c
+++ b/src/bin/pgcopydb/extensions.c
@@ -14,6 +14,7 @@
 #include "log.h"
 #include "schema.h"
 #include "signals.h"
+#include "sql_queries.h"
 
 
 static bool copydb_copy_ext_table(PGSQL *src, PGSQL *dst, char *qname, char *condition);
@@ -916,45 +917,14 @@ citus_prepare_restore(CopyDataSpec *copySpecs)
 		.ok = true
 	};
 
-	/*
-	 * Query 1: distributed tables.
-	 *
-	 * Within each co-location group (same colocation_id) order tables
-	 * alphabetically; the first one becomes the anchor and is created with
-	 * shard_count := N, colocate_with := 'none'.  Subsequent tables in the
-	 * group reference the anchor by name.
-	 */
-	char *distSql =
-		"with ordered as ("
-		"  select"
-		"    table_name::text                                          as tname,"
-		"    distribution_column,"
-		"    colocation_id,"
-		"    shard_count,"
-		"    row_number() over (partition by colocation_id"
-		"                       order by table_name::text)            as rn,"
-		"    first_value(table_name::text) over ("
-		"        partition by colocation_id"
-		"        order by table_name::text)                           as anchor"
-		"  from citus_tables"
-		"  where citus_table_type = 'distributed'"
-		")"
-		" select"
-		"  case"
-		"    when rn = 1 then"
-		"      format("
-		"        'select create_distributed_table(%L, %L,"
-		"                                         shard_count := %s,"
-		"                                         colocate_with := %L)',"
-		"        tname, distribution_column, shard_count, 'none')"
-		"    else"
-		"      format("
-		"        'select create_distributed_table(%L, %L,"
-		"                                         colocate_with := %L)',"
-		"        tname, distribution_column, anchor)"
-		"  end"
-		" from ordered"
-		" order by colocation_id, rn";
+	const char *distSql = NULL;
+
+	if (!pgcopydb_sql_citus_distributed_tables(&distSql))
+	{
+		(void) pgsql_finish(&src);
+		(void) pgsql_finish(&dst);
+		return false;
+	}
 
 	if (!pgsql_execute_with_params(&src, distSql,
 								   0, NULL, NULL,
@@ -974,18 +944,14 @@ citus_prepare_restore(CopyDataSpec *copySpecs)
 		return false;
 	}
 
-	/*
-	 * Query 2: reference tables.
-	 *
-	 * These are replicated in full to every worker node and must be created
-	 * after all distributed tables so they are never used as co-location
-	 * anchors by accident.
-	 */
-	char *refSql =
-		"select format('select create_reference_table(%L)', table_name::text)"
-		"  from citus_tables"
-		" where citus_table_type = 'reference'"
-		" order by table_name::text";
+	const char *refSql = NULL;
+
+	if (!pgcopydb_sql_citus_reference_tables(&refSql))
+	{
+		(void) pgsql_finish(&src);
+		(void) pgsql_finish(&dst);
+		return false;
+	}
 
 	if (!pgsql_execute_with_params(&src, refSql,
 								   0, NULL, NULL,

--- a/src/bin/pgcopydb/extensions.c
+++ b/src/bin/pgcopydb/extensions.c
@@ -20,6 +20,8 @@ static bool copydb_copy_ext_table(PGSQL *src, PGSQL *dst, char *qname, char *con
 static bool copydb_copy_ext_sequence(PGSQL *src, PGSQL *dst, char *qname);
 static bool copydb_copy_extensions_hook(void *ctx, SourceExtension *ext);
 static bool copydb_create_extension_hook(void *ctx, SourceExtension *ext);
+static bool citus_prepare_restore(CopyDataSpec *copySpecs);
+static void citusDistributeCallback(void *ctx, PGresult *result);
 
 
 /*
@@ -679,13 +681,13 @@ copydb_create_pinned_extensions(CopyDataSpec *copySpecs)
  * be needed for some extensions.
  *
  * At the moment we need to call timescaledb_pre_restore() when timescaledb has
- * been used.
+ * been used, and to distribute tables and reference tables when citus has been
+ * used.
  */
 bool
 copydb_prepare_extensions_restore(CopyDataSpec *copySpecs)
 {
 	DatabaseCatalog *filterDB = &(copySpecs->catalogs.filter);
-	const char *extensionName = "timescaledb";
 
 	SourceExtension *extension = (SourceExtension *) calloc(1, sizeof(SourceExtension));
 
@@ -695,7 +697,7 @@ copydb_prepare_extensions_restore(CopyDataSpec *copySpecs)
 		return false;
 	}
 
-	if (!catalog_lookup_s_extension_by_extname(filterDB, extensionName, extension))
+	if (!catalog_lookup_s_extension_by_extname(filterDB, "timescaledb", extension))
 	{
 		/* errors have already been logged*/
 		return false;
@@ -706,6 +708,25 @@ copydb_prepare_extensions_restore(CopyDataSpec *copySpecs)
 		log_info("Executing pre-restore steps for timescaledb extension");
 
 		if (!timescaledb_pre_restore(copySpecs, extension))
+		{
+			/* errors have already been logged */
+			return false;
+		}
+	}
+
+	bzero(extension, sizeof(SourceExtension));
+
+	if (!catalog_lookup_s_extension_by_extname(filterDB, "citus", extension))
+	{
+		/* errors have already been logged*/
+		return false;
+	}
+
+	if (extension->oid > 0)
+	{
+		log_info("Executing post-schema restore steps for citus extension");
+
+		if (!citus_prepare_restore(copySpecs))
 		{
 			/* errors have already been logged */
 			return false;
@@ -812,6 +833,180 @@ timescaledb_post_restore(CopyDataSpec *copySpecs, SourceExtension *extension)
 				  extension->extnamespace);
 		return false;
 	}
+
+	return true;
+}
+
+
+/*
+ * Context for the Citus distribution callback: carries the open target
+ * connection and a success flag (callbacks cannot return bool).
+ */
+typedef struct CitusRestoreContext
+{
+	char sqlstate[SQLSTATE_LENGTH];
+	PGSQL *dst;
+	bool ok;
+} CitusRestoreContext;
+
+
+/*
+ * citusDistributeCallback executes each DDL string returned by the source
+ * query against the target database.  A single PGresult may contain many rows;
+ * each row's first column is a ready-to-execute SQL statement.
+ */
+static void
+citusDistributeCallback(void *ctx, PGresult *result)
+{
+	CitusRestoreContext *context = (CitusRestoreContext *) ctx;
+
+	int nTuples = PQntuples(result);
+
+	for (int rowNum = 0; rowNum < nTuples; rowNum++)
+	{
+		char *ddl = PQgetvalue(result, rowNum, 0);
+
+		log_info("Citus: %s", ddl);
+
+		if (!pgsql_execute(context->dst, ddl))
+		{
+			context->ok = false;
+			return;
+		}
+	}
+}
+
+
+/*
+ * citus_prepare_restore reads the Citus distribution metadata from the source
+ * database and replays it on the target.  It is called after pg_restore
+ * --pre-data (tables exist as plain relations on target) and before the data
+ * copy phase.
+ *
+ * Two queries drive the work:
+ *
+ *  1. Distributed tables – the anchor of each co-location group is created
+ *     with an explicit shard_count; co-located peers reference the anchor via
+ *     colocate_with so Citus places their shards on the same nodes.
+ *
+ *  2. Reference tables – replicated to every node, created last so they are
+ *     never accidentally chosen as a co-location anchor.
+ */
+static bool
+citus_prepare_restore(CopyDataSpec *copySpecs)
+{
+	PGSQL src = { 0 };
+	PGSQL dst = { 0 };
+
+	if (!pgsql_init(&src, copySpecs->connStrings.source_pguri, PGSQL_CONN_SOURCE))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	if (!pgsql_init(&dst, copySpecs->connStrings.target_pguri, PGSQL_CONN_TARGET))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	CitusRestoreContext context = {
+		.sqlstate = { 0 },
+		.dst = &dst,
+		.ok = true
+	};
+
+	/*
+	 * Query 1: distributed tables.
+	 *
+	 * Within each co-location group (same colocation_id) order tables
+	 * alphabetically; the first one becomes the anchor and is created with
+	 * shard_count := N, colocate_with := 'none'.  Subsequent tables in the
+	 * group reference the anchor by name.
+	 */
+	char *distSql =
+		"with ordered as ("
+		"  select"
+		"    table_name::text                                          as tname,"
+		"    distribution_column,"
+		"    colocation_id,"
+		"    shard_count,"
+		"    row_number() over (partition by colocation_id"
+		"                       order by table_name::text)            as rn,"
+		"    first_value(table_name::text) over ("
+		"        partition by colocation_id"
+		"        order by table_name::text)                           as anchor"
+		"  from citus_tables"
+		"  where citus_table_type = 'distributed'"
+		")"
+		" select"
+		"  case"
+		"    when rn = 1 then"
+		"      format("
+		"        'select create_distributed_table(%L, %L,"
+		"                                         shard_count := %s,"
+		"                                         colocate_with := %L)',"
+		"        tname, distribution_column, shard_count, 'none')"
+		"    else"
+		"      format("
+		"        'select create_distributed_table(%L, %L,"
+		"                                         colocate_with := %L)',"
+		"        tname, distribution_column, anchor)"
+		"  end"
+		" from ordered"
+		" order by colocation_id, rn";
+
+	if (!pgsql_execute_with_params(&src, distSql,
+								   0, NULL, NULL,
+								   &context, &citusDistributeCallback))
+	{
+		/* errors have already been logged */
+		(void) pgsql_finish(&src);
+		(void) pgsql_finish(&dst);
+		return false;
+	}
+
+	if (!context.ok)
+	{
+		log_error("Failed to distribute tables on Citus target");
+		(void) pgsql_finish(&src);
+		(void) pgsql_finish(&dst);
+		return false;
+	}
+
+	/*
+	 * Query 2: reference tables.
+	 *
+	 * These are replicated in full to every worker node and must be created
+	 * after all distributed tables so they are never used as co-location
+	 * anchors by accident.
+	 */
+	char *refSql =
+		"select format('select create_reference_table(%L)', table_name::text)"
+		"  from citus_tables"
+		" where citus_table_type = 'reference'"
+		" order by table_name::text";
+
+	if (!pgsql_execute_with_params(&src, refSql,
+								   0, NULL, NULL,
+								   &context, &citusDistributeCallback))
+	{
+		/* errors have already been logged */
+		(void) pgsql_finish(&src);
+		(void) pgsql_finish(&dst);
+		return false;
+	}
+
+	if (!context.ok)
+	{
+		log_error("Failed to create reference tables on Citus target");
+		(void) pgsql_finish(&src);
+		(void) pgsql_finish(&dst);
+		return false;
+	}
+
+	(void) pgsql_finish(&src);
+	(void) pgsql_finish(&dst);
 
 	return true;
 }

--- a/src/bin/pgcopydb/sql/citus_distributed_tables.sql
+++ b/src/bin/pgcopydb/sql/citus_distributed_tables.sql
@@ -1,0 +1,27 @@
+with ordered as (
+  select
+    table_name::text                                            as tname,
+    distribution_column,
+    colocation_id,
+    shard_count,
+    row_number() over (partition by colocation_id
+                       order by table_name::text)              as rn,
+    first_value(table_name::text) over (
+        partition by colocation_id
+        order by table_name::text)                             as anchor
+  from citus_tables
+  where citus_table_type = 'distributed'
+)
+ select
+  case
+    when rn = 1 then
+      format(
+        'select create_distributed_table(%L, %L, shard_count := %s, colocate_with := %L)',
+        tname, distribution_column, shard_count, 'none')
+    else
+      format(
+        'select create_distributed_table(%L, %L, colocate_with := %L)',
+        tname, distribution_column, anchor)
+  end
+ from ordered
+ order by colocation_id, rn;

--- a/src/bin/pgcopydb/sql/citus_reference_tables.sql
+++ b/src/bin/pgcopydb/sql/citus_reference_tables.sql
@@ -1,0 +1,4 @@
+select format('select create_reference_table(%L)', table_name::text)
+  from citus_tables
+ where citus_table_type = 'reference'
+ order by table_name::text;

--- a/src/bin/pgcopydb/sql/sql_queries_data.inc
+++ b/src/bin/pgcopydb/sql/sql_queries_data.inc
@@ -2,6 +2,43 @@
  * Run 'make gen-sql' after modifying any .sql file.
  */
 
+static const char sql_citus_distributed_tables[] =
+	"with ordered as (\n"
+	"  select\n"
+	"    table_name::text                                            as tname,\n"
+	"    distribution_column,\n"
+	"    colocation_id,\n"
+	"    shard_count,\n"
+	"    row_number() over (partition by colocation_id\n"
+	"                       order by table_name::text)              as rn,\n"
+	"    first_value(table_name::text) over (\n"
+	"        partition by colocation_id\n"
+	"        order by table_name::text)                             as anchor\n"
+	"  from citus_tables\n"
+	"  where citus_table_type = 'distributed'\n"
+	")\n"
+	" select\n"
+	"  case\n"
+	"    when rn = 1 then\n"
+	"      format(\n"
+	"        'select create_distributed_table(%L, %L, shard_count := %s, colocate_with := %L)',\n"
+	"        tname, distribution_column, shard_count, 'none')\n"
+	"    else\n"
+	"      format(\n"
+	"        'select create_distributed_table(%L, %L, colocate_with := %L)',\n"
+	"        tname, distribution_column, anchor)\n"
+	"  end\n"
+	" from ordered\n"
+	" order by colocation_id, rn\n"
+;
+
+static const char sql_citus_reference_tables[] =
+	"select format('select create_reference_table(%L)', table_name::text)\n"
+	"  from citus_tables\n"
+	" where citus_table_type = 'reference'\n"
+	" order by table_name::text\n"
+;
+
 static const char sql_filter_table_arrays[] =
 	"-- SQLite query used by catalog_filter_table_arrays().\n"
 	"-- $1 : section name ('excl_table', 'incl_table', 'xdat_table', 'excl_index')\n"

--- a/src/bin/pgcopydb/sql_queries.c
+++ b/src/bin/pgcopydb/sql_queries.c
@@ -18,6 +18,22 @@
 
 
 bool
+pgcopydb_sql_citus_distributed_tables(const char **sql)
+{
+	*sql = sql_citus_distributed_tables;
+	return true;
+}
+
+
+bool
+pgcopydb_sql_citus_reference_tables(const char **sql)
+{
+	*sql = sql_citus_reference_tables;
+	return true;
+}
+
+
+bool
 pgcopydb_sql_list_collations(const char **sql)
 {
 	*sql = sql_list_collations;

--- a/src/bin/pgcopydb/sql_queries.h
+++ b/src/bin/pgcopydb/sql_queries.h
@@ -12,6 +12,10 @@
 
 #include <stdbool.h>
 
+/* Citus extension support */
+bool pgcopydb_sql_citus_distributed_tables(const char **sql);
+bool pgcopydb_sql_citus_reference_tables(const char **sql);
+
 bool pgcopydb_sql_list_collations(const char **sql);
 bool pgcopydb_sql_list_database_properties(const char **sql);
 bool pgcopydb_sql_list_databases(const char **sql);

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -89,6 +89,9 @@ follow-filtering: build
 timescaledb: build
 	$(MAKE) -C $@
 
+citus: build
+	$(MAKE) -C $@
+
 build:
 	@docker image inspect pagila > /dev/null 2>&1 \
 	  && echo "pagila image already present — skipping build (run 'make force-build' to rebuild)" \
@@ -122,3 +125,4 @@ clean-images:
 .PHONY: cdc-endpos-in-multi-wal-txn cdc-file-rotation
 .PHONY: cdc-pgoutput cdc-filtering-pgoutput follow-pgoutput follow-filtering
 .PHONY: follow-wal2json follow-9.6
+.PHONY: timescaledb citus

--- a/tests/citus/Dockerfile
+++ b/tests/citus/Dockerfile
@@ -1,0 +1,10 @@
+FROM pagila
+
+WORKDIR /usr/src/pgcopydb
+
+COPY ./copydb.sh copydb.sh
+COPY ./ddl.sql ddl.sql
+COPY ./dml.sql dml.sql
+
+USER docker
+CMD ["/usr/src/pgcopydb/copydb.sh"]

--- a/tests/citus/Makefile
+++ b/tests/citus/Makefile
@@ -1,0 +1,20 @@
+# Copyright (c) 2021 The PostgreSQL Global Development Group.
+# Licensed under the PostgreSQL License.
+
+COMPOSE_EXIT = --exit-code-from=test --abort-on-container-exit
+
+test: down run down ;
+
+up: down build
+	docker compose up --remove-orphans $(COMPOSE_EXIT)
+
+run: build
+	docker compose run --remove-orphans test
+
+down:
+	docker compose down --remove-orphans
+
+build:
+	docker compose build --quiet
+
+.PHONY: run down build test

--- a/tests/citus/compose.yml
+++ b/tests/citus/compose.yml
@@ -1,0 +1,27 @@
+services:
+  source:
+    image: citusdata/citus:14.1-pg16
+    expose:
+      - 5432
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: h4ckm3
+      POSTGRES_HOST_AUTH_METHOD: trust
+  target:
+    image: citusdata/citus:14.1-pg16
+    expose:
+      - 5432
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: h4ckm3
+      POSTGRES_HOST_AUTH_METHOD: trust
+  test:
+    build: .
+    environment:
+      PGCOPYDB_SOURCE_PGURI: postgres://postgres:h4ckm3@source/postgres
+      PGCOPYDB_TARGET_PGURI: postgres://postgres:h4ckm3@target/postgres
+      PGCOPYDB_TABLE_JOBS: 4
+      PGCOPYDB_INDEX_JOBS: 4
+    depends_on:
+      - source
+      - target

--- a/tests/citus/copydb.sh
+++ b/tests/citus/copydb.sh
@@ -26,17 +26,32 @@ psql -d "${PGCOPYDB_SOURCE_PGURI}" -f /usr/src/pgcopydb/dml.sql
 pgcopydb clone --notice
 
 # Verify that the distribution metadata matches on both sides.
+# Show the full citus_tables output (table_name, citus_table_type,
+# distribution_column, shard_count) so the result is visible in the
+# test log, then diff the two sides to confirm they are identical.
+# colocation_id is excluded: it is an autoincrement that restarts from
+# a different value on the fresh target cluster.  table_size and
+# shard_size are excluded because they are not stable across copies.
+
+CITUS_DISTRIBUTION_QUERY="
+select table_name::text,
+       citus_table_type::text,
+       distribution_column,
+       shard_count
+  from citus_tables
+ order by table_name::text"
+
+echo "=== source citus_tables ==="
+psql -d "${PGCOPYDB_SOURCE_PGURI}" -c "${CITUS_DISTRIBUTION_QUERY}"
+
+echo "=== target citus_tables ==="
+psql -d "${PGCOPYDB_TARGET_PGURI}" -c "${CITUS_DISTRIBUTION_QUERY}"
+
 psql -d "${PGCOPYDB_SOURCE_PGURI}" \
-     -c "\copy (select table_name::text, citus_table_type::text, distribution_column \
-                from citus_tables \
-                order by table_name::text) \
-         to '/tmp/source_citus_tables.out'"
+     -c "\copy (${CITUS_DISTRIBUTION_QUERY}) to '/tmp/source_citus_tables.out'"
 
 psql -d "${PGCOPYDB_TARGET_PGURI}" \
-     -c "\copy (select table_name::text, citus_table_type::text, distribution_column \
-                from citus_tables \
-                order by table_name::text) \
-         to '/tmp/target_citus_tables.out'"
+     -c "\copy (${CITUS_DISTRIBUTION_QUERY}) to '/tmp/target_citus_tables.out'"
 
 diff /tmp/source_citus_tables.out /tmp/target_citus_tables.out
 

--- a/tests/citus/copydb.sh
+++ b/tests/citus/copydb.sh
@@ -1,0 +1,61 @@
+#! /bin/bash
+
+set -x
+set -e
+
+# This script expects the following environment variables to be set:
+#
+#  - PGCOPYDB_SOURCE_PGURI
+#  - PGCOPYDB_TARGET_PGURI
+
+# Wait for both Citus clusters to be ready (extension is pre-installed by the
+# citusdata/citus Docker image entrypoint).
+pgcopydb ping
+
+# Install the Citus-native multi-tenant tutorial schema on source, then seed it
+# with data.  The DDL script itself calls create_distributed_table() and
+# create_reference_table() so the source is fully distributed before we clone.
+psql -d "${PGCOPYDB_SOURCE_PGURI}" -f /usr/src/pgcopydb/ddl.sql
+psql -d "${PGCOPYDB_SOURCE_PGURI}" -f /usr/src/pgcopydb/dml.sql
+
+# Clone source → target.  pgcopydb detects the citus extension in the source
+# catalog and calls create_distributed_table() / create_reference_table() on
+# the target (in copydb_prepare_extensions_restore) before copying any data,
+# so data is inserted through the Citus coordinator and lands in the correct
+# shards.
+pgcopydb clone --notice
+
+# Verify that the distribution metadata matches on both sides.
+psql -d "${PGCOPYDB_SOURCE_PGURI}" \
+     -c "\copy (select table_name::text, citus_table_type::text, distribution_column \
+                from citus_tables \
+                order by table_name::text) \
+         to '/tmp/source_citus_tables.out'"
+
+psql -d "${PGCOPYDB_TARGET_PGURI}" \
+     -c "\copy (select table_name::text, citus_table_type::text, distribution_column \
+                from citus_tables \
+                order by table_name::text) \
+         to '/tmp/target_citus_tables.out'"
+
+diff /tmp/source_citus_tables.out /tmp/target_citus_tables.out
+
+echo "Distribution metadata matches between source and target"
+
+# Verify row counts for every table.
+for table in companies campaigns ads clicks impressions geo_ips; do
+    src_count=$(psql -d "${PGCOPYDB_SOURCE_PGURI}" -t -c "select count(*) from ${table}")
+    tgt_count=$(psql -d "${PGCOPYDB_TARGET_PGURI}" -t -c "select count(*) from ${table}")
+
+    # trim whitespace
+    src_count=$(echo "${src_count}" | tr -d ' ')
+    tgt_count=$(echo "${tgt_count}" | tr -d ' ')
+
+    echo "Table ${table}: source=${src_count} target=${tgt_count}"
+    test "${src_count}" -eq "${tgt_count}"
+done
+
+echo "Row counts match for all tables"
+
+# Verify schema parity (compare schemas on source and target).
+pgcopydb compare schema

--- a/tests/citus/ddl.sql
+++ b/tests/citus/ddl.sql
@@ -1,0 +1,87 @@
+--
+-- Citus multi-tenant tutorial schema.
+-- Tables are already in "Citus-native" form: the distribution column
+-- (company_id) is present in every distributed table and is the first
+-- column of every composite primary / foreign key.
+--
+-- Source: https://docs.citusdata.com/en/stable/use_cases/multi_tenant.html
+--
+
+create table companies (
+    id          bigserial primary key,
+    name        text not null,
+    image_url   text,
+    created_at  timestamptz not null default now(),
+    updated_at  timestamptz not null default now()
+);
+
+create table campaigns (
+    company_id  bigint not null references companies (id),
+    id          bigserial,
+    name        text not null,
+    cost_model  text not null,
+    state       text not null,
+    monthly_budget bigint,
+    created_at  timestamptz not null default now(),
+    updated_at  timestamptz not null default now(),
+    primary key (company_id, id)
+);
+
+create table ads (
+    company_id        bigint not null,
+    id                bigserial,
+    campaign_id       bigint not null,
+    name              text not null,
+    image_url         text,
+    target_url        text,
+    impressions_count bigint default 0,
+    clicks_count      bigint default 0,
+    created_at        timestamptz not null default now(),
+    updated_at        timestamptz not null default now(),
+    primary key (company_id, id),
+    foreign key (company_id, campaign_id) references campaigns (company_id, id)
+);
+
+create table clicks (
+    company_id         bigint not null,
+    id                 bigserial,
+    ad_id              bigint not null,
+    clicked_at         timestamptz not null,
+    site_url           text not null,
+    cost_per_click_usd numeric(20, 10),
+    user_ip            inet not null,
+    user_data          jsonb not null,
+    primary key (company_id, id),
+    foreign key (company_id, ad_id) references ads (company_id, id)
+);
+
+create table impressions (
+    company_id              bigint not null,
+    id                      bigserial,
+    ad_id                   bigint not null,
+    seen_at                 timestamptz not null,
+    site_url                text not null,
+    cost_per_impression_usd numeric(20, 10),
+    user_ip                 inet not null,
+    user_data               jsonb not null,
+    primary key (company_id, id),
+    foreign key (company_id, ad_id) references ads (company_id, id)
+);
+
+-- geo_ips is a reference table: the same rows appear on every node.
+create table geo_ips (
+    addrs     cidr not null,
+    latitude  float not null,
+    longitude float not null
+);
+
+-- Distribute tables.  The companies table is the co-location anchor; all
+-- other per-tenant tables are co-located with it so that cross-table JOINs
+-- that filter on company_id stay local to one shard.
+select create_distributed_table('companies',  'id');
+select create_distributed_table('campaigns',  'company_id', colocate_with := 'companies');
+select create_distributed_table('ads',        'company_id', colocate_with := 'companies');
+select create_distributed_table('clicks',     'company_id', colocate_with := 'companies');
+select create_distributed_table('impressions','company_id', colocate_with := 'companies');
+
+select create_reference_table('geo_ips');

--- a/tests/citus/dml.sql
+++ b/tests/citus/dml.sql
@@ -1,0 +1,87 @@
+--
+-- Seed data for the Citus multi-tenant tutorial schema.
+-- All IDs are explicit (OVERRIDING SYSTEM VALUE) so that foreign-key
+-- references are deterministic and sequences on the target are set
+-- correctly by pgcopydb.
+--
+
+-- 5 companies
+insert into companies (id, name, image_url, created_at, updated_at)
+    overriding system value
+values
+    (1, 'Acme Corp',     'https://example.com/acme.png',     '2024-01-01', '2024-01-01'),
+    (2, 'Globex',        'https://example.com/globex.png',   '2024-01-01', '2024-01-01'),
+    (3, 'Initech',       'https://example.com/initech.png',  '2024-01-01', '2024-01-01'),
+    (4, 'Umbrella Corp', 'https://example.com/umbrella.png', '2024-01-01', '2024-01-01'),
+    (5, 'Hooli',         'https://example.com/hooli.png',    '2024-01-01', '2024-01-01');
+
+-- 2 campaigns per company (10 total)
+insert into campaigns (company_id, id, name, cost_model, state, monthly_budget, created_at, updated_at)
+    overriding system value
+values
+    (1, 1,  'Spring Sale',      'cpc', 'active', 10000, '2024-01-01', '2024-01-01'),
+    (1, 2,  'Summer Push',      'cpm', 'paused',  5000, '2024-01-01', '2024-01-01'),
+    (2, 3,  'Brand Awareness',  'cpc', 'active', 20000, '2024-01-01', '2024-01-01'),
+    (2, 4,  'Retargeting',      'cpc', 'active',  8000, '2024-01-01', '2024-01-01'),
+    (3, 5,  'Launch Campaign',  'cpm', 'active', 15000, '2024-01-01', '2024-01-01'),
+    (3, 6,  'Product Refresh',  'cpc', 'paused',  3000, '2024-01-01', '2024-01-01'),
+    (4, 7,  'Global Outreach',  'cpm', 'active', 50000, '2024-01-01', '2024-01-01'),
+    (4, 8,  'Local Promo',      'cpc', 'active',  2000, '2024-01-01', '2024-01-01'),
+    (5, 9,  'Tech Blitz',       'cpc', 'active', 30000, '2024-01-01', '2024-01-01'),
+    (5, 10, 'Viral Drive',      'cpm', 'paused', 12000, '2024-01-01', '2024-01-01');
+
+-- 2 ads per campaign (20 total)
+insert into ads (company_id, id, campaign_id, name, impressions_count, clicks_count, created_at, updated_at)
+    overriding system value
+values
+    (1,  1,  1,  'Acme Ad A',      1200, 45, '2024-01-01', '2024-01-01'),
+    (1,  2,  1,  'Acme Ad B',       800, 30, '2024-01-01', '2024-01-01'),
+    (1,  3,  2,  'Acme Summer A',   500, 10, '2024-01-01', '2024-01-01'),
+    (1,  4,  2,  'Acme Summer B',   300,  5, '2024-01-01', '2024-01-01'),
+    (2,  5,  3,  'Globex Brand A', 2000, 90, '2024-01-01', '2024-01-01'),
+    (2,  6,  3,  'Globex Brand B', 1800, 75, '2024-01-01', '2024-01-01'),
+    (2,  7,  4,  'Globex Retarget A', 900, 40, '2024-01-01', '2024-01-01'),
+    (2,  8,  4,  'Globex Retarget B', 600, 22, '2024-01-01', '2024-01-01'),
+    (3,  9,  5,  'Initech Launch A', 3000, 120, '2024-01-01', '2024-01-01'),
+    (3, 10,  5,  'Initech Launch B', 2500, 100, '2024-01-01', '2024-01-01'),
+    (3, 11,  6,  'Initech Refresh A', 400, 15, '2024-01-01', '2024-01-01'),
+    (3, 12,  6,  'Initech Refresh B', 200,  8, '2024-01-01', '2024-01-01'),
+    (4, 13,  7,  'Umbrella Global A', 5000, 200, '2024-01-01', '2024-01-01'),
+    (4, 14,  7,  'Umbrella Global B', 4500, 180, '2024-01-01', '2024-01-01'),
+    (4, 15,  8,  'Umbrella Local A',   700, 28, '2024-01-01', '2024-01-01'),
+    (4, 16,  8,  'Umbrella Local B',   350, 12, '2024-01-01', '2024-01-01'),
+    (5, 17,  9,  'Hooli Blitz A',    4000, 160, '2024-01-01', '2024-01-01'),
+    (5, 18,  9,  'Hooli Blitz B',    3500, 140, '2024-01-01', '2024-01-01'),
+    (5, 19, 10,  'Hooli Viral A',    1500, 60, '2024-01-01', '2024-01-01'),
+    (5, 20, 10,  'Hooli Viral B',    1200, 48, '2024-01-01', '2024-01-01');
+
+-- 2 clicks per ad for company 1 (ad IDs 1–4)
+insert into clicks (company_id, id, ad_id, clicked_at, site_url, cost_per_click_usd, user_ip, user_data)
+    overriding system value
+values
+    (1, 1, 1, '2024-02-01 10:00:00', 'https://news.example.com', 0.25, '203.0.113.5',  '{"browser":"Chrome"}'),
+    (1, 2, 1, '2024-02-01 10:05:00', 'https://blog.example.com', 0.18, '203.0.113.6',  '{"browser":"Firefox"}'),
+    (1, 3, 2, '2024-02-02 11:00:00', 'https://shop.example.com', 0.30, '203.0.113.7',  '{"browser":"Safari"}'),
+    (1, 4, 2, '2024-02-02 11:10:00', 'https://news.example.com', 0.22, '203.0.113.8',  '{"browser":"Edge"}'),
+    (1, 5, 3, '2024-02-03 09:00:00', 'https://tech.example.com', 0.15, '203.0.113.9',  '{"browser":"Chrome"}'),
+    (1, 6, 4, '2024-02-03 09:30:00', 'https://blog.example.com', 0.20, '203.0.113.10', '{"browser":"Firefox"}');
+
+-- 2 impressions per ad for company 2 (ad IDs 5–8)
+insert into impressions (company_id, id, ad_id, seen_at, site_url, cost_per_impression_usd, user_ip, user_data)
+    overriding system value
+values
+    (2, 1, 5, '2024-02-01 08:00:00', 'https://news.example.com', 0.002, '198.51.100.1', '{"os":"Linux"}'),
+    (2, 2, 5, '2024-02-01 08:05:00', 'https://blog.example.com', 0.002, '198.51.100.2', '{"os":"macOS"}'),
+    (2, 3, 6, '2024-02-02 09:00:00', 'https://shop.example.com', 0.003, '198.51.100.3', '{"os":"Windows"}'),
+    (2, 4, 6, '2024-02-02 09:10:00', 'https://tech.example.com', 0.003, '198.51.100.4', '{"os":"iOS"}'),
+    (2, 5, 7, '2024-02-03 07:00:00', 'https://news.example.com', 0.001, '198.51.100.5', '{"os":"Android"}'),
+    (2, 6, 8, '2024-02-03 07:30:00', 'https://blog.example.com', 0.002, '198.51.100.6', '{"os":"Linux"}');
+
+-- geo_ips reference data (same on every node)
+insert into geo_ips (addrs, latitude, longitude)
+values
+    ('10.0.0.0/8',      37.77,  -122.41),
+    ('172.16.0.0/12',   51.51,    -0.12),
+    ('192.168.0.0/16',  35.69,   139.69),
+    ('203.0.113.0/24',  40.71,   -74.01),
+    ('198.51.100.0/24', 48.86,     2.35);


### PR DESCRIPTION
## Problem

When cloning a Citus coordinator to another Citus coordinator, pgcopydb correctly copies the schema and data through the coordinator (shard tables are transparent), but the target tables end up as plain PostgreSQL relations. The Citus distribution metadata — which tables are distributed on which column, how they are co-located, which are reference tables — is not part of the pg_dump output and was never applied on the target.

## Root Cause

The distribution metadata lives in Citus catalog tables (`pg_dist_partition`, `pg_dist_colocation`, etc.) and is only installed by calling `create_distributed_table()` / `create_reference_table()` on the target. There was no hook in pgcopydb to do this.

## Fix

Add `citus_prepare_restore()` in `src/bin/pgcopydb/extensions.c`, called from the existing `copydb_prepare_extensions_restore()` hook (between pg_restore --pre-data and the data copy phase, when tables exist on the target as empty relations).

The function runs two queries against the source database using the `citus_tables` view:

1. **Distributed tables** — reads co-location groups and emits `create_distributed_table()` calls ordered so each group's alphabetical anchor is created first with `shard_count := N, colocate_with := 'none'`, and co-located peers reference the anchor via `colocate_with`.

2. **Reference tables** — emits `create_reference_table()` for each, always after distributed tables so they are never accidentally treated as co-location anchors.

Citus is detected by `catalog_lookup_s_extension_by_extname()` matching the existing extension catalog, consistent with the timescaledb detection pattern.

A new test under `tests/citus/` uses `citusdata/citus:14.1-pg16` for both source and target, seeds the Citus multi-tenant tutorial schema (companies / campaigns / ads / clicks / impressions / geo_ips), runs `pgcopydb clone`, and verifies that:
- `citus_tables` distribution metadata matches between source and target
- row counts match for all 6 tables
- `pgcopydb compare schema` finds no differences

Closes #671