### PR TITLE
ci: upgrade bump-homebrew-formula-action to v4.1 (Node 24 compat)

### DIFF
--- a/.github/workflows/homebrew-bump.yml
+++ b/.github/workflows/homebrew-bump.yml
@@ -15,7 +15,7 @@ jobs:
     if: "!contains(inputs.tag || github.ref_name, '-')"
     runs-on: ubuntu-latest
     steps:
-      - uses: mislav/bump-homebrew-formula-action@v3
+      - uses: mislav/bump-homebrew-formula-action@v4.1
         with:
           formula-name: pgcopydb
           homebrew-tap: Homebrew/homebrew-core


### PR DESCRIPTION
## Problem

`mislav/bump-homebrew-formula-action@v3` is built for Node 20. GitHub Actions now forces Node 24, which breaks the action's HTTP redirect handling, causing `unexpected HTTP 303 response` on every run. See https://github.com/dimitri/pgcopydb/actions/runs/28320809337/job/83902290481.

## Fix

Upgrade to `v4.1` (released March 2026), which targets Node 24. No API or input changes — runtime upgrade only.