### PR TITLE
follow: keep keepalives off the apply cursor, and prove the drain before stopping

### DIFF
--- a/src/bin/pgcopydb/cli_stream.c
+++ b/src/bin/pgcopydb/cli_stream.c
@@ -1524,7 +1524,9 @@ cli_stream_apply(int argc, char **argv)
 		 */
 		specs.sentinel.replay_lsn = InvalidXLogRecPtr;
 
-		if (!stream_transform_from_outputdb(&specs, InvalidXLogRecPtr))
+		if (!stream_transform_from_outputdb(&specs,
+											InvalidXLogRecPtr,
+											InvalidXLogRecPtr))
 		{
 			exit(EXIT_CODE_INTERNAL_ERROR);
 		}

--- a/src/bin/pgcopydb/ld_apply.c
+++ b/src/bin/pgcopydb/ld_apply.c
@@ -151,6 +151,15 @@ stream_apply_catchup(StreamSpecs *specs)
 #define APPLY_STATE_SYNC_EVERY 64
 
 /*
+ * How many consecutive passes may move nothing at all while the spool still
+ * holds committed work below endpos.  Those passes sleep 100 ms, so this is
+ * thirty seconds: three times STREAM_EMPTY_TX_TIMEOUT, so a receive that is
+ * merely idle still resets the count with its keepalives well before the
+ * bound, and only a pipeline that has actually stopped reaches it.
+ */
+#define APPLY_DRAIN_STALL_LIMIT 300
+
+/*
  * stream_apply_state_progressed returns true when the in-memory apply pipeline
  * state advanced between two snapshots — i.e. the transform stage wrote a new
  * transaction to replayDB, or the apply stage committed one to the target.
@@ -239,6 +248,7 @@ stream_apply_replaydb(StreamSpecs *specs, StreamApplyContext *context)
 	specs->private.applyState = &current;
 
 	int syncCounter = 0;
+	int stalledPasses = 0;
 
 	for (;;)
 	{
@@ -291,7 +301,10 @@ stream_apply_replaydb(StreamSpecs *specs, StreamApplyContext *context)
 		}
 		lock_held = true;
 
-		if (!ld_store_replay_next_event(replayDB, context->previousLSN, &s))
+		if (!ld_store_replay_next_event(replayDB,
+										context->previousLSN,
+										context->keepaliveLSN,
+										&s))
 		{
 			/* errors have already been logged */
 			success = false;
@@ -315,17 +328,28 @@ stream_apply_replaydb(StreamSpecs *specs, StreamApplyContext *context)
 			 * transaction it writes, so comparing against this snapshot tells
 			 * us whether the transform stage made progress this pass.
 			 *
-			 * The call is safe to repeat: ld_store_iter_output uses
-			 * specs->sentinel.replay_lsn as a cursor and only processes rows
-			 * newer than the last committed apply position.  Afterwards
-			 * specs->private.midTxnEndpos may be set, meaning receive finished
-			 * with an uncommitted transaction open.
+			 * The call is safe to repeat: ld_store_iter_output only processes
+			 * transactions committing above previousLSN and markers above
+			 * keepaliveLSN, so a pass that hands over nothing changes nothing.
+			 * Afterwards specs->private.midTxnEndpos may be set, meaning
+			 * receive finished with an uncommitted transaction open.
 			 */
 			PipelineStateEntry before = current;
 
-			if (!stream_transform_from_outputdb(specs, context->previousLSN))
+			if (!stream_transform_from_outputdb(specs,
+												context->previousLSN,
+												context->keepaliveLSN))
 			{
-				log_warn("Failed to transform from outputDB, will retry");
+				/*
+				 * A transform that keeps failing never produces the rest of
+				 * the spool, and this loop reads "no new work" as "nothing
+				 * left to do": swallowing the failure ends the run short of
+				 * endpos and calls it a success.
+				 */
+				log_error("Failed to transform from outputDB, "
+						  "see above for details");
+				success = false;
+				break;
 			}
 
 			if (specs->private.midTxnEndpos)
