### PR TITLE
fix: override client_encoding to SQL_ASCII when source server encoding is SQL_ASCII (#874)

### DIFF
--- a/src/bin/pgcopydb/pgsql.c
+++ b/src/bin/pgcopydb/pgsql.c
@@ -1084,6 +1084,48 @@ pgsql_server_version(PGSQL *pgsql)
 
 
 /*
+ * pgsql_set_client_encoding_for_server overrides client_encoding to match the
+ * server encoding when the server uses SQL_ASCII.
+ *
+ * COMMON_GUC_SETTINGS forces client_encoding='UTF-8' on every connection so
+ * that data flows through pgcopydb as UTF-8. That is the right default for
+ * most migrations (e.g. SQL_ASCII → UTF-8) because it makes Postgres validate
+ * the bytes on the way out of the source.
+ *
+ * However when the source itself is SQL_ASCII the forced UTF-8 client encoding
+ * causes COPY TO STDOUT to fail for any byte that is not valid UTF-8 (e.g.
+ * 0xff), even when the target database is also SQL_ASCII and would happily
+ * store those bytes. For a SQL_ASCII source we want raw bytes to pass through
+ * unchanged; the target-side connection (still using client_encoding=UTF-8)
+ * will then validate the data against the target encoding, which is the right
+ * place for that check.
+ *
+ * PQparameterStatus() returns the cached value libpq received during
+ * connection setup — no extra SQL query is issued.
+ */
+bool
+pgsql_set_client_encoding_for_server(PGSQL *pgsql)
+{
+	const char *server_enc =
+		PQparameterStatus(pgsql->connection, "server_encoding");
+
+	if (server_enc != NULL && strcmp(server_enc, "SQL_ASCII") == 0)
+	{
+		log_notice("Source database server encoding is SQL_ASCII; "
+				   "overriding client_encoding to SQL_ASCII so that "
+				   "bytes are passed through unchanged during COPY");
+
+		if (!pgsql_execute(pgsql, "SET client_encoding = 'SQL_ASCII'"))
+		{
+			return false;
+		}
+	}
+
+	return true;
+}
+
+
+/*
  * pgsql_set_transaction calls SET ISOLATION LEVEl with the specific
  * transaction modes parameters.
  */

--- a/src/bin/pgcopydb/pgsql.h
+++ b/src/bin/pgcopydb/pgsql.h
@@ -266,6 +266,7 @@ bool pgsql_commit(PGSQL *pgsql);
 bool pgsql_rollback(PGSQL *pgsql);
 
 bool pgsql_server_version(PGSQL *pgsql);
+bool pgsql_set_client_encoding_for_server(PGSQL *pgsql);
 
 bool pgsql_set_transaction(PGSQL *pgsql,
 						   IsolationLevel level,

--- a/src/bin/pgcopydb/snapshot.c
+++ b/src/bin/pgcopydb/snapshot.c
@@ -127,6 +127,13 @@ copydb_export_snapshot(TransactionSnapshot *snapshot)
 		return false;
 	}
 
+	if (!pgsql_set_client_encoding_for_server(pgsql))
+	{
+		log_fatal("Failed to set client_encoding on the source connection, "
+				  "see above for details");
+		return false;
+	}
+
 	return true;
 }
 
@@ -206,6 +213,13 @@ copydb_set_snapshot(CopyDataSpec *copySpecs)
 	if (!pgsql_set_gucs(pgsql, settings))
 	{
 		log_fatal("Failed to set our GUC settings on the source connection, "
+				  "see above for details");
+		return false;
+	}
+
+	if (!pgsql_set_client_encoding_for_server(pgsql))
+	{
+		log_fatal("Failed to set client_encoding on the source connection, "
 				  "see above for details");
 		return false;
 	}


### PR DESCRIPTION
## Problem

`pgcopydb clone` (and `copy table-data`) fails with `ERROR: invalid byte sequence for encoding "UTF8"` when the source database has `SQL_ASCII` server encoding and contains bytes that are not valid UTF-8 (e.g. `0xff`):

```sql
CREATE DATABASE source WITH ENCODING 'SQL_ASCII' TEMPLATE template0;
\c source
CREATE TABLE foo(t TEXT);
SET client_encoding = 'SQL_ASCII';
INSERT INTO foo VALUES(E'\377');  -- byte 0xff
```

```
ERROR:  invalid byte sequence for encoding "UTF8": 0xff
```

## Root Cause

`COMMON_GUC_SETTINGS` (defined in `copydb.h`) sets `client_encoding='UTF-8'` on every source and target connection. For the **source** connection this is intentional for most migrations: it makes Postgres validate/convert data to UTF-8 on the way out of COPY, which catches data problems early when migrating to a UTF-8 target.

However, when the **source server encoding is SQL_ASCII** (which Postgres treats as "no encoding" — raw bytes, no validation), setting `client_encoding=UTF-8` causes Postgres to attempt a conversion from SQL_ASCII to UTF-8 during COPY TO, and any byte that is not valid UTF-8 triggers the error. This breaks:

- SQL_ASCII → SQL_ASCII migrations with non-UTF-8 bytes (should work transparently)
- SQL_ASCII → UTF-8 migrations with non-UTF-8 bytes (will also fail at the target side, but the error should come from the target, not the source)

## Fix

After applying `srcSettings` (which includes `client_encoding=UTF-8`), the new `pgsql_set_client_encoding_for_server` function checks `PQparameterStatus(conn, "server_encoding")` — a cached libpq value, no extra SQL query. If the server encoding is `SQL_ASCII`, it issues `SET client_encoding = 'SQL_ASCII'` to override.

This is called in both snapshot-connection entry points in `snapshot.c`:
- `copydb_export_snapshot` — the main-process source connection
- `copydb_set_snapshot` — each COPY worker's source connection

The destination-side connections are unaffected and keep `client_encoding=UTF-8`, so a UTF-8 target database still validates incoming bytes correctly.

Closes #874