### PR TITLE
compare: exit non-zero when data differs

### DIFF
--- a/src/bin/pgcopydb/cli_compare.c
+++ b/src/bin/pgcopydb/cli_compare.c
@@ -30,6 +30,13 @@ static void cli_compare_data(int argc, char **argv);
 
 static bool cli_compare_data_table_hook(void *ctx, SourceTable *table);
 
+/*
+ * Counts tables whose contents differ between source and target. compare data
+ * reported differences only in the log and still exited zero, so callers that
+ * checked the exit status read a mismatch as a match.
+ */
+static uint64_t compareDataDiffCount = 0;
+
 static CommandLine compare_schema_command =
 	make_command(
 		"schema",
@@ -451,6 +458,19 @@ cli_compare_data(int argc, char **argv)
 		/* errors have already been logged */
 		exit(EXIT_CODE_INTERNAL_ERROR);
 	}
+
+	/*
+	 * After the report, so a caller keeps the per-table detail that says which
+	 * tables differ. Same verdict shape as compare schema, which already exits
+	 * non-zero on diffCount > 0.
+	 */
+	if (compareDataDiffCount > 0)
+	{
+		log_fatal("Data on source and target database differ: "
+				  "%lld table(s) do not match",
+				  (long long) compareDataDiffCount);
+		exit(EXIT_CODE_INTERNAL_ERROR);
+	}
 }
 
 
@@ -460,6 +480,16 @@ cli_compare_data(int argc, char **argv)
 static bool
 cli_compare_data_table_hook(void *ctx, SourceTable *table)
 {
+	/*
+	 * Count before formatting, so both the JSON and the tabular output paths
+	 * feed the same verdict.
+	 */
+	if (table->sourceChecksum.rowcount != table->targetChecksum.rowcount ||
+		!streq(table->sourceChecksum.checksum, table->targetChecksum.checksum))
+	{
+		++compareDataDiffCount;
+	}
+
 	if (outputJSON)
 	{
 		JSON_Array *jsArray = (JSON_Array *) ctx;


### PR DESCRIPTION
Fixes #1046.

`pgcopydb compare data` logs row-count and checksum differences and exits 0, so the exit
status cannot distinguish "databases match" from "databases differ". `compare schema`
already counts diffs and exits non-zero; this brings `compare data` in line.

## Change

Count differing tables in `cli_compare_data_table_hook()`, so the `--json` and tabular
output paths share one verdict, and exit non-zero **after** the report is written so a
caller keeps the per-table detail that says which tables differ.

The count sits in the hook rather than in `compare_table()` because returning false there
would exit before the report is printed, and because `compare_table()`'s false already
means "the comparison could not run", which is a different condition.

## Verification

Two PostgreSQL 14 instances, a clone, then three rows deleted on the target. Reproduction
script is in #1046.

Before:

```
identical data : exit=0
target -3 rows : exit=0
ERROR  compare.c:523  Table public.t has 100 rows on source, 97 rows on target
```

After:

```
identical data : exit=0
target -3 rows : exit=12
ERROR  compare.c:523  Table public.t has 100 rows on source, 97 rows on target
FATAL  cli_compare.c  Data on source and target database differ: 1 table(s) do not match
```

The difference was detected and logged in both cases. Only the exit status changed.

## Not covered

`--all-databases` returns from `cli_compare_data()` before this check.