@@ -375,6 +399,8 @@ stream_apply_replaydb(StreamSpecs *specs, StreamApplyContext *context)
 			 */
 			if (stream_apply_state_progressed(&before, &current))
 			{
+				stalledPasses = 0;
+
 				/* checkpoint progress to sourceDB once in a while */
 				if ((++syncCounter % APPLY_STATE_SYNC_EVERY) == 0)
 				{
@@ -385,12 +411,37 @@ stream_apply_replaydb(StreamSpecs *specs, StreamApplyContext *context)
 			}
 
 			/*
-			 * No new work from the transform stage.  Before checking whether
-			 * receive has finished, see if the receive process rotated to a new
-			 * output.db file.  If the current output.db has been closed
-			 * (done_time_epoch IS NOT NULL in cdc_files) and a successor file
-			 * exists, advance to it immediately rather than spinning.
+			 * No new work from the transform stage.  What outputDB still holds
+			 * below endpos decides two things: whether the current CDC file may
+			 * be retired, and whether the drain is finished.  Ask once.
+			 *
+			 * Only complete transactions count, so an endpos falling inside an
+			 * open transaction still drains empty and the loop terminates.
 			 */
+			ReplayDBOutputMessage pending = { 0 };
+
+			if (context->endpos != InvalidXLogRecPtr &&
+				!ld_store_lookup_output_complete_txn(specs->outputDB,
+													 context->previousLSN,
+													 context->endpos,
+													 &pending))
+			{
+				log_error("Failed to look up the transactions left to apply "
+						  "in outputDB, see above for details");
+				success = false;
+				break;
+			}
+
+			/*
+			 * Receive rotates to a new output.db once it has closed the current
+			 * one (done_time_epoch IS NOT NULL in cdc_files); follow it rather
+			 * than spin.  Not while this file still holds committed work below
+			 * endpos, though: every later pass asks the drain question of
+			 * whichever file is open, so moving on would hide that work and let
+			 * the drain report success.  Receive only closes a file it has
+			 * finished writing, so this cannot wait on rows that never arrive.
+			 */
+			if (pending.lsn == InvalidXLogRecPtr)
 			{
 				bool advanced = false;
 
@@ -410,14 +461,17 @@ stream_apply_replaydb(StreamSpecs *specs, StreamApplyContext *context)
 					 */
 					replayDB = specs->replayDB;
 					context->replayDB = replayDB;
+					stalledPasses = 0;
 					continue;
 				}
 			}
 
 			/*
-			 * No new work from the transform stage.  If receive has finished
-			 * there is nothing left to do: everything up to the last committed
-			 * transaction boundary at or before endpos has been applied.
+			 * Receive being finished is necessary to stop here, and not
+			 * sufficient: the transform hands over one unit per pass and a
+			 * KEEPALIVE unit reports no transaction progress, so "this pass
+			 * produced nothing" says nothing about what is still spooled.  The
+			 * lookup above answers that; this only decides who asked.
 			 *
 			 * In FOLLOW mode the upstream_done flag signals receive completion;
 			 * in CATCHUP mode (no pipe) consult receive's pipeline_state row.
@@ -440,24 +494,52 @@ stream_apply_replaydb(StreamSpecs *specs, StreamApplyContext *context)
 					}
 				}
 
-				if (receive_done)
+				if (receive_done && pending.lsn == InvalidXLogRecPtr)
 				{
-					log_notice("Apply: receive done and no more complete "
-							   "transactions to transform — stopping at last "
+					log_notice("Apply: receive is done and outputDB holds "
+							   "no complete transaction committing at or "
+							   "below endpos %X/%X, stopping at last "
 							   "commit %X/%X",
+							   LSN_FORMAT_ARGS(context->endpos),
 							   LSN_FORMAT_ARGS(context->previousLSN));
 
 					context->reachedEndPos = true;
 					(void) stream_apply_sync_sentinel(context, false);
 					break;
 				}
+
+				/*
+				 * Committed work is still spooled below endpos and nothing has
+				 * come through the pipeline for a while.  Fail rather than
+				 * spin, and above all rather than report a cutover that
+				 * dropped those transactions.
+				 */
+				if (pending.lsn != InvalidXLogRecPtr &&
+					(receive_done || context->endPosRecordSeen) &&
+					++stalledPasses >= APPLY_DRAIN_STALL_LIMIT)
+				{
+					log_error("Apply is stuck draining: %d passes moved "
+							  "nothing while outputDB still holds xid %u "
+							  "committing at %X/%X, at or below endpos "
+							  "%X/%X, with apply at %X/%X",
+							  stalledPasses,
+							  pending.xid,
+							  LSN_FORMAT_ARGS(pending.lsn),
+							  LSN_FORMAT_ARGS(context->endpos),
+							  LSN_FORMAT_ARGS(context->previousLSN));
+
+					success = false;
+					break;
+				}
 			}
 
 			/*
 			 * Not caught up yet.  In pipe mode the select() ceiling gives
-			 * ≤100 ms latency; in catchup-only mode sleep briefly.
+			 * ≤100 ms latency; with no pipe left to wait on, sleep briefly so
+			 * a count of idle passes is also a wall-clock bound.  Passes that
+			 * produced work have already continued above.
 			 */
-			if (pipe_rd < 0 && !specs->upstream_done)
+			if (pipe_rd < 0)
 			{
 				pg_usleep(100 * 1000);  /* 100 ms */
 			}
