### PR TITLE
ci: bump actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0 # all history for all branches and tags
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,7 +27,7 @@ jobs:
           - 18
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0 # all history for all branches and tags
 
@@ -71,7 +71,7 @@ jobs:
             | zstd -T0 -9 - -o images.tar.zst
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: docker-images-pg${{ matrix.PGVERSION }}
           path: images.tar.zst
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Run banned.h check
         run: sh ./ci/banned.h.sh
@@ -145,7 +145,7 @@ jobs:
             PGVERSION: 18
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0 # all history for all branches and tags
 
@@ -158,7 +158,7 @@ jobs:
             echo "PGVERSION=${{ matrix.PGVERSION }}" >> $GITHUB_ENV
 
       - name: Download pre-built Docker images
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: docker-images-pg${{ matrix.PGVERSION }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -29,7 +29,7 @@ jobs:
           - 18
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0 # all history for all branches and tags
 
@@ -73,7 +73,7 @@ jobs:
             | zstd -T0 -9 - -o images.tar.zst
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: docker-images-pg${{ matrix.PGVERSION }}
           path: images.tar.zst
@@ -88,7 +88,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Run banned.h check
         run: sh ./ci/banned.h.sh
@@ -173,7 +173,7 @@ jobs:
             PGVERSION: 16
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0 # all history for all branches and tags
 
@@ -186,7 +186,7 @@ jobs:
             echo "PGVERSION=${{ matrix.PGVERSION }}" >> $GITHUB_ENV
 
       - name: Download pre-built Docker images
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: docker-images-pg${{ matrix.PGVERSION }}
 
@@ -218,7 +218,7 @@ jobs:
     runs-on: ubuntu-latest
     container: citus/stylechecker:no-py
     steps:
-    - uses: actions/checkout@v4.1.7
+    - uses: actions/checkout@v5
       name: Checkout code
 
     - name: Set safe directory for git
@@ -232,7 +232,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Build docs
         uses: ammaraskar/sphinx-action@master


### PR DESCRIPTION
## Problem

GitHub deprecated Node.js 20 on Actions runners on 2025-09-19. All three workflow files reference Node.js 20-based action versions, producing this warning on every run:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/upload-artifact@v4. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## Fix

Bump to the Node.js 24-based major versions, mirroring what was already done in the pgloader repo:

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `v4` / `v4.1.7` | `v5` |
| `actions/upload-artifact` | `v4` | `v7` |
| `actions/download-artifact` | `v4` | `v8` |

Files changed: `.github/workflows/run-tests.yml`, `nightly.yml`, `docker-publish.yml`.