### PR TITLE
fix: keep Case 3 filter adoption in memory, never write it back

### DIFF
--- a/src/bin/pgcopydb/catalog.c
+++ b/src/bin/pgcopydb/catalog.c
@@ -851,6 +851,49 @@ catalog_stored_filter_type(const char *filtersJson)
 
 
 /*
+ * catalog_filters_match_adoption returns true when the given serialized filters
+ * are what the current command would write after adopting the catalog's stored
+ * filter type: that type, no relation filters, and the extension filters of the
+ * command itself.
+ */
+static bool
+catalog_filters_match_adoption(SourceFilters *filters,
+							   const char *filtersJson,
+							   SourceFilterType storedType)
+{
+	SourceFilters adopted = { 0 };
+
+	adopted.type = storedType;
+
+	/*
+	 * Extension filtering never contributes to the filter type, so a command
+	 * filtering only extensions still adopts the stored type and keeps its own
+	 * extension lists.  Borrow them for the comparison; filters_as_json only
+	 * reads the lists, and this struct owns nothing.
+	 */
+	adopted.excludeExtensionList = filters->excludeExtensionList;
+	adopted.includeOnlyExtensionList = filters->includeOnlyExtensionList;
+
+	JSON_Value *js = json_value_init_object();
+
+	if (!filters_as_json(&adopted, js))
+	{
+		/* errors have already been logged */
+		json_value_free(js);
+		return false;
+	}
+
+	char *adoptedJson = json_serialize_to_string(js);
+	bool match = streq(filtersJson, adoptedJson);
+
+	json_free_serialized_string(adoptedJson);
+	json_value_free(js);
+
+	return match;
+}
+
+
+/*
  * catalog_register_setup_from_specs registers the current copySpecs setup.
  */
 bool
@@ -1280,16 +1323,42 @@ catalog_register_setup_from_specs(CopyDataSpec *copySpecs)
 			else if (strstr(setup->filters, "SOURCE_FILTER_TYPE_NONE") == NULL &&
 					 strstr(json, "SOURCE_FILTER_TYPE_NONE") == NULL)
 			{
-				/* Case 2: both sides have filters but they differ — conflict. */
-				log_info("Current filtering setup is: %s", json);
-				log_info("Catalog filtering setup is: %s", setup->filters);
-				log_error("Catalogs at \"%s\" have been setup for a different "
-						  "filtering than the current command, "
-						  "see above for details",
-						  sourceDB->dbfile);
+				/*
+				 * Case 2: both sides have filters, and they differ.
+				 *
+				 * Before calling that a conflict, allow for a command that
+				 * adopted the catalog's stored filter type in case 3 below:
+				 * its own filters then serialize to that type, no relation
+				 * filters, and whatever extensions it filters itself.  Worker
+				 * processes forked by a clone that runs without the stored
+				 * filters land here, having inherited that from their parent.
+				 *
+				 * A real filters file always fills at least one relation list,
+				 * which is what gives it its type, so it cannot match here.
+				 */
+				SourceFilterType storedType =
+					catalog_stored_filter_type(setup->filters);
 
-				json_free_serialized_string(json);
-				return false;
+				if (storedType != SOURCE_FILTER_TYPE_NONE &&
+					catalog_filters_match_adoption(filters, json, storedType))
+				{
+					log_debug("Current filtering is the catalog's stored "
+							  "filter type (%s), as adopted by our parent "
+							  "process",
+							  filterTypeToString(storedType));
+				}
+				else
+				{
+					log_info("Current filtering setup is: %s", json);
+					log_info("Catalog filtering setup is: %s", setup->filters);
+					log_error("Catalogs at \"%s\" have been setup for a different "
+							  "filtering than the current command, "
+							  "see above for details",
+							  sourceDB->dbfile);
+
+					json_free_serialized_string(json);
+					return false;
+				}
 			}
 			else if (strstr(setup->filters, "SOURCE_FILTER_TYPE_NONE") == NULL &&
 					 strstr(json, "SOURCE_FILTER_TYPE_NONE") != NULL)
@@ -1297,9 +1366,9 @@ catalog_register_setup_from_specs(CopyDataSpec *copySpecs)
 				/*
 				 * Case 3: catalog was created with filters; the current
 				 * command has none (e.g. pgcopydb clone without --filters,
-				 * pgcopydb list table-parts, pgcopydb stream sentinel).
-				 * These commands operate on the already-filtered catalog
-				 * data and do not need --filters repeated.
+				 * pgcopydb list table-parts).  These commands operate on
+				 * the already-filtered catalog data and do not need
+				 * --filters repeated.
 				 *
 				 * Adopt the stored filter TYPE so that
 				 * copydb_fetch_filtered_oids uses the correct complement
@@ -1308,11 +1377,15 @@ catalog_register_setup_from_specs(CopyDataSpec *copySpecs)
 				 * are not needed: filtersDB already holds the pre-computed
 				 * OIDs from the earlier list commands.
 				 *
-				 * Also update the stored JSON in source.db to match the
-				 * current command's serialization (adopted type, empty
-				 * patterns).  Worker processes independently call this
-				 * function and must see the same stored JSON or they would
-				 * trigger Case 2 (both sides non-NONE but mismatched).
+				 * The adoption stays in memory: the stored record is never
+				 * rewritten from here.  Every filter-checked command run
+				 * without the stored filters lands in this case, so writing
+				 * the adopted type back replaced the stored patterns with the
+				 * serialization of our own empty lists, and a single
+				 * `pgcopydb list tables` was enough to leave the directory
+				 * unusable by its --filters owner (#1038).  Worker processes
+				 * that inherit the adopted type are recognized by the
+				 * comparison in case 2 above instead.
 				 */
 				SourceFilterType storedType =
 					catalog_stored_filter_type(setup->filters);
