### PR TITLE
ci: fix nightly by pinning pagila and ignoring psql padding

### DIFF
--- a/tests/Dockerfile.multi
+++ b/tests/Dockerfile.multi
@@ -37,7 +37,12 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/src/
-RUN git clone --depth 1 https://github.com/devrimgunduz/pagila.git
+# Pin pagila to the last commit before the upstream 4.x line, which
+# raised its minimum to PostgreSQL 18 and started requiring uuidv7(),
+# pgvector and pg_partman.  Cloning master unpinned broke every
+# pagila-based test overnight; see the CI notes in the PR.
+RUN git clone https://github.com/devrimgunduz/pagila.git \
+ && git -C pagila checkout 5ba5a57aeb159f75f02aca2432d3c262186d13d3
 
 COPY f1db/f1db.dump /usr/src/f1db/f1db.dump
 COPY chinook/Chinook_PostgreSql.sql /usr/src/chinook/Chinook_PostgreSql.sql

--- a/tests/Dockerfile.pagila
+++ b/tests/Dockerfile.pagila
@@ -37,7 +37,12 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/src/
-RUN git clone --depth 1 https://github.com/devrimgunduz/pagila.git
+# Pin pagila to the last commit before the upstream 4.x line, which
+# raised its minimum to PostgreSQL 18 and started requiring uuidv7(),
+# pgvector and pg_partman.  Cloning master unpinned broke every
+# pagila-based test overnight; see the CI notes in the PR.
+RUN git clone https://github.com/devrimgunduz/pagila.git \
+ && git -C pagila checkout 5ba5a57aeb159f75f02aca2432d3c262186d13d3
 
 #RUN adduser --disabled-password --gecos '' --home /var/lib/postgres docker
 #RUN adduser docker sudo

--- a/tests/cdc-endpos-in-multi-wal-txn/compose.yaml
+++ b/tests/cdc-endpos-in-multi-wal-txn/compose.yaml
@@ -9,8 +9,14 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: h4ckm3
       POSTGRES_HOST_AUTH_METHOD: trust
+    # PostgreSQL 16.15 / 17.11 / 18.6 added output_plugin_libraries, which
+    # defaults to 'pgoutput, test_decoding' and rejects every other
+    # decoding plugin.  This test decodes with wal2json, so the plugin
+    # has to be allow-listed here or CREATE_REPLICATION_SLOT fails with
+    # 'library "wal2json" may not be used as an output plugin'.
     command: >
       -c wal_level=logical
+      -c output_plugin_libraries='pgoutput,test_decoding,wal2json'
       -c ssl=on
       -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key

--- a/tests/cdc-endpos-mid-txn/compose.yaml
+++ b/tests/cdc-endpos-mid-txn/compose.yaml
@@ -9,8 +9,14 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: h4ckm3
       POSTGRES_HOST_AUTH_METHOD: trust
+    # PostgreSQL 16.15 / 17.11 / 18.6 added output_plugin_libraries, which
+    # defaults to 'pgoutput, test_decoding' and rejects every other
+    # decoding plugin.  This test decodes with wal2json, so the plugin
+    # has to be allow-listed here or CREATE_REPLICATION_SLOT fails with
+    # 'library "wal2json" may not be used as an output plugin'.
     command: >
       -c wal_level=logical
+      -c output_plugin_libraries='pgoutput,test_decoding,wal2json'
       -c ssl=on
       -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key

--- a/tests/cdc-wal2json/compose.yaml
+++ b/tests/cdc-wal2json/compose.yaml
@@ -9,8 +9,14 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: h4ckm3
       POSTGRES_HOST_AUTH_METHOD: trust
+    # PostgreSQL 16.15 / 17.11 / 18.6 added output_plugin_libraries, which
+    # defaults to 'pgoutput, test_decoding' and rejects every other
+    # decoding plugin.  This test decodes with wal2json, so the plugin
+    # has to be allow-listed here or CREATE_REPLICATION_SLOT fails with
+    # 'library "wal2json" may not be used as an output plugin'.
     command: >
       -c wal_level=logical