@@ -471,6 +553,14 @@ stream_apply_replaydb(StreamSpecs *specs, StreamApplyContext *context)
 		 */
 		semaphore_unlock(&(replayDB->sema));
 		lock_held = false;
+
+		/*
+		 * The pipeline moved: the transform put this row in replayDB and the
+		 * apply is taking it.  A KEEPALIVE row reaches this point too, and it
+		 * changes no transaction state, so the drain bound would otherwise
+		 * count an idle source's keepalives as a stall.
+		 */
+		stalledPasses = 0;
 
 		if (s.action == STREAM_ACTION_BEGIN)
 		{
@@ -619,6 +709,14 @@ stream_apply_replaydb(StreamSpecs *specs, StreamApplyContext *context)
 
 			if (s.action == STREAM_ACTION_KEEPALIVE)
 			{
+				/*
+				 * The row is consumed now, whichever way the handler took it,
+				 * and the query must not hand it back.  The cursor lives here
+				 * rather than in previousLSN, which selects the transactions
+				 * still to apply.
+				 */
+				context->keepaliveLSN = s.lsn;
+
 				bool findDurableLSN = false;
 
 				if (!stream_apply_sync_sentinel(context, findDurableLSN))
@@ -632,21 +730,14 @@ stream_apply_replaydb(StreamSpecs *specs, StreamApplyContext *context)
 				current.run_end_lsn = context->previousLSN;
 			}
 
-			if (context->reachedEndPos)
-			{
-				log_info("Apply reached endpos %X/%X",
-						 LSN_FORMAT_ARGS(context->endpos));
-
-				/*
-				 * Do NOT push previousLSN up to endpos here. It is published
-				 * as the sentinel replay_lsn, and overwriting it reports work
-				 * the apply did not do. follow_reached_endpos() check (b)
-				 * already ends the loop from the apply exiting run_state=done
-				 * when endpos falls between or inside transactions.
-				 */
-				(void) stream_apply_sync_sentinel(context, false);
-				break;
-			}
+			/*
+			 * A KEEPALIVE at or past endpos does not end the run on its own.
+			 * The walEnd it carries can sit ahead of transactions the server
+			 * has not decoded yet, and those still commit below endpos and
+			 * belong to this migration.  Termination is decided in the drained
+			 * path above: receive done, and nothing complete left in outputDB
+			 * below endpos.
+			 */
 		}
 	}
 
@@ -1191,6 +1282,13 @@ stream_apply_setup(StreamSpecs *specs, StreamApplyContext *context)
 		log_error("Failed to setup replication origin on the target database");
 		return false;
 	}
+
+	/*
+	 * Keepalives are consumed with their own cursor, so that previousLSN only
+	 * ever moves to a COMMIT the apply executed.  Start it at the origin, or a
+	 * resumed run replays every keepalive the previous one already saw.
+	 */
+	context->keepaliveLSN = context->previousLSN;
 
 	/* build the target relkind cache (matview detection) */
 	if (!stream_apply_load_target_relkinds(context))
@@ -1876,12 +1974,21 @@ stream_apply_sql(StreamApplyContext *context,
 			if (context->endpos != InvalidXLogRecPtr &&
 				context->endpos < metadata->lsn)
 			{
+				/*
+				 * previousLSN is the apply filter, the transform cursor and
+				 * the restart seed at once, and it only ever moves forward.
+				 * Moving it to a keepalive at or past endpos hides every
+				 * transaction that commits below that position from this run
+				 * and from any later one, which is how committed rows go
+				 * missing at cutover.  Record the sighting separately and
+				 * leave the cursor on the last commit we applied.
+				 */
 				context->reachedEndPos = true;
-				context->previousLSN = metadata->lsn;
+				context->endPosRecordSeen = true;
 
 				log_notice("Apply reached end position %X/%X at KEEPALIVE %X/%X",
 						   LSN_FORMAT_ARGS(context->endpos),
-						   LSN_FORMAT_ARGS(context->previousLSN));
+						   LSN_FORMAT_ARGS(metadata->lsn));
 
 				return true;
 			}
@@ -1969,7 +2076,7 @@ stream_apply_sql(StreamApplyContext *context,
 				return false;
 			}
 
