### PR TITLE
ci: do not run docker-publish on pull requests

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,8 +10,6 @@ on:
     branches: [ main ]
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
-  pull_request:
-    branches: [ main ]
 
 env:
   # Use docker.io for Docker Hub if empty


### PR DESCRIPTION
## Problem

The `docker-publish` workflow ran on every PR but did nothing useful. Both `push:` and the `cosign sign` step are gated on `github.event_name != 'pull_request'`, so the job built a multi-platform (`linux/amd64` + `linux/arm64`) image and immediately discarded it.

`run-tests.yml` already builds the pgcopydb image twice per PR (PG16 and PG18). The arm64 cross-compile added on top of that was pure wasted runner time.

## Fix

Remove `pull_request` from the trigger. The workflow now only runs when there is something to publish: pushes to `main` and `v*.*.*` tags.