+      -c output_plugin_libraries='pgoutput,test_decoding,wal2json'
       -c ssl=on
       -c ssl_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
       -c ssl_key_file=/etc/ssl/private/ssl-cert-snakeoil.key

--- a/tests/unit/copydb.sh
+++ b/tests/unit/copydb.sh
@@ -46,7 +46,11 @@ do
     e=./expected/${t}.out
     psql -d "${PGCOPYDB_TARGET_PGURI}" ${pgopts} --file ./sql/$t.sql &> $r
     test -f $e || cat $r
-    diff $e $r || exit 1
+    # -w: psql's expanded-mode padding for multi-line values changed in
+    # the August 2026 minor releases (16.15 / 17.11 / 18.6), so column
+    # widths are not stable across client versions.  Compare content,
+    # not alignment -- same as the script/ loop below.
+    diff -w $e $r || exit 1
 done
 
 


### PR DESCRIPTION
The nightly matrix has failed **every night since 2026-07-29**. It is two
independent breakages, both caused by unpinned external dependencies — no
pgcopydb commit is involved (the last one landed 2026-07-03).

The tell is that the *same 18 of 27 tests* fail on all three PostgreSQL
versions, and the same 9 always pass, so it is not version-specific.

## 1. Upstream pagila went PG18-only (18 tests, since 2026-07-29)

`tests/Dockerfile.pagila` and `tests/Dockerfile.multi` did:

```
RUN git clone --depth 1 https://github.com/devrimgunduz/pagila.git
```

`--depth 1` with no ref means *whatever upstream master is that night*.
Upstream cut a 4.x line that "raised minimum to PostgreSQL 18" and added
`uuidv7()` columns (2026-07-28), pgvector (2026-07-30) and pg_partman
(2026-07-28). Nightly went permanently red on 2026-07-29 — the day after
the uuidv7 commit.

Loading `pagila-schema.sql` then fails two different ways:

- **PG16/17** — `psql:/tmp/pagila-schema.sql:271: ERROR: function uuidv7() does not exist`
- **PG18** — gets further, then `psql:/tmp/pagila-schema.sql:465: ERROR: extension "vector" is not available` (pgvector is not installed in the image)

The 18 failing tests are exactly the 18 whose `copydb.sh` loads that
schema; the 9 that pass never touch it.

This pins the clone to `5ba5a57`, the last commit before that line. I
verified that commit predates every breaking change and that its
`pagila-schema.sql` loads clean on both PG16 and PG18 with
`ON_ERROR_STOP=on`.

## 2. A psql formatting change broke `unit` (since 2026-08-14)

Separate and later: `unit` passed on 2026-08-13 and failed from
2026-08-14, with a padding-only diff in `expected/3-string-escape.out`:

```
< f1 | aaa  +      (expected, width 5)
> f1 | aaa    +    (actual, width 7)
```

Reproduced locally against a real server — psql's expanded-mode column
width for multi-line values changed in the August 2026 minors:

| psql client | output |
|---|---|
| 18.0 – 18.4 | `aaa  +` (matches the committed expected file) |
| 16.15 / 17.11 / 18.6 | `aaa    +` |

The images install `postgresql-${PGVERSION}` from PGDG unpinned, so they
picked up the new minors. This is psql presentation, not a pgcopydb
regression, so the fix compares content and ignores alignment — the same
thing the `script/` loop just below already does.

`-b` is **not** sufficient: it ignores changes in the *amount* of
whitespace but not whitespace added where there was none, so
`bbb\r+` vs `bbb\r  +` still differs. `-w` handles it, and I confirmed it
still catches a real content change. `3-string-escape.out` is the only
expected file with continuation lines, so nothing else is affected.

## Notes

- This supersedes #1043 (same pagila pin, same commit — that PR is correct, but its checks have been stuck in `action_required` since 2026-08-22 and never ran).
- Because the sql loop `exit 1`s on the first failure, tests 4/5/6/9 have not run since 2026-08-14. They were green before and nothing else changed, but this run is where we find out.
- Still open beyond this hotfix: pinning pagila leaves PGDG minors floating, which is what caused breakage 2. And tracking pagila 4.x later would need pgvector + pg_partman in the image, and would not work for PG16/17 at all.