-			context->previousLSN = metadata->lsn;
+			/* only a COMMIT moves previousLSN: see the endpos check above */
 
 			/*
 			 * At COMMIT time we might have reached the endpos: we know
@@ -1978,13 +2085,14 @@ stream_apply_sql(StreamApplyContext *context,
 			 * last entry of the file we're applying.
 			 */
 			if (context->endpos != InvalidXLogRecPtr &&
-				context->endpos <= context->previousLSN)
+				context->endpos <= metadata->lsn)
 			{
 				context->reachedEndPos = true;
+				context->endPosRecordSeen = true;
 
 				log_notice("Apply reached end position %X/%X at KEEPALIVE %X/%X",
 						   LSN_FORMAT_ARGS(context->endpos),
-						   LSN_FORMAT_ARGS(context->previousLSN));
+						   LSN_FORMAT_ARGS(metadata->lsn));
 				break;
 			}
 

--- a/src/bin/pgcopydb/ld_apply.c
+++ b/src/bin/pgcopydb/ld_apply.c
@@ -578,11 +578,13 @@ stream_apply_replaydb(StreamSpecs *specs, StreamApplyContext *context)
 						   xid,
 						   LSN_FORMAT_ARGS(context->previousLSN));
 
-				/* ensure replay_lsn advances to endpos for follow_reached_endpos */
-				if (context->previousLSN < context->endpos)
-				{
-					context->previousLSN = context->endpos;
-				}
+				/*
+				 * Do NOT push previousLSN up to endpos here. It is published
+				 * as the sentinel replay_lsn, and overwriting it reports work
+				 * the apply did not do. follow_reached_endpos() check (b)
+				 * already ends the loop from the apply exiting run_state=done
+				 * when endpos falls between or inside transactions.
+				 */
 				(void) stream_apply_sync_sentinel(context, false);
 				break;
 			}
@@ -635,11 +637,13 @@ stream_apply_replaydb(StreamSpecs *specs, StreamApplyContext *context)
 				log_info("Apply reached endpos %X/%X",
 						 LSN_FORMAT_ARGS(context->endpos));
 
-				/* ensure replay_lsn advances to endpos for follow_reached_endpos */
-				if (context->previousLSN < context->endpos)
-				{
-					context->previousLSN = context->endpos;
-				}
+				/*
+				 * Do NOT push previousLSN up to endpos here. It is published
+				 * as the sentinel replay_lsn, and overwriting it reports work
+				 * the apply did not do. follow_reached_endpos() check (b)
+				 * already ends the loop from the apply exiting run_state=done
+				 * when endpos falls between or inside transactions.
+				 */
 				(void) stream_apply_sync_sentinel(context, false);
 				break;
 			}
