### PR TITLE
fix: count table bytes from s_table_size in list progress

### DIFF
--- a/src/bin/pgcopydb/catalog.c
+++ b/src/bin/pgcopydb/catalog.c
@@ -10610,8 +10610,8 @@ catalog_count_summary_done_fetch(SQLiteQuery *query)
 
 /*
  * catalog_count_bytes returns byte totals used by list progress to show
- * transfer volume.  total is the sum of source catalog sizes (s_table.bytes);
- * transferred is the sum of summary.bytes for all table rows — done rows
+ * transfer volume.  total sums the source catalog sizes, which live in
+ * s_table_size and not in s_table; transferred sums summary.bytes: done rows
  * hold their final bytesTransmitted, in-progress rows hold the last value
  * flushed by the periodic stats hook (every ~5 s with PID-based jitter).
  */
@@ -10628,7 +10628,8 @@ catalog_count_bytes(DatabaseCatalog *catalog, CatalogBytesCounts *count)
 
 	char *sql =
 		"select "
-		"  coalesce((select sum(bytes) from s_table), 0) as total, "
+		"  coalesce((select sum(ts.bytes) from s_table t"
+		"             left join s_table_size ts on ts.oid = t.oid), 0) as total, "
 		"  coalesce((select sum(bytes) from summary"
 		"             where tableoid is not null and done_time_epoch is not null), 0)"
 		"    as done, "

--- a/src/bin/pgcopydb/catalog.h
+++ b/src/bin/pgcopydb/catalog.h
@@ -707,7 +707,7 @@ bool catalog_count_summary_done_fetch(SQLiteQuery *query);
 
 typedef struct CatalogBytesCounts
 {
-	uint64_t total;       /* sum of s_table.bytes (source catalog sizes) */
+	uint64_t total;       /* sum of s_table_size.bytes (source catalog sizes) */
 	uint64_t done;        /* sum of summary.bytes for completed tables */
 	uint64_t inProgress;  /* sum of summary.bytes for in-progress tables (last flush) */
 } CatalogBytesCounts;

--- a/tests/pagila-multi-steps/copydb.sh
+++ b/tests/pagila-multi-steps/copydb.sh
@@ -42,6 +42,8 @@ pgcopydb copy constraints --resume --notice
 pgcopydb restore post-data --resume
 
 pgcopydb list progress --summary
+pgcopydb list progress --json > /tmp/progress.json
+jq --exit-status '.bytes.total > 0' < /tmp/progress.json
 
 kill -TERM ${COPROC_PID}
 wait ${COPROC_PID}


### PR DESCRIPTION
`pgcopydb list progress` fails with `[SQLite] no such column: bytes`: catalog_count_bytes sums bytes from s_table, but #684 moved table sizes into s_table_size, and the function arrived later (#1002) still reading the pre-#684 column. CI never caught it because only `list progress --summary` is exercised, which bypasses this query.

Fix: read the total through the s_table_size join, the same shape catalog_s_table_stats uses. Regression: tests/pagila-multi-steps now runs `pgcopydb list progress --json` and asserts bytes.total is positive.

Fixes #1036.
