### PR TITLE
follow: stop overwriting replay_lsn with endpos

### DIFF
--- a/src/bin/pgcopydb/ld_apply.c
+++ b/src/bin/pgcopydb/ld_apply.c
@@ -578,11 +578,13 @@ stream_apply_replaydb(StreamSpecs *specs, StreamApplyContext *context)
 						   xid,
 						   LSN_FORMAT_ARGS(context->previousLSN));
 
-				/* ensure replay_lsn advances to endpos for follow_reached_endpos */
-				if (context->previousLSN < context->endpos)
-				{
-					context->previousLSN = context->endpos;
-				}
+				/*
+				 * Do NOT push previousLSN up to endpos here. It is published
+				 * as the sentinel replay_lsn, and overwriting it reports work
+				 * the apply did not do. follow_reached_endpos() check (b)
+				 * already ends the loop from the apply exiting run_state=done
+				 * when endpos falls between or inside transactions.
+				 */
 				(void) stream_apply_sync_sentinel(context, false);
 				break;
 			}
@@ -635,11 +637,13 @@ stream_apply_replaydb(StreamSpecs *specs, StreamApplyContext *context)
 				log_info("Apply reached endpos %X/%X",
 						 LSN_FORMAT_ARGS(context->endpos));
 
-				/* ensure replay_lsn advances to endpos for follow_reached_endpos */
-				if (context->previousLSN < context->endpos)
-				{
-					context->previousLSN = context->endpos;
-				}
+				/*
+				 * Do NOT push previousLSN up to endpos here. It is published
+				 * as the sentinel replay_lsn, and overwriting it reports work
+				 * the apply did not do. follow_reached_endpos() check (b)
+				 * already ends the loop from the apply exiting run_state=done
+				 * when endpos falls between or inside transactions.
+				 */
 				(void) stream_apply_sync_sentinel(context, false);
 				break;
 			}
@@ -1399,7 +1403,9 @@ stream_apply_sync_sentinel(StreamApplyContext *context, bool findDurableLSN)
 	uint64_t durableLSN = InvalidXLogRecPtr;
 
 	/*
-	 * If we know we reached endpos, then publish that as the replay_lsn.
+	 * At endpos, publish the last LSN the apply actually committed. It is not
+	 * necessarily endpos: endpos can fall between or inside transactions, and
+	 * replay_lsn has to stay a measurement of applied work.
 	 */
 	if (context->reachedEndPos || !findDurableLSN)
 	{


### PR DESCRIPTION
Fixes #1048.

At the end of a drain the apply overwrites its own cursor with `endpos` and publishes that
as the sentinel `replay_lsn`, so the field reports where the apply was told to stop rather
than where it applied to. A consumer reading `pgcopydb stream sentinel get --replay-lsn`
is told the drain is complete while transactions below `endpos` are unapplied.

## Change

Remove both assignments. `previousLSN` now only advances to the LSN of a COMMIT the apply
executed.

The overwrite is not needed to end the loop. `follow_reached_endpos()` already has a
second check for this case, keyed on the apply exiting with `run_state='done'`, carrying
the comment "endpos fell between or inside transactions. replay_lsn is still at the last
real commit (< endpos)". Both removed sites `break` out of the apply loop immediately, so
the apply exits and that check fires.

In the first of the two the assignment was already dead: the branch is entered only when
`endpos <= previousLSN`, guarded by `if (previousLSN < endpos)`.

## Consequence a reviewer should weigh

This is not only a reporting fix. `cli_clone_follow.c` short-circuits a resumed run and
exits 0 when `endpos <= sentinel.replay_lsn`, and `--resume` preserves the sentinel row.
With `replay_lsn` assigned `endpos` that condition is always true, so a resumed run after a
short drain is a silent no-op reported as success. With the measured value it is false and
a resumed run replays.

## Depends on

Nothing. It is a prerequisite for #1052, which does not apply cleanly without it.

## Not covered

No standalone reproduction: see the reproduction status in #1048 for what was tried and
which exit paths it ruled out. The reproduction in #1049 exercises the same loop and passes
only with this change present.

Consumers that wait on `replay_lsn` reaching `endpos` without going through
`follow_reached_endpos()` would need review.