@@ -1399,7 +1403,9 @@ stream_apply_sync_sentinel(StreamApplyContext *context, bool findDurableLSN)
 	uint64_t durableLSN = InvalidXLogRecPtr;
 
 	/*
-	 * If we know we reached endpos, then publish that as the replay_lsn.
+	 * At endpos, publish the last LSN the apply actually committed. It is not
+	 * necessarily endpos: endpos can fall between or inside transactions, and
+	 * replay_lsn has to stay a measurement of applied work.
 	 */
 	if (context->reachedEndPos || !findDurableLSN)
 	{

--- a/src/bin/pgcopydb/ld_store.c
+++ b/src/bin/pgcopydb/ld_store.c
@@ -437,7 +437,8 @@ ld_store_set_cdc_filename_at_lsn(StreamSpecs *specs, uint64_t lsn)
 		 */
 		ReplayDBOutputMessage output = { 0 };
 
-		if (!ld_store_lookup_output_after_lsn(candidateDB, lsn, &output))
+		/* the probe asks "any row from here on", so both cursors are lsn */
+		if (!ld_store_lookup_output_after_lsn(candidateDB, lsn, lsn, &output))
 		{
 			/* errors have already been logged */
 			sqlite3_close(probeDB);
@@ -595,6 +596,7 @@ ld_store_lookup_output_at_lsn(DatabaseCatalog *catalog, uint64_t lsn,
 bool
 ld_store_lookup_output_after_lsn(DatabaseCatalog *catalog,
 								 uint64_t lsn,
+								 uint64_t keepaliveLSN,
 								 ReplayDBOutputMessage *output)
 {
 	sqlite3 *db = catalog->db;
@@ -656,9 +658,12 @@ ld_store_lookup_output_after_lsn(DatabaseCatalog *catalog,
 	 *      (wal2json emits them at the same WAL position), so use >=.
 	 *
 	 *   2. KEEPALIVE ('K') or SWITCH ('X') — non-transactional markers
-	 *      that appear between committed transactions.  Use strict > so
-	 *      that after recording transform_lsn = keepalive.lsn the next
-	 *      call moves past the row without a +1 trick.
+	 *      that appear between committed transactions.  They carry the
+	 *      server's walEnd, which sits above transactions the server has
+	 *      not decoded yet, so they get their own cursor ($2) instead of
+	 *      riding on the transaction cursor ($1), which would hide those
+	 *      transactions.  Strict > so that the marker the apply just
+	 *      consumed is not handed back.
 	 *
 	 * DML rows (I/U/D/T) are NEVER returned here: they are always inside
 	 * a transaction and are consumed exclusively by the inner iterator
@@ -678,7 +683,9 @@ ld_store_lookup_output_after_lsn(DatabaseCatalog *catalog,
 		"order by lsn asc, case when action = 'B' then 0 else 1 end, id asc "
 		"limit 1";
 
-	log_debug("ld_store_lookup_output_after_lsn: %X/%X", LSN_FORMAT_ARGS(lsn));
+	log_debug("ld_store_lookup_output_after_lsn: %X/%X (keepalive %X/%X)",
+			  LSN_FORMAT_ARGS(lsn),
+			  LSN_FORMAT_ARGS(keepaliveLSN));
 
 	SQLiteQuery query = {
 		.errorOnZeroRows = false,
@@ -697,7 +704,7 @@ ld_store_lookup_output_after_lsn(DatabaseCatalog *catalog,
 	/* bind our parameters now */
 	BindParam params[] = {
 		{ BIND_PARAMETER_TYPE_INT64, "lsn", lsn },
-		{ BIND_PARAMETER_TYPE_INT64, "lsn", lsn }
+		{ BIND_PARAMETER_TYPE_INT64, "keepaliveLSN", keepaliveLSN }
 	};
 
 	int count = sizeof(params) / sizeof(params[0]);
@@ -781,6 +788,93 @@ ld_store_lookup_output_xid_end(DatabaseCatalog *catalog,
 	};
 
 	if (!catalog_sql_bind(&query, params, 1))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	if (!catalog_sql_execute_once(&query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	return true;
+}
+
+
+/*
+ * ld_store_lookup_output_complete_txn returns the oldest complete transaction
+ * in the output table that commits after previousLSN and at or before endpos,
+ * with the commit LSN in output->lsn.  output->lsn is InvalidXLogRecPtr when
+ * there is none.
+ *
+ * The join to the COMMIT row is what makes a transaction count as complete: an
+ * endpos that falls inside a transaction still leaves nothing to drain here,
+ * which is how the apply loop terminates in that case.
+ *
+ * Only a COMMIT terminates a transaction for this purpose.  A ROLLBACK leaves
+ * previousLSN where it was, by design, so counting one as work left to drain
+ * would hold the window open on a transaction the apply is never going to
+ * move past.  ld_store_lookup_output_xid_end documents the reconnect case
+ * where one xid carries both a stale artificial ROLLBACK and the re-delivered
+ * real COMMIT; correlating on c.id > b.id keeps the stale row from pairing
+ * with the later BEGIN.
+ */
+bool
+ld_store_lookup_output_complete_txn(DatabaseCatalog *catalog,
+									uint64_t previousLSN,
+									uint64_t endpos,
+									ReplayDBOutputMessage *output)
+{
+	/* the apply closes and re-opens this handle on CDC file rotation */
+	if (catalog == NULL || catalog->db == NULL)
+	{
+		log_error("BUG: ld_store_lookup_output_complete_txn: db is NULL");
+		return false;
+	}
+
+	sqlite3 *db = catalog->db;
+
+	/*
+	 * The BEGIN row carries the transaction, the C/R row carries the position
+	 * the apply compares against: report c.lsn as the row lsn.  The message
+	 * body is never read here, so select null for it and skip its malloc.
+	 */
+	char *sql =
+		"  select b.id, b.action, b.xid, c.lsn, b.timestamp, null, "
+		"         b.nspname, b.relname, b.old_type "
+		"    from output b "
+		"    join output c on c.xid = b.xid and c.action = 'C' and c.id > b.id "
+		"   where b.action = 'B' and c.lsn > $1 and c.lsn <= $2 "
+		"order by c.lsn asc "
+		"   limit 1";
+
+	log_debug("ld_store_lookup_output_complete_txn: %X/%X .. %X/%X",
+			  LSN_FORMAT_ARGS(previousLSN),
+			  LSN_FORMAT_ARGS(endpos));
+
+	/* errorOnZeroRows = false: an empty drain is the expected answer */
+	SQLiteQuery query = {
+		.errorOnZeroRows = false,
+		.context = output,
+		.fetchFunction = &ld_store_output_fetch
+	};
+
+	if (!catalog_sql_prepare(db, sql, &query))
+	{
+		/* errors have already been logged */
+		return false;
+	}
+
+	BindParam params[] = {
+		{ BIND_PARAMETER_TYPE_INT64, "previousLSN", previousLSN, NULL },
+		{ BIND_PARAMETER_TYPE_INT64, "endpos", endpos, NULL }
+	};
+
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(&query, params, count))
 	{
 		/* errors have already been logged */
 		return false;
@@ -2126,6 +2220,7 @@ ld_store_iter_output(StreamSpecs *specs, ReplayDBOutputIterFun *callback)
 
 	iter->catalog = specs->outputDB;
 	iter->transform_lsn = specs->sentinel.replay_lsn;  /* apply reads from replay_lsn */
+	iter->keepalive_lsn = specs->private.keepaliveLSN;
 	iter->endpos = specs->endpos;
 
 
@@ -2362,7 +2457,10 @@ ld_store_iter_output_init(ReplayDBOutputIterator *iter)
 	 * ENDPOS rows no longer appear in the output table: receive signals
 	 * transform via the pipe_rt lifecycle pipe instead.
 	 */
-	if (!ld_store_lookup_output_after_lsn(catalog, iter->transform_lsn, &first))
+	if (!ld_store_lookup_output_after_lsn(catalog,
+										  iter->transform_lsn,
+										  iter->keepalive_lsn,
+										  &first))
 	{
 		/* errors have already been logged */
 		iter->output = NULL;
@@ -2467,10 +2565,9 @@ ld_store_iter_output_init(ReplayDBOutputIterator *iter)
 			}
 
 			/*
-			 * The non-transactional branch in ld_store_lookup_output_after_lsn
-			 * uses `lsn > transform_lsn` (strict), so a DML row at exactly
-			 * transform_lsn is never returned — the cursor-collision can no
-			 * longer occur.
+			 * ld_store_lookup_output_after_lsn returns BEGIN rows and markers
+			 * only, and the markers ride their own strict cursor, so a row at
+			 * exactly transform_lsn cannot come back as a starting point.
 			 */
 			if (last.lsn == InvalidXLogRecPtr)
 			{
@@ -2969,7 +3066,7 @@ ld_store_replay_event_fetch(SQLiteQuery *query)
  * already exists in the replay table (endlsn > previousLSN ensures this).
  *
  * For non-transactional events (KEEPALIVE only — ENDPOS rows are no longer
- * written to the replay table): returns the first row at lsn >= previousLSN.
+ * written to the replay table): returns the first row at lsn > keepaliveLSN.
  *
  * Apply exits when no more rows AND pipeline_state['transform'].run_end_lsn
  * has been reached (set at stream_apply_catchup startup).
@@ -2980,6 +3077,7 @@ ld_store_replay_event_fetch(SQLiteQuery *query)
 bool
 ld_store_replay_next_event(DatabaseCatalog *catalog,
 						   uint64_t previousLSN,
+						   uint64_t keepaliveLSN,
 						   ReplayDBStmt *s)
 {
 	sqlite3 *db = catalog->db;
@@ -3002,12 +3100,13 @@ ld_store_replay_next_event(DatabaseCatalog *catalog,
 	 *
 	 * For non-transactional events (KEEPALIVE only — ENDPOS rows are no
 	 * longer written to the replay table): return the first KEEPALIVE row
-	 * at lsn STRICTLY greater than previousLSN.
+	 * at lsn STRICTLY greater than keepaliveLSN.
 	 *
-	 * Using lsn > $1 (strict) rather than lsn >= $1 is essential: after
-	 * apply processes a KEEPALIVE at lsn=X and sets previousLSN=X, the
-	 * next call uses $1=X.  With >=, the same KEEPALIVE is returned again
-	 * and apply spins.  With >, the same row is not returned a second time.
+	 * Keepalives get their own cursor because previousLSN also selects the
+	 * transactions still to apply.  A keepalive LSN sits above transactions
+	 * that commit below it and have not been applied yet, so filtering them
+	 * with it would drop them.  The cursor is still strict (>), because with
+	 * >= the row apply just consumed comes back and apply spins.
 	 */
 	char *sql =
 		"select b.id, b.action, b.xid, b.lsn, b.endlsn, b.timestamp "
@@ -3018,7 +3117,7 @@ ld_store_replay_next_event(DatabaseCatalog *catalog,
 		"select id, action, xid, lsn, endlsn, timestamp "
 		"  from replay "
 		" where action = 'K' "            /* KEEPALIVE only — no ENDPOS rows */
-		"   and lsn > $1 "                /* strict: avoids re-delivering same row */
+		"   and lsn > $2 "                /* strict: avoids re-delivering same row */
 		"order by lsn asc, id asc "
 		"limit 1";
 
@@ -3037,10 +3136,13 @@ ld_store_replay_next_event(DatabaseCatalog *catalog,
 	}
 
 	BindParam params[] = {
-		{ BIND_PARAMETER_TYPE_INT64, "previousLSN", previousLSN, NULL }
+		{ BIND_PARAMETER_TYPE_INT64, "previousLSN", previousLSN, NULL },
+		{ BIND_PARAMETER_TYPE_INT64, "keepaliveLSN", keepaliveLSN, NULL }
 	};
 
-	if (!catalog_sql_bind(&query, params, 1))
+	int count = sizeof(params) / sizeof(params[0]);
+
+	if (!catalog_sql_bind(&query, params, count))
 	{
 		/* errors have already been logged */
 		return false;

--- a/src/bin/pgcopydb/ld_store.h
+++ b/src/bin/pgcopydb/ld_store.h
@@ -72,11 +72,17 @@ bool ld_store_lookup_output_at_lsn(DatabaseCatalog *catalog,
 
 bool ld_store_lookup_output_after_lsn(DatabaseCatalog *catalog,
 									  uint64_t lsn,
+									  uint64_t keepaliveLSN,
 									  ReplayDBOutputMessage *output);
 
 bool ld_store_lookup_output_xid_end(DatabaseCatalog *catalog,
 									uint32_t xid,
 									ReplayDBOutputMessage *output);
+
+bool ld_store_lookup_output_complete_txn(DatabaseCatalog *catalog,
+										 uint64_t previousLSN,
+										 uint64_t endpos,
+										 ReplayDBOutputMessage *output);
 
 bool ld_store_output_fetch(SQLiteQuery *query);
 
@@ -122,6 +128,15 @@ typedef struct ReplayDBOutputIterator
 	SQLiteQuery query;
 
 	uint64_t transform_lsn;
+
+	/*
+	 * KEEPALIVE and SWITCH rows sit above the transactions that commit below
+	 * them, so transform_lsn cannot skip them: it selects the transactions
+	 * still to transform.  They get their own cursor, advanced by the apply
+	 * as it consumes each marker out of replayDB.
+	 */
+	uint64_t keepalive_lsn;
+
 	uint64_t endpos;
 
 	/*
@@ -169,11 +184,11 @@ bool ld_store_iter_replay_finish(ReplayDBReplayIterator *iter);
 
 
 /*
- * ld_store_replay_next_event returns the next event to apply after
- * previousLSN.  For transactions it returns the BEGIN row only when the
- * full transaction has been written (endlsn > previousLSN).  For
- * non-transactional events (KEEPALIVE/SWITCH/ENDPOS) it returns the first
- * row at lsn >= previousLSN.
+ * ld_store_replay_next_event returns the next event to apply.  For
+ * transactions it returns the BEGIN row only when the full transaction has
+ * been written (endlsn > previousLSN).  KEEPALIVE rows have their own cursor,
+ * keepaliveLSN: they must not be re-delivered, and previousLSN only ever
+ * moves to a COMMIT the apply executed.
  *
  * s->action is set to STREAM_ACTION_UNKNOWN when no rows are available.
  */
@@ -181,6 +196,7 @@ bool ld_store_replay_event_fetch(SQLiteQuery *query);
 
 bool ld_store_replay_next_event(DatabaseCatalog *catalog,
 								uint64_t previousLSN,
+								uint64_t keepaliveLSN,
 								ReplayDBStmt *s);
 
 

--- a/src/bin/pgcopydb/ld_stream.h
+++ b/src/bin/pgcopydb/ld_stream.h
@@ -475,6 +475,12 @@ typedef struct StreamContext
 	bool midTxnEndpos;
 
 	/*
+	 * Cursor over the KEEPALIVE and SWITCH rows of outputDB, set by
+	 * stream_transform_from_outputdb from the apply's own marker cursor.
+	 */
+	uint64_t keepaliveLSN;
+
+	/*
 	 * In-memory apply pipeline state owned by the apply driver loop
 	 * (stream_apply_replaydb).  The inline-transform hook updates these fields
 	 * as it writes each complete transaction to replayDB, so the driver can
@@ -548,6 +554,7 @@ typedef struct StreamApplyContext
 	char origin[BUFSIZE];
 
 	uint64_t previousLSN;       /* register COMMIT LSN progress */
+	uint64_t keepaliveLSN;      /* last KEEPALIVE consumed, cursor only */
 	uint64_t switchLSN;         /* LSN of the most recent SWITCH WAL message */
 
 	LSNTracking *lsnTrackingList;
@@ -560,6 +567,7 @@ typedef struct StreamApplyContext
 	bool reachedStartPos;
 	bool continuedTxn;
 	bool reachedEndPos;
+	bool endPosRecordSeen;      /* saw a record at or past endpos */
 	bool reachedEOF;
 	bool transactionInProgress;
 	bool logSQL;
@@ -779,7 +787,9 @@ bool stream_transform_write_replay_stmt(StreamSpecs *specs);
 bool stream_transform_write_replay_txn(StreamSpecs *specs);
 
 bool stream_transform_context_init(StreamSpecs *specs);
-bool stream_transform_from_outputdb(StreamSpecs *specs, uint64_t previousLSN);
+bool stream_transform_from_outputdb(StreamSpecs *specs,
+									uint64_t previousLSN,
+									uint64_t keepaliveLSN);
 
 bool stream_transform_message(StreamContext *privateContext,
 							  char *message);

--- a/src/bin/pgcopydb/ld_transform.c
+++ b/src/bin/pgcopydb/ld_transform.c
@@ -171,14 +171,22 @@ stream_transform_context_init(StreamSpecs *specs)
  * static hook to parse each JSON row from outputDB and write the corresponding
  * parameterised SQL into replayDB (stmt + replay tables).
  *
+ * KEEPALIVE and SWITCH markers are selected by keepaliveLSN instead, the
+ * position of the last marker the apply consumed.  previousLSN cannot serve:
+ * a marker carries the server's walEnd and sits above transactions that
+ * commit below it, so skipping past one with previousLSN would drop them.
+ *
  * After this call returns, specs->private.midTxnEndpos may be true; the caller
  * must check that flag and exit cleanly without advancing previousLSN if so.
  */
 bool
-stream_transform_from_outputdb(StreamSpecs *specs, uint64_t previousLSN)
+stream_transform_from_outputdb(StreamSpecs *specs,
+							   uint64_t previousLSN,
+							   uint64_t keepaliveLSN)
 {
 	/* tell ld_store_iter_output where to start (last committed LSN) */
 	specs->sentinel.replay_lsn = previousLSN;
+	specs->private.keepaliveLSN = keepaliveLSN;
 
 
 	/* reset the mid-transaction endpos flag before each pass */


### PR DESCRIPTION
Fixes #1049. Fixes #1050.

The apply loop exits with committed transactions below `endpos` never applied, and the
process exits 0. Reproduction script and both outputs are in #1049.

```
upstream main : source 1017000, target 1012000, exit 0   <- 5000 committed rows lost
with this PR  : source 1017000, target 1017000, exit 0
```

On upstream `main` the apply logs a claim the code never establishes:

```
NOTICE ld_apply.c  Apply: receive done and no more complete transactions to
                   transform — stopping at last commit 0/A839278
INFO   follow.c    Follow mode is now done, reached endpos 0/A92AFF8 with
                   replay_lsn 0/A839278
```

5000 commits are still in the spool and `replay_lsn` is below `endpos`.

## Change

**The cursor.** `previousLSN` was the apply filter, the transform's seed into `outputDB`,
and the restart position, all at once. Both KEEPALIVE branches moved it to the keepalive's
LSN, which carries the server's walEnd and sits ahead of transactions not yet decoded.
Everything committing below it became invisible to the rest of the run and to any later
one. Keepalives and switch markers now use a separate cursor that both stages read; only a
COMMIT the apply executed moves `previousLSN`; the sighting of a record at or past `endpos`
is recorded in its own flag.

**The break.** `receive_done` stays necessary. The break now proves its claim with a lookup
for a BEGIN joined to its `C`/`R` row where `commit_lsn > previousLSN and commit_lsn <=
endpos`, and stops only when that is empty. With work pending it continues, bounded: after
a stall limit it logs the pending xid and LSN and exits non-zero.

**A swallowed error.** A transform failure was discarded with `log_warn` and fell into the
same break. It is an error now.

## Why one change and not two

Each half alone is worse than the defect. The cursor split without the drain check gives a
deterministic drain failure, because nothing lets the loop continue once the keepalive no
longer ends it. The drain check without the cursor split never runs, because the keepalive
ends the loop first. Splitting ships two broken intermediate states.

## Depends on

#1051. The cursor change does not apply cleanly without it, and the resume path it restores
relies on `replay_lsn` staying below `endpos`.

## Verified

Termination traced for `endpos` on a commit boundary, `endpos` mid-transaction, an idle
source, a source emitting keepalives indefinitely with nothing spooled, and receive never
signalling done. The drain window was checked against a scratch SQLite database: `(110,130]`
returns the commit at 130, `(130,200]` with a BEGIN and no COMMIT returns nothing, so a
mid-transaction `endpos` still terminates.

## Not covered

The drain lookup queries the current CDC file. A rotation retiring a file that still holds
transactions below `endpos` could take the success path; not observed, not ruled out. The
stall limit fails a run whose transform is slow rather than wedged. `ld_replay.c` is dead on
the follow path and is untouched.
