### PR TITLE
ci: add tag input to homebrew-bump workflow_dispatch

### DIFF
--- a/.github/workflows/homebrew-bump.yml
+++ b/.github/workflows/homebrew-bump.yml
@@ -5,17 +5,21 @@ on:
     tags:
       - 'v*.*'
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to bump (e.g. v0.18)'
+        required: true
 
 jobs:
   bump-formula:
-    if: "!contains(github.ref_name, '-')"
+    if: "!contains(inputs.tag || github.ref_name, '-')"
     runs-on: ubuntu-latest
     steps:
       - uses: mislav/bump-homebrew-formula-action@v3
         with:
           formula-name: pgcopydb
           homebrew-tap: Homebrew/homebrew-core
-          tag-name: ${{ github.ref_name }}
+          tag-name: ${{ inputs.tag || github.ref_name }}
           create-pullrequest: true
         env:
           COMMITTER_TOKEN: ${{ secrets.HOMEBREW_CORE_TOKEN }}


### PR DESCRIPTION
## Problem

`gh workflow run homebrew-bump.yml --ref v0.18` fails with "Workflow does not have 'workflow_dispatch' trigger" because GitHub checks the workflow file **at the specified ref**, and `v0.18` predates the `workflow_dispatch` addition.

## Fix

Add a `tag` input to `workflow_dispatch` so the workflow can be triggered from `main` (where the trigger lives) while specifying an arbitrary release tag:

```bash
gh workflow run homebrew-bump.yml --repo dimitri/pgcopydb -f tag=v0.18
```

The `tag-name` field uses `inputs.tag || github.ref_name` so tag-push automation (the normal path) is unaffected.