### PR TITLE
tests: pin the pagila clone to the pre-v4 commit (hotfix)

### DIFF
--- a/tests/Dockerfile.multi
+++ b/tests/Dockerfile.multi
@@ -37,7 +37,8 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/src/
-RUN git clone --depth 1 https://github.com/devrimgunduz/pagila.git
+RUN git clone https://github.com/devrimgunduz/pagila.git \
+ && git -C pagila checkout 5ba5a57aeb159f75f02aca2432d3c262186d13d3
 
 COPY f1db/f1db.dump /usr/src/f1db/f1db.dump
 COPY chinook/Chinook_PostgreSql.sql /usr/src/chinook/Chinook_PostgreSql.sql

--- a/tests/Dockerfile.pagila
+++ b/tests/Dockerfile.pagila
@@ -37,7 +37,8 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/src/
-RUN git clone --depth 1 https://github.com/devrimgunduz/pagila.git
+RUN git clone https://github.com/devrimgunduz/pagila.git \
+ && git -C pagila checkout 5ba5a57aeb159f75f02aca2432d3c262186d13d3
 
 #RUN adduser --disabled-password --gecos '' --home /var/lib/postgres docker
 #RUN adduser docker sudo


### PR DESCRIPTION
Every pagila-based suite currently fails at fixture load: pagila v4 (2026-07-28) requires PostgreSQL 18 for uuidv7 and pulls in pgvector, and the postgres images these tests build have neither. This pins the clone in both tests/Dockerfile.pagila and tests/Dockerfile.multi to 5ba5a57, the last pagila commit before that rework, which is also the revision the checked-in expected outputs were generated against. The --depth 1 flag has to go, because a shallow clone cannot check out an older commit.

I ran the full suite set locally against the pin, including the filtering suite, whose expected-output diffs come out clean.

It might still be neccessary to fix it more "sustainable" in the long run. 
