### PR TITLE
fix: allow CTID split from standby, skip ANALYZE only (#1028)

### DIFF
--- a/src/bin/pgcopydb/copydb_schema.c
+++ b/src/bin/pgcopydb/copydb_schema.c
@@ -825,18 +825,11 @@ copydb_prepare_table_specs_hook(void *ctx, SourceTable *source)
 	 * CTID range scan is supported (see columnar storage extensions), so
 	 * we skip partitioning altogether in that case.
 	 *
-	 * Also, we cannot execute ANALYZE on a database that is in recovery mode,
-	 * so we skip partitioning in that case too.
+	 * When the source is a standby (pg_is_in_recovery()), ANALYZE cannot run
+	 * because it writes WAL. We skip ANALYZE below but still partition using
+	 * the pre-existing pg_class.relpages statistics replicated from the
+	 * primary, which are available as a plain read on the standby.
 	 */
-
-	if (specs->sourceSnapshot.isReadOnly)
-	{
-		log_warn("Connected to a standby server where pg_is_in_recovery(): "
-				 "skipping partitioning for table %s",
-				 source->qname);
-
-		return true;
-	}
 
 	if (IS_EMPTY_STRING_BUFFER(source->partKey) &&
 		streq(source->amname, "heap"))
@@ -867,9 +860,13 @@ copydb_prepare_table_specs_hook(void *ctx, SourceTable *source)
 
 		/*
 		 * Make sure we have proper statistics (relpages) about the table
-		 * before compute the CTID ranges for the concurrent table scans.
+		 * before computing the CTID ranges for the concurrent table scans.
+		 *
+		 * Skip ANALYZE when estimating table sizes (the caller already has
+		 * size information) or when connected to a standby server (ANALYZE
+		 * writes WAL and is rejected during recovery).
 		 */
-		if (specs->estimateTableSizes)
+		if (specs->estimateTableSizes || specs->sourceSnapshot.isReadOnly)
 		{
 			log_debug("Skipping running ANALYZE on table %s for CTID split",
 					  source->qname);
@@ -896,6 +893,22 @@ copydb_prepare_table_specs_hook(void *ctx, SourceTable *source)
 			log_error("Failed to fetch table %s relpages",
 					  source->qname);
 			return false;
+		}
+
+		/*
+		 * On a standby, pg_class.relpages may be zero if the table has
+		 * never been analyzed on the primary. Without page-count statistics
+		 * we cannot compute CTID partition boundaries, so fall back to a
+		 * single COPY and advise the user to run ANALYZE on the primary.
+		 */
+		if (source->relpages == 0 && specs->sourceSnapshot.isReadOnly)
+		{
+			log_warn("Table %s has no statistics on the standby server "
+					 "(relpages = 0 in pg_class): skipping CTID split. "
+					 "Run ANALYZE on the primary to enable partitioning.",
+					 source->qname);
+
+			return true;
 		}
 	}
 	else if (!streq(source->amname, "heap"))


### PR DESCRIPTION
## Problem

When running `pgcopydb clone --split-tables-larger-than ...` against a standby server (`pg_is_in_recovery() = true`), large tables are not split into concurrent COPY workers. Instead, pgcopydb logs a warning and falls back to a single COPY per table:

```
WARN   copydb_schema.c:834  Connected to a standby server where pg_is_in_recovery(): skipping partitioning for table public.table1
```

## Root Cause

`copydb_prepare_table_specs_hook` (`src/bin/pgcopydb/copydb_schema.c:832`) contained an early return for any standby source that skipped both ANALYZE and partitioning together. The motivation was that ANALYZE cannot run on a standby — it writes WAL to update `pg_statistic` and `pg_class.relpages`, which is rejected with `ERROR: cannot execute ANALYZE during recovery` and has been since Hot Standby was introduced in PostgreSQL 9.0.

The over-eager early return conflated two independent concerns: ANALYZE (which must be skipped) and CTID partition planning (which only reads `pg_class.relpages` via a plain SELECT, fully available on standbys). Integer-key partition paths (`SELECT MIN/MAX`) are likewise read-only and work fine on standbys.

## Fix

Three changes, all in `copydb_prepare_table_specs_hook`:

1. **Remove the early return** for `isReadOnly` so that the function proceeds to partition planning.
2. **Add `specs->sourceSnapshot.isReadOnly` to the ANALYZE skip condition** (alongside the existing `estimateTableSizes` guard), preventing the ANALYZE call while letting the rest of the CTID path run.
3. **Guard against `relpages = 0`** after `schema_list_relpages`: if the table has never been analyzed on the primary, `pg_class.relpages` will be zero on the standby, making CTID partitioning impossible. A WARN is logged advising the user to run ANALYZE on the primary, and the table falls back to a single COPY — the same behaviour as before the fix, but now limited to tables that genuinely have no statistics, rather than all tables.

Closes #1028