### PR TITLE
ci: fix tag pattern (v*.* not v*.*.*) and add workflow_dispatch to docker-publish

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,8 +8,9 @@ name: Docker
 on:
   push:
     branches: [ main ]
-    # Publish semver tags as releases.
-    tags: [ 'v*.*.*' ]
+    # Publish semver tags as releases. Matches v0.18, v0.18.1, etc.
+    tags: [ 'v*.*' ]
+  workflow_dispatch:
 
 env:
   # Use docker.io for Docker Hub if empty

--- a/.github/workflows/homebrew-bump.yml
+++ b/.github/workflows/homebrew-bump.yml
@@ -3,7 +3,7 @@ name: Homebrew
 on:
   push:
     tags:
-      - 'v*.*.*'
+      - 'v*.*'
 
 jobs:
   bump-formula:

--- a/.github/workflows/homebrew-bump.yml
+++ b/.github/workflows/homebrew-bump.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*.*'
+  workflow_dispatch:
 
 jobs:
   bump-formula:


### PR DESCRIPTION
## Problem

The `docker-publish.yml` and `homebrew-bump.yml` workflows use `v*.*.*` as the tag trigger pattern, but pgcopydb tags releases as `v0.18` (two components). As a result, pushing a release tag never triggered the Docker image build or the Homebrew formula bump — only pushes to `main` fired `docker-publish`, which pushed `:latest` but no versioned tag.

There is also no `workflow_dispatch` trigger, so there was no way to manually re-run the workflow against an existing tag.

## Fix

- Changed tag pattern from `v*.*.*` to `v*.*` in both `docker-publish.yml` and `homebrew-bump.yml`. This matches `v0.18`, `v0.19`, and also `v0.18.1` patch releases.
- Added `workflow_dispatch` to `docker-publish.yml` so the workflow can be manually triggered via `gh workflow run docker-publish.yml --repo dimitri/pgcopydb --ref v0.18` to backfill the `ghcr.io/dimitri/pgcopydb:0.18` image for the current release.