### PR TITLE
docs: document extension-aware migration for TimescaleDB and Citus

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -87,6 +87,14 @@ Change Data Capture
 
     See the reference manual for the ``pgcopydb fork --follow`` command.
 
+Extension-aware migration
+    pgcopydb detects TimescaleDB and Citus in the source database and
+    automatically runs the required pre/post-restore hooks so that
+    hypertables and distributed tables are correctly set up on the target
+    without any manual intervention.
+
+    See :ref:`extension_aware_migration` for details.
+
 .. toctree::
    :hidden:
    :caption: Getting Started

--- a/docs/ref/pgcopydb_clone.rst
+++ b/docs/ref/pgcopydb_clone.rst
@@ -204,6 +204,53 @@ owns the source and target databases.
    does not apply to extension members, and pg_dump does not provide a
    mechanism to exclude extensions.
 
+.. _extension_aware_migration:
+
+Extension-aware migration
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+pgcopydb detects certain extensions in the source catalog and automatically
+runs extension-specific steps at the right point in the pipeline. No
+configuration is required: the behaviour is triggered by the presence of the
+extension in the source database. If an extension is listed under
+``[exclude-extension]`` in the :ref:`config` filter file it is
+never fetched into the catalog, so its hook is skipped.
+
+TimescaleDB
+~~~~~~~~~~~
+
+When ``timescaledb`` is detected in the source database, pgcopydb calls two
+functions on the *target* database:
+
+- **Before** ``pg_restore --pre-data``: ``timescaledb_pre_restore()`` puts
+  TimescaleDB into restore mode so it does not interfere with schema
+  restore.
+
+- **After** ``pg_restore --post-data``: ``timescaledb_post_restore()``
+  re-enables normal TimescaleDB operation.
+
+Both the source and the target databases must have the TimescaleDB extension
+installed.
+
+Citus
+~~~~~
+
+When ``citus`` is detected in the source database, pgcopydb queries the
+``citus_tables`` view on the source coordinator and, **after**
+``pg_restore --pre-data`` (at which point tables exist on the target as
+empty plain PostgreSQL tables), calls ``create_distributed_table()`` and
+``create_reference_table()`` on the *target* coordinator.
+
+Co-location groups are preserved: within each group the alphabetically
+first table is created with ``shard_count := N, colocate_with := 'none'``
+and the remaining tables reference it via ``colocate_with``. Reference
+tables are always created after all distributed tables.
+
+Data is then copied through the Citus coordinator, which routes rows to the
+correct shards transparently — shard tables are never visible to pgcopydb.
+Both the source and the target must be Citus coordinators (multi-worker
+clusters are fully supported).
+
 .. _all_databases:
 
 Cloning all databases with ``--all-databases``


### PR DESCRIPTION
## What

Add a new **Extension-aware migration** section to `docs/ref/pgcopydb_clone.rst` and a feature bullet in `docs/index.rst`, documenting the automatic extension hooks that were implemented but never documented.

## TimescaleDB

- Before `pg_restore --pre-data`: `timescaledb_pre_restore()` puts TimescaleDB into restore mode
- After `pg_restore --post-data`: `timescaledb_post_restore()` re-enables normal operation

## Citus (added in #1011)

- After `pg_restore --pre-data`: queries `citus_tables` on the source coordinator and calls `create_distributed_table()` / `create_reference_table()` on the target coordinator
- Co-location groups are preserved (alphabetical anchor + `colocate_with`)
- Data copy flows through the Citus coordinator transparently; multi-worker clusters are fully supported

The `[exclude-extension]` interaction is also noted: excluded extensions are never fetched into the catalog so their hook is skipped.

Docs build cleanly with `make -C docs html` (no warnings).