### PR TITLE
docs: expose --split-tables-larger-than and --split-max-parts in copy table-data help (#921)

### DIFF
--- a/docs/include/copy-table-data.rst
+++ b/docs/include/copy-table-data.rst
@@ -3,13 +3,15 @@
    pgcopydb copy table-data: Copy the data from all tables in database from source to target
    usage: pgcopydb copy table-data  --source ... --target ... [ --table-jobs ... --index-jobs ... ] 
    
-     --source             Postgres URI to the source database
-     --target             Postgres URI to the target database
-     --dir                Work directory to use
-     --table-jobs         Number of concurrent COPY jobs to run
-     --filters <filename> Use the filters defined in <filename>
-     --restart            Allow restarting when temp files exist already
-     --resume             Allow resuming operations after a failure
-     --not-consistent     Allow taking a new snapshot on the source database
-     --snapshot           Use snapshot obtained with pg_export_snapshot
+     --source                      Postgres URI to the source database
+     --target                      Postgres URI to the target database
+     --dir                         Work directory to use
+     --table-jobs                  Number of concurrent COPY jobs to run
+     --split-tables-larger-than    Same-table concurrency size threshold
+     --split-max-parts             Maximum number of jobs for Same-table concurrency
+     --filters <filename>          Use the filters defined in <filename>
+     --restart                     Allow restarting when temp files exist already
+     --resume                      Allow resuming operations after a failure
+     --not-consistent              Allow taking a new snapshot on the source database
+     --snapshot                    Use snapshot obtained with pg_export_snapshot
    

--- a/src/bin/pgcopydb/cli_copy.c
+++ b/src/bin/pgcopydb/cli_copy.c
@@ -126,15 +126,17 @@ static CommandLine copy_table_data_command =
 		"table-data",
 		"Copy the data from all tables in database from source to target",
 		" --source ... --target ... [ --table-jobs ... --index-jobs ... ] ",
-		"  --source             Postgres URI to the source database\n"
-		"  --target             Postgres URI to the target database\n"
-		"  --dir                Work directory to use\n"
-		"  --table-jobs         Number of concurrent COPY jobs to run\n"
-		"  --filters <filename> Use the filters defined in <filename>\n"
-		"  --restart            Allow restarting when temp files exist already\n"
-		"  --resume             Allow resuming operations after a failure\n"
-		"  --not-consistent     Allow taking a new snapshot on the source database\n"
-		"  --snapshot           Use snapshot obtained with pg_export_snapshot\n",
+		"  --source                      Postgres URI to the source database\n"
+		"  --target                      Postgres URI to the target database\n"
+		"  --dir                         Work directory to use\n"
+		"  --table-jobs                  Number of concurrent COPY jobs to run\n"
+		"  --split-tables-larger-than    Same-table concurrency size threshold\n"
+		"  --split-max-parts             Maximum number of jobs for Same-table concurrency\n"
+		"  --filters <filename>          Use the filters defined in <filename>\n"
+		"  --restart                     Allow restarting when temp files exist already\n"
+		"  --resume                      Allow resuming operations after a failure\n"
+		"  --not-consistent              Allow taking a new snapshot on the source database\n"
+		"  --snapshot                    Use snapshot obtained with pg_export_snapshot\n",
 		cli_copy_db_getopts,
 		cli_copy_table_data);
 


### PR DESCRIPTION
## Problem

`pgcopydb copy table-data` accepts `--split-tables-larger-than` and `--split-max-parts` but does not list them in its `--help` output, leading users to believe the options are not supported for this subcommand.

## Root Cause

All `pgcopydb copy *` subcommands share the `cli_copy_db_getopts` parser, which already parses both split options (lines 716–718 of `cli_common.c`). The values flow correctly through `copydb_init_specs` into `CopyDataSpec.splitTablesLargerThan` / `splitMaxParts` and are honoured by `copydb_prepare_table_specs`. The `copy_table_data_command` help string in `cli_copy.c` simply omitted the two option lines.

## Fix

Added `--split-tables-larger-than` and `--split-max-parts` to the `copy_table_data_command` help string in `cli_copy.c`, using the same wording as the `clone` command. No logic changes.

Closes #921