@@ -1320,31 +1393,6 @@ catalog_register_setup_from_specs(CopyDataSpec *copySpecs)
 				if (storedType != SOURCE_FILTER_TYPE_NONE)
 				{
 					filters->type = storedType;
-
-					json_free_serialized_string(json);
-
-					JSON_Value *jsAdopted = json_value_init_object();
-
-					if (!filters_as_json(filters, jsAdopted))
-					{
-						/* errors have already been logged */
-						return false;
-					}
-
-					json = json_serialize_to_string(jsAdopted);
-
-					if (!catalog_update_filters(sourceDB, json))
-					{
-						log_error("Failed to update filters in catalog database");
-						json_free_serialized_string(json);
-						return false;
-					}
-
-					if (setup->filters != NULL)
-					{
-						free(setup->filters);
-					}
-					setup->filters = strdup(json);
 				}
 
 				log_debug("Adopting catalog's stored filter type (%s) for "

--- a/src/bin/pgcopydb/cli_list.c
+++ b/src/bin/pgcopydb/cli_list.c
@@ -2039,6 +2039,14 @@ cli_list_progress(int argc, char **argv)
 		}
 	}
 
+	/*
+	 * list progress is filter-agnostic: it reports on the work that previous
+	 * commands recorded in the catalogs and never reads or writes any
+	 * filter-dependent data.  Skip the filter consistency check so that it
+	 * works the same on a filtered and on an unfiltered work directory.
+	 */
+	copySpecs.skipFilterCheck = true;
+
 	if (!catalog_init_from_specs(&copySpecs))
 	{
 		log_error("Failed to initialize pgcopydb internal catalogs");

--- a/tests/filtering/Dockerfile
+++ b/tests/filtering/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /usr/src/pgcopydb
 COPY ./copydb.sh copydb.sh
 COPY ./include.ini include.ini
 COPY ./exclude.ini exclude.ini
+COPY ./ext-only.ini ext-only.ini
 COPY ./extra.sql extra.sql
 
 # unit tests

--- a/tests/filtering/copydb.sh
+++ b/tests/filtering/copydb.sh
@@ -51,6 +51,42 @@ EOF
 
 pgcopydb clone --filters /usr/src/pgcopydb/exclude.ini --resume --not-consistent
 
+# Whatever runs against this work directory without repeating its filters must
+# leave them stored as they are (#1038).
+assert_filters_intact()
+{
+    sqlite3 /tmp/exclude/pgcopydb/schema/source.db 'select filters from setup;' \
+        | grep -F exclude-schema \
+        || { echo "the exclude filters are gone from the work directory (#1038)"; exit 1; }
+}
+
+# A list command that opens the catalog without --filters.
+pgcopydb list table-parts --split-tables-larger-than 10GB \
+         --schema-name seq --table-name default_table
+
+# list progress can fail here for its own reasons (#1036); what we check is
+# what it leaves behind in the catalog.
+pgcopydb list progress --json || true
+
+assert_filters_intact
+
+pgcopydb clone --filters /usr/src/pgcopydb/exclude.ini --resume --not-consistent
+
+# A filterless clone, whose forked workers re-enter the setup check carrying
+# the filter type their parent adopted.
+pgcopydb clone --resume --not-consistent
+
+assert_filters_intact
+
+# Extension filtering carries no filter type, so this clone adopts the stored
+# one and its workers carry the extension list along with it.
+pgcopydb clone --filters /usr/src/pgcopydb/ext-only.ini --resume --not-consistent
+
+assert_filters_intact
+
+# The directory must still be usable by the filters it was created with.
+pgcopydb clone --filters /usr/src/pgcopydb/exclude.ini --resume --not-consistent
+
 export TMPDIR=/tmp/include
 
 # now compare the output of running the SQL command with what's expected

--- a/tests/filtering/ext-only.ini
+++ b/tests/filtering/ext-only.ini
@@ -1,0 +1,5 @@
+; Extension filtering carries no filter type of its own, so this file parses
+; as SOURCE_FILTER_TYPE_NONE with a non-empty extension list.
+
+[exclude-extension]
+plpgsql


### PR DESCRIPTION
Any filter-checked command invoked without --filters on a filtered work dir (Case 3: list progress, list table-parts, compare, or clone when the filters file is simply not passed) adopts the stored filter type, then persists its own re-serialization via catalog_update_filters. That serialization comes from the command's empty SourceFilters, so the pattern arrays are dropped: `{"type":"SOURCE_FILTER_TYPE_EXCL","exclude-schema":["audit"]}` degrades to `{"type":"SOURCE_FILTER_TYPE_EXCL"}`. Every later `clone --filters` on that work dir (or its live workers) then fails the setup comparison and exits 12; one bare `list progress` poisons the work dir for good.

The write-back exists so forked workers, which inherit the adopted type with empty relation lists, pass the comparison on re-entry (1089e6c). This patch keeps that property without mutating the catalog: the stored record becomes immutable, and the comparison recognizes the adopted signature, the stored type plus whatever extension filtering the parent carried (extension filters contribute no filter type, so an extension-only --filters file also adopts). list progress is additionally marked filter-agnostic (skipFilterCheck) like the sentinel commands.

Regression: tests/filtering now runs list table-parts, list progress, a filterless clone, and an extension-only clone between a filtered clone and its --resume rerun, asserting the stored filtering survives each; tests/pagila-standby keeps covering the filterless-clone worker re-entry path.

Fixes #1038.
